### PR TITLE
Discussion: Expose useful information to the user when initially replicating

### DIFF
--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -102,6 +102,7 @@
     const dbSyncStartTime = Date.now();
     const dbSyncStartData = getDataUsage();
 
+    const maximumDocuments = remoteDocCount - localDocCount;
     const MAX_SAMPLES = 5; // cannot be less than two
     const FUDGE_FACTOR = 1.2; // 20% higher time estimates
     const dates = [];
@@ -136,7 +137,6 @@
             dates[idx] = Date.now();
             counts[idx] = docsRead;
 
-            let percentLeft;
             let minutes;
 
             const samples = dates.length;
@@ -163,7 +163,7 @@
               minutes = '<1';
             }
 
-            percentLeft = Math.floor((docsRead / maximumDocuments) * 100);
+            const percentLeft = Math.floor((docsRead / maximumDocuments) * 100);
 
             setUiStatus('FETCH_INFO', {
               percent: percentLeft || '?',

--- a/webapp/src/js/bootstrapper/translator.js
+++ b/webapp/src/js/bootstrapper/translator.js
@@ -4,7 +4,7 @@ const eurodigit = require('eurodigit');
 
 const TRANSLATIONS = {
   en: {
-    FETCH_INFO: ({ count, total }) => `Fetching info (${count} of ${total} docs )…`,
+    FETCH_INFO: ({ total, percent, minutes }) => `Fetching info (${total} docs) ${percent}% complete, ${minutes}min remaining`;
     LOAD_APP: 'Loading app…',
     PURGE_INIT: 'Checking data…',
     PURGE_INFO: ({ count }) => `Cleaned ${count} documents…`,

--- a/webapp/src/js/bootstrapper/translator.js
+++ b/webapp/src/js/bootstrapper/translator.js
@@ -4,7 +4,8 @@ const eurodigit = require('eurodigit');
 
 const TRANSLATIONS = {
   en: {
-    FETCH_INFO: ({ total, percent, minutes }) => `Fetching info (${total} docs) ${percent}% complete, ${minutes}min remaining`;
+    FETCH_INFO: ({ total, percent, minutes }) => 
+      `Fetching info (${total} docs) ${percent}% complete, ${minutes}min remaining`,
     LOAD_APP: 'Loading app…',
     PURGE_INIT: 'Checking data…',
     PURGE_INFO: ({ count }) => `Cleaned ${count} documents…`,


### PR DESCRIPTION
Show the % complete, based on how far each change write is through the
entire database. This may not be that accurate.

Show the time remaining, based on a sampled rolling window of the time
it takes getween change writes, and an estimate on how many change
writes are left.

Demo: https://www.youtube.com/watch?v=f80l6rs5vt8&feature=youtu.be

One big question here, is whether or not taking the max db seq and then the progress seq numbers from the change chunks actually translates into useful numbers in production. It does locally, but that would definitely need to be tested in a real DB to see how much it makes sense. @dianabarsan as the last person to touch replication, can you guess as to how useful this estimation would be?