### PR TITLE
Refactors registration transition

### DIFF
--- a/shared-libs/transitions/src/lib/utils.js
+++ b/shared-libs/transitions/src/lib/utils.js
@@ -149,7 +149,7 @@ module.exports = {
   * NB: Not all ids have registration documents against them, and so this
   *     is not a valid way of determining if the patient with that id exists
   */
-  getRegistrations: (options, callback) => {
+  getRegistrations: (options) => {
     const viewOptions = {
       include_docs: true,
     };
@@ -158,20 +158,15 @@ module.exports = {
     } else if (options.ids) {
       viewOptions.keys = options.ids;
     } else {
-      return callback(null, []);
+      return Promise.resolve([]);
     }
-    db.medic.query('medic-client/registered_patients', viewOptions)
+    return db.medic
+      .query('medic-client/registered_patients', viewOptions)
       .then(data => {
-        callback(
-          null,
-          data.rows
-            .map(row => row.doc)
-            .filter(doc =>
-              registrationUtils.isValidRegistration(doc, config.getAll())
-            )
-        );
-      })
-      .catch(callback);
+        return data.rows
+          .map(row => row.doc)
+          .filter(doc => registrationUtils.isValidRegistration(doc, config.getAll()));
+      });
   },
   getForm: formCode => {
     const forms = config.get('forms');
@@ -227,10 +222,8 @@ module.exports = {
    * Given a patient "shortcode" (as used in SMS reports), return the _id
    * of the patient's person contact to the caller
    */
-  getPatientContactUuid: (patientShortcodeId, callback) => {
-    getPatient(patientShortcodeId, false)
-      .then(results => callback(null, results))
-      .catch(callback);
+  getPatientContactUuid: (patientShortcodeId) => {
+    return getPatient(patientShortcodeId, false);
   },
   /*
    * Given a patient "shortcode" (as used in SMS reports), return the

--- a/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
@@ -13,14 +13,9 @@ module.exports = {
     return type && type.person;
   },
   onMatch: change => {
-    return new Promise((resolve, reject) => {
-      transitionUtils.addUniqueId(change.doc, err => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(true);
-      });
-    });
+    return transitionUtils
+      .addUniqueId(change.doc)
+      .then(() => true);
   },
   asynchronousOnly: true
 };

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -1,5 +1,4 @@
 const _ = require('underscore'),
-  async = require('async'),
   utils = require('../lib/utils'),
   transitionUtils = require('./utils'),
   logger = require('../lib/logger'),
@@ -15,17 +14,15 @@ const _ = require('underscore'),
   NAME = 'registration';
 
 const findFirstDefinedValue = (doc, fields) => {
-  const definedField = _.find(fields, field => {
-    return !_.isUndefined(doc.fields[field]) && !_.isNull(doc.fields[field]);
-  });
+  const definedField = fields.find(field => doc.fields[field] !== undefined && doc.fields[field] !== null);
   return definedField && doc.fields[definedField];
 };
 
-const getRegistrations = (patientId, callback) => {
+const getRegistrations = (patientId) => {
   if (!patientId) {
-    return callback();
+    return Promise.resolve([]);
   }
-  utils.getRegistrations({ id: patientId }, callback);
+  return utils.getRegistrations({ id: patientId });
 };
 
 const getPatientNameField = params => {
@@ -75,6 +72,38 @@ const booleanExpressionFails = (doc, expr) => {
   return result;
 };
 
+const getDOB = doc => {
+  if (!doc || !doc.fields) {
+    return '';
+  }
+  const reportedDate = moment(doc.reported_date).startOf('day');
+  const years = parseInt(getYearsSinceDOB(doc), 10);
+  if (!isNaN(years)) {
+    return reportedDate.subtract(years, 'years');
+  }
+  const months = parseInt(getMonthsSinceDOB(doc), 10);
+  if (!isNaN(months)) {
+    return reportedDate.subtract(months, 'months');
+  }
+  const weeks = parseInt(getWeeksSinceDOB(doc), 10);
+  if (!isNaN(weeks)) {
+    return reportedDate.subtract(weeks, 'weeks');
+  }
+  const days = parseInt(getDaysSinceDOB(doc), 10);
+  if (!isNaN(days)) {
+    return reportedDate.subtract(days, 'days');
+  }
+  // no given date of birth - return reportedDate as it's the best we can do
+  return reportedDate;
+};
+
+const setBirthDate = doc => {
+  const dob = getDOB(doc);
+  if (dob) {
+    doc.birth_date = dob.toISOString();
+  }
+};
+
 // NB: this is very similar to a function in accept_patient_reports, except
 //     we also allow for an empty event_type
 const messageRelevant = (msg, doc) => {
@@ -88,9 +117,274 @@ const messageRelevant = (msg, doc) => {
   }
 };
 
+const assignSchedule = (options) => {
+  const patientId = options.doc.fields && options.doc.fields.patient_id;
+
+  return getRegistrations(patientId).then(registrations => {
+    options.params.forEach(scheduleName => {
+      const schedule = schedules.getScheduleConfig(scheduleName);
+      schedules.assignSchedule(
+        options.doc,
+        schedule,
+        registrations,
+        options.doc.patient
+      );
+    });
+  });
+};
+
+const addMessages = (config, doc) => {
+  const patientId = doc.fields && doc.fields.patient_id;
+  if (!config.messages || !config.messages.length) {
+    return;
+  }
+
+  return getRegistrations(patientId).then(registrations => {
+    const context = {
+      patient: doc.patient,
+      registrations: registrations,
+      templateContext: {
+        next_msg: schedules.getNextTimes(doc, moment(date.getDate())),
+      },
+    };
+    config.messages.forEach(msg => {
+      if (messageRelevant(msg, doc)) {
+        messages.addMessage(doc, msg, msg.recipient, context);
+      }
+    });
+  });
+};
+
+const setId = (options) => {
+  const doc = options.doc;
+  const patientIdField = options.params.patient_id_field;
+
+  if (patientIdField) {
+    const providedId = doc.fields[options.params.patient_id_field];
+
+    if (!providedId) {
+      transitionUtils.addRejectionMessage(doc, options.registrationConfig, 'no_provided_patient_id');
+      return Promise.resolve();
+    }
+
+    return transitionUtils
+      .isIdUnique(providedId)
+      .then(isUnique => {
+        if (!isUnique) {
+          transitionUtils.addRejectionMessage(doc, options.registrationConfig, 'provided_patient_id_not_unique');
+          return;
+        }
+
+        doc.patient_id = providedId;
+      });
+  } else {
+    return transitionUtils
+      .getUniqueId()
+      .then(uniqueId => {
+        doc.patient_id = uniqueId;
+        return;
+      });
+  }
+};
+
+const addPatient = (options) => {
+  const doc = options.doc,
+        patientShortcode = doc.patient_id,
+        patientNameField = getPatientNameField(options.params);
+
+  return utils
+    .getPatientContactUuid(patientShortcode)
+    .then(patientContactId => {
+      if (patientContactId) {
+        return;
+      }
+
+      return db.medic
+        .query('medic-client/contacts_by_phone', { key: doc.from, include_docs: true })
+        .then(result => {
+          const contact = result && result.rows && result.rows[0] && result.rows[0].doc;
+          lineage.minify(contact);
+
+          const patient = {
+            name: doc.fields[patientNameField],
+            created_by: contact && contact._id,
+            parent: contact && contact.parent,
+            reported_date: doc.reported_date,
+            patient_id: patientShortcode,
+            source_id: doc._id,
+          };
+          if (options.params.contact_type) {
+            patient.type = 'contact';
+            patient.contact_type = options.params.contact_type;
+          } else {
+            patient.type = 'person';
+          }
+          // include the DOB if it was generated on report
+          if (doc.birth_date) {
+            patient.date_of_birth = doc.birth_date;
+          }
+          return db.medic.post(patient);
+        });
+    });
+
+};
+
+/*
+ * Given a doc get the LMP value as a number, including 0.  Supports three
+ * property names atm.
+ * */
+const getWeeksSinceLMP = doc => {
+  const props = ['weeks_since_lmp', 'last_menstrual_period', 'lmp'];
+  let ret;
+  props.forEach(prop => {
+    if (_.isNumber(ret) && !_.isNaN(ret)) {
+      return;
+    }
+    const val = Number(doc.fields && doc.fields[prop]);
+    if (_.isNumber(val)) {
+      ret = val;
+    }
+  });
+  return ret;
+};
+
+const setExpectedBirthDate = doc => {
+  const lmp = Number(getWeeksSinceLMP(doc)),
+        start = moment(doc.reported_date).startOf('day');
+  if (lmp === 0) {
+    // means baby was already born, chw just wants a registration.
+    doc.lmp_date = null;
+    doc.expected_date = null;
+  } else {
+    start.subtract(lmp, 'weeks');
+    doc.lmp_date = start.toISOString();
+    doc.expected_date = start
+      .clone()
+      .add(40, 'weeks')
+      .toISOString();
+  }
+};
+
+const validate = (config, doc) => {
+  const validations = config && config.validations && config.validations.list;
+  return new Promise(resolve => validation.validate(doc, validations, resolve));
+};
+
+const getYearsSinceDOB = doc => {
+  const fields = ['years_since_dob', 'years_since_birth', 'age_in_years'];
+  return findFirstDefinedValue(doc, fields);
+};
+
+const getMonthsSinceDOB = doc => {
+  const fields = ['months_since_dob', 'months_since_birth', 'age_in_months'];
+  return findFirstDefinedValue(doc, fields);
+};
+
+const getWeeksSinceDOB = doc => {
+  const fields = [
+    'weeks_since_dob',
+    'dob',
+    'weeks_since_birth',
+    'age_in_weeks',
+  ];
+  return findFirstDefinedValue(doc, fields);
+};
+
+const getDaysSinceDOB = doc => {
+  const fields = ['days_since_dob', 'days_since_birth', 'age_in_days'];
+  return findFirstDefinedValue(doc, fields);
+};
+
+const getConfig = () => config.get('registrations');
+
+/*
+ * Given a form code and config array, return config for that form.
+ * */
+const getRegistrationConfig = (config, form_code) => {
+  return config.find(conf => utils.isFormCodeSame(form_code, conf.form));
+};
+
+const triggers = {
+  add_patient: (options) => {
+    // if we already have a patient id then return
+    if (options.doc.patient_id) {
+      return;
+    }
+
+    return setId(options).then(() => addPatient(options));
+  },
+  add_patient_id: (options) => {
+    // Deprecated name for add_patient
+    logger.warn('Use of add_patient_id trigger. This is deprecated in favour of add_patient.');
+    return triggers.add_patient(options);
+  },
+  add_expected_date: (options) => {
+    setExpectedBirthDate(options.doc);
+  },
+  add_birth_date: (options) => {
+    setBirthDate(options.doc);
+  },
+  assign_schedule: (options) => {
+    assignSchedule(options);
+  },
+  clear_schedule: (options) => {
+    // Registration forms that clear schedules do so fully
+    // silence_type will be split again later, so join them back
+    const config = {
+      silence_type: options.params.join(','),
+      silence_for: null,
+    };
+
+    return utils
+      .getReportsBySubject({
+        ids: utils.getSubjectIds(options.doc.patient),
+        registrations: true
+      })
+      .then(registrations => {
+        return new Promise((resolve, reject) => {
+          acceptPatientReports.silenceRegistrations(
+            config,
+            options.doc,
+            registrations,
+            (err, result) => err ? reject(err) : resolve(result)
+          );
+        });
+      });
+  },
+};
+
+const fireConfiguredTriggers = (registrationConfig, doc) => {
+  const promises = registrationConfig.events
+    .map(event => {
+      const trigger = triggers[event.trigger];
+      if (!trigger || event.name !== 'on_create') {
+        return;
+      }
+
+      const obj = Object.assign({}, doc.fields, doc);
+      if (booleanExpressionFails(obj, event.bool_expr)) {
+        return;
+      }
+
+      const options = {
+        doc: doc,
+        registrationConfig: registrationConfig,
+        params: parseParams(event.params),
+      };
+      logger.debug(`Parsed params for form "${options.form}", trigger "${event.trigger}, params: ${options.params}"`);
+      return () => trigger(options);
+    })
+    .filter(item => !!item);
+
+  return promises
+    .reduce((promise, triggerFn) => promise.then(triggerFn), Promise.resolve())
+    .then(() => addMessages(registrationConfig, doc))
+    .then(() => true);
+};
+
 module.exports = {
   init: () => {
-    const registrations = module.exports.getConfig();
+    const registrations = getConfig();
     registrations.forEach(registration => {
       if (registration.events) {
         registration.events.forEach(event => {
@@ -121,7 +415,7 @@ module.exports = {
             if (!event.params) {
               throw new Error(`Configuration error. Expecting params to be defined as the name of the schedule(s) for ${registration.form}.${event.trigger}`);
             }
-            if (!_.isArray(params)) {
+            if (!Array.isArray(params)) {
               throw new Error(`Configuration error. Expecting params to be a string, comma separated list, or an array for ${registration.form}.${event.trigger}: '${event.params}'`);
             }
           }
@@ -130,402 +424,40 @@ module.exports = {
     });
   },
   filter: (doc, info = {}) => {
-    const self = module.exports;
     return Boolean(
       doc.type === 'data_record' &&
-      self.getRegistrationConfig(self.getConfig(), doc.form) &&
+      getRegistrationConfig(getConfig(), doc.form) &&
       !transitionUtils.hasRun(info, NAME) &&
       utils.isValidSubmission(doc) // requires either an xform, a known submitter or public form for SMS
     );
   },
-  getDOB: doc => {
-    if (!doc || !doc.fields) {
-      return '';
-    }
-    const reportedDate = moment(doc.reported_date).startOf('day');
-    const years = parseInt(module.exports.getYearsSinceDOB(doc), 10);
-    if (!isNaN(years)) {
-      return reportedDate.subtract(years, 'years');
-    }
-    const months = parseInt(module.exports.getMonthsSinceDOB(doc), 10);
-    if (!isNaN(months)) {
-      return reportedDate.subtract(months, 'months');
-    }
-    const weeks = parseInt(module.exports.getWeeksSinceDOB(doc), 10);
-    if (!isNaN(weeks)) {
-      return reportedDate.subtract(weeks, 'weeks');
-    }
-    const days = parseInt(module.exports.getDaysSinceDOB(doc), 10);
-    if (!isNaN(days)) {
-      return reportedDate.subtract(days, 'days');
-    }
-    // no given date of birth - return reportedDate as it's the best we can do
-    return reportedDate;
-  },
-  getYearsSinceDOB: doc => {
-    const fields = ['years_since_dob', 'years_since_birth', 'age_in_years'];
-    return findFirstDefinedValue(doc, fields);
-  },
-  getMonthsSinceDOB: doc => {
-    const fields = ['months_since_dob', 'months_since_birth', 'age_in_months'];
-    return findFirstDefinedValue(doc, fields);
-  },
-  getWeeksSinceDOB: doc => {
-    const fields = [
-      'weeks_since_dob',
-      'dob',
-      'weeks_since_birth',
-      'age_in_weeks',
-    ];
-    return findFirstDefinedValue(doc, fields);
-  },
-  getDaysSinceDOB: doc => {
-    const fields = ['days_since_dob', 'days_since_birth', 'age_in_days'];
-    return findFirstDefinedValue(doc, fields);
-  },
-  /*
-   * Given a doc get the LMP value as a number, including 0.  Supports three
-   * property names atm.
-   * */
-  getWeeksSinceLMP: doc => {
-    const props = ['weeks_since_lmp', 'last_menstrual_period', 'lmp'];
-    let ret;
-    let val;
-    _.each(props, prop => {
-      if (_.isNumber(ret) && !_.isNaN(ret)) {
-        return;
-      }
-      val = Number(doc.fields && doc.fields[prop]);
-      if (_.isNumber(val)) {
-        ret = val;
-      }
-    });
-    return ret;
-  },
-  isIdOnly: doc => {
-    /* if true skip schedule creation */
-    return Boolean(doc.getid || doc.skip_schedule_creation);
-  },
-  setExpectedBirthDate: doc => {
-    const lmp = Number(module.exports.getWeeksSinceLMP(doc)),
-      start = moment(doc.reported_date).startOf('day');
-    if (lmp === 0) {
-      // means baby was already born, chw just wants a registration.
-      doc.lmp_date = null;
-      doc.expected_date = null;
-    } else {
-      start.subtract(lmp, 'weeks');
-      doc.lmp_date = start.toISOString();
-      doc.expected_date = start
-        .clone()
-        .add(40, 'weeks')
-        .toISOString();
-    }
-  },
-  setBirthDate: doc => {
-    const dob = module.exports.getDOB(doc);
-    if (dob) {
-      doc.birth_date = dob.toISOString();
-    }
-  },
-  getConfig: () => {
-    return config.get('registrations');
-  },
-  /*
-   * Given a form code and config array, return config for that form.
-   * */
-  getRegistrationConfig: (config, form_code) => {
-    return _.find(config, conf => utils.isFormCodeSame(form_code, conf.form));
-  },
-  validate: (config, doc, callback) => {
-    const validations = config.validations && config.validations.list;
-    return validation.validate(doc, validations, callback);
-  },
   onMatch: change => {
-    const self = module.exports,
-      doc = change.doc,
-      registrationConfig = self.getRegistrationConfig(
-        self.getConfig(),
-        doc.form
-      );
+    const doc = change.doc;
+    const registrationConfig = getRegistrationConfig(getConfig(), doc.form);
 
-    return new Promise((resolve, reject) => {
-      self.validate(registrationConfig, doc, errors => {
+    return validate(registrationConfig, doc)
+      .then(errors => {
         if (errors && errors.length > 0) {
-          messages.addErrors(registrationConfig, doc, errors, {
-            patient: doc.patient,
-          });
-          return resolve(true);
+          messages.addErrors(registrationConfig, doc, errors, { patient: doc.patient });
+          return true;
         }
 
         const patientId = doc.fields && doc.fields.patient_id;
 
         if (!patientId) {
-          return self
-            .fireConfiguredTriggers(registrationConfig, doc)
-            .then(resolve)
-            .catch(reject);
+          return fireConfiguredTriggers(registrationConfig, doc);
         }
 
         // We're attaching this registration to an existing patient, let's
         // make sure it's valid
-        return utils.getPatientContactUuid(
-          patientId,
-          (err, patientContactId) => {
-            if (err) {
-              return reject(err);
-            }
-
-            if (!patientContactId) {
-              transitionUtils.addRegistrationNotFoundError(
-                doc,
-                registrationConfig
-              );
-              return resolve(true);
-            }
-            return self
-              .fireConfiguredTriggers(registrationConfig, doc)
-              .then(resolve)
-              .catch(reject);
-          }
-        );
-      });
-    });
-  },
-  fireConfiguredTriggers: (registrationConfig, doc) => {
-    const self = module.exports;
-
-    return new Promise((resolve, reject) => {
-      const series = registrationConfig.events
-        .map(event => cb => {
-          const trigger = self.triggers[event.trigger];
-          if (!trigger || event.name !== 'on_create') {
-            return cb();
-          }
-          const obj = _.defaults({}, doc, doc.fields);
-
-          if (booleanExpressionFails(obj, event.bool_expr)) {
-            return cb();
+        return utils.getPatientContactUuid(patientId).then(patientContactId => {
+          if (!patientContactId) {
+            transitionUtils.addRegistrationNotFoundError(doc, registrationConfig);
+            return true;
           }
 
-          const options = {
-            doc: doc,
-            registrationConfig: registrationConfig,
-            params: parseParams(event.params),
-          };
-          logger.debug(
-            `Parsed params for form "${options.form}", trigger "${
-              event.trigger
-            }, params: ${options.params}"`
-          );
-          trigger.apply(null, [options, cb]);
-        })
-        .filter(item => !!item);
-
-      async.series(series, err => {
-        if (err) {
-          return reject(err);
-        }
-
-        // add messages is done last so data on doc can be used in
-        // messages
-        self.addMessages(registrationConfig, doc, () => {
-          resolve(true);
+          return fireConfiguredTriggers(registrationConfig, doc);
         });
       });
-    });
   },
-  triggers: {
-    add_patient: (options, cb) => {
-      // if we already have a patient id then return
-      if (options.doc.patient_id) {
-        return cb();
-      }
-      async.series(
-        [
-          _.partial(module.exports.setId, options),
-          _.partial(module.exports.addPatient, options),
-        ],
-        cb
-      );
-    },
-    add_patient_id: (options, cb) => {
-      // Deprecated name for add_patient
-      logger.warn(
-        'Use of add_patient_id trigger. This is deprecated in favour of add_patient.'
-      );
-      module.exports.triggers.add_patient(options, cb);
-    },
-    add_expected_date: (options, cb) => {
-      module.exports.setExpectedBirthDate(options.doc);
-      cb();
-    },
-    add_birth_date: (options, cb) => {
-      module.exports.setBirthDate(options.doc);
-      cb();
-    },
-    assign_schedule: (options, cb) => {
-      module.exports.assignSchedule(options, cb);
-    },
-    clear_schedule: (options, cb) => {
-      // Registration forms that clear schedules do so fully
-      // silence_type will be split again later, so join them back
-      const config = {
-        silence_type: options.params.join(','),
-        silence_for: null,
-      };
-
-      utils
-        .getReportsBySubject({
-          ids: utils.getSubjectIds(options.doc.patient),
-          registrations: true
-        })
-        .then(registrations => {
-          acceptPatientReports.silenceRegistrations(
-            config,
-            options.doc,
-            registrations,
-            cb
-          );
-        })
-        .catch(cb);
-    },
-  },
-  addMessages: (config, doc, callback) => {
-    const patientId = doc.fields && doc.fields.patient_id;
-    if (!config.messages || !config.messages.length) {
-      return callback();
-    }
-
-    getRegistrations(patientId, (err, registrations) => {
-      if (err) {
-        return callback(err);
-      }
-      const context = {
-        patient: doc.patient,
-        registrations: registrations,
-        templateContext: {
-          next_msg: schedules.getNextTimes(doc, moment(date.getDate())),
-        },
-      };
-      config.messages.forEach(msg => {
-        if (messageRelevant(msg, doc)) {
-          messages.addMessage(doc, msg, msg.recipient, context);
-        }
-      });
-      callback();
-    });
-  },
-  assignSchedule: (options, callback) => {
-    const patientId = options.doc.fields && options.doc.fields.patient_id;
-
-    getRegistrations(patientId, (err, registrations) => {
-      if (err) {
-        return callback(err);
-      }
-      options.params.forEach(scheduleName => {
-        const schedule = schedules.getScheduleConfig(scheduleName);
-        schedules.assignSchedule(
-          options.doc,
-          schedule,
-          registrations,
-          options.doc.patient
-        );
-      });
-      callback();
-    });
-  },
-  setId: (options, callback) => {
-    const doc = options.doc,
-      patientIdField = options.params.patient_id_field;
-
-    if (patientIdField) {
-      const providedId = doc.fields[options.params.patient_id_field];
-
-      if (!providedId) {
-        transitionUtils.addRejectionMessage(
-          doc,
-          options.registrationConfig,
-          'no_provided_patient_id'
-        );
-        return callback(null, true);
-      }
-
-      transitionUtils.isIdUnique(providedId, (err, isUnique) => {
-        if (err) {
-          return callback(err);
-        }
-
-        if (isUnique) {
-          doc.patient_id = providedId;
-          return callback();
-        }
-
-        transitionUtils.addRejectionMessage(
-          doc,
-          options.registrationConfig,
-          'provided_patient_id_not_unique'
-        );
-        callback(null, true);
-      });
-    } else {
-      transitionUtils.addUniqueId(doc, callback);
-    }
-  },
-  addPatient: (options, callback) => {
-    const doc = options.doc,
-      patientShortcode = doc.patient_id,
-      patientNameField = getPatientNameField(options.params);
-
-    utils.getPatientContactUuid(
-      patientShortcode,
-      (err, patientContactId) => {
-        if (err) {
-          return callback(err);
-        }
-
-        if (patientContactId) {
-          return callback();
-        }
-
-        db.medic.query(
-          'medic-client/contacts_by_phone',
-          {
-            key: doc.from,
-            include_docs: true,
-          },
-          (err, result) => {
-            if (err) {
-              return callback(err);
-            }
-
-            const contact = _.result(_.first(result.rows), 'doc');
-            lineage.minify(contact);
-            // create a new patient with this patient_id
-            const patient = {
-              name: doc.fields[patientNameField],
-              created_by: contact && contact._id,
-              parent: contact && contact.parent,
-              reported_date: doc.reported_date,
-              patient_id: patientShortcode,
-              source_id: doc._id,
-            };
-            if (options.params.contact_type) {
-              patient.type = 'contact';
-              patient.contact_type = options.params.contact_type;
-            } else {
-              patient.type = 'person';
-            }
-            // include the DOB if it was generated on report
-            if (doc.birth_date) {
-              patient.date_of_birth = doc.birth_date;
-            }
-            db.medic.post(patient, callback);
-          }
-        );
-      }
-    );
-  },
-  _booleanExpressionFails: booleanExpressionFails,
-  _lineage: lineage,
 };

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -178,12 +178,7 @@ const setId = (options) => {
         doc.patient_id = providedId;
       });
   } else {
-    return transitionUtils
-      .getUniqueId()
-      .then(uniqueId => {
-        doc.patient_id = uniqueId;
-        return;
-      });
+    return transitionUtils.addUniqueId(doc);
   }
 };
 

--- a/shared-libs/transitions/src/transitions/utils.js
+++ b/shared-libs/transitions/src/transitions/utils.js
@@ -41,18 +41,20 @@ module.exports = {
   addRegistrationNotFoundError: (doc, reportConfig) => {
     module.exports.addRejectionMessage(doc, reportConfig, 'registration_not_found');
   },
-  isIdUnique: (id, callback) => {
-    db.medic.query('medic-client/contacts_by_reference', {
-      key: [ 'shortcode', id ]
-    }, (err, results) => {
-      callback(err, !(results && results.rows && results.rows.length));
-    });
+  isIdUnique: (id) => {
+    return db.medic
+      .query('medic-client/contacts_by_reference', { key: [ 'shortcode', id ]})
+      .then(results => !(results && results.rows && results.rows.length));
   },
-  addUniqueId: (doc, callback) => {
-    idGenerator.next().value.then(patientId => {
-      doc.patient_id = patientId;
-      callback();
-    }).catch(callback);
+  getUniqueId: () => {
+    return idGenerator.next().value;
+  },
+  addUniqueId: (doc) => {
+    return module.exports
+      .getUniqueId()
+      .then(patientId => {
+        doc.patient_id = patientId;
+      });
   },
   hasRun: (doc, transition) => {
     return !!(doc.transitions && doc.transitions[transition]);

--- a/shared-libs/transitions/src/transitions/utils.js
+++ b/shared-libs/transitions/src/transitions/utils.js
@@ -46,15 +46,10 @@ module.exports = {
       .query('medic-client/contacts_by_reference', { key: [ 'shortcode', id ]})
       .then(results => !(results && results.rows && results.rows.length));
   },
-  getUniqueId: () => {
-    return idGenerator.next().value;
-  },
   addUniqueId: (doc) => {
-    return module.exports
-      .getUniqueId()
-      .then(patientId => {
-        doc.patient_id = patientId;
-      });
+    return idGenerator.next().value.then(patientId => {
+      doc.patient_id = patientId;
+    });
   },
   hasRun: (doc, transition) => {
     return !!(doc.transitions && doc.transitions[transition]);

--- a/shared-libs/transitions/test/unit/birth_registration.js
+++ b/shared-libs/transitions/test/unit/birth_registration.js
@@ -91,7 +91,11 @@ describe('birth registration', () => {
   it('valid form adds patient_id and expected_date', () => {
       // doc already exists bc we aren't testing the create patient step
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'UUID'});
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
+        doc.patient_id = 12345;
+        return Promise.resolve();
+      });
 
       var doc = {
           form: 'BIR',

--- a/shared-libs/transitions/test/unit/birth_registration.js
+++ b/shared-libs/transitions/test/unit/birth_registration.js
@@ -1,15 +1,19 @@
-var transition = require('../../src/transitions/registration'),
-    sinon = require('sinon'),
-    assert = require('chai').assert,
-    moment = require('moment'),
-    transitionUtils = require('../../src/transitions/utils'),
-    utils = require('../../src/lib/utils');
+const sinon = require('sinon');
+const assert = require('chai').assert;
+const rewire = require('rewire');
+const  moment = require('moment');
+const transitionUtils = require('../../src/transitions/utils');
+const utils = require('../../src/lib/utils');
+const config = require('../../src/config');
+
+const transition = rewire('../../src/transitions/registration');
+transition.setBirthDate = transition.__get__('setBirthDate');
 
 describe('birth registration', () => {
   afterEach(() => sinon.restore());
 
   beforeEach(() => {
-    sinon.stub(transition, 'getConfig').returns([{
+    sinon.stub(config, 'get').returns([{
         form: 'BIR',
         events: [
            {
@@ -86,12 +90,8 @@ describe('birth registration', () => {
 
   it('valid form adds patient_id and expected_date', () => {
       // doc already exists bc we aren't testing the create patient step
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'UUID'});
-
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-          doc.patient_id = 12345;
-          callback();
-      });
+      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'UUID'});
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       var doc = {
           form: 'BIR',

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -222,15 +222,9 @@ describe('due tasks', () => {
     const translate = sinon
       .stub(utils, 'translate')
       .returns('Please visit {{patient_name}} asap');
-    const getRegistrations = sinon
-      .stub(utils, 'getRegistrations')
-      .callsArgWith(1, null, []);
-    const getPatientContactUuid = sinon
-      .stub(utils, 'getPatientContactUuid')
-      .callsArgWith(1, null, patientUuid);
-    const fetchHydratedDoc = sinon
-      .stub(schedule._lineage, 'fetchHydratedDoc')
-      .callsArgWith(1, null, { name: 'jim' });
+    const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
+    const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').resolves(patientUuid);
+    const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
     const minified = {
@@ -301,7 +295,7 @@ describe('due tasks', () => {
     });
     sinon
       .stub(schedule._lineage, 'hydrateDocs')
-      .returns(Promise.resolve([hydrated]));
+      .resolves([hydrated]);
     const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
 
     schedule.execute(err => {
@@ -335,15 +329,11 @@ describe('due tasks', () => {
     const patientUuid = '123-456-789';
     const expectedPhone = '5556918';
     const expectedMessage = 'old message';
-    const getRegistrations = sinon
-      .stub(utils, 'getRegistrations')
-      .callsArgWith(1, null, []);
-    const getPatientContactUuid = sinon
-      .stub(utils, 'getPatientContactUuid')
-      .callsArgWith(1, null, patientUuid);
+    const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
+    const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').resolves(patientUuid);
     const fetchHydratedDoc = sinon
       .stub(schedule._lineage, 'fetchHydratedDoc')
-      .callsArgWith(1, null, { name: 'jim' });
+      .resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
     const minified = {
@@ -443,8 +433,8 @@ describe('due tasks', () => {
           phone = '123456789';
 
     sinon.stub(utils, 'translate').returns('Please visit {{patient_name}} asap');
-    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, [{ fields: { patient_id: '12345' } }]);
-    sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null);
+    sinon.stub(utils, 'getRegistrations').resolves([{ fields: { patient_id: '12345' } }]);
+    sinon.stub(utils, 'getPatientContactUuid').resolves(null);
     sinon.stub(schedule._lineage, 'fetchHydratedDoc');
     sinon.stub(utils, 'setTaskState');
 
@@ -523,8 +513,8 @@ describe('due tasks', () => {
           phone = '123456789';
 
     sinon.stub(utils, 'translate').returns('Please visit {{patient_name}} asap');
-    sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, [{ fields: { patient_id: '12345' } }]);
-    sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null);
+    sinon.stub(utils, 'getRegistrations').resolves([{ fields: { patient_id: '12345' } }]);
+    sinon.stub(utils, 'getPatientContactUuid').resolves(null);
     sinon.stub(schedule._lineage, 'fetchHydratedDoc');
     sinon.stub(utils, 'setTaskState').callsFake((task, state) => task.state = state);
 

--- a/shared-libs/transitions/test/unit/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/test/unit/generate_patient_id_on_people.js
@@ -14,7 +14,7 @@ describe('generate_patient_id_on_people transition', () => {
   afterEach(() => sinon.restore());
 
   it('adds patient_id to people', () => {
-    sinon.stub(transitionUtils, 'addUniqueId');
+    sinon.stub(transitionUtils, 'addUniqueId').resolves();
     transition.onMatch({}, {}, {}, {});
     assert.equal(transitionUtils.addUniqueId.callCount, 1);
   });

--- a/shared-libs/transitions/test/unit/lib/utils.js
+++ b/shared-libs/transitions/test/unit/lib/utils.js
@@ -36,12 +36,11 @@ describe('utils util', () => {
   });
 
   describe('getRegistrations', () => {
-    it('works with single key', done => {
+    it('works with single key', () => {
       sinon.stub(config, 'getAll').returns({});
       sinon.stub(registrationUtils, 'isValidRegistration').returns(true);
       db.medic.query.resolves({ rows: [] });
-      utils.getRegistrations({ id: 'my_id' }, (err, result) => {
-        (!!err).should.equal(false);
+      return utils.getRegistrations({ id: 'my_id' }).then((result) => {
         result.should.deep.equal([]);
         db.medic.query.callCount.should.equal(1);
         db.medic.query.args[0][0].should.equal('medic-client/registered_patients');
@@ -49,16 +48,14 @@ describe('utils util', () => {
           include_docs: true,
           key: 'my_id'
         });
-        done();
       });
     });
 
-    it('should work with multiple keys', done => {
+    it('should work with multiple keys', () => {
       sinon.stub(config, 'getAll').returns({});
       sinon.stub(registrationUtils, 'isValidRegistration').returns(true);
       db.medic.query.resolves({ rows: [] });
-      utils.getRegistrations({ ids: ['1', '2', '3'] }, (err, result) => {
-        (!!err).should.equal(false);
+      return utils.getRegistrations({ ids: ['1', '2', '3'] }).then((result) => {
         result.should.deep.equal([]);
         db.medic.query.callCount.should.equal(1);
         db.medic.query.args[0][0].should.equal('medic-client/registered_patients');
@@ -66,22 +63,22 @@ describe('utils util', () => {
           include_docs: true,
           keys: ['1', '2', '3']
         });
-        done();
       });
     });
 
-    it('should catch db errors', done => {
+    it('should catch db errors', () => {
       sinon.stub(config, 'getAll');
       sinon.stub(registrationUtils, 'isValidRegistration');
       db.medic.query.rejects({ some: 'error' });
-      utils.getRegistrations({ id: 'my_id' }, (err, result) => {
-        err.should.deep.equal({ some: 'error' });
-        (!!result).should.equal(false);
-        done();
-      });
+      return utils
+        .getRegistrations({ id: 'my_id' })
+        .then(r => r.should.deep.equal('Should have thrown'))
+        .catch(err => {
+          err.should.deep.equal({ some: 'error' });
+        });
     });
 
-    it('should test each registration for validity and only return valid ones', done => {
+    it('should test each registration for validity and only return valid ones', () => {
       sinon.stub(config, 'getAll').returns('config');
       sinon.stub(registrationUtils, 'isValidRegistration').callsFake(doc => !!doc.valid);
 
@@ -93,8 +90,7 @@ describe('utils util', () => {
         { _id: 'reg5', valid: false }
       ];
       db.medic.query.resolves({ rows: registrations.map(registration => ({ doc: registration }))});
-      utils.getRegistrations({ id: 'my_id' }, (err, result) => {
-        (!!err).should.equal(false);
+      return utils.getRegistrations({ id: 'my_id' }).then((result) => {
         result.should.deep.equal([
           { _id: 'reg1', valid: true },
           { _id: 'reg4', valid: true }
@@ -109,7 +105,6 @@ describe('utils util', () => {
           [{ _id: 'reg4', valid: true }, 'config'],
           [{ _id: 'reg5', valid: false }, 'config']
         ]);
-        done();
       });
     });
   });

--- a/shared-libs/transitions/test/unit/patient_registration.js
+++ b/shared-libs/transitions/test/unit/patient_registration.js
@@ -244,7 +244,11 @@ describe('patient registration', () => {
 
   it('valid form adds patient_id and patient document', () => {
     sinon.stub(utils, 'getPatientContactUuid').resolves();
-    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
     const doc = {
       _id: 'docid',
@@ -293,7 +297,7 @@ describe('patient registration', () => {
     sinon
       .stub(utils, 'getPatientContactUuid')
       .resolves({ _id: 'uuid' });
-    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').resolves();
 
     const doc = {
       form: 'PATR',
@@ -355,7 +359,7 @@ describe('patient registration', () => {
     sinon
       .stub(utils, 'getPatientContactUuid')
       .resolves({ _id: 'uuid' });
-    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').resolves();
 
     const doc = {
       form: 'PATR',
@@ -504,7 +508,7 @@ describe('patient registration', () => {
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getPatientContact');
       sinon.stub(utils, 'getPatientContactUuid').resolves(false);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+      sinon.stub(transitionUtils, 'addUniqueId');
 
       sinon.stub(db.medic, 'query')
         .withArgs('medic-client/contacts_by_phone')
@@ -521,7 +525,7 @@ describe('patient registration', () => {
         assert.equal(utils.getRegistrations.callCount, 0);
         assert.equal(utils.getPatientContact.callCount, 0);
         assert.equal(utils.getPatientContactUuid.callCount, 1);
-        assert.equal(transitionUtils.getUniqueId.callCount, 0);
+        assert.equal(transitionUtils.addUniqueId.callCount, 0);
 
         assert.equal(db.medic.query.callCount, 1);
         assert.deepEqual(db.medic.query.args[0][0], 'medic-client/contacts_by_phone');
@@ -554,7 +558,7 @@ describe('patient registration', () => {
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getPatientContact');
       sinon.stub(utils, 'getPatientContactUuid').resolves(false);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+      sinon.stub(transitionUtils, 'addUniqueId');
 
       sinon.stub(db.medic, 'query');
       db.medic.query
@@ -578,7 +582,7 @@ describe('patient registration', () => {
         assert.equal(utils.getRegistrations.callCount, 0);
         assert.equal(utils.getPatientContact.callCount, 0);
         assert.equal(utils.getPatientContactUuid.callCount, 1);
-        assert.equal(transitionUtils.getUniqueId.callCount, 0);
+        assert.equal(transitionUtils.addUniqueId.callCount, 0);
 
         assert.equal(db.medic.query.callCount, 2);
         assert.deepEqual(db.medic.query.args[0][0], 'medic-client/contacts_by_reference');
@@ -615,7 +619,7 @@ describe('patient registration', () => {
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getPatientContact');
       sinon.stub(utils, 'getPatientContactUuid').resolves(false);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+      sinon.stub(transitionUtils, 'addUniqueId');
 
       sinon.stub(db.medic, 'query');
       db.medic.query
@@ -638,7 +642,7 @@ describe('patient registration', () => {
         assert.equal(utils.getRegistrations.callCount, 0);
         assert.equal(utils.getPatientContact.callCount, 0);
         assert.equal(utils.getPatientContactUuid.callCount, 1);
-        assert.equal(transitionUtils.getUniqueId.callCount, 0);
+        assert.equal(transitionUtils.addUniqueId.callCount, 0);
 
         assert.equal(db.medic.query.callCount, 2);
         assert.deepEqual(db.medic.query.args[0][0], 'medic-client/contacts_by_reference');

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -1,10 +1,13 @@
-var _ = require('underscore'),
-    transition = require('../../src/transitions/registration'),
-    sinon = require('sinon'),
-    assert = require('chai').assert,
-    moment = require('moment'),
-    transitionUtils = require('../../src/transitions/utils'),
-    utils = require('../../src/lib/utils');
+const _ = require('underscore');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const assert = require('chai').assert;
+const moment = require('moment');
+const transitionUtils = require('../../src/transitions/utils');
+const utils = require('../../src/lib/utils');
+const config = require('../../src/config');
+
+const transition = rewire('../../src/transitions/registration');
 
 const getMessage = doc => {
     if (!doc || !doc.tasks) {
@@ -13,11 +16,12 @@ const getMessage = doc => {
     return _.first(_.first(doc.tasks).messages).message;
 };
 
-describe('patient registration', () => {
+describe('pregnancy registration', () => {
   afterEach(() => sinon.restore());
 
   beforeEach(() => {
-    sinon.stub(transition, 'getConfig').returns([{
+    transition.setExpectedBirthDate = transition.__get__('setExpectedBirthDate');
+    sinon.stub(config, 'get').returns([{
         form: 'p',
         type: 'pregnancy',
         events: [
@@ -131,19 +135,6 @@ describe('patient registration', () => {
       assert(transition.filter(doc));
   });
 
-  it('is id only', () => {
-      assert.equal(transition.isIdOnly({}), false);
-      assert.equal(transition.isIdOnly({
-          getid: undefined
-      }), false);
-      assert.equal(transition.isIdOnly({
-          getid: ''
-      }), false);
-      assert.equal(transition.isIdOnly({
-          getid: 'x'
-      }), true);
-  });
-
   it('setExpectedBirthDate sets lmp_date and expected_date to null when lmp 0', () => {
       var doc = { fields: { lmp: 0 }, type: 'data_record' };
       transition.setExpectedBirthDate(doc);
@@ -176,12 +167,9 @@ describe('patient registration', () => {
   it('valid adds lmp_date and patient_id', () => {
       var start = moment().startOf('day').subtract(5, 'weeks');
 
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'uuid'});
+      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-          doc.patient_id = 12345;
-          callback();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',
@@ -201,8 +189,8 @@ describe('patient registration', () => {
   });
 
   it('pregnancies on existing patients fail without valid patient id', () => {
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
 
       const doc = {
           form: 'ep',
@@ -221,8 +209,8 @@ describe('patient registration', () => {
   });
 
   it('pregnancies on existing patients succeeds with a valid patient id', () => {
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'uuid'});
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
       const doc = {
           form: 'ep',
@@ -241,12 +229,9 @@ describe('patient registration', () => {
 
 
   it('zero lmp value only registers patient', () => {
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'uuid'});
+      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-          doc.patient_id = 12345;
-          callback();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',
@@ -266,12 +251,9 @@ describe('patient registration', () => {
   });
 
   it('id only logic with valid name', () => {
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'uuid'});
+      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-          doc.patient_id = 12345;
-          callback();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',
@@ -291,8 +273,8 @@ describe('patient registration', () => {
   });
 
   it('id only logic with invalid name', () => {
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1, null, {_id: 'uuid'});
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
       const doc = {
           form: 'p',

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -169,7 +169,10 @@ describe('pregnancy registration', () => {
 
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
       const doc = {
           form: 'p',
@@ -231,9 +234,12 @@ describe('pregnancy registration', () => {
   it('zero lmp value only registers patient', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
-      const doc = {
+    const doc = {
           form: 'p',
           type: 'data_record',
           fields: {
@@ -253,7 +259,10 @@ describe('pregnancy registration', () => {
   it('id only logic with valid name', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
       const doc = {
           form: 'p',

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -79,7 +79,10 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         getPatientContactUuid.callCount.should.equal(1);
@@ -204,7 +207,10 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves('05649');
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = '05649';
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -339,7 +345,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -385,7 +394,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -428,10 +440,13 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
+
 
       return transition.onMatch(change).then(() => {
-        console.log(JSON.stringify(saveDoc.args, null, 2));
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].name.should.equal(patientName);
       });

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -1,42 +1,46 @@
-const should = require('chai').should(),
-  sinon = require('sinon'),
-  db = require('../../../src/db'),
-  transition = require('../../../src/transitions/registration'),
-  schedules = require('../../../src/lib/schedules'),
-  messages = require('../../../src/lib/messages'),
-  utils = require('../../../src/lib/utils'),
-  config = require('../../../src/config'),
-  transitionUtils = require('../../../src/transitions/utils'),
-  acceptPatientReports = require('../../../src/transitions/accept_patient_reports');
+require('chai').should();
+const sinon = require('sinon');
+const rewire = require('rewire');
+const db = require('../../../src/db');
+const schedules = require('../../../src/lib/schedules');
+const messages = require('../../../src/lib/messages');
+const utils = require('../../../src/lib/utils');
+const config = require('../../../src/config');
+const transitionUtils = require('../../../src/transitions/utils');
+const acceptPatientReports = require('../../../src/transitions/accept_patient_reports');
+const validation = require('../../../src/lib/validation');
+
+let transition = rewire('../../../src/transitions/registration');
 
 describe('registration', () => {
   afterEach(done => {
     sinon.restore();
+    transition = rewire('../../../src/transitions/registration');
     done();
   });
 
   describe('booleanExpressionFails', () => {
+    beforeEach(() => {
+      transition.booleanExpressionFails = transition.__get__('booleanExpressionFails');
+    });
+
     it('is false if there is no valid expression', () => {
-      transition._booleanExpressionFails({}, '').should.equal(false);
+      transition.booleanExpressionFails({}, '').should.equal(false);
     });
 
     it('is true if the expresison fails', () => {
-      transition
-        ._booleanExpressionFails({ foo: 'bar' }, `doc.foo !== 'bar'`)
-        .should.equal(true);
+      transition.booleanExpressionFails({ foo: 'bar' }, `doc.foo !== 'bar'`).should.equal(true);
     });
 
     it('is true if the expression is invalid', () => {
       // TODO: should this error instead of just returning false?
       //       If there is a typo we're not going to know about it
-      transition
-        ._booleanExpressionFails({}, `doc.foo.bar === 'smang'`)
-        .should.equal(true);
+      transition.booleanExpressionFails({}, `doc.foo.bar === 'smang'`).should.equal(true);
     });
   });
 
   describe('addPatient', () => {
-    it('trigger creates a new patient', done => {
+    it('trigger creates a new patient', () => {
       const patientName = 'jack';
       const submitterId = 'abc';
       const parentId = 'papa';
@@ -55,11 +59,9 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      const getPatientContactUuid = sinon
-        .stub(utils, 'getPatientContactUuid')
-        .callsArgWith(1);
+      const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
-      const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+      const view = sinon.stub(db.medic, 'query').resolves({
         rows: [
           {
             doc: {
@@ -69,20 +71,17 @@ describe('registration', () => {
           },
         ],
       });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [{ name: 'on_create', trigger: 'add_patient' }],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-        doc.patient_id = patientId;
-        callback();
-      });
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
-      transition.onMatch(change).then(() => {
+      return transition.onMatch(change).then(() => {
         getPatientContactUuid.callCount.should.equal(1);
         view.callCount.should.equal(1);
         view.args[0][0].should.equal('medic-client/contacts_by_phone');
@@ -97,11 +96,10 @@ describe('registration', () => {
         saveDoc.args[0][0].date_of_birth.should.equal(dob);
         saveDoc.args[0][0].source_id.should.equal(reportId);
         saveDoc.args[0][0].created_by.should.equal(submitterId);
-        done();
       });
     });
 
-    it('does nothing when patient already added', done => {
+    it('does nothing when patient already added', () => {
       const patientId = '05649';
       const change = {
         doc: {
@@ -115,19 +113,18 @@ describe('registration', () => {
       };
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [{ name: 'on_create', trigger: 'add_patient_id' }],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      transition.onMatch(change).then(() => {
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(0);
-        done();
       });
     });
 
@@ -142,14 +139,14 @@ describe('registration', () => {
         birth_date: '2017-03-31T01:15:09.000Z',
       };
       const change = { doc: doc };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves(1);
       const eventConfig = {
         form: 'R',
         events: [
@@ -161,8 +158,8 @@ describe('registration', () => {
         ],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      sinon.stub(transitionUtils, 'isIdUnique').callsArgWith(1, null, true);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(transitionUtils, 'isIdUnique').resolves(true);
 
       return transition.onMatch(change).then(() => {
         saveDoc.args[0][0].patient_id.should.equal(patientId);
@@ -171,7 +168,7 @@ describe('registration', () => {
       });
     });
 
-    it('trigger creates a new contact with the given type', done => {
+    it('trigger creates a new contact with the given type', () => {
       const change = {
         doc: {
           _id: 'def',
@@ -183,9 +180,9 @@ describe('registration', () => {
           birth_date: '2017-03-31T01:15:09.000Z',
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
-      sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+      sinon.stub(db.medic, 'query').resolves({
         rows: [
           {
             doc: {
@@ -195,7 +192,7 @@ describe('registration', () => {
           },
         ],
       });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [{
@@ -205,18 +202,14 @@ describe('registration', () => {
         }],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-        doc.patient_id = '05649';
-        callback();
-      });
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves('05649');
 
-      transition.onMatch(change).then(() => {
+      return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].type.should.equal('contact');
         saveDoc.args[0][0].contact_type.should.equal('patient');
-        done();
       });
     });
 
@@ -231,14 +224,14 @@ describe('registration', () => {
         birth_date: '2017-03-31T01:15:09.000Z',
       };
       const change = { doc: doc };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
-      sinon.stub(db.medic, 'post').callsArgWith(1);
+      sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [
@@ -253,7 +246,7 @@ describe('registration', () => {
       configGet.withArgs('outgoing_deny_list').returns('');
       configGet.returns([eventConfig]);
 
-      sinon.stub(transition, 'validate').callsArgWith(2);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
 
       return transition.onMatch(change).then(() => {
         (typeof doc.patient_id).should.equal('undefined');
@@ -277,14 +270,14 @@ describe('registration', () => {
         birth_date: '2017-03-31T01:15:09.000Z',
       };
       const change = { doc: doc };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves(1);
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
-      sinon.stub(db.medic, 'post').callsArgWith(1);
+      sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [
@@ -299,9 +292,9 @@ describe('registration', () => {
       configGet.withArgs('outgoing_deny_list').returns('');
       configGet.returns([eventConfig]);
 
-      sinon.stub(transitionUtils, 'isIdUnique').callsArgWith(1, null, false);
+      sinon.stub(transitionUtils, 'isIdUnique').resolves(false);
 
-      sinon.stub(transition, 'validate').callsArgWith(2);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
 
       return transition.onMatch(change).then(() => {
         (typeof doc.patient_id).should.be.equal('undefined');
@@ -314,7 +307,7 @@ describe('registration', () => {
       });
     });
 
-    it('event parameter overwrites the default property for the name of the patient', done => {
+    it('event parameter overwrites the default property for the name of the patient', () => {
       const patientName = 'jack';
       const submitterId = 'papa';
       const patientId = '05649';
@@ -330,35 +323,31 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: submitterId } } }],
         });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [{ name: 'on_create', trigger: 'add_patient', params: 'name' }],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-        doc.patient_id = patientId;
-        callback();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
-      transition.onMatch(change).then(() => {
+      return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].name.should.equal(patientName);
-        done();
       });
     });
 
-    it('event parameter overwrites the default property for the name of the patient using JSON config', done => {
+    it('event parameter overwrites the default property for the name of the patient using JSON config', () => {
       const patientName = 'jack';
       const submitterId = 'papa';
       const patientId = '05649';
@@ -374,14 +363,14 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves(2, null, {
           rows: [{ doc: { parent: { _id: submitterId } } }],
         });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [
@@ -393,22 +382,18 @@ describe('registration', () => {
         ],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-        doc.patient_id = patientId;
-        callback();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
-      transition.onMatch(change).then(() => {
+      return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].name.should.equal(patientName);
-        done();
       });
     });
 
-    it('add_patient and add_patient_id triggers are idempotent', done => {
+    it('add_patient and add_patient_id triggers are idempotent', () => {
       const patientName = 'jack';
       const submitterId = 'papa';
       const patientId = '05649';
@@ -424,14 +409,14 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').callsArgWith(1);
+      sinon.stub(utils, 'getPatientContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: submitterId } } }],
         });
-      const saveDoc = sinon.stub(db.medic, 'post').callsArgWith(1);
+      const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
         events: [
@@ -440,18 +425,15 @@ describe('registration', () => {
         ],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
-      sinon.stub(utils, 'getRegistrations').callsArgWith(1, null, []);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc, callback) => {
-        doc.patient_id = patientId;
-        callback();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
-      transition.onMatch(change).then(() => {
+      return transition.onMatch(change).then(() => {
+        console.log(JSON.stringify(saveDoc.args, null, 2));
         saveDoc.callCount.should.equal(1);
         saveDoc.args[0][0].name.should.equal(patientName);
-        done();
       });
     });
 
@@ -484,7 +466,7 @@ describe('registration', () => {
   });
 
   describe('assign_schedule', () => {
-    it('event creates the named schedule', done => {
+    it('event creates the named schedule', () => {
       const change = {
         doc: {
           type: 'data_record',
@@ -496,10 +478,10 @@ describe('registration', () => {
       };
       sinon
         .stub(db.medic, 'query')
-        .callsArgWith(2, null, {
+        .resolves(2, null, {
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
-      sinon.stub(db.medic, 'post').callsArgWith(1);
+      sinon.stub(db.medic, 'post').resolves(1);
       const eventConfig = {
         form: 'R',
         events: [
@@ -511,36 +493,34 @@ describe('registration', () => {
         ],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      sinon.stub(transition, 'validate').callsArgWith(2);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
       const getRegistrations = sinon
         .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, [{ _id: 'xyz' }]);
+        .resolves([{ _id: 'xyz' }]);
       sinon.stub(schedules, 'getScheduleConfig').returns('someschedule');
       sinon
         .stub(utils, 'getPatientContactUuid')
-        .callsArgWith(1, null, { _id: 'uuid' });
+        .resolves({ _id: 'uuid' });
       const assignSchedule = sinon
         .stub(schedules, 'assignSchedule')
         .returns(true);
-      transition.onMatch(change).then(() => {
+      return transition.onMatch(change).then(() => {
         assignSchedule.callCount.should.equal(1);
         assignSchedule.args[0][1].should.equal('someschedule');
         assignSchedule.args[0][2][0]._id.should.equal('xyz');
         getRegistrations.callCount.should.equal(1);
-        done();
       });
     });
   });
 
   describe('filter', () => {
-    it('returns false for reports with no registration configured', done => {
+    it('returns false for reports with no registration configured', () => {
       const doc = { form: 'R', type: 'data_record' };
       const configGet = sinon.stub(config, 'get').returns([{ form: 'XYZ' }]);
       const actual = transition.filter(doc);
       configGet.callCount.should.equal(1);
       configGet.args[0][0].should.equal('registrations');
       actual.should.equal(false);
-      done();
     });
 
     it('returns false for reports that are not valid submissions', () => {
@@ -555,7 +535,7 @@ describe('registration', () => {
       actual.should.equal(false);
     });
 
-    it('returns true for reports that are valid submissions', done => {
+    it('returns true for reports that are valid submissions', () => {
       const doc = { form: 'R', type: 'data_record' };
       sinon.stub(utils, 'isValidSubmission').returns(true);
       sinon.stub(config, 'get').returns([{ form: 'R' }]);
@@ -565,12 +545,16 @@ describe('registration', () => {
       utils.isValidSubmission.callCount.should.equal(1);
       utils.isValidSubmission.args[0].should.deep.equal([doc]);
       actual.should.equal(true);
-      done();
     });
   });
 
   describe('trigger param configuration', () => {
-    it('supports strings', done => {
+    beforeEach(() => {
+      transition.fireConfiguredTriggers = transition.__get__('fireConfiguredTriggers');
+      transition.triggers = transition.__get__('triggers');
+    });
+
+    it('supports strings', () => {
       const eventConfig = {
         form: 'R',
         events: [
@@ -578,17 +562,15 @@ describe('registration', () => {
         ],
       };
 
-      transition.triggers.testparamparsing = (options, cb) => {
-        cb(options);
-      };
+      transition.triggers.testparamparsing = sinon.stub();
 
-      transition.fireConfiguredTriggers(eventConfig, {}).catch(options => {
-        options.params.should.deep.equal(['foo']);
-        done();
+      return transition.fireConfiguredTriggers(eventConfig, {}).then(() => {
+        transition.triggers.testparamparsing.callCount.should.equal(1);
+        transition.triggers.testparamparsing.args[0][0].params.should.deep.equal(['foo']);
       });
     });
 
-    it('supports comma-delimited strings as array', done => {
+    it('supports comma-delimited strings as array', () => {
       const eventConfig = {
         form: 'R',
         events: [
@@ -596,17 +578,15 @@ describe('registration', () => {
         ],
       };
 
-      transition.triggers.testparamparsing = (options, cb) => {
-        cb(options);
-      };
+      transition.triggers.testparamparsing = sinon.stub();
 
-      transition.fireConfiguredTriggers(eventConfig, {}).catch(options => {
-        options.params.should.deep.equal(['foo', 'bar']);
-        done();
+      return transition.fireConfiguredTriggers(eventConfig, {}).then(() => {
+        transition.triggers.testparamparsing.callCount.should.equal(1);
+        transition.triggers.testparamparsing.args[0][0].params.should.deep.equal(['foo', 'bar']);
       });
     });
 
-    it('supports arrays as a string', done => {
+    it('supports arrays as a string', () => {
       const eventConfig = {
         form: 'R',
         events: [
@@ -618,17 +598,15 @@ describe('registration', () => {
         ],
       };
 
-      transition.triggers.testparamparsing = (options, cb) => {
-        cb(options);
-      };
+      transition.triggers.testparamparsing = sinon.stub();
 
-      transition.fireConfiguredTriggers(eventConfig, {}).catch(options => {
-        options.params.should.deep.equal(['foo', 'bar', 3]);
-        done();
+      return transition.fireConfiguredTriggers(eventConfig, {}).then(() => {
+        transition.triggers.testparamparsing.callCount.should.equal(1);
+        transition.triggers.testparamparsing.args[0][0].params.should.deep.equal(['foo', 'bar', 3]);
       });
     });
 
-    it('supports JSON as a string', done => {
+    it('supports JSON as a string', () => {
       const eventConfig = {
         form: 'R',
         events: [
@@ -640,17 +618,15 @@ describe('registration', () => {
         ],
       };
 
-      transition.triggers.testparamparsing = (options, cb) => {
-        cb(options);
-      };
+      transition.triggers.testparamparsing = sinon.stub();
 
-      transition.fireConfiguredTriggers(eventConfig, {}).catch(options => {
-        options.params.should.deep.equal({ foo: 'bar' });
-        done();
+      return transition.fireConfiguredTriggers(eventConfig, {}).then(() => {
+        transition.triggers.testparamparsing.callCount.should.equal(1);
+        transition.triggers.testparamparsing.args[0][0].params.should.deep.equal({ foo: 'bar' });
       });
     });
 
-    it('supports direct JSON', done => {
+    it('supports direct JSON', () => {
       const eventConfig = {
         form: 'R',
         events: [
@@ -662,13 +638,11 @@ describe('registration', () => {
         ],
       };
 
-      transition.triggers.testparamparsing = (options, cb) => {
-        cb(options);
-      };
+      transition.triggers.testparamparsing = sinon.stub();
 
-      transition.fireConfiguredTriggers(eventConfig, {}).catch(options => {
-        options.params.should.deep.equal({ foo: 'bar' });
-        done();
+      return transition.fireConfiguredTriggers(eventConfig, {}).then(() => {
+        transition.triggers.testparamparsing.callCount.should.equal(1);
+        transition.triggers.testparamparsing.args[0][0].params.should.deep.equal({ foo: 'bar' });
       });
     });
 
@@ -864,7 +838,11 @@ describe('registration', () => {
   });
 
   describe('addMessages', () => {
-    it('prepops and passes the right information to messages.addMessage', done => {
+    beforeEach(() => {
+      transition.addMessages = transition.__get__('addMessages');
+    });
+
+    it('prepops and passes the right information to messages.addMessage', () => {
       const testPhone = '1234',
         testMessage1 = {
           message: 'A Test Message 1',
@@ -883,7 +861,7 @@ describe('registration', () => {
 
       sinon
         .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, testRegistration);
+        .resolves(testRegistration);
 
       const testConfig = { messages: [testMessage1, testMessage2] };
       const testDoc = {
@@ -893,8 +871,7 @@ describe('registration', () => {
         patient: testPatient,
       };
 
-      transition.addMessages(testConfig, testDoc, err => {
-        should.not.exist(err);
+      return transition.addMessages(testConfig, testDoc).then(() => {
         // Registration will send messages with no event_type
         addMessage.callCount.should.equal(2);
 
@@ -920,10 +897,10 @@ describe('registration', () => {
         addMessage.args[1][1].should.equal(testMessage2);
         addMessage.args[1][2].should.equal(testPhone);
         addMessage.args[1][3].should.deep.equal(expectedContext);
-        done();
       });
     });
-    it('supports ignoring messages based on bool_expr', done => {
+
+    it('supports ignoring messages based on bool_expr', () => {
       const testPhone = '1234',
         testMessage1 = {
           message: 'A Test Message 1',
@@ -943,7 +920,7 @@ describe('registration', () => {
 
       sinon
         .stub(utils, 'getRegistrations')
-        .callsArgWith(1, null, testRegistration);
+        .resolves(testRegistration);
 
       const testConfig = { messages: [testMessage1, testMessage2] };
       const testDoc = {
@@ -953,8 +930,7 @@ describe('registration', () => {
         patient: testPatient,
       };
 
-      transition.addMessages(testConfig, testDoc, err => {
-        should.not.exist(err);
+      return transition.addMessages(testConfig, testDoc).then( () => {
         addMessage.callCount.should.equal(1);
         const expectedContext = {
           patient: testPatient,
@@ -974,29 +950,27 @@ describe('registration', () => {
         addMessage.args[0][1].should.equal(testMessage1);
         addMessage.args[0][2].should.equal(testPhone);
         addMessage.args[0][3].should.deep.equal(expectedContext);
-        done();
       });
     });
   });
 
   describe('clear_schedule', () => {
-    it('should work when doc has no patient', done => {
-      sinon.stub(utils, 'getReportsBySubject').resolves([]);
-
-      transition.triggers.clear_schedule({ doc: {}, params: [] }, err => {
-        (!!err).should.equal(false);
-        done();
-      });
+    beforeEach(() => {
+      transition.triggers = transition.__get__('triggers');
     });
 
-    it('should query utils.getReportsBySubject with correct params', done => {
+    it('should work when doc has no patient', () => {
+      sinon.stub(utils, 'getReportsBySubject').resolves([]);
+      return transition.triggers.clear_schedule({ doc: {}, params: [] });
+    });
+
+    it('should query utils.getReportsBySubject with correct params', () => {
       sinon.stub(utils, 'getReportsBySubject').resolves([]);
       sinon.stub(utils, 'getSubjectIds').returns(['uuid', 'patient_id']);
       const doc = { patient: { _id: 'uuid', patient_id: 'patient_id' } };
       sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, null);
 
-      transition.triggers.clear_schedule({ doc, params: [] }, err => {
-        (!!err).should.equal(false);
+      return transition.triggers.clear_schedule({ doc, params: [] }).then(() => {
         utils.getSubjectIds.callCount.should.equal(1);
         utils.getSubjectIds.args[0].should.deep.equal([doc.patient]);
         utils.getReportsBySubject.callCount.should.equal(1);
@@ -1004,11 +978,10 @@ describe('registration', () => {
           ids: ['uuid', 'patient_id'],
           registrations: true
         } ]);
-        done();
       });
     });
 
-    it('should call silenceRegistrations with correct params', done => {
+    it('should call silenceRegistrations with correct params', () => {
       const doc = { _id: 'uuid', patient_id: 'patient_id' },
             params = ['1', '2', '3', '4'],
             registrations = ['a', 'b', 'c'];
@@ -1016,8 +989,7 @@ describe('registration', () => {
       sinon.stub(utils, 'getSubjectIds').returns(['uuid', 'patient_id']);
       sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, null);
 
-      transition.triggers.clear_schedule({ doc, params }, err => {
-        (!!err).should.equal(false);
+      return transition.triggers.clear_schedule({ doc, params }).then(() => {
         acceptPatientReports.silenceRegistrations.callCount.should.equal(1);
         acceptPatientReports.silenceRegistrations.args[0][0].should.deep.equal({
           silence_type: '1,2,3,4',
@@ -1025,35 +997,38 @@ describe('registration', () => {
         });
         acceptPatientReports.silenceRegistrations.args[0][1].should.deep.equal(doc);
         acceptPatientReports.silenceRegistrations.args[0][2].should.deep.equal(registrations);
-        done();
       });
     });
 
-    it('should catch getReportsBySubject errors', done => {
+    it('should catch getReportsBySubject errors', () => {
       sinon.stub(utils, 'getReportsBySubject').rejects({ some: 'error' });
       sinon.stub(utils, 'getSubjectIds').returns([]);
       sinon.stub(acceptPatientReports, 'silenceRegistrations');
 
-      transition.triggers.clear_schedule({ doc: {}, params: [] }, err => {
-        err.should.deep.equal({ some: 'error' });
-        utils.getReportsBySubject.callCount.should.equal(1);
-        utils.getSubjectIds.callCount.should.equal(1);
-        acceptPatientReports.silenceRegistrations.callCount.should.equal(0);
-        done();
+      return transition.triggers
+        .clear_schedule({ doc: {}, params: [] })
+        .then(r => r.should.deep.equal('Should have thrown'))
+        .catch((err) => {
+          err.should.deep.equal({ some: 'error' });
+          utils.getReportsBySubject.callCount.should.equal(1);
+          utils.getSubjectIds.callCount.should.equal(1);
+          acceptPatientReports.silenceRegistrations.callCount.should.equal(0);
       });
     });
 
-    it('should catch silenceRegistrations errors', done => {
+    it('should catch silenceRegistrations errors', () => {
       sinon.stub(utils, 'getReportsBySubject').resolves([]);
       sinon.stub(utils, 'getSubjectIds').returns([]);
       sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, { some: 'err' });
-      transition.triggers.clear_schedule({ doc: {}, params: [] }, err => {
-        err.should.deep.equal({ some: 'err' });
-        utils.getReportsBySubject.callCount.should.equal(1);
-        utils.getSubjectIds.callCount.should.equal(1);
-        acceptPatientReports.silenceRegistrations.callCount.should.equal(1);
-        done();
-      });
+      return transition.triggers
+        .clear_schedule({ doc: {}, params: [] })
+        .then(r => r.should.deep.equal('Should have thrown'))
+        .catch(err => {
+          err.should.deep.equal({ some: 'err' });
+          utils.getReportsBySubject.callCount.should.equal(1);
+          utils.getSubjectIds.callCount.should.equal(1);
+          acceptPatientReports.silenceRegistrations.callCount.should.equal(1);
+        });
     });
   });
 });

--- a/shared-libs/transitions/test/unit/utils.js
+++ b/shared-libs/transitions/test/unit/utils.js
@@ -55,42 +55,36 @@ describe('utils', () => {
 
   describe('getPatientContactUuid', () => {
 
-    it('returns the ID for the given short code', done => {
+    it('returns the ID for the given short code', () => {
       const expected = 'abc123';
       const given = '55998';
       const patients = [ { id: expected } ];
       const query = db.medic.query.resolves({ rows: patients });
-      utils.getPatientContactUuid(given, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getPatientContactUuid(given).then((actual) => {
         assert.equal(actual, expected);
         assert.equal(query.callCount, 1);
         assert.equal(query.args[0][0], 'medic-client/contacts_by_reference');
         assert.equal(query.args[0][1].key[0], 'shortcode');
         assert.equal(query.args[0][1].key[1], given);
         assert.equal(query.args[0][1].include_docs, false);
-        done();
       });
     });
 
-    it('returns empty when no patient found', done => {
+    it('returns empty when no patient found', () => {
       const given = '55998';
       const patients = [ ];
       const query = db.medic.query.resolves({ rows: patients });
-      utils.getPatientContactUuid(given, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getPatientContactUuid(given).then((actual) => {
         assert.equal(actual, null);
         assert.equal(query.callCount, 1);
-        done();
       });
     });
 
-    it('returns empty when no shortcode given', done => {
+    it('returns empty when no shortcode given', () => {
       const query = db.medic.query;
-      utils.getPatientContactUuid(null, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getPatientContactUuid(null).then((actual) => {
         assert.equal(actual, null);
         assert.equal(query.callCount, 0);
-        done();
       });
     });
 
@@ -140,15 +134,14 @@ describe('utils', () => {
 
   describe('getRegistrations', () => {
 
-    it('queries by id if given', done => {
+    it('queries by id if given', () => {
       sinon.stub(registrationUtils, 'isValidRegistration').returns(true);
       sinon.stub(config, 'getAll').returns({ config: 'all' });
       const expectedDoc = { _id: 'a' };
       const expected = [ { doc: expectedDoc } ];
       const given = '22222';
       const query = db.medic.query.resolves({ rows: expected });
-      utils.getRegistrations({ id: given }, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getRegistrations({ id: given }).then((actual) => {
         assert.deepEqual(actual, [ expectedDoc ]);
         assert.equal(query.callCount, 1);
         assert.equal(registrationUtils.isValidRegistration.callCount, 1);
@@ -156,11 +149,10 @@ describe('utils', () => {
         assert.equal(query.args[0][0], 'medic-client/registered_patients');
         assert.equal(query.args[0][1].key, given);
         assert.equal(query.args[0][1].include_docs, true);
-        done();
       });
     });
 
-    it('queries by ids if given', done => {
+    it('queries by ids if given', () => {
       sinon.stub(registrationUtils, 'isValidRegistration').returns(true);
       sinon.stub(config, 'getAll').returns({ config: 'all' });
       const expectedDoc1 = { id: 'a' };
@@ -168,8 +160,7 @@ describe('utils', () => {
       const expected = [ { doc: expectedDoc1 } , { doc: expectedDoc2 } ];
       const given = ['11111', '22222'];
       const view = db.medic.query.resolves({ rows: expected });
-      utils.getRegistrations({ ids: given }, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getRegistrations({ ids: given }).then((actual) => {
         assert.equal(registrationUtils.isValidRegistration.callCount, 2);
         assert.deepEqual(registrationUtils.isValidRegistration.args[0], [expectedDoc1, { config: 'all' }]);
         assert.deepEqual(registrationUtils.isValidRegistration.args[1], [expectedDoc2, { config: 'all' }]);
@@ -178,21 +169,18 @@ describe('utils', () => {
         assert.equal(view.args[0][0], 'medic-client/registered_patients');
         assert.equal(view.args[0][1].keys, given);
         assert.equal(view.args[0][1].include_docs, true);
-        done();
       });
     });
 
-    it('returns empty array if id or ids', done => {
+    it('returns empty array if id or ids', () => {
       const query = db.medic.query;
-      utils.getRegistrations({ }, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getRegistrations({ }).then((actual) => {
         assert.deepEqual(actual, []);
         assert.equal(query.callCount, 0);
-        done();
       });
     });
 
-    it('only returns valid registrations', done => {
+    it('only returns valid registrations', () => {
       sinon.stub(registrationUtils, 'isValidRegistration');
       sinon.stub(config, 'getAll').returns({ config: 'all' });
       const docs = [{ _id: 'a' }, { _id: 'b' }, { _id: 'c' }, { _id: 'd' }, { _id: 'e' }, { _id: 'f' }];
@@ -206,11 +194,9 @@ describe('utils', () => {
         .withArgs({ _id: 'e' }).returns(false)
         .withArgs({ _id: 'f' }).returns(false);
 
-      utils.getRegistrations({ ids: ['111', '222'] }, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getRegistrations({ ids: ['111', '222'] }).then((actual) => {
         assert.equal(registrationUtils.isValidRegistration.callCount, 6);
         assert.deepEqual(actual, [{ _id: 'a' }, { _id: 'd' }]);
-        done();
       });
     });
   });


### PR DESCRIPTION
# Description

Refactors registration transition
1. to use Promises instead of callbacks
2. to not export _every_ method from the file. 

medic/cht-core#5614

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
