### PR TITLE
Unset selected task explicitly

### DIFF
--- a/webapp/src/js/controllers/tasks-content.js
+++ b/webapp/src/js/controllers/tasks-content.js
@@ -10,6 +10,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
     GlobalActions,
     Selectors,
     Snackbar,
+    TasksActions,
     Telemetry,
     TranslateFrom,
     XmlForms
@@ -33,13 +34,15 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
     };
     const mapDispatchToTarget = function(dispatch) {
       const globalActions = GlobalActions(dispatch);
+      const tasksActions = TasksActions(dispatch);
       return {
         clearCancelCallback: globalActions.clearCancelCallback,
         setCancelCallback: globalActions.setCancelCallback,
         setEnketoEditedStatus: globalActions.setEnketoEditedStatus,
         setEnketoSavingStatus: globalActions.setEnketoSavingStatus,
         setEnketoError: globalActions.setEnketoError,
-        setTitle: globalActions.setTitle
+        setTitle: globalActions.setTitle,
+        setSelectedTask: tasksActions.setSelectedTask,
       };
     };
     const unsubscribe = $ngRedux.connect(mapStateToTarget, mapDispatchToTarget)(ctrl);
@@ -71,6 +74,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
 
     ctrl.performAction = function(action, skipDetails) {
       ctrl.setCancelCallback(function() {
+        ctrl.setSelectedTask(null);
         if (skipDetails) {
           $state.go('tasks.detail', { id: null });
         } else {
@@ -140,7 +144,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
           ctrl.setEnketoSavingStatus(false);
           ctrl.setEnketoEditedStatus(false);
           Enketo.unload(ctrl.form);
-          $scope.unsetSelected();
+          ctrl.setSelectedTask(null);
           $scope.clearSelected();
           ctrl.clearCancelCallback();
         })

--- a/webapp/src/js/controllers/tasks-content.js
+++ b/webapp/src/js/controllers/tasks-content.js
@@ -140,9 +140,9 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
           ctrl.setEnketoSavingStatus(false);
           ctrl.setEnketoEditedStatus(false);
           Enketo.unload(ctrl.form);
+          $scope.unsetSelected();
           $scope.clearSelected();
           ctrl.clearCancelCallback();
-          $state.go('tasks.detail', { id: null });
         })
         .then(() => {
           telemetryData.postSave = Date.now();


### PR DESCRIPTION
# Description

Adds `selectedTask(null)` calls every time the user navigates away from the task-content controller:
a) after filling the task form
b) when cancelling filling the form: in mobile view, when pressing "X" header button and in desktop view when pressing "cancel"

medic/cht-core#6065

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
