### PR TITLE
Reuse existing translation key to stop error

### DIFF
--- a/webapp/src/js/controllers/contacts-deceased.js
+++ b/webapp/src/js/controllers/contacts-deceased.js
@@ -40,7 +40,7 @@ angular.module('inboxControllers').controller('ContactsDeceasedCtrl',
           return $scope.setSelected(model);
         })
         .then(function() {
-          $translate('contact.deceased')
+          $translate('contact.deceased.title')
             .then(ctrl.setTitle)
             .catch(function(err) {
               $log.error('Failed to translate title', err);


### PR DESCRIPTION
medic/cht-core#6062

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
