### PR TITLE
Fix rendering of people who died today

### DIFF
--- a/webapp/src/js/filters/date.js
+++ b/webapp/src/js/filters/date.js
@@ -156,6 +156,7 @@ var _ = require('underscore'),
       return $sce.trustAsHtml(getRelativeDate(dod, {
         FormatDate: FormatDate,
         RelativeDate: RelativeDate,
+        withoutTime: true,
         prefix: $translate.instant('contact.deceased.date.prefix') + '&nbsp;'
       }));
     };


### PR DESCRIPTION
Instead of showing "Died 00:00", show "Died today".

medic/cht-core#6053

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
