### PR TITLE
Handle errors during app bootstrap

### DIFF
--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -12,8 +12,10 @@ const serverChecks = require('@medic/server-checks');
 const environment = require('../../../src/environment');
 const logger = require('../../../src/logger');
 const purgedDocs = require('../../../src/services/purged-docs');
+const serverUtils = require('../../../src/server-utils');
 
 require('chai').should();
+
 let testReq;
 let testRes;
 let userCtx;
@@ -205,6 +207,22 @@ describe('Changes controller', () => {
     it('initializes the continuous changes feed', () => {
       controller.request(testReq, testRes);
       changesSpy.callCount.should.equal(1);
+    });
+
+    it('handles initialization errors', () => {
+      const error = sinon.stub(serverUtils, 'error');
+      db.medic.info.rejects({ error: 'timeout' });
+      return controller.request(testReq, testRes).then(() => {
+        error.callCount.should.equal(1);
+      });
+    });
+
+    it('handles feed initialization errors', () => {
+      const error = sinon.stub(serverUtils, 'error');
+      authorization.getAuthorizationContext.rejects({ error: 'timeout' });
+      return controller.request(testReq, testRes).then(() => {
+        error.callCount.should.equal(1);
+      });
     });
 
     it('only initializes on first call', () => {

--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -59,6 +59,9 @@
         fetch(`${utils.getBaseUrl()}/api/v1/users-info`, fetchOpts).then(res => res.json())
       ])
       .then(([ local, remote ]) => {
+        if (remote && remote.code && remote.code !== 200) {
+          console.warn('Error fetching users-info - ignoring', remote);
+        }
         localDocCount = local.total_rows;
         remoteDocCount = remote.total_docs;
 

--- a/webapp/src/js/bootstrapper/purger.js
+++ b/webapp/src/js/bootstrapper/purger.js
@@ -5,7 +5,14 @@ const MAX_HISTORY_LENGTH = 10;
 
 const sortedUniqueRoles = roles => JSON.stringify([...new Set(roles)].sort());
 const purgeFetch = (url) => {
-  return fetch(url, { headers: opts.remote_headers, credentials: 'same-origin' }).then(res => res.json());
+  return fetch(url, { headers: opts.remote_headers, credentials: 'same-origin' })
+    .then(res => res.json())
+    .then(res => {
+      if (res && res.code && res.code !== 200) {
+        throw new Error('Error fetching purge data: ' + JSON.stringify(res));
+      }
+      return res;
+    });
 };
 
 const getPurgeLog = (localDb) => {
@@ -75,7 +82,7 @@ module.exports.shouldPurge = (localDb, userCtx) => {
       return true;
     })
     .catch(err => {
-      console.debug('Not purging:', err);
+      console.warn('Not purging:', err);
       return false;
     });
 };

--- a/webapp/tests/mocha/unit/purger.spec.js
+++ b/webapp/tests/mocha/unit/purger.spec.js
@@ -64,7 +64,19 @@ describe('Purger', () => {
       });
     });
 
-    it('should throw fetch errors', done => {
+    it('should throw when fetch rejects', done => {
+      fetch.rejects({ some: 'error' });
+      purger.info()
+        .then(() => {
+          done(new Error('Expected error to be thrown'));
+        })
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          done();
+        });
+    });
+
+    it('should throw when fetch resolves with an error code', done => {
       fetch.resolves({ json: sinon.stub().resolves({ code: 500, error: 'Server error' }) });
       purger.info()
         .then(() => {
@@ -78,7 +90,21 @@ describe('Purger', () => {
   });
 
   describe('checkpoint', () => {
-    it('should throw fetch errors', done => {
+
+    it('should throw when fetch rejects', done => {
+      fetch.rejects({ some: 'error' });
+      purger.checkpoint('seq')
+        .then(() => {
+          done(new Error('Expected error to be thrown'));
+        })
+        .catch(err => {
+          chai.expect(err).to.deep.equal({ some: 'error' });
+          chai.expect(fetch.callCount).to.equal(1);
+          done();
+        });
+    });
+
+    it('should throw when fetch resolves with an error code', done => {
       fetch.resolves({ json: sinon.stub().resolves({ code: 500, error: 'Server error' }) });
       purger.checkpoint('seq')
         .then(() => {

--- a/webapp/tests/mocha/unit/purger.spec.js
+++ b/webapp/tests/mocha/unit/purger.spec.js
@@ -64,21 +64,31 @@ describe('Purger', () => {
       });
     });
 
-    it('should throw fetch errors', () => {
-      fetch.rejects({ some: 'error' });
-      return purger.info().catch(err => {
-        chai.expect(err).to.deep.equal({ some: 'error' });
-      });
+    it('should throw fetch errors', done => {
+      fetch.resolves({ json: sinon.stub().resolves({ code: 500, error: 'Server error' }) });
+      purger.info()
+        .then(() => {
+          done(new Error('Expected error to be thrown'));
+        })
+        .catch(err => {
+          chai.expect(err.message).to.equal('Error fetching purge data: {"code":500,"error":"Server error"}');
+          done();
+        });
     });
   });
 
   describe('checkpoint', () => {
-    it('should throw fetch errors', () => {
-      fetch.rejects({ some: 'error' });
-      return purger.checkpoint('seq').catch(err => {
-        chai.expect(err).to.deep.equal({ some: 'error' });
-        chai.expect(fetch.callCount).to.equal(1);
-      });
+    it('should throw fetch errors', done => {
+      fetch.resolves({ json: sinon.stub().resolves({ code: 500, error: 'Server error' }) });
+      purger.checkpoint('seq')
+        .then(() => {
+          done(new Error('Expected error to be thrown'));
+        })
+        .catch(err => {
+          chai.expect(err.message).to.equal('Error fetching purge data: {"code":500,"error":"Server error"}');
+          chai.expect(fetch.callCount).to.equal(1);
+          done();
+        });
     });
 
     it('should not call purge checkpoint when no seq provided', () => {


### PR DESCRIPTION
API was throwing uncaught promise rejections which caused the
client to hang indefinitely waiting for a response during
bootstrapping.

In addition the client wasn't correctly detecting errors during
`fetch`.

medic/cht-core#6084

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
