### PR TITLE
Adds support for creating places by SMS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1065,10 +1065,10 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('unit', 'Unit tests', [
-    'karma:unit',
-    'karma:admin',
+    //'karma:unit',
+    //'karma:admin',
     'env:unit-test',
-    'exec:shared-lib-unit',
+    //'exec:shared-lib-unit',
     'mochaTest:unit',
     'env:general',
   ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1065,10 +1065,10 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('unit', 'Unit tests', [
-    //'karma:unit',
-    //'karma:admin',
+    'karma:unit',
+    'karma:admin',
     'env:unit-test',
-    //'exec:shared-lib-unit',
+    'exec:shared-lib-unit',
     'mochaTest:unit',
     'env:general',
   ]);

--- a/api/package.json
+++ b/api/package.json
@@ -89,6 +89,7 @@
   ],
   "sharedLibs": [
     "bulk-docs-utils",
+    "contact-types-utils",
     "infodoc",
     "lineage",
     "message-utils",

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -164,7 +164,7 @@ module.exports = {
           logger.info('Detected translations change - reloading');
           loadTranslations().then(() => initTransitionLib());
         } else if (change.id.startsWith('form:')) {
-          //logger.info('Detected form change - generating attachments');
+          logger.info('Detected form change - generating attachments');
           generateXform.update(change.id).catch(err => {
             logger.error('Failed to update xform: %o', err);
           });

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -164,7 +164,7 @@ module.exports = {
           logger.info('Detected translations change - reloading');
           loadTranslations().then(() => initTransitionLib());
         } else if (change.id.startsWith('form:')) {
-          logger.info('Detected form change - generating attachments');
+          //logger.info('Detected form change - generating attachments');
           generateXform.update(change.id).catch(err => {
             logger.error('Failed to update xform: %o', err);
           });

--- a/api/src/controllers/people.js
+++ b/api/src/controllers/people.js
@@ -4,6 +4,7 @@ const config = require('../config');
 const utils = require('./utils');
 const places = require('./places');
 const lineage = require('@medic/lineage')(Promise, db.medic);
+const contactTypeUtils = require('@medic/contact-types-utils');
 
 const getPerson = id => {
   return lineage.fetchHydratedDoc(id)
@@ -21,32 +22,14 @@ const getPerson = id => {
     });
 };
 
-const getContactType = typeId => {
-  const types = config.get('contact_types') || [];
-  return types.find(type => type.id === typeId);
-};
-
 const isAPerson = person => {
-  let type;
-  if (person.type === 'person') {
-    // backwards compatibility mode
-    type = getContactType('person');
-  } else if (person.type === 'contact') {
-    // configurable hierarchy mode
-    type = getContactType(person.contact_type);
-  } else {
-    // invalid type
-    return false;
-  }
-  return type && type.person;
+  const getTypeId = contactTypeUtils.getTypeId(person);
+  return contactTypeUtils.isPersonType(config, getTypeId);
 };
 
 const getDefaultPersonType = () => {
-  const types = config.get('contact_types') || [];
-  // the old hardcoded type was "person" - kept for backwards compatibility
-  if (types.some(type => type.id === 'person')) {
-    return 'person';
-  }
+  const type = contactTypeUtils.getTypeById(config,'person');
+  return type && type.id;
 };
 
 const validatePerson = obj => {

--- a/api/src/controllers/people.js
+++ b/api/src/controllers/people.js
@@ -22,13 +22,10 @@ const getPerson = id => {
     });
 };
 
-const isAPerson = person => {
-  const getTypeId = contactTypeUtils.getTypeId(person);
-  return contactTypeUtils.isPersonType(config, getTypeId);
-};
+const isAPerson = person => contactTypeUtils.isPerson(config.get(), person);
 
 const getDefaultPersonType = () => {
-  const type = contactTypeUtils.getTypeById(config,'person');
+  const type = contactTypeUtils.getTypeById(config.get(),'person');
   return type && type.id;
 };
 

--- a/api/src/controllers/places.js
+++ b/api/src/controllers/places.js
@@ -23,15 +23,8 @@ const getPlace = id => {
     });
 };
 
-const getContactType = place => {
-  const typeId = contactTypesUtils.getTypeId(place);
-  return contactTypesUtils.getTypeById(config, typeId);
-};
-
-const isAPlace = place => {
-  const typeId = contactTypesUtils.getTypeId(place);
-  return contactTypesUtils.isPlaceType(config, typeId);
-};
+const isAPlace = place => place && contactTypesUtils.isPlace(config.get(), place);
+const getContactType = place => place && contactTypesUtils.getContactType(config.get(), place);
 
 /*
  * Validate the basic data structure for a place.  Not checking against the
@@ -73,8 +66,8 @@ const validatePlace = place => {
     if (!place.parent) {
       return err(`Place ${placeId} is missing a "parent" property.`);
     }
-    const parentTypeId = contactTypesUtils.getTypeId(place.parent);
-    if (!contactTypesUtils.isParentOf(parentTypeId, type)) {
+    const parentType = getContactType(place.parent);
+    if (!contactTypesUtils.isParentOf(parentType, type)) {
       return err(`${type.id} "${placeId}" should have one of the following parent types: "${type.parents}".`);
     }
   }

--- a/api/src/controllers/places.js
+++ b/api/src/controllers/places.js
@@ -4,6 +4,7 @@ const people = require('./people');
 const utils = require('./utils');
 const db = require('../db');
 const lineage = require('@medic/lineage')(Promise, db.medic);
+const contactTypesUtils = require('@medic/contact-types-utils');
 const PLACE_EDITABLE_FIELDS = ['name', 'parent', 'contact', 'place_id'];
 
 const getPlace = id => {
@@ -23,17 +24,13 @@ const getPlace = id => {
 };
 
 const getContactType = place => {
-  const types = config.get('contact_types') || [];
-  const typeId = place.contact_type || place.type;
-  return types.find(type => type.id === typeId);
+  const typeId = contactTypesUtils.getTypeId(place);
+  return contactTypesUtils.getTypeById(config, typeId);
 };
 
 const isAPlace = place => {
-  if (place.contact_type && place.type !== 'contact') {
-    return false;
-  }
-  const type = getContactType(place);
-  return type && !type.person;
+  const typeId = contactTypesUtils.getTypeId(place);
+  return contactTypesUtils.isPlaceType(config, typeId);
 };
 
 /*
@@ -72,12 +69,12 @@ const validatePlace = place => {
     return err(`Property "name" on place ${placeId} must be a string.`);
   }
   const type = getContactType(place);
-  if (type.parents && type.parents.length) {
+  if (contactTypesUtils.hasParents(type)) {
     if (!place.parent) {
       return err(`Place ${placeId} is missing a "parent" property.`);
     }
-    const parentType = place.parent.contact_type || place.parent.type;
-    if (!type.parents.includes(parentType)) {
+    const parentTypeId = contactTypesUtils.getTypeId(place.parent);
+    if (!contactTypesUtils.isParentOf(parentTypeId, type)) {
       return err(`${type.id} "${placeId}" should have one of the following parent types: "${type.parents}".`);
     }
   }

--- a/api/src/resource-extraction.js
+++ b/api/src/resource-extraction.js
@@ -39,7 +39,7 @@ const extractAttachment = (extractToDirectory, attachmentName) => db.medic
     createFolderIfDne(path.dirname(outputPath));
 
     fs.writeFile(outputPath, raw, err => {
-      logger.debug(`Extracted attachment ${outputPath}`);
+      //logger.debug(`Extracted attachment ${outputPath}`);
       if (err) {
         return reject(err);
       }

--- a/api/src/resource-extraction.js
+++ b/api/src/resource-extraction.js
@@ -39,7 +39,7 @@ const extractAttachment = (extractToDirectory, attachmentName) => db.medic
     createFolderIfDne(path.dirname(outputPath));
 
     fs.writeFile(outputPath, raw, err => {
-      //logger.debug(`Extracted attachment ${outputPath}`);
+      logger.debug(`Extracted attachment ${outputPath}`);
       if (err) {
         return reject(err);
       }

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -105,17 +105,17 @@ app.use((req, res, next) => {
 });
 
 morgan.token('id', req => req.id);
-//
-// app.use(
-//   morgan('REQ :id :remote-addr :remote-user :method :url HTTP/:http-version', {
-//     immediate: true,
-//   })
-// );
-// app.use(
-//   morgan(
-//     'RES :id :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] :response-time ms'
-//   )
-// );
+
+app.use(
+  morgan('REQ :id :remote-addr :remote-user :method :url HTTP/:http-version', {
+    immediate: true,
+  })
+);
+app.use(
+  morgan(
+    'RES :id :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] :response-time ms'
+  )
+);
 
 app.use(
   helmet({

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -105,17 +105,17 @@ app.use((req, res, next) => {
 });
 
 morgan.token('id', req => req.id);
-
-app.use(
-  morgan('REQ :id :remote-addr :remote-user :method :url HTTP/:http-version', {
-    immediate: true,
-  })
-);
-app.use(
-  morgan(
-    'RES :id :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] :response-time ms'
-  )
-);
+//
+// app.use(
+//   morgan('REQ :id :remote-addr :remote-user :method :url HTTP/:http-version', {
+//     immediate: true,
+//   })
+// );
+// app.use(
+//   morgan(
+//     'RES :id :remote-addr :remote-user :method :url HTTP/:http-version :status :res[content-length] :response-time ms'
+//   )
+// );
 
 app.use(
   helmet({

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -113,7 +113,7 @@ const updateAttachments = (accumulator, doc) => {
       results.push(null); // not an enketo form - no update required
       return results;
     }
-    logger.debug(`Generating html and xml model for enketo form "${doc._id}"`);
+    //logger.debug(`Generating html and xml model for enketo form "${doc._id}"`);
     return module.exports._generate(form.data.toString()).then(result => {
       results.push(result);
       return results;
@@ -134,7 +134,7 @@ const updateAllAttachments = docs => {
 module.exports = {
 
   /**
-   * Updates the model and form attachments of the given form if necessary. 
+   * Updates the model and form attachments of the given form if necessary.
    * @param {string} docId - The db id of the doc defining the form.
    */
   update: docId => {
@@ -143,10 +143,10 @@ module.exports = {
       .then(docs => {
         const doc = docs.length && docs[0];
         if (doc) {
-          logger.info(`Updating form with ID "${docId}"`);
+          //logger.info(`Updating form with ID "${docId}"`);
           return db.medic.put(doc);
         } else {
-          logger.info(`Form with ID "${docId}" does not need to be updated.`);
+          //logger.info(`Form with ID "${docId}" does not need to be updated.`);
         }
       });
   },
@@ -163,7 +163,7 @@ module.exports = {
         return updateAllAttachments(docs);
       })
       .then(toSave => {
-        logger.info(`Updating ${toSave.length} enketo form${toSave.length === 1 ? '' : 's'}`);
+        //logger.info(`Updating ${toSave.length} enketo form${toSave.length === 1 ? '' : 's'}`);
         if (!toSave.length) {
           return;
         }

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -113,7 +113,7 @@ const updateAttachments = (accumulator, doc) => {
       results.push(null); // not an enketo form - no update required
       return results;
     }
-    //logger.debug(`Generating html and xml model for enketo form "${doc._id}"`);
+    logger.debug(`Generating html and xml model for enketo form "${doc._id}"`);
     return module.exports._generate(form.data.toString()).then(result => {
       results.push(result);
       return results;
@@ -143,10 +143,10 @@ module.exports = {
       .then(docs => {
         const doc = docs.length && docs[0];
         if (doc) {
-          //logger.info(`Updating form with ID "${docId}"`);
+          logger.info(`Updating form with ID "${docId}"`);
           return db.medic.put(doc);
         } else {
-          //logger.info(`Form with ID "${docId}" does not need to be updated.`);
+          logger.info(`Form with ID "${docId}" does not need to be updated.`);
         }
       });
   },
@@ -163,7 +163,7 @@ module.exports = {
         return updateAllAttachments(docs);
       })
       .then(toSave => {
-        //logger.info(`Updating ${toSave.length} enketo form${toSave.length === 1 ? '' : 's'}`);
+        logger.info(`Updating ${toSave.length} enketo form${toSave.length === 1 ? '' : 's'}`);
         if (!toSave.length) {
           return;
         }

--- a/api/src/services/messaging.js
+++ b/api/src/services/messaging.js
@@ -69,12 +69,12 @@ const getOutgoingMessageService = () => {
 };
 
 const checkDbForMessagesToSend = () => {
-  //logger.debug('Checking for a configured outgoing message service');
+  logger.debug('Checking for a configured outgoing message service');
   const service = getOutgoingMessageService();
   if (!service) {
     return Promise.resolve();
   }
-  //logger.debug('Checking for pending outgoing messages');
+  logger.debug('Checking for pending outgoing messages');
   return module.exports.getOutgoingMessages()
     .then(messages => {
       logger.info(`Sending ${messages.length} messages`);

--- a/api/src/services/messaging.js
+++ b/api/src/services/messaging.js
@@ -69,12 +69,12 @@ const getOutgoingMessageService = () => {
 };
 
 const checkDbForMessagesToSend = () => {
-  logger.debug('Checking for a configured outgoing message service');
+  //logger.debug('Checking for a configured outgoing message service');
   const service = getOutgoingMessageService();
   if (!service) {
     return Promise.resolve();
   }
-  logger.debug('Checking for pending outgoing messages');
+  //logger.debug('Checking for pending outgoing messages');
   return module.exports.getOutgoingMessages()
     .then(messages => {
       logger.info(`Sending ${messages.length} messages`);
@@ -184,7 +184,7 @@ const resolveMissingUuids = changes => {
 };
 
 module.exports = {
-  
+
   /**
    * Sends pending messages on the doc with the given ID using the
    * configured outgoing message service.
@@ -305,7 +305,7 @@ module.exports = {
   isMedicGatewayEnabled: () => {
     return getConfig().outgoing_service === 'medic-gateway';
   }
-  
+
 };
 
 if (process.env.UNIT_TEST_ENV) {

--- a/api/tests/mocha/controllers/people.spec.js
+++ b/api/tests/mocha/controllers/people.spec.js
@@ -96,7 +96,7 @@ describe('people controller', () => {
         name: 'Test',
         reported_date: 'x'
       };
-      sinon.stub(config, 'get').returns([{ id: 'person', person: true }]);
+      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves();
       sinon.stub(cutils, 'isDateStrValid').returns(false);
       controller.createPerson(person).catch(err => {
@@ -111,7 +111,7 @@ describe('people controller', () => {
         name: 'Test',
         reported_date: '123'
       };
-      sinon.stub(config, 'get').returns([{ id: 'person', person: true }]);
+      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves();
       const post = sinon.stub(db.medic, 'post').resolves();
       return controller.createPerson(person).then(() => {
@@ -124,7 +124,7 @@ describe('people controller', () => {
         name: 'Test',
         reported_date: '2011-10-10T14:48:00-0300'
       };
-      sinon.stub(config, 'get').returns([{ id: 'person', person: true }]);
+      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves();
       const post = sinon.stub(db.medic, 'post').resolves();
       return controller.createPerson(person).then(() => {
@@ -152,7 +152,7 @@ describe('people controller', () => {
           _id: 'b'
         }
       };
-      sinon.stub(config, 'get').returns([{ id: 'person', person: true }]);
+      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves(place);
       sinon.stub(controller._lineage, 'minifyLineage').returns(minified);
       sinon.stub(db.medic, 'post').resolves();
@@ -171,7 +171,7 @@ describe('people controller', () => {
       const person = {
         name: 'Test'
       };
-      sinon.stub(config, 'get').returns([{ id: 'person', person: true }]);
+      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(db.medic, 'post').resolves();
       return controller.createPerson(person).then(() => {
         const doc = db.medic.post.args[0][0];

--- a/api/tests/mocha/controllers/people.spec.js
+++ b/api/tests/mocha/controllers/people.spec.js
@@ -96,12 +96,13 @@ describe('people controller', () => {
         name: 'Test',
         reported_date: 'x'
       };
-      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
+      sinon.stub(config, 'get').returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves();
       sinon.stub(cutils, 'isDateStrValid').returns(false);
       controller.createPerson(person).catch(err => {
         chai.expect(err.code).to.equal(400);
         chai.expect(err.message).to.equal('Reported date is invalid: x');
+        chai.expect(config.get.args[0]).to.deep.equal([]);
         done();
       });
     });
@@ -111,11 +112,12 @@ describe('people controller', () => {
         name: 'Test',
         reported_date: '123'
       };
-      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
+      sinon.stub(config, 'get').returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves();
       const post = sinon.stub(db.medic, 'post').resolves();
       return controller.createPerson(person).then(() => {
         chai.expect(post.args[0][0].reported_date).to.equal(123);
+        chai.expect(config.get.args[0]).to.deep.equal([]);
       });
     });
 
@@ -124,11 +126,12 @@ describe('people controller', () => {
         name: 'Test',
         reported_date: '2011-10-10T14:48:00-0300'
       };
-      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
+      sinon.stub(config, 'get').returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves();
       const post = sinon.stub(db.medic, 'post').resolves();
       return controller.createPerson(person).then(() => {
         chai.expect(post.args[0][0].reported_date).to.equal(new Date('2011-10-10T14:48:00-0300').valueOf());
+        chai.expect(config.get.args[0]).to.deep.equal([]);
       });
     });
 
@@ -152,7 +155,7 @@ describe('people controller', () => {
           _id: 'b'
         }
       };
-      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
+      sinon.stub(config, 'get').returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(places, 'getOrCreatePlace').resolves(place);
       sinon.stub(controller._lineage, 'minifyLineage').returns(minified);
       sinon.stub(db.medic, 'post').resolves();
@@ -164,6 +167,7 @@ describe('people controller', () => {
         chai.expect(places.getOrCreatePlace.args[0][0]).to.equal('a');
         chai.expect(controller._lineage.minifyLineage.callCount).to.equal(1);
         chai.expect(controller._lineage.minifyLineage.args[0][0]).to.deep.equal(place);
+        chai.expect(config.get.args[0]).to.deep.equal([]);
       });
     });
 
@@ -171,13 +175,14 @@ describe('people controller', () => {
       const person = {
         name: 'Test'
       };
-      sinon.stub(config, 'get').withArgs().returns({ contact_types: [{ id: 'person', person: true }] });
+      sinon.stub(config, 'get').returns({ contact_types: [{ id: 'person', person: true }] });
       sinon.stub(db.medic, 'post').resolves();
       return controller.createPerson(person).then(() => {
         const doc = db.medic.post.args[0][0];
         // should be set to within 5 seconds of now
         chai.expect(doc.reported_date <= (new Date().valueOf())).to.equal(true);
         chai.expect(doc.reported_date > (new Date().valueOf() - 5000)).to.equal(true);
+        chai.expect(config.get.args[0]).to.deep.equal([]);
       });
     });
 

--- a/api/tests/mocha/controllers/places.spec.js
+++ b/api/tests/mocha/controllers/places.spec.js
@@ -65,7 +65,7 @@ describe('places controller', () => {
       name: 'St. Paul',
       parent: 'x'
     };
-    sinon.stub(config, 'get').withArgs().returns({ contact_types: contactTypes });
+    sinon.stub(config, 'get').returns({ contact_types: contactTypes });
   });
 
   afterEach(() => {

--- a/api/tests/mocha/controllers/places.spec.js
+++ b/api/tests/mocha/controllers/places.spec.js
@@ -65,7 +65,7 @@ describe('places controller', () => {
       name: 'St. Paul',
       parent: 'x'
     };
-    sinon.stub(config, 'get').returns(contactTypes);
+    sinon.stub(config, 'get').withArgs().returns({ contact_types: contactTypes });
   });
 
   afterEach(() => {

--- a/sentinel/package.json
+++ b/sentinel/package.json
@@ -56,6 +56,7 @@
     "winston"
   ],
   "sharedLibs": [
+    "contact-types-utils",
     "infodoc",
     "lineage",
     "message-utils",

--- a/sentinel/src/lib/purging.js
+++ b/sentinel/src/lib/purging.js
@@ -205,7 +205,7 @@ const getRecordGroupInfo = (row, groups, subjectIds) => {
   }
 
   if (row.doc.form) {
-    const subjectId = registrationUtils.getPatientId(row.doc);
+    const subjectId = registrationUtils.getSubjectId(row.doc);
     if (row.doc.needs_signoff) {
       // reports with needs_signoff will emit for every contact from their submitter lineage,
       // but we only want to process them once, either associated to their patient or alone, if no patient_id

--- a/sentinel/src/schedule/reminders.js
+++ b/sentinel/src/schedule/reminders.js
@@ -93,7 +93,7 @@ const parseDuration = (format) => {
 
 
 const getLeafPlaceIds = (startDocId) => {
-  const keys = contactTypesUtils.getLeafPlaceTypes(config).map(type => [ type.id ]);
+  const keys = contactTypesUtils.getLeafPlaceTypes(config.getAll()).map(type => [ type.id ]);
   const query = {
     limit: BATCH_SIZE,
     keys: JSON.stringify(keys),

--- a/sentinel/src/schedule/reminders.js
+++ b/sentinel/src/schedule/reminders.js
@@ -9,6 +9,7 @@ const later = require('later');
 const lineage = require('@medic/lineage')(Promise, db.medic);
 const logger = require('../lib/logger');
 const messages = config.getTransitionsLib().messages;
+const contactTypesUtils = require('@medic/contact-types-utils');
 
 const BATCH_SIZE = 1000;
 
@@ -90,17 +91,9 @@ const parseDuration = (format) => {
   return moment.duration(Number(tokens[0]), tokens[1]);
 };
 
-// A leaf place type is a contact type that does not have any child place types, but can have child person types
-const getLeafPlaceTypes = () => {
-  const types = config.get('contact_types') || [];
-  const placeTypes = types.filter(type => !type.person);
-  return placeTypes.filter(type => {
-    return placeTypes.every(inner => !inner.parents || !inner.parents.includes(type.id));
-  });
-};
 
 const getLeafPlaceIds = (startDocId) => {
-  const keys = getLeafPlaceTypes().map(type => [ type.id ]);
+  const keys = contactTypesUtils.getLeafPlaceTypes(config).map(type => [ type.id ]);
   const query = {
     limit: BATCH_SIZE,
     keys: JSON.stringify(keys),

--- a/sentinel/tests/unit/lib/purging.js
+++ b/sentinel/tests/unit/lib/purging.js
@@ -610,7 +610,7 @@ describe('ServerSidePurge', () => {
         ]});
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id);
 
       const purgeDbChanges = sinon.stub().resolves({ results: [] });
       sinon.stub(db, 'get').returns({ changes: purgeDbChanges, bulkDocs: sinon.stub() });
@@ -733,7 +733,7 @@ describe('ServerSidePurge', () => {
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
       sinon.stub(tombstoneUtils, 'extractStub').callsFake(id => ({ id: id.replace('-tombstone', '') }));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id);
 
       const purgeDbChanges = sinon.stub().resolves({ results: [] });
       sinon.stub(db, 'get').returns({ changes: purgeDbChanges, bulkDocs: sinon.stub() });
@@ -832,7 +832,7 @@ describe('ServerSidePurge', () => {
         ]});
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id || doc.place_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id || doc.place_id);
 
       const purgeDbChanges = sinon.stub().resolves({ results: [] });
       sinon.stub(db, 'get').returns({ changes: purgeDbChanges, bulkDocs: sinon.stub() });
@@ -920,7 +920,7 @@ describe('ServerSidePurge', () => {
         ]});
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id);
 
       const purgeDbChanges = sinon.stub().resolves({ results: [] });
       sinon.stub(db, 'get').returns({ changes: purgeDbChanges, bulkDocs: sinon.stub() });
@@ -1001,7 +1001,7 @@ describe('ServerSidePurge', () => {
         ]});
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id);
 
       sinon.stub(db.medic, 'query');
       db.medic.query.onCall(0).resolves({ rows: [
@@ -1099,7 +1099,7 @@ describe('ServerSidePurge', () => {
         ]});
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id);
 
       sinon.stub(db.medic, 'query');
       db.medic.query.onCall(0).resolves({ rows: [
@@ -1181,7 +1181,7 @@ describe('ServerSidePurge', () => {
         ]});
 
       sinon.stub(tombstoneUtils, 'isTombstoneId').callsFake(id => id.includes('tombstone'));
-      sinon.stub(registrationUtils, 'getPatientId').callsFake(doc => doc.patient_id);
+      sinon.stub(registrationUtils, 'getSubjectId').callsFake(doc => doc.patient_id);
 
       sinon.stub(db.medic, 'query');
       db.medic.query.onCall(0).resolves({ rows: [

--- a/sentinel/tests/unit/schedule/reminders.js
+++ b/sentinel/tests/unit/schedule/reminders.js
@@ -379,12 +379,12 @@ describe('reminders', () => {
           .withArgs({ keys: ['reminder:frm:5000:xxx'] }).resolves({ rows: [{ key: 'reminder:frm:5000:xxx', error: 'not_found' }] })
           .withArgs({ keys: ['xxx'], include_docs: true }).resolves({ rows: [{ doc: { _id: 'xxx', contact: { _id: 'maria' }}, id: 'xxx' }] });
 
-        sinon.stub(config, 'get').returns([
-          { id: 'person', person: true, parents: [ 'clinic' ] },     // not queried because we send reminders only to places
-          { id: 'clinic', parents: [ 'health_center' ] },            // queried
-          { id: 'health_center', parents: [ 'district_hospital' ] }, // not queried because its not a leaf
-          { id: 'district_hospital' }
-        ]);
+        sinon.stub(config, 'getAll').returns({ contact_types: [
+            { id: 'person', person: true, parents: [ 'clinic' ] },     // not queried because we send reminders only to places
+            { id: 'clinic', parents: [ 'health_center' ] },            // queried
+            { id: 'health_center', parents: [ 'district_hospital' ] }, // not queried because its not a leaf
+            { id: 'district_hospital' }
+          ]});
         reminders.__set__('lineage', { hydrateDocs: sinon.stub().resolves([{ _id: 'xxx', contact: 'maria' }]) });
 
         return reminders
@@ -445,12 +445,15 @@ describe('reminders', () => {
           .withArgs({ keys: ['reminder:frm:5000:xxx'] }).resolves({ rows: [{ key: 'reminder:frm:5000:xxx', error: 'not_found' }] })
           .withArgs({ keys: ['xxx'], include_docs: true }).resolves({ rows: [{ doc: { _id: 'xxx', contact: { _id: 'maria' }}, id: 'xxx' }] });
 
-        sinon.stub(config, 'get').returns([
-          { id: 'person', person: true, parents: [ 'clinic' ] },     // not queried because we send reminders only to places
-          { id: 'clinic', parents: [ 'health_center' ] },            // queried
-          { id: 'health_center', parents: [ 'district_hospital' ] }, // not queried because its not a leaf
-          { id: 'district_hospital' }
-        ]);
+        sinon.stub(config, 'getAll').returns({
+          contact_types: [
+            { id: 'person', person: true, parents: [ 'clinic' ] },     // not queried because we send reminders only to places
+            { id: 'clinic', parents: [ 'health_center' ] },            // queried
+            { id: 'health_center', parents: [ 'district_hospital' ] }, // not queried because its not a leaf
+            { id: 'district_hospital' }
+          ]
+        });
+
         reminders.__set__('lineage', { hydrateDocs: sinon.stub().resolves([{ _id: 'xxx', contact: 'maria' }]) });
 
         return reminders
@@ -472,7 +475,7 @@ describe('reminders', () => {
     });
 
     it('should do nothing if no places found', () => {
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get').resolves({ rows: [] });
       const lineage = { hydrateDocs: sinon.stub() };
       const messages = { addMessage: sinon.stub() };
@@ -498,7 +501,7 @@ describe('reminders', () => {
     it('should exclude places that already have a reminder', () => {
       const now = moment(1000);
       const reminder = { form: 'rform' };
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get')
         .onCall(0).resolves({ rows: [{ id: 'doc1' }, { id: 'doc2' }] })
         .onCall(1).resolves({ rows: [{ id: 'doc2' }] });
@@ -527,7 +530,7 @@ describe('reminders', () => {
     it('should exclude places that have no contact, are muted or have a legacy matching reminder', () => {
       const now = moment(123);
       const reminder = { form: 'vform' };
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get')
         .onCall(0).resolves({ rows: [{ id: 'doc1' }, { id: 'doc2' }, { id: 'doc3' }, { id: 'doc4' }, { id: 'doc5' }] })
         .onCall(1).resolves({ rows: [{ id: 'doc5' }] });
@@ -576,7 +579,7 @@ describe('reminders', () => {
       clock.tick(now);
       const reminderDate = 30 * 60 * 1000; // 30 minutes
       const reminder = { form: 'vform', mute_after_form_for: '10 minute' }; // 10 * 60 * 1000
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get')
         .onCall(0).resolves({ rows: [
           { id: 'doc1' }, // has new form
@@ -641,7 +644,7 @@ describe('reminders', () => {
     it('should create reminder docs for valid places', () => {
       const reminderDate = 30 * 60 * 1000;
       const reminder = { form: 'frm', mute_after_form_for: '10 minute', message: 'I shot the sheriff' };
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get')
         .onCall(0).resolves({ rows: [
           { id: 'doc1' },
@@ -764,7 +767,7 @@ describe('reminders', () => {
       const date = moment(reminderDate);
       const reminder = { form: 'form', message: 'Hello, darkness, my old friend' };
 
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get')
         .onCall(0).resolves({ rows: [ { id: 'doc1' }, { id: 'doc2' }]})
         .onCall(1).resolves({ rows: [{ id: 'doc2' }] });
@@ -850,7 +853,7 @@ describe('reminders', () => {
       const date = moment(reminderDate);
       const reminder = { form: 'form', message: 'Please send {{form}} for {{name}} {{type}} {{week}}-{{year}}' };
 
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       sinon.stub(request, 'get')
         .onCall(0).resolves({ rows: [ { id: 'doc1' }, { id: 'doc2' }] })
         .onCall(1).resolves({ rows: [ { id: 'doc2' }] });
@@ -920,7 +923,7 @@ describe('reminders', () => {
     });
 
     it('should process contacts in batches, calling itself after each batch and skipping already processed contacts', () => {
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       const batches = [
         ['doc1', 'doc2', 'doc3', 'doc4', 'doc5'],
         ['doc5', 'doc6', 'doc7', 'doc8', 'doc9'],
@@ -980,7 +983,7 @@ describe('reminders', () => {
     });
 
     it('should throw bulk save errors and stop execution', () => {
-      sinon.stub(config, 'get').returns([ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ]);
+      sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'tier2', parents: [ 'tier1' ] }, { id: 'tier1' } ] });
       const batches = [
         ['doc1', 'doc2', 'doc3', 'doc4', 'doc5'],
         ['doc5', 'doc6', 'doc7', 'doc8', 'doc9'],

--- a/shared-libs/contact-types-utils/package-lock.json
+++ b/shared-libs/contact-types-utils/package-lock.json
@@ -1,30 +1,9 @@
 {
-  "name": "@medic/transitions",
-  "version": "1.1.1",
+  "name": "@medic/contact-types-utils",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@medic/contact-types-utils": {
-      "version": "file:../contact-types-utils"
-    },
-    "@medic/infodoc": {
-      "version": "file:../infodoc"
-    },
-    "@medic/lineage": {
-      "version": "file:../lineage"
-    },
-    "@medic/message-utils": {
-      "version": "file:../message-utils"
-    },
-    "@medic/phone-number": {
-      "version": "file:../phone-number"
-    },
-    "@medic/registration-utils": {
-      "version": "file:../registration-utils"
-    },
-    "@medic/task-utils": {
-      "version": "file:../task-utils"
-    },
     "@sinonjs/commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
@@ -103,33 +82,11 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
-      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bikram-sambat": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.6.0.tgz",
-      "integrity": "sha512-jYHI/6obamcWpf8+vfbidSz7L3AUHAnHU/P9UIH7PdduECxnJ8JCKxdO7UpPTTr/1l4XMj0+uQ/AAPz5C7VM8Q==",
-      "requires": {
-        "eurodigit": "^3.1.3"
-      }
-    },
-    "bikram-sambat-bootstrap": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.5.0.tgz",
-      "integrity": "sha512-Ztm8i5x4QU09Rnj4Dr2xNwPYlv6VNvMXFPf4uwawfzOnYfAw6tWYTe1fVHRbRMwGSNwhZPl1+3eRmU2HOovMJw==",
-      "requires": {
-        "bikram-sambat": "^1.6.0",
-        "eurodigit": "^3.1.1"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -165,15 +122,6 @@
         "get-func-name": "^2.0.0",
         "pathval": "^1.1.0",
         "type-detect": "^4.0.5"
-      }
-    },
-    "chai-exclude": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/chai-exclude/-/chai-exclude-2.0.2.tgz",
-      "integrity": "sha512-QmNVnvdSw8Huccdjm49mKu3HtoHxvjdavgYkY0KPQ5MI5UWfbc9sX1YqRgaMPf2GGtDXPoF2ram3AeNS4945Xw==",
-      "dev": true,
-      "requires": {
-        "fclone": "^1.0.11"
       }
     },
     "chalk": {
@@ -350,17 +298,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "eurodigit": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/eurodigit/-/eurodigit-3.1.3.tgz",
-      "integrity": "sha512-/bS2/yTT1/sa5tiT3sjxQ6dobYwGDkWRCeoWYUSUFcLYomEPWlgVfnCE3Iv4eJDJE9upHhtNycxD9XQbR+zicg=="
-    },
-    "fclone": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=",
-      "dev": true
-    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -417,21 +354,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "google-libphonenumber": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.5.tgz",
-      "integrity": "sha512-Y0r7MFCI11UDLn0KaMPBEInhROyIOkWkQIyvWMFVF2I+h+sHE3vbl5a7FVe39td6u/w+nlKDdUMP9dMOZyv+2Q=="
-    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "gsm": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/gsm/-/gsm-0.1.4.tgz",
-      "integrity": "sha1-+CdiTYokdi+lC8Sb/KgsIAbR6wo="
     },
     "has": {
       "version": "1.0.3",
@@ -540,28 +467,10 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsverify": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/jsverify/-/jsverify-0.8.4.tgz",
-      "integrity": "sha512-nUG73Sfi8L4eOkc7pv9sflgAm43v+z6XMuePGVdRoBUxBLJiVcMcf3Xgc4h19eHHF3JwsaagOkUu825UnPBLJw==",
-      "dev": true,
-      "requires": {
-        "lazy-seq": "^1.0.0",
-        "rc4": "~0.1.5",
-        "trampa": "^1.0.0",
-        "typify-parser": "^1.1.0"
-      }
-    },
     "just-extend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
-      "dev": true
-    },
-    "lazy-seq": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazy-seq/-/lazy-seq-1.0.0.tgz",
-      "integrity": "sha1-iAy4qrJWAmOC4C9T7AiWgqdMW2o=",
       "dev": true
     },
     "locate-path": {
@@ -650,21 +559,11 @@
         "yargs-unparser": "1.6.0"
       }
     },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
-    },
-    "mustache": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.1.0.tgz",
-      "integrity": "sha512-3Bxq1R5LBZp7fbFPZzFe5WN4s0q3+gxZaZuZVY+QctYJiCiVgXHOTIC0/HgZuOPFt/6BQcx5u0H2CUOxT/RoGQ=="
     },
     "nise": {
       "version": "1.5.2",
@@ -700,11 +599,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
-    },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -786,12 +680,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
-    "rc4": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/rc4/-/rc4-0.1.5.tgz",
-      "integrity": "sha1-CMbgSgFo9utiHCKrbLEVG9n0pk0=",
       "dev": true
     },
     "require-directory": {
@@ -904,28 +792,11 @@
         "has-flag": "^3.0.0"
       }
     },
-    "trampa": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trampa/-/trampa-1.0.1.tgz",
-      "integrity": "sha512-93WeyHNuRggPEsfCe+yHxCgM2s6H3Q8Wmlt6b6ObJL8qc7eZlRaFjQxwTrB+zbvGtlDRnAkMoYYo3+2uH/fEwA==",
-      "dev": true
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "typify-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typify-parser/-/typify-parser-1.1.0.tgz",
-      "integrity": "sha1-rHO/pfJTQ0aOLQ8zRsYRe8A9PJk=",
-      "dev": true
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "which": {
       "version": "1.3.1",

--- a/shared-libs/contact-types-utils/package.json
+++ b/shared-libs/contact-types-utils/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@medic/contact-types-utils",
+  "version": "1.0.0",
+  "description": "Provides helper function that manages flexible contact types",
+  "main": "src/index.js",
+  "scripts": {
+    "test": "mocha ./test"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4",
+    "sinon": "^7.3.2"
+  },
+  "dependencies": {}
+}

--- a/shared-libs/contact-types-utils/src/index.js
+++ b/shared-libs/contact-types-utils/src/index.js
@@ -1,17 +1,27 @@
-const getConfig = config => config && config.get && config.get('contact_types') || [];
+const HARDCODED_PERSON_TYPE = 'person';
 
-const getTypeId = (doc) => doc && ((doc.type === 'contact' && doc.contact_type) || doc.type);
-
-const getTypeById = (config, typeId) => getConfig(config).find(type => type.id === typeId);
-
-const isPersonType = (config, typeId) => {
-  const type = getTypeById(config, typeId);
-  return type && type.person || typeId === 'person';
+const getContactTypes = config => {
+  return config && config['contact_types'] || [];
 };
 
-const isPlaceType = (config, typeId) => {
-  const type = getTypeById(config, typeId);
-  return type && !type.person;
+const getTypeId = (doc) => {
+  if (!doc) {
+    return;
+  }
+  return doc.type === 'contact' ? doc.contact_type : doc.type;
+};
+
+const getTypeById = (config, typeId) => {
+  const contactTypes = getContactTypes(config);
+  return contactTypes.find(type => type.id === typeId);
+};
+
+const isPersonType = (type) => {
+  return type && (type.person || type.id === HARDCODED_PERSON_TYPE);
+};
+
+const isPlaceType = (type) => {
+  return type && !type.person && type.id !== HARDCODED_PERSON_TYPE;
 };
 
 const hasParents = (type) => !!(type && type.parents && type.parents.length);
@@ -27,11 +37,28 @@ const isParentOf = (parentType, childType) => {
 
 // A leaf place type is a contact type that does not have any child place types, but can have child person types
 const getLeafPlaceTypes = (config) => {
-  const types = getConfig(config);
+  const types = getContactTypes(config);
   const placeTypes = types.filter(type => !type.person);
   return placeTypes.filter(type => {
     return placeTypes.every(inner => !inner.parents || !inner.parents.includes(type.id));
   });
+};
+
+const getContactType = (config, contact) => {
+  const typeId = getTypeId(contact);
+  return typeId && getTypeById(config, typeId);
+};
+
+// returns true if contact's type exists and is a person type OR if contact's type is the hardcoded person type
+const isPerson = (config, contact) => {
+  const typeId = getTypeId(contact);
+  const type = getTypeById(config, typeId) || { id: typeId };
+  return isPersonType(type);
+};
+
+const isPlace = (config, contact) => {
+  const type = getContactType(config, contact);
+  return isPlaceType(type);
 };
 
 module.exports = {
@@ -42,4 +69,7 @@ module.exports = {
   hasParents,
   isParentOf,
   getLeafPlaceTypes,
+  getContactType,
+  isPerson,
+  isPlace,
 };

--- a/shared-libs/contact-types-utils/src/index.js
+++ b/shared-libs/contact-types-utils/src/index.js
@@ -1,4 +1,4 @@
-const getConfig = config => config.get('contact_types') || [];
+const getConfig = config => config && config.get && config.get('contact_types') || [];
 
 const getTypeId = (doc) => doc && ((doc.type === 'contact' && doc.contact_type) || doc.type);
 
@@ -16,13 +16,13 @@ const isPlaceType = (config, typeId) => {
 
 const hasParents = (type) => !!(type && type.parents && type.parents.length);
 
-const isParentOf = (config, parent, child) => {
-  const parentType = getTypeById(config, getTypeId(parent));
-  const childType = getTypeById(config, getTypeId(child));
+const isParentOf = (parentType, childType) => {
   if (!parentType || !childType) {
     return false;
   }
-  return !!(childType && childType.parents && childType.parents.includes(parentType.id));
+
+  const parentTypeId = typeof parentType === 'string' ? parentType : parentType.id;
+  return !!(childType && childType.parents && childType.parents.includes(parentTypeId));
 };
 
 // A leaf place type is a contact type that does not have any child place types, but can have child person types

--- a/shared-libs/contact-types-utils/src/index.js
+++ b/shared-libs/contact-types-utils/src/index.js
@@ -1,7 +1,13 @@
 const HARDCODED_PERSON_TYPE = 'person';
+const HARDCODED_TYPES = [
+  'district_hospital',
+  'health_center',
+  'clinic',
+  'person'
+];
 
 const getContactTypes = config => {
-  return config && config['contact_types'] || [];
+  return config && Array.isArray(config.contact_types) && config.contact_types || [];
 };
 
 const getTypeId = (doc) => {
@@ -61,6 +67,21 @@ const isPlace = (config, contact) => {
   return isPlaceType(type);
 };
 
+const isHardcodedType = type => HARDCODED_TYPES.includes(type);
+
+const isOrphan = (type) => !type.parents || !type.parents.length;
+/**
+ * Returns an array of child types for the given type id.
+ * If parent is falsey, returns the types with no parent.
+ */
+const getChildren = (config, parentType) => {
+  const types = getContactTypes(config);
+  return types.filter(type => (!parentType && isOrphan(type)) || isParentOf(parentType, type));
+};
+
+const getPlaceTypes = (config) => getContactTypes(config).filter(isPlaceType);
+const getPersonTypes = (config) => getContactTypes(config).filter(isPersonType);
+
 module.exports = {
   getTypeId,
   getTypeById,
@@ -72,4 +93,10 @@ module.exports = {
   getContactType,
   isPerson,
   isPlace,
+  isHardcodedType,
+  HARDCODED_TYPES,
+  getContactTypes,
+  getChildren,
+  getPlaceTypes,
+  getPersonTypes,
 };

--- a/shared-libs/contact-types-utils/src/index.js
+++ b/shared-libs/contact-types-utils/src/index.js
@@ -1,0 +1,45 @@
+const getConfig = config => config.get('contact_types') || [];
+
+const getTypeId = (doc) => doc && ((doc.type === 'contact' && doc.contact_type) || doc.type);
+
+const getTypeById = (config, typeId) => getConfig(config).find(type => type.id === typeId);
+
+const isPersonType = (config, typeId) => {
+  const type = getTypeById(config, typeId);
+  return type && type.person || typeId === 'person';
+};
+
+const isPlaceType = (config, typeId) => {
+  const type = getTypeById(config, typeId);
+  return type && !type.person;
+};
+
+const hasParents = (type) => !!(type && type.parents && type.parents.length);
+
+const isParentOf = (config, parent, child) => {
+  const parentType = getTypeById(config, getTypeId(parent));
+  const childType = getTypeById(config, getTypeId(child));
+  if (!parentType || !childType) {
+    return false;
+  }
+  return !!(childType && childType.parents && childType.parents.includes(parentType.id));
+};
+
+// A leaf place type is a contact type that does not have any child place types, but can have child person types
+const getLeafPlaceTypes = (config) => {
+  const types = getConfig(config);
+  const placeTypes = types.filter(type => !type.person);
+  return placeTypes.filter(type => {
+    return placeTypes.every(inner => !inner.parents || !inner.parents.includes(type.id));
+  });
+};
+
+module.exports = {
+  getTypeId,
+  getTypeById,
+  isPersonType,
+  isPlaceType,
+  hasParents,
+  isParentOf,
+  getLeafPlaceTypes,
+};

--- a/shared-libs/contact-types-utils/test/index.js
+++ b/shared-libs/contact-types-utils/test/index.js
@@ -203,8 +203,36 @@ describe('ContactType Utils', () => {
   });
 
   describe('getLeafPlaceTypes', () => {
-    it('should ', () => {
-      
+    it('should not crash with no config', () => {
+      chai.expect(utils.getLeafPlaceTypes()).to.deep.equal([]);
+      chai.expect(utils.getLeafPlaceTypes({})).to.deep.equal([]);
+    });
+
+    it('should return leaf place types', () => {
+      const hierarchy = [
+        { id: 'root' },
+        { id: 'l1', parents: ['root'] },
+        { id: 'b1', parents: ['root'] },
+        { id: 'b2', parents: ['root'] },
+        { id: 'b3', parents: ['b1'] },
+        { id: 'l2', parents: ['b2'] },
+        { id: 'l3', parents: ['b2'] },
+        { id: 'b4', parents: ['b3'] },
+        { id: 'b5', parents: ['b3'] },
+        { id: 'l4', parents: ['b4'] },
+        { id: 'l5', parents: ['b5'] },
+        { id: 'p1', parents: ['l1', 'l3', 'b3', 'b5'], person: true },
+        { id: 'p2', parents: ['root', 'l2', 'l4', 'b4'], person: true },
+        { id: 'p4', parents: ['l1', 'l2', 'l3', 'l4', 'l5'], person: true },
+      ];
+      config.get.returns(hierarchy);
+      chai.expect(utils.getLeafPlaceTypes(config)).to.have.deep.members([
+        { id: 'l1', parents: ['root'] },
+        { id: 'l2', parents: ['b2'] },
+        { id: 'l3', parents: ['b2'] },
+        { id: 'l4', parents: ['b4'] },
+        { id: 'l5', parents: ['b5'] },
+      ]);
     });
   });
 });

--- a/shared-libs/contact-types-utils/test/index.js
+++ b/shared-libs/contact-types-utils/test/index.js
@@ -1,80 +1,101 @@
 const utils = require('../src/index');
-const sinon = require('sinon');
 const chai = require('chai');
 
-let config;
+const districtHospitalType = {
+  id: 'my_district_hospital',
+  name_key: 'contact.type.district_hospital',
+  group_key: 'contact.type.district_hospital.plural',
+  create_key: 'contact.type.district_hospital.new',
+  edit_key: 'contact.type.place.edit',
+  icon: 'medic-district-hospital',
+  create_form: 'form:contact:district_hospital:create',
+  edit_form: 'form:contact:district_hospital:edit',
+};
+
+const healthCenterType = {
+  id: 'my_health_center',
+  name_key: 'contact.type.health_center',
+  group_key: 'contact.type.health_center.plural',
+  create_key: 'contact.type.health_center.new',
+  edit_key: 'contact.type.place.edit',
+  parents: [ 'my_district_hospital' ],
+  icon: 'medic-health-center',
+  create_form: 'form:contact:health_center:create',
+  edit_form: 'form:contact:health_center:edit',
+};
+
+const clinicType = {
+  id: 'my_clinic',
+  name_key: 'contact.type.clinic',
+  group_key: 'contact.type.clinic.plural',
+  create_key: 'contact.type.clinic.new',
+  edit_key: 'contact.type.place.edit',
+  parents: [ 'my_health_center' ],
+  icon: 'medic-clinic',
+  create_form: 'form:contact:clinic:create',
+  edit_form: 'form:contact:clinic:edit',
+  count_visits: true,
+  person: false,
+};
+
+const personType = {
+  id: 'person',
+  name_key: 'contact.type.person',
+  group_key: 'contact.type.person.plural',
+  create_key: 'contact.type.person.new',
+  edit_key: 'contact.type.person.edit',
+  primary_contact_key: 'clinic.field.contact',
+  parents: [ 'my_district_hospital', 'my_health_center', 'my_clinic' ],
+  icon: 'medic-person',
+  create_form: 'form:contact:person:create',
+  edit_form: 'form:contact:person:edit',
+  person: true,
+};
+
+const patientType = {
+  id: 'patient',
+  name_key: 'contact.type.patient',
+  group_key: 'contact.type.patient.plural',
+  create_key: 'contact.type.patient.new',
+  edit_key: 'contact.type.patient.edit',
+  primary_contact_key: 'clinic.field.contact',
+  parents: [ 'my_district_hospital', 'my_health_center', 'my_clinic' ],
+  icon: 'medic-person',
+  create_form: 'form:contact:patient:create',
+  edit_form: 'form:contact:patient:edit',
+  person: true,
+};
+
+const chwType = {
+  id: 'chw',
+  name_key: 'contact.type.chw',
+  group_key: 'contact.type.chw.plural',
+  create_key: 'contact.type.chw.new',
+  edit_key: 'contact.type.chw.edit',
+  primary_contact_key: 'clinic.field.contact',
+  parents: [ 'district_hospital', 'health_center' ],
+  icon: 'medic-person',
+  create_form: 'form:contact:chw:create',
+  edit_form: 'form:contact:chw:edit',
+  person: true,
+};
+
+const settings = {
+  contact_types: [
+    districtHospitalType,
+    healthCenterType,
+    clinicType,
+    chwType,
+    patientType,
+    personType,
+  ]
+};
 
 describe('ContactType Utils', () => {
-  beforeEach(() => {
-    config = { get: sinon.stub() };
-    config.get.returns([
-      {
-        id: 'my_district_hospital',
-        name_key: 'contact.type.district_hospital',
-        group_key: 'contact.type.district_hospital.plural',
-        create_key: 'contact.type.district_hospital.new',
-        edit_key: 'contact.type.place.edit',
-        icon: 'medic-district-hospital',
-        create_form: 'form:contact:district_hospital:create',
-        edit_form: 'form:contact:district_hospital:edit'
-      },
-      {
-        id: 'my_health_center',
-        name_key: 'contact.type.health_center',
-        group_key: 'contact.type.health_center.plural',
-        create_key: 'contact.type.health_center.new',
-        edit_key: 'contact.type.place.edit',
-        parents: [ 'district_hospital' ],
-        icon: 'medic-health-center',
-        create_form: 'form:contact:health_center:create',
-        edit_form: 'form:contact:health_center:edit'
-      },
-      {
-        id: 'my_clinic',
-        name_key: 'contact.type.clinic',
-        group_key: 'contact.type.clinic.plural',
-        create_key: 'contact.type.clinic.new',
-        edit_key: 'contact.type.place.edit',
-        parents: [ 'health_center' ],
-        icon: 'medic-clinic',
-        create_form: 'form:contact:clinic:create',
-        edit_form: 'form:contact:clinic:edit',
-        count_visits: true
-      },
-      {
-        id: 'my_person',
-        name_key: 'contact.type.person',
-        group_key: 'contact.type.person.plural',
-        create_key: 'contact.type.person.new',
-        edit_key: 'contact.type.person.edit',
-        primary_contact_key: 'clinic.field.contact',
-        parents: [ 'district_hospital', 'health_center', 'clinic' ],
-        icon: 'medic-person',
-        create_form: 'form:contact:person:create',
-        edit_form: 'form:contact:person:edit',
-        person: true
-      },
-      {
-        id: 'my_person2',
-        name_key: 'contact.type.person2',
-        group_key: 'contact.type.person2.plural',
-        create_key: 'contact.type.person2.new',
-        edit_key: 'contact.type.person2.edit',
-        primary_contact_key: 'clinic.field.contact',
-        parents: [ 'district_hospital', 'health_center' ],
-        icon: 'medic-person',
-        create_form: 'form:contact:person2:create',
-        edit_form: 'form:contact:person2:edit',
-        person: true
-      },
-    ]);
-  });
-  afterEach(() => sinon.restore());
-
   describe('getTypeId', () => {
     it('should not crash with no input', () => {
       chai.expect(utils.getTypeId()).to.equal(undefined);
-      chai.expect(utils.getTypeId(false)).to.equal(false);
+      chai.expect(utils.getTypeId(false)).to.equal(undefined);
       chai.expect(utils.getTypeId({})).to.equal(undefined);
     });
 
@@ -95,74 +116,63 @@ describe('ContactType Utils', () => {
 
   describe('getTypeById', () => {
     it('should return nothing when no matching type', () => {
-      chai.expect(utils.getTypeById(config, 'some_type')).to.equal(undefined);
-      chai.expect(utils.getTypeById(config, 'clinic')).to.equal(undefined);
-      chai.expect(utils.getTypeById(config, 'person')).to.equal(undefined);
+      chai.expect(utils.getTypeById()).to.equal(undefined);
+      chai.expect(utils.getTypeById({})).to.equal(undefined);
+      chai.expect(utils.getTypeById(settings, '')).to.equal(undefined);
+      chai.expect(utils.getTypeById(settings, 'some_type')).to.equal(undefined);
+      chai.expect(utils.getTypeById(settings, 'clinic')).to.equal(undefined);
+      chai.expect(utils.getTypeById(settings, 'district_hospital')).to.equal(undefined);
     });
 
     it('should return matching type', () => {
-      chai.expect(utils.getTypeById(config, 'my_person')).to.deep.equal({
-        id: 'my_person',
-        name_key: 'contact.type.person',
-        group_key: 'contact.type.person.plural',
-        create_key: 'contact.type.person.new',
-        edit_key: 'contact.type.person.edit',
-        primary_contact_key: 'clinic.field.contact',
-        parents: [ 'district_hospital', 'health_center', 'clinic' ],
-        icon: 'medic-person',
-        create_form: 'form:contact:person:create',
-        edit_form: 'form:contact:person:edit',
-        person: true
-      });
-      chai.expect(utils.getTypeById(config, 'my_person')).to.deep.equal({
-        id: 'my_person',
-        name_key: 'contact.type.person',
-        group_key: 'contact.type.person.plural',
-        create_key: 'contact.type.person.new',
-        edit_key: 'contact.type.person.edit',
-        primary_contact_key: 'clinic.field.contact',
-        parents: [ 'district_hospital', 'health_center', 'clinic' ],
-        icon: 'medic-person',
-        create_form: 'form:contact:person:create',
-        edit_form: 'form:contact:person:edit',
-        person: true
-      });
-      chai.expect(utils.getTypeById(config, 'my_district_hospital')).to.deep.equal({
-        id: 'my_district_hospital',
-        name_key: 'contact.type.district_hospital',
-        group_key: 'contact.type.district_hospital.plural',
-        create_key: 'contact.type.district_hospital.new',
-        edit_key: 'contact.type.place.edit',
-        icon: 'medic-district-hospital',
-        create_form: 'form:contact:district_hospital:create',
-        edit_form: 'form:contact:district_hospital:edit'
-      });
+      chai.expect(utils.getTypeById(settings, 'patient')).to.deep.equal(patientType);
+      chai.expect(utils.getTypeById(settings, 'chw')).to.deep.equal(chwType);
+      chai.expect(utils.getTypeById(settings, 'my_district_hospital')).to.deep.equal(districtHospitalType);
+      chai.expect(utils.getTypeById(settings, 'my_health_center')).to.deep.equal(healthCenterType);
     });
   });
 
   describe('isPersonType', () => {
+    it('should return falsy for no type', () => {
+      chai.expect(utils.isPersonType(false)).to.equal(false);
+      chai.expect(utils.isPersonType()).to.equal(undefined);
+    });
+
     it('should return false for non-person types', () => {
-      chai.expect(utils.isPersonType(config, 'nonexistent')).to.equal(false);
-      chai.expect(utils.isPersonType(config, 'my_district_hospital')).to.equal(false);
-      chai.expect(utils.isPersonType(config, 'my_health_center')).to.equal(false);
+      chai.expect(utils.isPersonType(false)).to.equal(false);
+      chai.expect(utils.isPersonType({ id: 'something' })).to.equal(false);
+      chai.expect(utils.isPersonType({ id: 'other', person: false})).to.equal(false);
+      chai.expect(utils.isPersonType(healthCenterType)).to.equal(false);
+      chai.expect(utils.isPersonType(clinicType)).to.equal(false);
     });
 
     it('should return true for person types', () => {
-      chai.expect(utils.isPersonType(config, 'my_person')).to.equal(true);
-      chai.expect(utils.isPersonType(config, 'my_person2')).to.equal(true);
+      chai.expect(utils.isPersonType({ id: 'person' })).to.equal(true);
+      chai.expect(utils.isPersonType({ id: 'other', person: true })).to.equal(true);
+      chai.expect(utils.isPersonType(personType)).to.equal(true);
+      chai.expect(utils.isPersonType(chwType)).to.equal(true);
+      chai.expect(utils.isPersonType(patientType)).to.equal(true);
     });
   });
 
   describe('isPlaceType', () => {
-    it('should return false for non-person types', () => {
-      chai.expect(utils.isPlaceType(config, 'my_district_hospital')).to.equal(true);
-      chai.expect(utils.isPlaceType(config, 'my_health_center')).to.equal(true);
+    it('should return false for no type', () => {
+      chai.expect(utils.isPlaceType(false)).to.equal(false);
+      chai.expect(utils.isPlaceType()).to.equal(undefined);
     });
 
-    it('should return true for person types or non-existent types', () => {
-      chai.expect(utils.isPlaceType(config, 'nonexistent')).to.equal(undefined);
-      chai.expect(utils.isPlaceType(config, 'my_person')).to.equal(false);
-      chai.expect(utils.isPlaceType(config, 'my_person2')).to.equal(false);
+    it('should return false for person types', () => {
+      chai.expect(utils.isPlaceType({ id: 'person' })).to.equal(false);
+      chai.expect(utils.isPlaceType(personType)).to.equal(false);
+      chai.expect(utils.isPlaceType(chwType)).to.equal(false);
+      chai.expect(utils.isPlaceType(patientType)).to.equal(false);
+    });
+
+    it('should return true for non-person types', () => {
+      chai.expect(utils.isPlaceType({ id: 'place' })).to.equal(true);
+      chai.expect(utils.isPlaceType(districtHospitalType)).to.equal(true);
+      chai.expect(utils.isPlaceType(healthCenterType)).to.equal(true);
+      chai.expect(utils.isPlaceType(clinicType)).to.equal(true);
     });
   });
 
@@ -225,14 +235,95 @@ describe('ContactType Utils', () => {
         { id: 'p2', parents: ['root', 'l2', 'l4', 'b4'], person: true },
         { id: 'p4', parents: ['l1', 'l2', 'l3', 'l4', 'l5'], person: true },
       ];
-      config.get.returns(hierarchy);
-      chai.expect(utils.getLeafPlaceTypes(config)).to.have.deep.members([
+      chai.expect(utils.getLeafPlaceTypes({ contact_types: hierarchy })).to.have.deep.members([
         { id: 'l1', parents: ['root'] },
         { id: 'l2', parents: ['b2'] },
         { id: 'l3', parents: ['b2'] },
         { id: 'l4', parents: ['b4'] },
         { id: 'l5', parents: ['b5'] },
       ]);
+    });
+  });
+
+  describe('getContactType', () => {
+    it('should return falsy when no input', () => {
+      chai.expect(utils.getContactType()).to.equal(undefined);
+      chai.expect(utils.getContactType(undefined, {})).to.equal(undefined);
+      chai.expect(utils.getContactType({})).to.equal(undefined);
+      chai.expect(utils.getContactType(settings, 'whatever')).to.equal(undefined);
+      chai.expect(utils.getContactType(settings, [])).to.equal(undefined);
+    });
+
+    it('should return falsy for non-existing contact type', () => {
+      chai.expect(utils.getContactType(settings, { type: 'contact' })).to.equal(undefined);
+      chai.expect(utils.getContactType(settings, { type: 'contact', contact_type: 'something' })).to.equal(undefined);
+    });
+
+    it('should return contact type', () => {
+      chai.expect(utils.getContactType(settings, { type: 'person' })).to.equal(personType);
+      chai.expect(utils.getContactType(settings, { type: 'contact', contact_type: 'person' })).to.equal(personType);
+      chai.expect(utils.getContactType(settings, { type: 'contact', contact_type: 'my_health_center' })).to.equal(healthCenterType);
+      chai.expect(utils.getContactType(settings, { type: 'my_health_center' })).to.equal(healthCenterType);
+    });
+  });
+
+  describe('isPerson', () => {
+    it('should return falsy for falsy input', () => {
+      chai.expect(utils.isPerson()).to.equal(false);
+      chai.expect(utils.isPerson(false, false)).to.equal(false);
+      chai.expect(utils.isPerson({}, false)).to.equal(false);
+      chai.expect(utils.isPerson([], false)).to.equal(false);
+      chai.expect(utils.isPerson(settings, 'whaaat')).to.equal(false);
+    });
+
+    it('should return falsy for non existent contact types', () => {
+      chai.expect(utils.isPerson(settings, { type: 'other' })).to.equal(false);
+      chai.expect(utils.isPerson(settings, { type: 'contact', contact_type: 'other' })).to.equal(false);
+    });
+
+    it('should return falsy for place types', () => {
+      chai.expect(utils.isPerson(settings, { type: districtHospitalType.id })).to.equal(false);
+      chai.expect(utils.isPerson(settings, { type: clinicType.id })).to.equal(false);
+      chai.expect(utils.isPerson(settings, { type: 'contact', contact_type: districtHospitalType.id })).to.equal(false);
+      chai.expect(utils.isPerson(settings, { type: 'contact', contact_type: clinicType.id })).to.equal(false);
+    });
+
+    it('should return true for person types', () => {
+      chai.expect(utils.isPerson({}, { type: 'person' })).to.equal(true);
+      chai.expect(utils.isPerson(settings, { type: 'person' })).to.equal(true);
+      chai.expect(utils.isPerson(settings, { type: chwType.id })).to.equal(true);
+      chai.expect(utils.isPerson(settings, { type: 'contact', contact_type: 'person' })).to.equal(true);
+      chai.expect(utils.isPerson(settings, { type: 'contact', contact_type: chwType.id })).to.equal(true);
+    });
+  });
+
+  describe('isPlace', () => {
+    it('should return falsy for falsy input', () => {
+      chai.expect(utils.isPlace()).to.equal(undefined);
+      chai.expect(utils.isPlace(false, false)).to.equal(undefined);
+      chai.expect(utils.isPlace({}, false)).to.equal(undefined);
+      chai.expect(utils.isPlace([], false)).to.equal(undefined);
+      chai.expect(utils.isPlace(settings, 'whaaat')).to.equal(undefined);
+    });
+
+    it('should return falsy for non existent contact types', () => {
+      chai.expect(utils.isPlace(settings, { type: 'other' })).to.equal(undefined);
+      chai.expect(utils.isPlace(settings, { type: 'contact', contact_type: 'other' })).to.equal(undefined);
+    });
+
+    it('should return falsy for person types', () => {
+      chai.expect(utils.isPlace({}, { type: 'person' })).to.equal(undefined);
+      chai.expect(utils.isPlace(settings, { type: personType.id })).to.equal(false);
+      chai.expect(utils.isPlace(settings, { type: patientType.id })).to.equal(false);
+      chai.expect(utils.isPlace(settings, { type: 'contact', contact_type: personType.id })).to.equal(false);
+      chai.expect(utils.isPlace(settings, { type: 'contact', contact_type: patientType.id })).to.equal(false);
+    });
+
+    it('should return true for place types', () => {
+      chai.expect(utils.isPlace(settings, { type: districtHospitalType.id })).to.equal(true);
+      chai.expect(utils.isPlace(settings, { type: clinicType.id })).to.equal(true);
+      chai.expect(utils.isPlace(settings, { type: 'contact', contact_type: clinicType.id })).to.equal(true);
+      chai.expect(utils.isPlace(settings, { type: 'contact', contact_type: healthCenterType.id })).to.equal(true);
     });
   });
 });

--- a/shared-libs/contact-types-utils/test/index.js
+++ b/shared-libs/contact-types-utils/test/index.js
@@ -1,0 +1,210 @@
+const utils = require('../src/index');
+const sinon = require('sinon');
+const chai = require('chai');
+
+let config;
+
+describe('ContactType Utils', () => {
+  beforeEach(() => {
+    config = { get: sinon.stub() };
+    config.get.returns([
+      {
+        id: 'my_district_hospital',
+        name_key: 'contact.type.district_hospital',
+        group_key: 'contact.type.district_hospital.plural',
+        create_key: 'contact.type.district_hospital.new',
+        edit_key: 'contact.type.place.edit',
+        icon: 'medic-district-hospital',
+        create_form: 'form:contact:district_hospital:create',
+        edit_form: 'form:contact:district_hospital:edit'
+      },
+      {
+        id: 'my_health_center',
+        name_key: 'contact.type.health_center',
+        group_key: 'contact.type.health_center.plural',
+        create_key: 'contact.type.health_center.new',
+        edit_key: 'contact.type.place.edit',
+        parents: [ 'district_hospital' ],
+        icon: 'medic-health-center',
+        create_form: 'form:contact:health_center:create',
+        edit_form: 'form:contact:health_center:edit'
+      },
+      {
+        id: 'my_clinic',
+        name_key: 'contact.type.clinic',
+        group_key: 'contact.type.clinic.plural',
+        create_key: 'contact.type.clinic.new',
+        edit_key: 'contact.type.place.edit',
+        parents: [ 'health_center' ],
+        icon: 'medic-clinic',
+        create_form: 'form:contact:clinic:create',
+        edit_form: 'form:contact:clinic:edit',
+        count_visits: true
+      },
+      {
+        id: 'my_person',
+        name_key: 'contact.type.person',
+        group_key: 'contact.type.person.plural',
+        create_key: 'contact.type.person.new',
+        edit_key: 'contact.type.person.edit',
+        primary_contact_key: 'clinic.field.contact',
+        parents: [ 'district_hospital', 'health_center', 'clinic' ],
+        icon: 'medic-person',
+        create_form: 'form:contact:person:create',
+        edit_form: 'form:contact:person:edit',
+        person: true
+      },
+      {
+        id: 'my_person2',
+        name_key: 'contact.type.person2',
+        group_key: 'contact.type.person2.plural',
+        create_key: 'contact.type.person2.new',
+        edit_key: 'contact.type.person2.edit',
+        primary_contact_key: 'clinic.field.contact',
+        parents: [ 'district_hospital', 'health_center' ],
+        icon: 'medic-person',
+        create_form: 'form:contact:person2:create',
+        edit_form: 'form:contact:person2:edit',
+        person: true
+      },
+    ]);
+  });
+  afterEach(() => sinon.restore());
+
+  describe('getTypeId', () => {
+    it('should not crash with no input', () => {
+      chai.expect(utils.getTypeId()).to.equal(undefined);
+      chai.expect(utils.getTypeId(false)).to.equal(false);
+      chai.expect(utils.getTypeId({})).to.equal(undefined);
+    });
+
+    it('should return hardcoded contact type', () => {
+      chai.expect(utils.getTypeId({ type: 'person' })).to.equal('person');
+      chai.expect(utils.getTypeId({ type: 'district_hospital' })).to.equal('district_hospital');
+      chai.expect(utils.getTypeId({ type: 'health_center' })).to.equal('health_center');
+      chai.expect(utils.getTypeId({ type: 'whatever' })).to.equal('whatever');
+    });
+
+    it('should return contact_type value', () => {
+      chai.expect(utils.getTypeId({ type: 'contact', contact_type: 'person' })).to.equal('person');
+      chai.expect(utils.getTypeId({ type: 'contact', contact_type: 'chw' })).to.equal('chw');
+      chai.expect(utils.getTypeId({ type: 'contact', contact_type: 'patient' })).to.equal('patient');
+      chai.expect(utils.getTypeId({ type: 'contact', contact_type: 'health_center' })).to.equal('health_center');
+    });
+  });
+
+  describe('getTypeById', () => {
+    it('should return nothing when no matching type', () => {
+      chai.expect(utils.getTypeById(config, 'some_type')).to.equal(undefined);
+      chai.expect(utils.getTypeById(config, 'clinic')).to.equal(undefined);
+      chai.expect(utils.getTypeById(config, 'person')).to.equal(undefined);
+    });
+
+    it('should return matching type', () => {
+      chai.expect(utils.getTypeById(config, 'my_person')).to.deep.equal({
+        id: 'my_person',
+        name_key: 'contact.type.person',
+        group_key: 'contact.type.person.plural',
+        create_key: 'contact.type.person.new',
+        edit_key: 'contact.type.person.edit',
+        primary_contact_key: 'clinic.field.contact',
+        parents: [ 'district_hospital', 'health_center', 'clinic' ],
+        icon: 'medic-person',
+        create_form: 'form:contact:person:create',
+        edit_form: 'form:contact:person:edit',
+        person: true
+      });
+      chai.expect(utils.getTypeById(config, 'my_person')).to.deep.equal({
+        id: 'my_person',
+        name_key: 'contact.type.person',
+        group_key: 'contact.type.person.plural',
+        create_key: 'contact.type.person.new',
+        edit_key: 'contact.type.person.edit',
+        primary_contact_key: 'clinic.field.contact',
+        parents: [ 'district_hospital', 'health_center', 'clinic' ],
+        icon: 'medic-person',
+        create_form: 'form:contact:person:create',
+        edit_form: 'form:contact:person:edit',
+        person: true
+      });
+      chai.expect(utils.getTypeById(config, 'my_district_hospital')).to.deep.equal({
+        id: 'my_district_hospital',
+        name_key: 'contact.type.district_hospital',
+        group_key: 'contact.type.district_hospital.plural',
+        create_key: 'contact.type.district_hospital.new',
+        edit_key: 'contact.type.place.edit',
+        icon: 'medic-district-hospital',
+        create_form: 'form:contact:district_hospital:create',
+        edit_form: 'form:contact:district_hospital:edit'
+      });
+    });
+  });
+
+  describe('isPersonType', () => {
+    it('should return false for non-person types', () => {
+      chai.expect(utils.isPersonType(config, 'nonexistent')).to.equal(false);
+      chai.expect(utils.isPersonType(config, 'my_district_hospital')).to.equal(false);
+      chai.expect(utils.isPersonType(config, 'my_health_center')).to.equal(false);
+    });
+
+    it('should return true for person types', () => {
+      chai.expect(utils.isPersonType(config, 'my_person')).to.equal(true);
+      chai.expect(utils.isPersonType(config, 'my_person2')).to.equal(true);
+    });
+  });
+
+  describe('isPlaceType', () => {
+    it('should return false for non-person types', () => {
+      chai.expect(utils.isPlaceType(config, 'my_district_hospital')).to.equal(true);
+      chai.expect(utils.isPlaceType(config, 'my_health_center')).to.equal(true);
+    });
+
+    it('should return true for person types or non-existent types', () => {
+      chai.expect(utils.isPlaceType(config, 'nonexistent')).to.equal(undefined);
+      chai.expect(utils.isPlaceType(config, 'my_person')).to.equal(false);
+      chai.expect(utils.isPlaceType(config, 'my_person2')).to.equal(false);
+    });
+  });
+
+  describe('hasParents', () => {
+    it('should return false when no parents', () => {
+      chai.expect(utils.hasParents(false)).to.equal(false);
+      chai.expect(utils.hasParents({})).to.equal(false);
+      chai.expect(utils.hasParents({ parents: [] })).to.equal(false);
+    });
+
+    it('should return true when type has parents', () => {
+      chai.expect(utils.hasParents({ parents: ['a'] })).to.equal(true);
+      chai.expect(utils.hasParents({ parents: ['a', 'b'] })).to.equal(true);
+    });
+  });
+
+  describe('isParentOf', () => {
+    it('should return false when wrong input', () => {
+      chai.expect(utils.isParentOf()).to.equal(false);
+      chai.expect(utils.isParentOf(true, true)).to.equal(false);
+    });
+
+    it('should return false when not parent of', () => {
+      chai.expect(utils.isParentOf({ id: 'parent' }, { id: 'child' })).to.equal(false);
+      chai.expect(utils.isParentOf('parent', { id: 'child' })).to.equal(false);
+      chai.expect(utils.isParentOf({ id: 'parent' }, { id: 'child', parents: [] })).to.equal(false);
+      chai.expect(utils.isParentOf('parent', { id: 'child', parents: [] })).to.equal(false);
+      chai.expect(utils.isParentOf({ id: 'parent' }, { id: 'child', parents: ['other'] })).to.equal(false);
+      chai.expect(utils.isParentOf('parent', { id: 'child', parents: ['other'] })).to.equal(false);
+    });
+
+    it('should return true when parent of', () => {
+      chai.expect(utils.isParentOf({ id: 'parent' }, { id: 'child', parents: ['parent'] })).to.equal(true);
+      chai.expect(utils.isParentOf('parent', { id: 'child', parents: ['parent'] })).to.equal(true);
+      chai.expect(utils.isParentOf({ id: 'parent' }, { id: 'child', parents: ['other', 'parent'] })).to.equal(true);
+      chai.expect(utils.isParentOf('parent', { id: 'child', parents: ['other', 'parent'] })).to.equal(true);
+    });
+  });
+
+  describe('getLeafPlaceTypes', () => {
+    it('should ', () => {
+      
+    });
+  });
+});

--- a/shared-libs/lineage/src/minify.js
+++ b/shared-libs/lineage/src/minify.js
@@ -45,6 +45,7 @@ function minify(doc) {
   }
   if (doc.type === 'data_record') {
     delete doc.patient;
+    delete doc.place;
   }
 }
 

--- a/shared-libs/lineage/test/minify.spec.js
+++ b/shared-libs/lineage/test/minify.spec.js
@@ -142,6 +142,35 @@ describe('Minify', function() {
       chai.expect(actual).to.deep.equal(expected);
     });
 
+    it('removes the place', () => {
+      // Given
+      const actual = {
+        _id: 'c',
+        type: 'data_record',
+        place_id: '123',
+        place: {
+          _id: 'a',
+          name: 'Alice',
+          place_id: '123',
+          parent: {
+            _id: 'b',
+            name: 'Bob'
+          }
+        }
+      };
+      const expected = {
+        _id: 'c',
+        type: 'data_record',
+        place_id: '123'
+      };
+
+      // when
+      lineage.minify(actual);
+
+      // then
+      chai.expect(actual).to.deep.equal(expected);
+    });
+
     it('errors out on potential infinite recursion', function() {
       const doc = {
         _id: 'same_id',

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -167,7 +167,8 @@ var extractTemplateContext = function(doc) {
 
 var extendedTemplateContext = function(doc, extras) {
   var templateContext = {
-    patient: extras.patient
+    patient: extras.patient,
+    place: extras.place,
   };
 
   if (extras.templateContext) {
@@ -180,6 +181,10 @@ var extendedTemplateContext = function(doc, extras) {
     // Don't want to add this to extractTemplateContext as 'name' is too generic
     // and eTC gets called elsewhere
     templateContext.patient_name = templateContext.patient_name || extras.patient.name;
+  }
+
+  if (extras.place) {
+    _.defaults(templateContext, extractTemplateContext(extras.place));
   }
 
   _.defaults(templateContext, extractTemplateContext(doc));

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -199,39 +199,49 @@ describe('messageUtils', () => {
       const doc = { name: 'alice', fields: { name: 'bob' } };
       const patient = { name: 'charles' };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations });
       actual.name.should.equal('charles');
     });
 
-    it('picks doc.fields properties second', () => {
+    it('should pick place data second', () => {
+      const doc = { name: 'alice', fields: { name: 'bob' } };
+      const place = { name: 'charles' };
+      const actual = utils._extendedTemplateContext(doc, { place });
+      actual.name.should.equal('charles');
+    });
+
+    it('picks doc.fields properties third', () => {
       const doc = { name: 'alice', fields: { name: 'bob' } };
       const patient = { };
+      const place = { };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place });
       actual.name.should.equal('bob');
     });
 
-    it('picks doc properties third', () => {
+    it('picks doc properties fourth', () => {
       const doc = { name: 'alice' };
       const patient = { };
+      const place = { };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place });
       actual.name.should.equal('alice');
-    });
-
-    it('picks registration[0].fields properties fourth', () => {
-      const doc = { };
-      const patient = { };
-      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
-      actual.name.should.equal('elisa');
     });
 
     it('picks registration[0].fields properties fifth', () => {
       const doc = { };
       const patient = { };
+      const place = { };
+      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place });
+      actual.name.should.equal('elisa');
+    });
+
+    it('picks registration[0].fields properties sixth', () => {
+      const doc = { };
+      const patient = { };
       const registrations = [{ name: 'doug' }];
-      const actual = utils._extendedTemplateContext(doc, { patient: patient, registrations: registrations });
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations });
       actual.name.should.equal('doug');
     });
 

--- a/shared-libs/registration-utils/src/index.js
+++ b/shared-libs/registration-utils/src/index.js
@@ -58,7 +58,7 @@ exports.getSubjectIds = (contact) => {
   return subjectIds;
 };
 
-const getPatientId = report => report.patient_id || (report.fields && (report.fields.patient_id || report.patient_uuid));
+const getPatientId = report => report.patient_id || (report.fields && (report.fields.patient_id || report.fields.patient_uuid));
 const getPlaceId   = report => report.place_id   || (report.fields && (report.fields.place_id));
 
 exports.getSubjectId = report => {

--- a/shared-libs/registration-utils/src/index.js
+++ b/shared-libs/registration-utils/src/index.js
@@ -58,8 +58,10 @@ exports.getSubjectIds = (contact) => {
   return subjectIds;
 };
 
-const getPatientId = report => report.patient_id || (report.fields && (report.fields.patient_id || report.fields.patient_uuid));
-const getPlaceId   = report => report.place_id   || (report.fields && (report.fields.place_id));
+const getPatientId = report => report.patient_id ||
+                               (report.fields && (report.fields.patient_id || report.fields.patient_uuid));
+const getPlaceId   = report => report.place_id ||
+                               (report.fields && (report.fields.place_id));
 
 exports.getSubjectId = report => {
   if (!report) {

--- a/shared-libs/registration-utils/src/index.js
+++ b/shared-libs/registration-utils/src/index.js
@@ -5,7 +5,7 @@ const formCodeMatches = (conf, form) => {
 // Returns whether `doc` is a valid registration against a configuration
 // This is done by checks roughly similar to the `registration` transition filter function
 // Serves as a replacement for checking for `transitions` metadata within the doc itself
-exports.isValidRegistration = function(doc, settings) {
+exports.isValidRegistration = (doc, settings) => {
   if (!doc ||
       (doc.errors && doc.errors.length) ||
       !settings ||
@@ -16,7 +16,7 @@ exports.isValidRegistration = function(doc, settings) {
   }
 
   // Registration transition should be configured for this form
-  var registrationConfiguration = settings.registrations.find(function(conf) {
+  const registrationConfiguration = settings.registrations.find((conf) => {
     return conf &&
            conf.form &&
            formCodeMatches(conf.form, doc.form);
@@ -30,7 +30,7 @@ exports.isValidRegistration = function(doc, settings) {
   }
 
   // SMS forms need to be configured
-  var form = settings.forms && settings.forms[doc.form];
+  const form = settings.forms && settings.forms[doc.form];
   if (!form) {
     return false;
   }
@@ -41,15 +41,15 @@ exports.isValidRegistration = function(doc, settings) {
 
 exports._formCodeMatches = formCodeMatches;
 
-var SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
-exports.getSubjectIds = function(contact) {
-  var subjectIds = [];
+const SUBJECT_PROPERTIES = ['_id', 'patient_id', 'place_id'];
+exports.getSubjectIds = (contact) => {
+  const subjectIds = [];
 
   if (!contact) {
     return subjectIds;
   }
 
-  SUBJECT_PROPERTIES.forEach(function(prop) {
+  SUBJECT_PROPERTIES.forEach((prop) => {
     if (contact[prop]) {
       subjectIds.push(contact[prop]);
     }
@@ -58,10 +58,13 @@ exports.getSubjectIds = function(contact) {
   return subjectIds;
 };
 
-exports.getPatientId = function(report) {
-  return report && (
-    report.patient_id ||
-    report.place_id ||
-    (report.fields && (report.fields.patient_id || report.fields.place_id || report.fields.patient_uuid))
-  );
+const getPatientId = report => report.patient_id || (report.fields && (report.fields.patient_id || report.patient_uuid));
+const getPlaceId   = report => report.place_id   || (report.fields && (report.fields.place_id));
+
+exports.getSubjectId = report => {
+  if (!report) {
+    return false;
+  }
+
+  return getPatientId(report) || getPlaceId(report);
 };

--- a/shared-libs/registration-utils/test/index.spec.js
+++ b/shared-libs/registration-utils/test/index.spec.js
@@ -233,23 +233,49 @@ describe('registrationUtils', () => {
     });
   });
 
-  describe('getPatientId', () => {
-    it('should return correct values', () => {
-      chai.expect(utils.getPatientId()).to.equal(undefined);
-      chai.expect(utils.getPatientId(false)).to.equal(false);
-      chai.expect(utils.getPatientId({})).to.equal(undefined);
-      chai.expect(utils.getPatientId({ patient_id: 'a' })).to.equal('a');
-      chai.expect(utils.getPatientId({ place_id: 'a' })).to.equal('a');
-      chai.expect(utils.getPatientId({ patient_id: 'a', place_id: 'b' })).to.equal('a');
-      chai.expect(utils.getPatientId({ patient_id: 'a', fields: {} })).to.equal('a');
-      chai.expect(utils.getPatientId({ patient_id: 'a', fields: { patient_id: 'b' } })).to.equal('a');
-      chai.expect(utils.getPatientId({ place_id: 'a', fields: { patient_id: 'b' } })).to.equal('a');
-      chai.expect(utils.getPatientId({ place_id: 'a', fields: { place_id: 'b' } })).to.equal('a');
-      chai.expect(utils.getPatientId({ fields: { place_id: 'b' } })).to.equal('b');
-      chai.expect(utils.getPatientId({ fields: { patient_id: 'b' } })).to.equal('b');
-      chai.expect(utils.getPatientId({ fields: { patient_uuid: 'b' } })).to.equal('b');
-      chai.expect(utils.getPatientId({ fields: { patient_id: 'a', patient_uuid: 'b' } })).to.equal('a');
-      chai.expect(utils.getPatientId({ fields: { place_id: 'a', patient_uuid: 'b' } })).to.equal('a');
+  describe('getSubjectId', () => {
+    it('should not crash on falsy input', () => {
+      chai.expect(utils.getSubjectId()).to.equal(undefined);
+      chai.expect(utils.getSubjectId(false)).to.equal(false);
+      chai.expect(utils.getSubjectId({})).to.equal(undefined);
+      chai.expect(utils.getSubjectId({ fields: {} })).to.equal(undefined);
+      chai.expect(utils.getSubjectId({ fields: { omg: 1} })).to.equal(undefined);
+    });
+
+    it('should return correct patient_id', () => {
+      chai.expect(utils.getSubjectId({ patient_id: 's1' })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ fields: { patient_id: 's1' } })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ patient_id: 's1', fields: { patient_id: 's2' } })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ patient_id: 's1', fields: {} })).to.equal('s1');
+    });
+
+    it('should return correct patient_uuid', () => {
+      chai.expect(utils.getSubjectId({ fields: { patient_uuid: 'id1' } })).to.equal('id1');
+    });
+
+    it('should prioritize patient shortcode over uuid', () => {
+      chai.expect(utils.getSubjectId({ patient_id: 's1', fields: { patient_uuid: 'id1' } })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ fields: { patient_uuid: 'id1', patient_id: 's1' } })).to.equal('s1');
+    });
+
+    it('should return correct place_id', () => {
+      chai.expect(utils.getSubjectId({ place_id: 's1' })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ fields: { place_id: 's1' } })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ place_id: 's1', fields: { place_id: 's2' } })).to.equal('s1');
+      chai.expect(utils.getSubjectId({ place_id: 's1', fields: {} })).to.equal('s1');
+    });
+
+    it('should priorotize patient over place', () => {
+      chai.expect(utils.getSubjectId({ patient_id: 'patient_s1', place_id: 'place_s1' })).to.equal('patient_s1');
+      chai.expect(utils.getSubjectId({ place_id: 'place_s1', fields: { patient_id: 'patient_s1' } })).to.equal('patient_s1');
+      chai.expect(utils.getSubjectId({ patient_id: 'patient_s1', fields: { place_id: 'place_s1' }})).to.equal('patient_s1');
+      chai.expect(utils.getSubjectId({ fields: {  place_id: 'place_s1', patient_id: 'patient_s1' } })).to.equal('patient_s1');
+
+      chai.expect(utils.getSubjectId({ fields: {  place_id: 'place_s1', patient_uuid: 'patient_id1' } })).to.equal('patient_id1');
+
+      chai.expect(utils.getSubjectId({ place_id: 'place_s1', fields: { patient_uuid: 'patient_id1' } })).to.equal('patient_id1');
+      chai.expect(utils.getSubjectId({ patient_id: 'patient_s1', fields: { place_id: 'place_s1' } })).to.equal('patient_s1');
+      chai.expect(utils.getSubjectId({ fields: { place_id: 'place_s1', patient_uuid: 'patient_id1' } })).to.equal('patient_id1');
     });
   });
 });

--- a/shared-libs/registration-utils/test/index.spec.js
+++ b/shared-libs/registration-utils/test/index.spec.js
@@ -235,11 +235,11 @@ describe('registrationUtils', () => {
 
   describe('getSubjectId', () => {
     it('should not crash on falsy input', () => {
-      chai.expect(utils.getSubjectId()).to.equal(undefined);
+      chai.expect(utils.getSubjectId()).to.equal(false);
       chai.expect(utils.getSubjectId(false)).to.equal(false);
       chai.expect(utils.getSubjectId({})).to.equal(undefined);
       chai.expect(utils.getSubjectId({ fields: {} })).to.equal(undefined);
-      chai.expect(utils.getSubjectId({ fields: { omg: 1} })).to.equal(undefined);
+      chai.expect(utils.getSubjectId({ fields: { omg: 1 } })).to.equal(undefined);
     });
 
     it('should return correct patient_id', () => {

--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -138,9 +138,10 @@ const refreshRulesEmissionForContacts = (provider, calculationTimestamp, contact
               registrationUtils.getSubjectIds(contactDoc).forEach(subjectId => agg.add(subjectId));
               return agg;
             }, new Set());
+
             const headlessSubjectIds = freshData.reportDocs
-              .map(doc => registrationUtils.getPatientId(doc))
-              .filter(patientId => !subjectIds.has(patientId));
+              .map(doc => registrationUtils.getSubjectId(doc))
+              .filter(subjectId => !subjectIds.has(subjectId));
 
             rulesStateStore.markAllFresh(calculationTimestamp, [...contactIds, ...headlessSubjectIds]);
           })

--- a/shared-libs/rules-engine/src/rules-emitter.js
+++ b/shared-libs/rules-engine/src/rules-emitter.js
@@ -180,8 +180,8 @@ const marshalDocsIntoNoolsFacts = (contactDocs, reportDocs, taskDocs) => {
   };
 
   for (let report of reportDocs) {
-    const patientIdInReport = registrationUtils.getPatientId(report);
-    const factOfPatient = factBySubjectId[patientIdInReport] || addHeadlessContact(patientIdInReport);
+    const subjectIdInReport = registrationUtils.getSubjectId(report);
+    const factOfPatient = factBySubjectId[subjectIdInReport] || addHeadlessContact(subjectIdInReport);
     factOfPatient.reports.push(report);
   }
 

--- a/shared-libs/transitions/package.json
+++ b/shared-libs/transitions/package.json
@@ -15,6 +15,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
+    "@medic/contact-types-utils": "file:../contact-types-utils",
     "@medic/infodoc": "file:../infodoc",
     "@medic/lineage": "file:../lineage",
     "@medic/message-utils": "file:../message-utils",

--- a/shared-libs/transitions/src/lib/utils.js
+++ b/shared-libs/transitions/src/lib/utils.js
@@ -112,12 +112,12 @@ const getReportsWithinTimeWindow = (
     .then(data => data.rows.map(row => row.doc));
 };
 
-const getPatient = (patientShortcodeId, includeDocs) => {
-  if (!patientShortcodeId) {
+const getContact = (shortCodeId, includeDocs) => {
+  if (!shortCodeId) {
     return Promise.resolve();
   }
   const viewOpts = {
-    key: ['shortcode', patientShortcodeId],
+    key: ['shortcode', shortCodeId],
     include_docs: includeDocs,
   };
   return db.medic.query('medic-client/contacts_by_reference', viewOpts).then(results => {
@@ -127,12 +127,12 @@ const getPatient = (patientShortcodeId, includeDocs) => {
 
     if (results.rows.length > 1) {
       logger.warn(
-        `More than one patient person document for shortcode ${patientShortcodeId}`
+        `More than one contact document for shortcode ${shortCodeId}`
       );
     }
 
-    const patient = results.rows[0];
-    return includeDocs ? patient.doc : patient.id;
+    const contact = results.rows[0];
+    return includeDocs ? contact.doc : contact.id;
   });
 };
 
@@ -219,20 +219,17 @@ module.exports = {
     return msg && msg.trim();
   },
   /*
-   * Given a patient "shortcode" (as used in SMS reports), return the _id
-   * of the patient's person contact to the caller
+   * Given a contact "shortcode" (as used in SMS reports), return the _id
+   * of the contact to the caller
    */
-  getPatientContactUuid: (patientShortcodeId) => {
-    return getPatient(patientShortcodeId, false);
+  getContactUuid: (shortCodeId) => {
+    return getContact(shortCodeId, false);
   },
   /*
-   * Given a patient "shortcode" (as used in SMS reports), return the
-   * patient's person record
+   * Given a contact "shortcode" (as used in SMS reports), return the contact record
    */
-  getPatientContact: (patientShortcodeId, callback) => {
-    getPatient(patientShortcodeId, true)
-      .then(results => callback(null, results))
-      .catch(callback);
+  getContact: (shortCodeId) => {
+    return getContact(shortCodeId, true);
   },
   isNonEmptyString: expr => typeof expr === 'string' && expr.trim() !== '',
   evalExpression: (expr, context) => vm.runInNewContext(expr, context),

--- a/shared-libs/transitions/src/lib/utils.js
+++ b/shared-libs/transitions/src/lib/utils.js
@@ -126,9 +126,7 @@ const getContact = (shortCodeId, includeDocs) => {
     }
 
     if (results.rows.length > 1) {
-      logger.warn(
-        `More than one contact document for shortcode ${shortCodeId}`
-      );
+      logger.warn(`More than one contact document for shortcode ${shortCodeId}`);
     }
 
     const contact = results.rows[0];

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -11,7 +11,7 @@ const async = require('async'),
 
 const getPatient = (patientShortcodeId) => {
   return utils
-    .getPatientContactUuid(patientShortcodeId)
+    .getContactUuid(patientShortcodeId)
     .then(uuid => {
       if (!uuid) {
         return;

--- a/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
@@ -1,34 +1,13 @@
-const config = require('../config');
-const transitionUtils = require('./utils');
-const contactTypeUtils = require('@medic/contact-types-utils');
+const logger = require('../lib/logger');
+const generateShortcodeOnContacts = require('./generate_shortcode_on_contacts');
 
 // As of 3.8.0, generates a shortcode for every configured contact type.
 module.exports = {
-  filter: doc => {
-    const contactType = contactTypeUtils.getContactType(config.getAll(), doc);
-    if (!contactType) {
-      return;
-    }
-
-    if (contactTypeUtils.isPersonType(contactType) && doc.patient_id) {
-      return; // person type that already had patient_id
-    }
-
-    if (contactTypeUtils.isPlaceType(contactType) && doc.place_id) {
-      return; // contact type that already has place_id
-    }
-
-    return true;
+  init: () => {
+    logger.warn('"generate_patient_id_on_people" transition is deprecated. Please use "generate_shortcode_on_contacts" transition instead.');
   },
-  onMatch: change => {
-    return transitionUtils
-      .getUniqueId()
-      .then(id => {
-        const isPerson = contactTypeUtils.isPerson(config.getAll(), change.doc);
-        const prop = isPerson ? 'patient_id' : 'place_id';
-        change.doc[prop] = id;
-        return true;
-      });
-  },
+
+  filter: (doc) => generateShortcodeOnContacts.filter(doc),
+  onMatch: (change) => generateShortcodeOnContacts.onMatch(change),
   asynchronousOnly: true
 };

--- a/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
@@ -4,24 +4,27 @@ const contactTypeUtils = require('@medic/contact-types-utils');
 
 module.exports = {
   filter: doc => {
-    const contactTypeId = contactTypeUtils.getTypeId(doc);
-    const contactType = contactTypeUtils.getTypeById(config, contactTypeId);
+    const contactType = contactTypeUtils.getContactType(config.getAll(), doc);
+    if (!contactType) {
+      return;
+    }
 
-    if (!contactType ||
-        (contactType.person && doc.patient_id) ||
-        (!contactType.person && doc.place_id)) {
+    if (contactTypeUtils.isPersonType(contactType) && doc.patient_id) {
+      return;
+    }
+
+    if (contactTypeUtils.isPlaceType(contactType) && doc.place_id) {
       return;
     }
 
     return true;
   },
   onMatch: change => {
-    const contactTypeId = contactTypeUtils.getTypeId(change.doc);
-    const contactType = contactTypeUtils.getTypeById(config, contactTypeId);
+    const isPerson = contactTypeUtils.isPerson(config.getAll(), change.doc);
     return transitionUtils
       .getUniqueId()
       .then(id => {
-        const prop = contactType.person ? 'patient_id' : 'place_id';
+        const prop = isPerson ? 'patient_id' : 'place_id';
         change.doc[prop] = id;
         return true;
       });

--- a/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
@@ -3,19 +3,22 @@ const transitionUtils = require('./utils');
 
 module.exports = {
   filter: doc => {
-    if (doc.patient_id) {
-      // already has a patient id
+    if (doc.place_id) {
+      // already has a place_id
       return;
     }
     const typeId = (doc.type === 'contact' && doc.contact_type) || doc.type;
     const contactTypes = config.get('contact_types') || [];
     const type = contactTypes.find(type => type.id === typeId);
-    return type && type.person;
+    return type && !type.person;
   },
   onMatch: change => {
     return transitionUtils
-      .addUniqueId(change.doc)
-      .then(() => true);
+      .getUniqueId()
+      .then(id => {
+        change.doc.place_id = id;
+        return true;
+      });
   },
   asynchronousOnly: true
 };

--- a/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
@@ -21,10 +21,10 @@ module.exports = {
     return true;
   },
   onMatch: change => {
-    const isPerson = contactTypeUtils.isPerson(config.getAll(), change.doc);
     return transitionUtils
       .getUniqueId()
       .then(id => {
+        const isPerson = contactTypeUtils.isPerson(config.getAll(), change.doc);
         const prop = isPerson ? 'patient_id' : 'place_id';
         change.doc[prop] = id;
         return true;

--- a/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/src/transitions/generate_patient_id_on_people.js
@@ -2,6 +2,7 @@ const config = require('../config');
 const transitionUtils = require('./utils');
 const contactTypeUtils = require('@medic/contact-types-utils');
 
+// As of 3.8.0, generates a shortcode for every configured contact type.
 module.exports = {
   filter: doc => {
     const contactType = contactTypeUtils.getContactType(config.getAll(), doc);
@@ -10,11 +11,11 @@ module.exports = {
     }
 
     if (contactTypeUtils.isPersonType(contactType) && doc.patient_id) {
-      return;
+      return; // person type that already had patient_id
     }
 
     if (contactTypeUtils.isPlaceType(contactType) && doc.place_id) {
-      return;
+      return; // contact type that already has place_id
     }
 
     return true;

--- a/shared-libs/transitions/src/transitions/generate_shortcode_on_contacts.js
+++ b/shared-libs/transitions/src/transitions/generate_shortcode_on_contacts.js
@@ -1,0 +1,35 @@
+const config = require('../config');
+const transitionUtils = require('./utils');
+const contactTypeUtils = require('@medic/contact-types-utils');
+
+module.exports = {
+  filter: doc => {
+    const contactType = contactTypeUtils.getContactType(config.getAll(), doc);
+    if (!contactType) {
+      return;
+    }
+
+    if (contactTypeUtils.isPersonType(contactType) && doc.patient_id) {
+      return; // person type that already had patient_id
+    }
+
+    if (contactTypeUtils.isPlaceType(contactType) && doc.place_id) {
+      return; // contact type that already has place_id
+    }
+
+    return true;
+  },
+
+  onMatch: change => {
+    return transitionUtils
+      .getUniqueId()
+      .then(id => {
+        const isPerson = contactTypeUtils.isPerson(config.getAll(), change.doc);
+        const prop = isPerson ? 'patient_id' : 'place_id';
+        change.doc[prop] = id;
+        return true;
+      });
+  },
+
+  asynchronousOnly: true
+};

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -296,6 +296,7 @@ const applyTransition = ({ key, change, transition }, callback) => {
     .catch(err => {
       // adds an error to the doc but it will only get saved if there are
       // other changes too.
+      console.log('error', err);
       const message = err.message || JSON.stringify(err);
       utils.addError(change.doc, {
         code: `${key}_error'`,

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -25,6 +25,7 @@ const AVAILABLE_TRANSITIONS = [
   'update_clinics',
   'registration',
   'accept_patient_reports',
+  'generate_shortcode_on_contacts',
   'generate_patient_id_on_people',
   'default_responses',
   'update_sent_by',

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -296,7 +296,6 @@ const applyTransition = ({ key, change, transition }, callback) => {
     .catch(err => {
       // adds an error to the doc but it will only get saved if there are
       // other changes too.
-      console.log('error', err);
       const message = err.message || JSON.stringify(err);
       utils.addError(change.doc, {
         code: `${key}_error'`,

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -303,8 +303,8 @@ const assignSchedule = (options) => {
 };
 
 const setId = (options) => {
-  const doc = options.doc,
-      patientIdField = options.params.patient_id_field;
+  const doc = options.doc;
+  const patientIdField = options.params.patient_id_field;
 
   if (patientIdField) {
     const providedId = doc.fields[options.params.patient_id_field];
@@ -317,15 +317,20 @@ const setId = (options) => {
     return transitionUtils
       .isIdUnique(providedId)
       .then(isUnique => {
-        if (isUnique) {
-          doc.patient_id = providedId;
+        if (!isUnique) {
+          transitionUtils.addRejectionMessage(doc, options.registrationConfig, 'provided_patient_id_not_unique');
           return;
         }
 
-        transitionUtils.addRejectionMessage(doc, options.registrationConfig, 'provided_patient_id_not_unique');
+        doc.patient_id = providedId;
       });
   } else {
-    return transitionUtils.addUniqueId(doc);
+    return transitionUtils
+      .getUniqueId()
+      .then(uniqueId => {
+        doc.patient_id = uniqueId;
+        return;
+      });
   }
 };
 

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -325,12 +325,7 @@ const setId = (options) => {
         doc.patient_id = providedId;
       });
   } else {
-    return transitionUtils
-      .getUniqueId()
-      .then(uniqueId => {
-        doc.patient_id = uniqueId;
-        return;
-      });
+    return transitionUtils.addUniqueId(doc);
   }
 };
 

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -400,9 +400,9 @@ const getParent = options => {
 };
 
 const validateParent = (parent, child) => {
-  const parentTypeId = contactTypesUtils.getTypeId(parent);
-  const childType = contactTypesUtils.getTypeById(config, contactTypesUtils.getTypeId(child));
-  return contactTypesUtils.isParentOf(parentTypeId, childType);
+  const parentType = contactTypesUtils.getContactType(config.getAll(), parent);
+  const childType = contactTypesUtils.getContactType(config.getAll(), child);
+  return contactTypesUtils.isParentOf(parentType, childType);
 };
 
 const addPatient = (options) => {
@@ -528,11 +528,11 @@ module.exports = {
               throw new Error(`Configuration error in ${registration.form}.${event.trigger}: patient_id_field cannot be set to patient_id`);
             }
             const typeId = params.contact_type || 'person';
-            const contactType = contactTypesUtils.getTypeById(config, typeId);
+            const contactType = contactTypesUtils.getTypeById(config.getAll(), typeId);
             if (!contactType) {
               throw new Error(`Configuration error in ${registration.form}.${event.trigger}: trigger would create a doc with an unknown contact type "${typeId}"`);
             }
-            if (!contactType.person) {
+            if (!contactTypesUtils.isPersonType(contactType)) {
               throw new Error(`Configuration error in ${registration.form}.${event.trigger}: trigger would create a person with a place contact type "${typeId}"`);
             }
           }
@@ -554,11 +554,11 @@ module.exports = {
             if (!typeId) {
               throw new Error(`Configuration error in ${registration.form}.${event.trigger}: trigger would create a place with an undefined contact type`);
             }
-            const contactType = contactTypesUtils.getTypeById(config, typeId);
+            const contactType = contactTypesUtils.getTypeById(config.getAll(), typeId);
             if (!contactType) {
               throw new Error(`Configuration error in ${registration.form}.${event.trigger}: trigger would create a place with an unknown contact type "${typeId}"`);
             }
-            if (contactType.person) {
+            if (!contactTypesUtils.isPlaceType(contactType)) {
               throw new Error(`Configuration error in ${registration.form}.${event.trigger}: trigger would create a place with a person contact type "${typeId}"`);
             }
           }

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -23,7 +23,7 @@ const findFirstDefinedValue = (doc, fields) => {
 
 const getRegistrations = (patientId) => {
   if (!patientId) {
-    return Promise.resolve([]);
+    return Promise.resolve();
   }
   return utils.getRegistrations({ id: patientId });
 };

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -476,12 +476,17 @@ const addPlace = (options) => {
   // create a new place with this place_id
   const place = {
     name: doc.fields[placeNameField],
-    type: 'contact',
-    contact_type: options.params.contact_type,
     reported_date: doc.reported_date,
     place_id: placeShortcode,
     source_id: doc._id,
   };
+
+  if (contactTypesUtils.isHardcodedType(options.params.contact_type)) {
+    place.type = options.params.contact_type;
+  } else {
+    place.type = 'contact';
+    place.contact_type = options.params.contact_type;
+  }
 
   return utils
     .getContactUuid(placeShortcode)

--- a/shared-libs/transitions/src/transitions/utils.js
+++ b/shared-libs/transitions/src/transitions/utils.js
@@ -46,15 +46,10 @@ module.exports = {
       .query('medic-client/contacts_by_reference', { key: [ 'shortcode', id ]})
       .then(results => !(results && results.rows && results.rows.length));
   },
-  getUniqueId: () => {
-    return idGenerator.next().value;
-  },
   addUniqueId: (doc) => {
-    return module.exports
-      .getUniqueId()
-      .then(patientId => {
-        doc.patient_id = patientId;
-      });
+    return idGenerator.next().value.then(patientId => {
+      doc.patient_id = patientId;
+    });
   },
   hasRun: (doc, transition) => {
     return !!(doc.transitions && doc.transitions[transition]);

--- a/shared-libs/transitions/src/transitions/utils.js
+++ b/shared-libs/transitions/src/transitions/utils.js
@@ -16,7 +16,7 @@ module.exports = {
     Adds a "message" and "error" of the configured key to the report. This
     indicates something went wrong, and the key indicates what went wrong.
   */
-  addRejectionMessage: (doc, reportConfig, errorKey) => {
+  addRejectionMessage: (doc, reportConfig, errorKey, context = {}) => {
     const config = findFirstMatchingMessage(reportConfig, errorKey);
     let message;
     let errorMessage;
@@ -30,13 +30,13 @@ module.exports = {
     const recipient = config && config.recipient || 'from';
     // A "message" ends up being a doc.task, which is something that is sent to
     // the caller via SMS
-    messages.addMessage(doc, message, recipient);
+    messages.addMessage(doc, message, recipient, context);
     // An "error" ends up being a doc.error, which is something that is shown
     // on the screen when you view the error. We need both
     messages.addError(doc, {
       message: errorMessage,
       code: errorKey
-    });
+    }, context);
   },
   addRegistrationNotFoundError: (doc, reportConfig) => {
     module.exports.addRejectionMessage(doc, reportConfig, 'registration_not_found');
@@ -51,6 +51,8 @@ module.exports = {
       doc.patient_id = patientId;
     });
   },
+  getUniqueId: () => idGenerator.next().value,
+
   hasRun: (doc, transition) => {
     return !!(doc.transitions && doc.transitions[transition]);
   }

--- a/shared-libs/transitions/src/transitions/utils.js
+++ b/shared-libs/transitions/src/transitions/utils.js
@@ -46,10 +46,15 @@ module.exports = {
       .query('medic-client/contacts_by_reference', { key: [ 'shortcode', id ]})
       .then(results => !(results && results.rows && results.rows.length));
   },
+  getUniqueId: () => {
+    return idGenerator.next().value;
+  },
   addUniqueId: (doc) => {
-    return idGenerator.next().value.then(patientId => {
-      doc.patient_id = patientId;
-    });
+    return module.exports
+      .getUniqueId()
+      .then(patientId => {
+        doc.patient_id = patientId;
+      });
   },
   hasRun: (doc, transition) => {
     return !!(doc.transitions && doc.transitions[transition]);

--- a/shared-libs/transitions/test/integration/schedules.js
+++ b/shared-libs/transitions/test/integration/schedules.js
@@ -252,7 +252,7 @@ describe('functional schedules', () => {
       }]
     }]);
     sinon.stub(schedules, 'getScheduleConfig').returns({});
-    sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+    sinon.stub(utils, 'getContactUuid').resolves({_id: 'uuid'});
     sinon.stub(utils, 'getRegistrations').resolves([]);
     sinon.stub(utils, 'translate').withArgs('thanks', 'en').returns('Thanks');
 
@@ -319,7 +319,7 @@ describe('functional schedules', () => {
       ]
     });
 
-    sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+    sinon.stub(utils, 'getContactUuid').resolves({_id: 'uuid'});
     const doc = {
       reported_date: moment().toISOString(),
       form: 'PATR',
@@ -464,7 +464,7 @@ describe('functional schedules', () => {
       fields: { patient_id: '98765' },
       patient: patient
     };
-    sinon.stub(utils, 'getPatientContactUuid').resolves('uuid');
+    sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
     return transition.onMatch({ doc: doc })
       .then(complete => {
@@ -521,7 +521,7 @@ describe('functional schedules', () => {
       fields: { patient_id: '98765' },
       patient: patient
     };
-    sinon.stub(utils, 'getPatientContactUuid').resolves('uuid');
+    sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
     return transition.onMatch({ doc: doc })
       .then(complete => {

--- a/shared-libs/transitions/test/unit/birth_registration.js
+++ b/shared-libs/transitions/test/unit/birth_registration.js
@@ -90,12 +90,9 @@ describe('birth registration', () => {
 
   it('valid form adds patient_id and expected_date', () => {
       // doc already exists bc we aren't testing the create patient step
-      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'UUID'});
+      sinon.stub(utils, 'getContactUuid').resolves({_id: 'UUID'});
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
-        doc.patient_id = 12345;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       var doc = {
           form: 'BIR',

--- a/shared-libs/transitions/test/unit/birth_registration.js
+++ b/shared-libs/transitions/test/unit/birth_registration.js
@@ -91,7 +91,11 @@ describe('birth registration', () => {
   it('valid form adds patient_id and expected_date', () => {
       // doc already exists bc we aren't testing the create patient step
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'UUID'});
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
+        doc.patient_id = 12345;
+        return Promise.resolve();
+      });
 
       var doc = {
           form: 'BIR',

--- a/shared-libs/transitions/test/unit/birth_registration.js
+++ b/shared-libs/transitions/test/unit/birth_registration.js
@@ -91,11 +91,7 @@ describe('birth registration', () => {
   it('valid form adds patient_id and expected_date', () => {
       // doc already exists bc we aren't testing the create patient step
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'UUID'});
-
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
-        doc.patient_id = 12345;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       var doc = {
           form: 'BIR',

--- a/shared-libs/transitions/test/unit/birth_registration.js
+++ b/shared-libs/transitions/test/unit/birth_registration.js
@@ -90,7 +90,7 @@ describe('birth registration', () => {
 
   it('valid form adds patient_id and expected_date', () => {
       // doc already exists bc we aren't testing the create patient step
-      sinon.stub(utils, 'getContactUuid').resolves({_id: 'UUID'});
+      sinon.stub(utils, 'getContactUuid').resolves('UUID');
 
       sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -223,7 +223,7 @@ describe('due tasks', () => {
       .stub(utils, 'translate')
       .returns('Please visit {{patient_name}} asap');
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').resolves(patientUuid);
+    const getPatientContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
@@ -330,7 +330,7 @@ describe('due tasks', () => {
     const expectedPhone = '5556918';
     const expectedMessage = 'old message';
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').resolves(patientUuid);
+    const getPatientContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
     const fetchHydratedDoc = sinon
       .stub(schedule._lineage, 'fetchHydratedDoc')
       .resolves({ name: 'jim' });
@@ -434,7 +434,7 @@ describe('due tasks', () => {
 
     sinon.stub(utils, 'translate').returns('Please visit {{patient_name}} asap');
     sinon.stub(utils, 'getRegistrations').resolves([{ fields: { patient_id: '12345' } }]);
-    sinon.stub(utils, 'getPatientContactUuid').resolves(null);
+    sinon.stub(utils, 'getContactUuid').resolves(null);
     sinon.stub(schedule._lineage, 'fetchHydratedDoc');
     sinon.stub(utils, 'setTaskState');
 
@@ -514,7 +514,7 @@ describe('due tasks', () => {
 
     sinon.stub(utils, 'translate').returns('Please visit {{patient_name}} asap');
     sinon.stub(utils, 'getRegistrations').resolves([{ fields: { patient_id: '12345' } }]);
-    sinon.stub(utils, 'getPatientContactUuid').resolves(null);
+    sinon.stub(utils, 'getContactUuid').resolves(null);
     sinon.stub(schedule._lineage, 'fetchHydratedDoc');
     sinon.stub(utils, 'setTaskState').callsFake((task, state) => task.state = state);
 

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -500,8 +500,8 @@ describe('due tasks', () => {
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
       assert.equal(utils.getRegistrations.callCount, 1);
-      assert.equal(utils.getPatientContactUuid.callCount, 1);
-      assert.equal(utils.getPatientContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.callCount, 1);
+      assert.equal(utils.getContactUuid.args[0][0], '123');
       assert.equal(schedule._lineage.fetchHydratedDoc.callCount, 0);
       assert.equal(utils.setTaskState.callCount, 0);
       done();
@@ -590,8 +590,8 @@ describe('due tasks', () => {
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
       assert.equal(utils.getRegistrations.callCount, 1);
-      assert.equal(utils.getPatientContactUuid.callCount, 1);
-      assert.equal(utils.getPatientContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.callCount, 1);
+      assert.equal(utils.getContactUuid.args[0][0], '123');
       assert.equal(schedule._lineage.fetchHydratedDoc.callCount, 0);
       assert.equal(utils.setTaskState.callCount, 1);
       assert.deepEqual(utils.setTaskState.args[0], [

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -223,7 +223,7 @@ describe('due tasks', () => {
       .stub(utils, 'translate')
       .returns('Please visit {{patient_name}} asap');
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getPatientContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
+    const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
@@ -305,8 +305,8 @@ describe('due tasks', () => {
       assert.equal(translate.callCount, 1);
       assert.equal(translate.args[0][0], 'visit-1');
       assert.equal(getRegistrations.callCount, 1);
-      assert.equal(getPatientContactUuid.callCount, 1);
-      assert.equal(getPatientContactUuid.args[0][0], '123');
+      assert.equal(getContactUuid.callCount, 1);
+      assert.equal(getContactUuid.args[0][0], '123');
       assert.equal(fetchHydratedDoc.callCount, 1);
       assert.equal(fetchHydratedDoc.args[0][0], patientUuid);
       assert.equal(setTaskState.callCount, 1);
@@ -330,7 +330,7 @@ describe('due tasks', () => {
     const expectedPhone = '5556918';
     const expectedMessage = 'old message';
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getPatientContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
+    const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
     const fetchHydratedDoc = sinon
       .stub(schedule._lineage, 'fetchHydratedDoc')
       .resolves({ name: 'jim' });
@@ -411,8 +411,8 @@ describe('due tasks', () => {
       assert.equal(view.callCount, 1);
       assert.equal(saveDoc.callCount, 1);
       assert.equal(getRegistrations.callCount, 1);
-      assert.equal(getPatientContactUuid.callCount, 1);
-      assert.equal(getPatientContactUuid.args[0][0], '123');
+      assert.equal(getContactUuid.callCount, 1);
+      assert.equal(getContactUuid.args[0][0], '123');
       assert.equal(fetchHydratedDoc.callCount, 1);
       assert.equal(fetchHydratedDoc.args[0][0], patientUuid);
       assert.equal(setTaskState.callCount, 1);

--- a/shared-libs/transitions/test/unit/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/test/unit/generate_patient_id_on_people.js
@@ -10,7 +10,7 @@ const types = [
 ];
 
 describe('generate_patient_id_on_people transition', () => {
-  beforeEach(() => sinon.stub(config, 'get').returns(types));
+  beforeEach(() => sinon.stub(config, 'getAll').returns({ contact_types: types }));
   afterEach(() => sinon.restore());
 
   it('adds patient_id to people', () => {

--- a/shared-libs/transitions/test/unit/generate_shortcode_on_contacts.js
+++ b/shared-libs/transitions/test/unit/generate_shortcode_on_contacts.js
@@ -2,15 +2,14 @@ const sinon = require('sinon');
 const assert = require('chai').assert;
 const config = require('../../src/config');
 const transitionUtils = require('../../src/transitions/utils');
-const transition = require('../../src/transitions/generate_patient_id_on_people');
-const generateShortcodeOnContacts = require('../../src/transitions/generate_shortcode_on_contacts');
+const transition = require('../../src/transitions/generate_shortcode_on_contacts');
 
 const types = [
   { id: 'person', person: true },
   { id: 'place' }
 ];
 
-describe('generate_patient_id_on_people transition', () => {
+describe('generate_shortcode_on_contacts transition', () => {
   beforeEach(() => sinon.stub(config, 'getAll').returns({ contact_types: types }));
   afterEach(() => sinon.restore());
 
@@ -46,14 +45,6 @@ describe('generate_patient_id_on_people transition', () => {
       const doc = { };
       assert.equal(!!transition.filter(doc), false);
     });
-
-    it('should call generate_shortcode_on_contacts.filter', () => {
-      sinon.stub(generateShortcodeOnContacts, 'filter').returns('something');
-      const result = transition.filter({ the: 'doc' });
-      assert.equal(generateShortcodeOnContacts.filter.callCount, 1);
-      assert.deepEqual(generateShortcodeOnContacts.filter.args[0], [{ the: 'doc' }]);
-      assert.equal(result, 'something');
-    });
   });
 
   describe('onMatch', () => {
@@ -73,14 +64,6 @@ describe('generate_patient_id_on_people transition', () => {
         assert.equal(result, true);
         assert.deepEqual(doc, { type: 'contact', contact_type: 'place', place_id: 'the_unique_id' });
       });
-    });
-
-    it('should call generate_shortcode_on_contacts.onMatch', () => {
-      sinon.stub(generateShortcodeOnContacts, 'onMatch').returns('the result');
-      const result = transition.onMatch({ my: 'object' });
-      assert.equal(generateShortcodeOnContacts.onMatch.callCount, 1);
-      assert.deepEqual(generateShortcodeOnContacts.onMatch.args[0], [{ my: 'object' }]);
-      assert.equal(result, 'the result');
     });
   });
 

--- a/shared-libs/transitions/test/unit/patient_registration.js
+++ b/shared-libs/transitions/test/unit/patient_registration.js
@@ -244,11 +244,7 @@ describe('patient registration', () => {
 
   it('valid form adds patient_id and patient document', () => {
     sinon.stub(utils, 'getPatientContactUuid').resolves();
-
-    sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
-      doc.patient_id = 12345;
-      return Promise.resolve();
-    });
+    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
     const doc = {
       _id: 'docid',
@@ -292,7 +288,7 @@ describe('patient registration', () => {
   it('registration sets up responses', () => {
     sinon.stub(utils, 'getRegistrations').resolves([]);
     sinon.stub(utils, 'getPatientContactUuid').resolves('uuid');
-    sinon.stub(transitionUtils, 'addUniqueId').resolves();
+    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
     const doc = {
       form: 'PATR',
@@ -349,7 +345,7 @@ describe('patient registration', () => {
   it('registration responses support locale', () => {
     sinon.stub(utils, 'getRegistrations').resolves([]);
     sinon.stub(utils, 'getPatientContactUuid').resolves('uuid');
-    sinon.stub(transitionUtils, 'addUniqueId').resolves();
+    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
     const doc = {
       form: 'PATR',
@@ -497,7 +493,7 @@ describe('patient registration', () => {
 
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getPatientContactUuid').resolves(false);
-      sinon.stub(transitionUtils, 'addUniqueId');
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       sinon.stub(db.medic, 'query')
         .withArgs('medic-client/contacts_by_phone')
@@ -513,7 +509,7 @@ describe('patient registration', () => {
         assert.equal(doc.errors[0].code, 'no_provided_patient_id');
         assert.equal(utils.getRegistrations.callCount, 0);
         assert.equal(utils.getPatientContactUuid.callCount, 1);
-        assert.equal(transitionUtils.addUniqueId.callCount, 0);
+        assert.equal(transitionUtils.getUniqueId.callCount, 0);
 
         assert.equal(db.medic.query.callCount, 1);
         assert.deepEqual(db.medic.query.args[0][0], 'medic-client/contacts_by_phone');
@@ -545,7 +541,7 @@ describe('patient registration', () => {
 
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getPatientContactUuid').resolves(false);
-      sinon.stub(transitionUtils, 'addUniqueId');
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       sinon.stub(db.medic, 'query');
       db.medic.query
@@ -568,7 +564,7 @@ describe('patient registration', () => {
         assert.equal(doc.errors[0].code, 'provided_patient_id_not_unique');
         assert.equal(utils.getRegistrations.callCount, 0);
         assert.equal(utils.getPatientContactUuid.callCount, 1);
-        assert.equal(transitionUtils.addUniqueId.callCount, 0);
+        assert.equal(transitionUtils.getUniqueId.callCount, 0);
 
         assert.equal(db.medic.query.callCount, 2);
         assert.deepEqual(db.medic.query.args[0][0], 'medic-client/contacts_by_reference');
@@ -604,7 +600,7 @@ describe('patient registration', () => {
 
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getPatientContactUuid').resolves(false);
-      sinon.stub(transitionUtils, 'addUniqueId');
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       sinon.stub(db.medic, 'query');
       db.medic.query
@@ -626,7 +622,7 @@ describe('patient registration', () => {
         assert.equal(doc.errors, undefined);
         assert.equal(utils.getRegistrations.callCount, 0);
         assert.equal(utils.getPatientContactUuid.callCount, 1);
-        assert.equal(transitionUtils.addUniqueId.callCount, 0);
+        assert.equal(transitionUtils.getUniqueId.callCount, 0);
 
         assert.equal(db.medic.query.callCount, 2);
         assert.deepEqual(db.medic.query.args[0][0], 'medic-client/contacts_by_reference');

--- a/shared-libs/transitions/test/unit/patient_registration.js
+++ b/shared-libs/transitions/test/unit/patient_registration.js
@@ -244,11 +244,13 @@ describe('patient registration', () => {
 
   it('valid form adds patient_id and patient document', () => {
     sinon.stub(utils, 'getContactUuid').resolves();
-    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
-    config.get.withArgs('contact_types').returns([
-      { id: 'some_place' },
-      { id: 'person', parents: ['some_place'], person: true }
-    ]);
+    sinon.stub(transitionUtils, 'getUniqueId').resolves('12345');
+    sinon.stub(config, 'getAll').returns({
+      contact_types: [
+        { id: 'some_place' },
+        { id: 'person', parents: ['some_place'], person: true }
+      ]
+    });
 
     const doc = {
       _id: 'docid',
@@ -488,10 +490,12 @@ describe('patient registration', () => {
       sinon.stub(utils, 'getRegistrations');
       sinon.stub(utils, 'getContactUuid').resolves(false);
       sinon.stub(transitionUtils, 'getUniqueId');
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' },
-        { id: 'person', person: true, parents: ['place'] },
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] },
+        ]
+      });
 
       sinon.stub(db.medic, 'post').resolves();
 
@@ -535,10 +539,12 @@ describe('patient registration', () => {
 
       sinon.stub(db.medic, 'query');
 
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' },
-        { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] }
+        ]
+      });
 
       db.medic.query
         .withArgs('medic-client/contacts_by_reference')
@@ -590,10 +596,12 @@ describe('patient registration', () => {
       sinon.stub(utils, 'getContactUuid').resolves(false);
       sinon.stub(transitionUtils, 'getUniqueId');
 
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' },
-        { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] }
+        ]
+      });
 
       sinon.stub(db.medic, 'query');
       db.medic.query

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -167,12 +167,9 @@ describe('pregnancy registration', () => {
   it('valid adds lmp_date and patient_id', () => {
       var start = moment().startOf('day').subtract(5, 'weeks');
 
-      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+      sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
-        doc.patient_id = 12345;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',
@@ -193,7 +190,7 @@ describe('pregnancy registration', () => {
 
   it('pregnancies on existing patients fail without valid patient id', () => {
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
 
       const doc = {
           form: 'ep',
@@ -213,7 +210,7 @@ describe('pregnancy registration', () => {
 
   it('pregnancies on existing patients succeeds with a valid patient id', () => {
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+      sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
       const doc = {
           form: 'ep',
@@ -232,12 +229,9 @@ describe('pregnancy registration', () => {
 
 
   it('zero lmp value only registers patient', () => {
-      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+      sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
-    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-      doc.patient_id = 12345;
-      return Promise.resolve();
-    });
+    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
     const doc = {
           form: 'p',
@@ -257,12 +251,9 @@ describe('pregnancy registration', () => {
   });
 
   it('id only logic with valid name', () => {
-      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+      sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = 12345;
-        return Promise.resolve();
-      });
+    sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',
@@ -283,7 +274,7 @@ describe('pregnancy registration', () => {
 
   it('id only logic with invalid name', () => {
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
+      sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
       const doc = {
           form: 'p',

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -169,7 +169,10 @@ describe('pregnancy registration', () => {
 
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
       const doc = {
           form: 'p',
@@ -231,7 +234,10 @@ describe('pregnancy registration', () => {
   it('zero lmp value only registers patient', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
     const doc = {
           form: 'p',
@@ -253,7 +259,10 @@ describe('pregnancy registration', () => {
   it('id only logic with valid name', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+      doc.patient_id = 12345;
+      return Promise.resolve();
+    });
 
       const doc = {
           form: 'p',

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -169,10 +169,7 @@ describe('pregnancy registration', () => {
 
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
-        doc.patient_id = 12345;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',
@@ -234,10 +231,7 @@ describe('pregnancy registration', () => {
   it('zero lmp value only registers patient', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-      doc.patient_id = 12345;
-      return Promise.resolve();
-    });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
     const doc = {
           form: 'p',
@@ -259,10 +253,7 @@ describe('pregnancy registration', () => {
   it('id only logic with valid name', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = 12345;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
 
       const doc = {
           form: 'p',

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -169,10 +169,10 @@ describe('pregnancy registration', () => {
 
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-    sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
-      doc.patient_id = 12345;
-      return Promise.resolve();
-    });
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake(doc => {
+        doc.patient_id = 12345;
+        return Promise.resolve();
+      });
 
       const doc = {
           form: 'p',
@@ -259,10 +259,10 @@ describe('pregnancy registration', () => {
   it('id only logic with valid name', () => {
       sinon.stub(utils, 'getPatientContactUuid').resolves({_id: 'uuid'});
 
-    sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-      doc.patient_id = 12345;
-      return Promise.resolve();
-    });
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = 12345;
+        return Promise.resolve();
+      });
 
       const doc = {
           form: 'p',

--- a/shared-libs/transitions/test/unit/transitions.js
+++ b/shared-libs/transitions/test/unit/transitions.js
@@ -14,6 +14,7 @@ const asyncOnlyTransitions = [
   'update_notifications',
   'multi_report_alerts',
   'generate_patient_id_on_people',
+  'generate_shortcode_on_contacts',
   'update_sent_forms'
 ];
 

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -81,7 +81,7 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
       sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
-      config.get.withArgs('contact_types').returns([
+        config.get.withArgs('contact_types').returns([
         { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
       ]);
 
@@ -472,7 +472,7 @@ describe('registration', () => {
       });
     });
 
-    it('fails when patient_id_field is set to patient_id', done => {
+    it('fails when patient_id_field is set to patient_id', () => {
       const eventConfig = [
         {
           form: 'R',
@@ -487,16 +487,1132 @@ describe('registration', () => {
       ];
 
       sinon.stub(config, 'get').returns(eventConfig);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal(
-          'Configuration error in R.add_patient: patient_id_field cannot be set to patient_id'
-        );
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error in R.add_patient: patient_id_field cannot be set to patient_id');
+    });
+
+    it('should add configured type of person', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { patient_name: 'Bob' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              contact_type: 'clinic',
+              type: 'contact',
+              parent: { _id: 'west_hc', name: 'west hc', contact_type: 'health_center', type: 'contact' }
+            }
+          },
+        }
+      };
+      const patientId = 'my_patient_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_patient', params: { contact_type: 'patient' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.patient',
+          message: [
+            {
+              locale: 'en',
+              content: 'Patient {{patient_name}} with type {{patient.contact_type}} was added to {{patient.parent.name}}({{patient.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'clinic', parents: ['health_center'] },
+        { id: 'patient', parents: ['clinic'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([patientId]);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'Bob',
+          patient_id: patientId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'patient',
+          parent: { _id: 'petes', parent: { _id: 'west_hc' } },
+          created_by: 'pete',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Patient Bob with type patient was added to Petes Place(clinic)'
+        });
+      });
+    });
+
+    it('should add person with selected parent', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { buddy_name: 'Marcel', parent: 'georges_place' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              place_id: 'petes_place',
+              type: 'contact',
+              contact_type: 'area_type_1',
+              parent: { _id: 'west_hc', name: 'west hc', contact_type: 'health_center', type: 'contact', place_id: 'the_west_hc' }
+            },
+          },
+        }
+      };
+      const parent = {
+        _id: 'georges',
+        name: 'Georges Place',
+        type: 'contact',
+        place_id: 'georges_place',
+        contact_type: 'area_type_2',
+        parent: { _id: 'west_hc' },
+      };
+      const patientId = 'my_patient_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves(parent);
+      sinon.stub(db.medic, 'post').resolves();
+
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_patient', params: { contact_type: 'buddy', patient_name_field: 'buddy_name', parent_id: 'parent' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.patient',
+          message: [
+            {
+              locale: 'en',
+              content: 'Friend {{buddy_name}} with type {{patient.contact_type}} was added to {{patient.parent.name}}({{patient.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'area_type_1', parents: ['health_center'] },
+        { id: 'area_type_2', parents: ['health_center'] },
+        { id: 'patient', parents: ['area_type_1'], person: true },
+        { id: 'buddy', parents: ['area_type_2'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([patientId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal([change.doc.fields.parent]);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'Marcel',
+          patient_id: patientId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'buddy',
+          parent: { _id: 'georges', parent: { _id: 'west_hc' } },
+          created_by: 'pete',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Friend Marcel with type buddy was added to Georges Place(area_type_2)'
+        });
+      });
+    });
+
+    it('should not create person when parent is required but not specified', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { patient_name: 'Patricia', parent_id: 'not_the_correct_parent_field' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              place_id: 'petes_place',
+              type: 'contact',
+              contact_type: 'area_type_1',
+              parent: { _id: 'west_hc', name: 'west hc', contact_type: 'health_center', type: 'contact', place_id: 'the_west_hc' }
+            },
+          },
+        }
+      };
+
+      const patientId = 'my_patient_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact');
+      sinon.stub(db.medic, 'post').resolves();
+
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_patient', params: { contact_type: 'patient', parent_id: 'parent' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [
+            {
+              locale: 'en',
+              content: 'Cannot create patient without parent'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'area_type_1', parents: ['health_center'] },
+        { id: 'area_type_2', parents: ['health_center'] },
+        { id: 'patient', parents: ['area_type_1'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+
+      return transition.onMatch(change).then(result => {
+        result.should.equal(true);
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([patientId]);
+        utils.getContact.callCount.should.equal(0);
+        db.medic.post.callCount.should.equal(0);
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          message: 'Cannot create patient without parent',
+          code: 'parent_field_not_provided',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Cannot create patient without parent'
+        });
+      });
+    });
+
+    it('should not create person when parent is required and missing', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { patient_name: 'Patricia', parent_id: 'non-existent-contact' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              place_id: 'petes_place',
+              type: 'contact',
+              contact_type: 'area_type_1',
+              parent: { _id: 'west_hc', name: 'west hc', contact_type: 'health_center', type: 'contact', place_id: 'the_west_hc' }
+            },
+          },
+        }
+      };
+
+      const patientId = 'my_patient_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves();
+      sinon.stub(db.medic, 'post').resolves();
+
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_patient', params: { contact_type: 'patient', parent_id: 'parent_id' } }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [
+            {
+              locale: 'en',
+              content: 'Selected parent {{fields.parent_id}} does not exists.'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'area_type_1', parents: ['health_center'] },
+        { id: 'area_type_2', parents: ['health_center'] },
+        { id: 'patient', parents: ['area_type_1'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+
+      return transition.onMatch(change).then(result => {
+        result.should.equal(true);
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([patientId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal([change.doc.fields.parent_id]);
+        db.medic.post.callCount.should.equal(0);
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          message: 'Selected parent non-existent-contact does not exists.',
+          code: 'parent_not_found',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Selected parent non-existent-contact does not exists.'
+        });
+      });
+    });
+
+    it('should not create person when parent is invalid', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { buddy_name: 'Marcel', the_parent_field: 'georges_place' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              place_id: 'petes_place',
+              type: 'contact',
+              contact_type: 'area_type_1',
+              parent: { _id: 'west_hc', name: 'west hc', contact_type: 'health_center', type: 'contact', place_id: 'the_west_hc' }
+            },
+          },
+        }
+      };
+      const parent = {
+        _id: 'georges',
+        name: 'Georges Place',
+        type: 'contact',
+        place_id: 'georges_place',
+        contact_type: 'area_type_1',
+        parent: { _id: 'west_hc' },
+      };
+      const patientId = 'my_patient_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves(parent);
+      sinon.stub(db.medic, 'post').resolves();
+
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_patient', params: { contact_type: 'patient', parent_id: 'the_parent_field' } }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'parent_invalid',
+          message: [
+            {
+              locale: 'en',
+              content: 'Cannot create patient under parent {{parent.name}}({{parent.place_id}}) of type {{parent.contact_type}}.'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'area_type_1', parents: ['health_center'] },
+        { id: 'area_type_2', parents: ['health_center'] },
+        { id: 'patient', parents: ['area_type_2'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+
+      return transition.onMatch(change).then(result => {
+        result.should.equal(true);
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([patientId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal([change.doc.fields.the_parent_field]);
+        db.medic.post.callCount.should.equal(0);
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          message: 'Cannot create patient under parent Georges Place(georges_place) of type area_type_1.',
+          code: 'parent_invalid',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Cannot create patient under parent Georges Place(georges_place) of type area_type_1.'
+        });
+      });
+    });
+  });
+
+  describe('addPlace', () => {
+    it('should add place with correct type under correct parent', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'new clinic', parent_id: 'north_hc_place' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              contact_type: 'clinic',
+              type: 'contact',
+              parent: {
+                _id: 'west_hc',
+                name: 'west hc',
+                contact_type: 'health_center',
+                type: 'contact',
+                place_id: 'south_hc_place',
+              }
+            }
+          },
+        }
+      };
+      const placeId = 'my_place_id';
+      const parent = {
+        _id: 'north_hc',
+        name: 'north hc',
+        type: 'contact',
+        contact_type: 'health_center',
+        place_id: 'north_hc_place',
+      };
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves(parent);
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic', parent_id: 'parent_id' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [
+            {
+              locale: 'en',
+              content: 'Place {{place_name}} with type {{place.contact_type}} was added to {{place.parent.name}}({{place.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'clinic', parents: ['health_center'] },
+        { id: 'patient', parents: ['clinic'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal([change.doc.fields.parent_id]);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'new clinic',
+          place_id: placeId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'clinic',
+          parent: { _id: 'north_hc' },
+          created_by: 'pete',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Place new clinic with type clinic was added to north hc(health_center)'
+        });
+      });
+    });
+
+    it('should default to submitter parent when parent_id param not specified', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'new clinic' },
+          contact: {
+            _id: 'supervisor',
+            name: 'Frank',
+            contact_type: 'supervisor',
+            type: 'contact',
+            parent: {
+              _id: 'west_hc',
+              name: 'west hc',
+              place_id: 'west_hc_place',
+              contact_type: 'health_center_1',
+              type: 'contact',
+            }
+          },
+        }
+      };
+      const placeId = 'my_place_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact');
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic_1' }}],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [
+            {
+              locale: 'en',
+              content: 'Place {{place_name}} with type {{place.contact_type}} was added to {{place.parent.name}}({{place.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center_1' },
+        { id: 'clinic_1', parents: ['health_center_1'] },
+        { id: 'supervisor', parents: ['health_center_1'], person: true },
+        { id: 'patient', parents: ['clinic_1'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(0);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'new clinic',
+          place_id: placeId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'clinic_1',
+          parent: { _id: 'west_hc' },
+          created_by: 'supervisor',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Place new clinic with type clinic_1 was added to west hc(health_center_1)'
+        });
+      });
+    });
+
+    it('should default to submitter by phone parent when parent_id param not specified', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'new clinic' },
+        }
+      };
+      const placeId = 'my_place_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact');
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic_1' }}],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [
+            {
+              locale: 'en',
+              content: 'Place {{place_name}} with type {{place.contact_type}} was added to {{place.parent.name}}({{place.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      sinon.stub(db.medic, 'query')
+        .withArgs('medic-client/contacts_by_phone')
+        .resolves({ rows: [
+            {
+              doc: {
+                _id: 'supervisor',
+                name: 'Frank',
+                contact_type: 'supervisor',
+                type: 'contact',
+                phone: '+111222',
+                parent: { _id: 'west_hc' }
+              }
+            }
+          ]});
+      sinon.stub(db.medic, 'get').withArgs('west_hc').resolves({
+        _id: 'west_hc',
+        name: 'west hc',
+        place_id: 'west_hc_place',
+        contact_type: 'health_center_1',
+        type: 'contact',
+      });
+      const contactTypes = [
+        { id: 'health_center_1' },
+        { id: 'clinic_1', parents: ['health_center_1'] },
+        { id: 'supervisor', parents: ['health_center_1'], person: true },
+        { id: 'patient', parents: ['clinic_1'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(0);
+        db.medic.query.callCount.should.equal(1);
+        db.medic.query.args[0].should.deep.equal(['medic-client/contacts_by_phone', { key: '+111222', include_docs: true }]);
+        db.medic.get.callCount.should.equal(1);
+        db.medic.get.args[0].should.deep.equal(['west_hc']);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'new clinic',
+          place_id: placeId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'clinic_1',
+          parent: { _id: 'west_hc' },
+          created_by: 'supervisor',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Place new clinic with type clinic_1 was added to west hc(health_center_1)'
+        });
+      });
+    });
+
+    it('should use the name property indicated within the event parameter ', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { doodle: 'newest place', parent_id: 'north_hc_place', place_name: 'this is a trick' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              contact_type: 'clinic',
+              type: 'contact',
+              parent: {
+                _id: 'west_hc',
+                name: 'west hc',
+                contact_type: 'health_center',
+                type: 'contact',
+                place_id: 'south_hc_place',
+              }
+            }
+          },
+        }
+      };
+      const placeId = 'my_place_id';
+      const parent = {
+        _id: 'north_hc',
+        name: 'north hc',
+        type: 'contact',
+        contact_type: 'health_center',
+        place_id: 'north_hc_place',
+      };
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves(parent);
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic', parent_id: 'parent_id', place_name_field: 'doodle' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [
+            {
+              locale: 'en',
+              content: 'Place {{place.name}} with type {{place.contact_type}} was added to {{place.parent.name}}({{place.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'clinic', parents: ['health_center'] },
+        { id: 'patient', parents: ['clinic'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal([change.doc.fields.parent_id]);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'newest place',
+          place_id: placeId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'clinic',
+          parent: { _id: 'north_hc' },
+          created_by: 'pete',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Place newest place with type clinic was added to north hc(health_center)'
+        });
+      });
+    });
+
+    it('should use the parent property indicated within the event parameter ', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { doodle: 'newest place', fiddle: 'north_hc_place', place_name: 'this is a trick' },
+          contact: {
+            _id: 'pete',
+            name: 'Pete',
+            contact_type: 'chw',
+            type: 'contact',
+            parent: {
+              _id: 'petes',
+              name: 'Petes Place',
+              contact_type: 'clinic',
+              type: 'contact',
+              parent: {
+                _id: 'west_hc',
+                name: 'west hc',
+                contact_type: 'health_center',
+                type: 'contact',
+                place_id: 'south_hc_place',
+              }
+            }
+          },
+        }
+      };
+      const placeId = 'my_place_id';
+      const parent = {
+        _id: 'north_hc',
+        name: 'north hc',
+        type: 'contact',
+        contact_type: 'health_center',
+        place_id: 'north_hc_place',
+      };
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves(parent);
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic', parent_id: 'fiddle', place_name_field: 'doodle' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [
+            {
+              locale: 'en',
+              content: 'Place {{place.name}} with type {{place.contact_type}} was added to {{place.parent.name}}({{place.parent.contact_type}})'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'health_center' },
+        { id: 'clinic', parents: ['health_center'] },
+        { id: 'patient', parents: ['clinic'], person: true },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal([change.doc.fields.fiddle]);
+        db.medic.post.callCount.should.equal(1);
+        db.medic.post.args[0].should.deep.equal([{
+          name: 'newest place',
+          place_id: placeId,
+          source_id: change.doc._id,
+          type: 'contact',
+          contact_type: 'clinic',
+          parent: { _id: 'north_hc' },
+          created_by: 'pete',
+          reported_date: change.doc.reported_date,
+        }]);
+        (!!change.doc.errors).should.equal(false);
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Place newest place with type clinic was added to north hc(health_center)'
+        });
+      });
+    });
+
+    it('should not create place when parent_id is not defined and no contact', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'New Orleans' },
+        }
+      };
+      const placeId = 'my_place_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact');
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [
+            {
+              locale: 'en',
+              content: 'Cannot create clinic with name {{place_name}}: parent not found.'
+            }
+          ]
+        }]
+      };
+      sinon.stub(config, 'get').withArgs('registrations').returns([eventConfig]);
+      sinon.stub(db.medic, 'query').withArgs('medic-client/contacts_by_phone').resolves({ rows: [] });
+      sinon.stub(db.medic, 'get');
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(0);
+        db.medic.post.callCount.should.equal(0);
+        db.medic.query.callCount.should.equal(1);
+        db.medic.query.args[0].should.deep.equal(['medic-client/contacts_by_phone', { key: '+111222', include_docs: true }]);
+        db.medic.get.callCount.should.equal(0);
+
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          code: 'parent_not_found',
+          message: 'Cannot create clinic with name New Orleans: parent not found.',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Cannot create clinic with name New Orleans: parent not found.'
+        });
+      });
+    });
+
+    it('should not create place when parent is not defined', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'New Orleans' },
+        }
+      };
+      const placeId = 'my_place_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact');
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic', parent_id: 'some_id' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [
+            {
+              locale: 'en',
+              content: 'Cannot create clinic with name {{place_name}}: parent field not provided.'
+            }
+          ]
+        }]
+      };
+      sinon.stub(config, 'get').withArgs('registrations').returns([eventConfig]);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(0);
+        db.medic.post.callCount.should.equal(0);
+
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          code: 'parent_field_not_provided',
+          message: 'Cannot create clinic with name New Orleans: parent field not provided.',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Cannot create clinic with name New Orleans: parent field not provided.'
+        });
+      });
+    });
+
+    it('should not create place when parent is not found', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'New Orleans' },
+        }
+      };
+      const placeId = 'my_place_id';
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact');
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'clinic', parent_id: 'some_id' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [
+            {
+              locale: 'en',
+              content: 'Cannot create clinic with name {{place_name}}: parent field not provided.'
+            }
+          ]
+        }]
+      };
+      sinon.stub(config, 'get').withArgs('registrations').returns([eventConfig]);
+
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(0);
+        db.medic.post.callCount.should.equal(0);
+
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          code: 'parent_field_not_provided',
+          message: 'Cannot create clinic with name New Orleans: parent field not provided.',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Cannot create clinic with name New Orleans: parent field not provided.'
+        });
+      });
+    });
+
+    it('should not create place when parent is not valid', () => {
+      const change = {
+        doc: {
+          _id: 'reportID',
+          type: 'data_record',
+          form: 'R',
+          reported_date: 53,
+          from: '+111222',
+          fields: { place_name: 'New Orleans', parent_id: 'hc2' },
+          contact: { _id: 'bob', name: 'Bob', parent: { _id: 'a_health_center', name: 'HC1', type: 'contact', contact_type: 'health_center', place_id: 'hc1' } }
+        }
+      };
+      const placeId = 'my_place_id';
+      const parent = {
+        _id: 'other_health_center',
+        name: 'Other health center',
+        place_id: 'hc2',
+        type: 'contact',
+        contact_type: 'health_center',
+        parent: { _id: 'district1' },
+      };
+      sinon.stub(utils, 'getContactUuid').resolves();
+      sinon.stub(utils, 'getContact').resolves(parent);
+      sinon.stub(db.medic, 'post').resolves();
+      const eventConfig = {
+        form: 'R',
+        events: [{ name: 'on_create', trigger: 'add_place', params: { contact_type: 'area', parent_id: 'parent_id' } }],
+        messages: [ {
+          recipient: 'reporting_unit',
+          event_type: 'parent_invalid',
+          message: [
+            {
+              locale: 'en',
+              content: 'Cannot create area with name {{place_name}} under parent {{parent.name}} of type {{parent.contact_type}}'
+            }
+          ]
+        }]
+      };
+      const contactTypes = [
+        { id: 'district' },
+        { id: 'health_center', parents: ['district'] },
+        { id: 'local_thing', parents: ['district'] },
+        { id: 'clinic', parents: ['health_center'] },
+        { id: 'area', parents: ['local_thing'] },
+      ];
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns([eventConfig])
+        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(validation, 'validate').callsArgWith(2, null);
+      sinon.stub(utils, 'getRegistrations').resolves([]);
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
+
+      return transition.onMatch(change).then(() => {
+        transitionUtils.getUniqueId.callCount.should.equal(1);
+        utils.getContactUuid.callCount.should.equal(1);
+        utils.getContactUuid.args[0].should.deep.equal([placeId]);
+        utils.getContact.callCount.should.equal(1);
+        utils.getContact.args[0].should.deep.equal(['hc2']);
+        db.medic.post.callCount.should.equal(0);
+
+        change.doc.errors.length.should.equal(1);
+        change.doc.errors[0].should.deep.equal({
+          code: 'parent_invalid',
+          message: 'Cannot create area with name New Orleans under parent Other health center of type health_center',
+        });
+        change.doc.tasks.length.should.equal(1);
+        change.doc.tasks[0].messages[0].should.include({
+          to: change.doc.from,
+          message: 'Cannot create area with name New Orleans under parent Other health center of type health_center'
+        });
+      });
     });
   });
 
@@ -679,7 +1795,7 @@ describe('registration', () => {
       });
     });
 
-    it('fails with no parameters', done => {
+    it('fails with no parameters', () => {
       const eventConfig = [
         {
           form: 'R',
@@ -694,19 +1810,10 @@ describe('registration', () => {
       ];
 
       sinon.stub(config, 'get').returns(eventConfig);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal(
-          'Configuration error. Expecting params to be defined as the name of the schedule(s) for R.assign_schedule'
-        );
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error. Expecting params to be defined as the name of the schedule(s) for R.assign_schedule');
     });
 
-    it('fails with object parameters', done => {
+    it('fails with object parameters', () => {
       const eventConfig = [
         {
           form: 'R',
@@ -721,19 +1828,10 @@ describe('registration', () => {
       ];
 
       sinon.stub(config, 'get').returns(eventConfig);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal(
-          'Configuration error. Expecting params to be a string, comma separated list, or an array for R.assign_schedule: \'{ "name": "hello" }\''
-        );
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error. Expecting params to be a string, comma separated list, or an array for R.assign_schedule: \'{ "name": "hello" }\'');
     });
 
-    it('succeeds with array parameters', done => {
+    it('succeeds with array parameters', () => {
       const eventConfig = [
         {
           form: 'R',
@@ -749,10 +1847,9 @@ describe('registration', () => {
 
       sinon.stub(config, 'get').returns(eventConfig);
       transition.init();
-      done();
     });
 
-    it('parse failure for invalid JSON propagates to the callbacks', done => {
+    it('parse failure for invalid JSON propagates to the callbacks', () => {
       const eventConfig = [
         {
           form: 'R',
@@ -767,19 +1864,10 @@ describe('registration', () => {
       ];
 
       sinon.stub(config, 'get').returns(eventConfig);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal(
-          'Configuration error. Unable to parse params for R.testparamparsing: \'{"foo": "bar"\'. Error: SyntaxError: Unexpected end of JSON input'
-        );
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error. Unable to parse params for R.testparamparsing: \'{"foo": "bar"\'. Error: SyntaxError: Unexpected end of JSON input');
     });
 
-    it('fails if the configured contact type is not known', done => {
+    it('add_patient fails if the configured contact type is not known', () => {
       const eventConfig = [{
         form: 'R',
         events: [{
@@ -793,17 +1881,10 @@ describe('registration', () => {
       sinon.stub(config, 'get')
         .withArgs('registrations').returns(eventConfig)
         .withArgs('contact_types').returns(contactTypes);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal('Configuration error in R.add_patient: trigger would create a doc with an unknown contact type "unknown"');
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error in R.add_patient: trigger would create a doc with an unknown contact type "unknown"');
     });
 
-    it('fails if the configured contact type is not a person', done => {
+    it('add_patient fails if the configured contact type is not a person', () => {
       const eventConfig = [{
         form: 'R',
         events: [{
@@ -817,17 +1898,10 @@ describe('registration', () => {
       sinon.stub(config, 'get')
         .withArgs('registrations').returns(eventConfig)
         .withArgs('contact_types').returns(contactTypes);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal('Configuration error in R.add_patient: trigger would create a doc with a place contact type "place"');
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error in R.add_patient: trigger would create a person with a place contact type "place"');
     });
 
-    it('fails if the default "person" contact type is not known', done => {
+    it('add_patient fails if the default "person" contact type is not known', () => {
       const eventConfig = [{
         form: 'R',
         events: [{
@@ -841,14 +1915,7 @@ describe('registration', () => {
       sinon.stub(config, 'get')
         .withArgs('registrations').returns(eventConfig)
         .withArgs('contact_types').returns(contactTypes);
-      try {
-        transition.init();
-        done(new Error('Expected validation error'));
-      } catch (e) {
-        (e instanceof Error).should.equal(true);
-        e.message.should.equal('Configuration error in R.add_patient: trigger would create a doc with an unknown contact type "person"');
-        done();
-      }
+      transition.init.should.throw(Error, 'Configuration error in R.add_patient: trigger would create a doc with an unknown contact type "person"');
     });
 
     it('succeeds for known person type', done => {
@@ -867,6 +1934,74 @@ describe('registration', () => {
         .withArgs('contact_types').returns(contactTypes);
       transition.init();
       done();
+    });
+
+    it('add_place should fail for no defined contact_type', () => {
+      const eventConfig = [{
+        form: 'R',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: ''
+        }],
+      }];
+      const contactTypes = [{ id: 'place' }];
+
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns(eventConfig)
+        .withArgs('contact_types').returns(contactTypes);
+      transition.init.should.throw(Error, 'Configuration error in R.add_place: trigger would create a place with an undefined contact type');
+    });
+
+    it('add_place should fail for unknown contact_type', () => {
+      const eventConfig = [{
+        form: 'R',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'oh_noo' }
+        }],
+      }];
+      const contactTypes = [{ id: 'place' }];
+
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns(eventConfig)
+        .withArgs('contact_types').returns(contactTypes);
+      transition.init.should.throw(Error, 'Configuration error in R.add_place: trigger would create a place with an unknown contact type "oh_noo"');
+    });
+
+    it('add_place should fail for person contact_type', () => {
+      const eventConfig = [{
+        form: 'R',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'person' }
+        }],
+      }];
+      const contactTypes = [{ id: 'place' }, { id: 'person', person: true }];
+
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns(eventConfig)
+        .withArgs('contact_types').returns(contactTypes);
+      transition.init.should.throw(Error, 'Configuration error in R.add_place: trigger would create a place with a person contact type "person"');
+    });
+
+    it('should succeed for known place type', () => {
+      const eventConfig = [{
+        form: 'R',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'place' }
+        }],
+      }];
+      const contactTypes = [{ id: 'place' }, { id: 'person', person: true }];
+
+      sinon.stub(config, 'get')
+        .withArgs('registrations').returns(eventConfig)
+        .withArgs('contact_types').returns(contactTypes);
+      transition.init();
     });
   });
 

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -59,7 +59,7 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      const getPatientContactUuid = sinon.stub(utils, 'getContactUuid').resolves();
+      const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       const view = sinon.stub(db.medic, 'query').resolves({
         rows: [
@@ -89,7 +89,7 @@ describe('registration', () => {
       });
 
       return transition.onMatch(change).then(() => {
-        getPatientContactUuid.callCount.should.equal(1);
+        getContactUuid.callCount.should.equal(1);
         view.callCount.should.equal(1);
         view.args[0][0].should.equal('medic-client/contacts_by_phone');
         view.args[0][1].key.should.equal(senderPhoneNumber);

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -79,7 +79,10 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         getPatientContactUuid.callCount.should.equal(1);
@@ -204,7 +207,10 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'getUniqueId').resolves('05649');
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = '05649';
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -339,7 +345,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -385,7 +394,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -428,7 +440,11 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
+        doc.patient_id = patientId;
+        return Promise.resolve();
+      });
+
 
 
       return transition.onMatch(change).then(() => {

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -79,10 +79,7 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
       return transition.onMatch(change).then(() => {
         getPatientContactUuid.callCount.should.equal(1);
@@ -207,10 +204,7 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = '05649';
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves('05649');
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -345,10 +339,7 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -394,10 +385,7 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -440,10 +428,7 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
 
 
       return transition.onMatch(change).then(() => {

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -59,7 +59,7 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      const getPatientContactUuid = sinon.stub(utils, 'getPatientContactUuid').resolves();
+      const getPatientContactUuid = sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       const view = sinon.stub(db.medic, 'query').resolves({
         rows: [
@@ -71,6 +71,7 @@ describe('registration', () => {
           },
         ],
       });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: parentId, type: 'contact', contact_type: 'place' });
       const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -79,10 +80,10 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
       return transition.onMatch(change).then(() => {
         getPatientContactUuid.callCount.should.equal(1);
@@ -125,6 +126,9 @@ describe('registration', () => {
         events: [{ name: 'on_create', trigger: 'add_patient_id' }],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(0);
@@ -142,13 +146,14 @@ describe('registration', () => {
         birth_date: '2017-03-31T01:15:09.000Z',
       };
       const change = { doc: doc };
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
         .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       const saveDoc = sinon.stub(db.medic, 'post').resolves(1);
       const eventConfig = {
         form: 'R',
@@ -163,6 +168,9 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(transitionUtils, 'isIdUnique').resolves(true);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
       return transition.onMatch(change).then(() => {
         saveDoc.args[0][0].patient_id.should.equal(patientId);
@@ -183,7 +191,7 @@ describe('registration', () => {
           birth_date: '2017-03-31T01:15:09.000Z',
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon.stub(db.medic, 'query').resolves({
         rows: [
@@ -195,6 +203,7 @@ describe('registration', () => {
           },
         ],
       });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -207,10 +216,10 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = '05649';
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves('05649');
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'patient', person: true, parents: ['place'] }
+      ]);
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -230,13 +239,14 @@ describe('registration', () => {
         birth_date: '2017-03-31T01:15:09.000Z',
       };
       const change = { doc: doc };
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
         .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -251,6 +261,9 @@ describe('registration', () => {
       const configGet = sinon.stub(config, 'get');
       configGet.withArgs('outgoing_deny_list').returns('');
       configGet.returns([eventConfig]);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
 
@@ -276,13 +289,14 @@ describe('registration', () => {
         birth_date: '2017-03-31T01:15:09.000Z',
       };
       const change = { doc: doc };
-      sinon.stub(utils, 'getPatientContactUuid').resolves(1);
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
         .resolves({
           rows: [{ doc: { parent: { _id: 'papa' } } }],
         });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -301,6 +315,9 @@ describe('registration', () => {
       sinon.stub(transitionUtils, 'isIdUnique').resolves(false);
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
       return transition.onMatch(change).then(() => {
         (typeof doc.patient_id).should.be.equal('undefined');
@@ -329,13 +346,14 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
         .resolves({
           rows: [{ doc: { parent: { _id: submitterId } } }],
         });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -345,10 +363,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -372,13 +390,14 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
-        .resolves(2, null, {
+        .resolves({
           rows: [{ doc: { parent: { _id: submitterId } } }],
         });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -394,10 +413,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -421,13 +440,14 @@ describe('registration', () => {
           birth_date: dob,
         },
       };
-      sinon.stub(utils, 'getPatientContactUuid').resolves();
+      sinon.stub(utils, 'getContactUuid').resolves();
       // return expected view results when searching for contacts_by_phone
       sinon
         .stub(db.medic, 'query')
         .resolves({
           rows: [{ doc: { parent: { _id: submitterId } } }],
         });
+      sinon.stub(db.medic, 'get').withArgs('papa').resolves({ _id: 'papa', type: 'place' });
       const saveDoc = sinon.stub(db.medic, 'post').resolves();
       const eventConfig = {
         form: 'R',
@@ -440,11 +460,10 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
-      sinon.stub(transitionUtils, 'addUniqueId').callsFake((doc) => {
-        doc.patient_id = patientId;
-        return Promise.resolve();
-      });
-
+      sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
+      config.get.withArgs('contact_types').returns([
+        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
+      ]);
 
 
       return transition.onMatch(change).then(() => {
@@ -514,9 +533,7 @@ describe('registration', () => {
         .stub(utils, 'getRegistrations')
         .resolves([{ _id: 'xyz' }]);
       sinon.stub(schedules, 'getScheduleConfig').returns('someschedule');
-      sinon
-        .stub(utils, 'getPatientContactUuid')
-        .resolves({ _id: 'uuid' });
+      sinon.stub(utils, 'getContactUuid').resolves('uuid');
       const assignSchedule = sinon
         .stub(schedules, 'assignSchedule')
         .returns(true);
@@ -893,6 +910,7 @@ describe('registration', () => {
 
         const expectedContext = {
           patient: testPatient,
+          place: undefined,
           registrations: testRegistration,
           templateContext: {
             next_msg: {
@@ -950,6 +968,7 @@ describe('registration', () => {
         addMessage.callCount.should.equal(1);
         const expectedContext = {
           patient: testPatient,
+          place: undefined,
           registrations: testRegistration,
           templateContext: {
             next_msg: {

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -81,9 +81,12 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
       sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
-        config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] },
+        ]
+      });
 
       return transition.onMatch(change).then(() => {
         getPatientContactUuid.callCount.should.equal(1);
@@ -126,9 +129,12 @@ describe('registration', () => {
         events: [{ name: 'on_create', trigger: 'add_patient_id' }],
       };
       sinon.stub(config, 'get').returns([eventConfig]);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] }
+        ]
+      });
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(0);
@@ -168,9 +174,12 @@ describe('registration', () => {
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(transitionUtils, 'isIdUnique').resolves(true);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] }
+        ]
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.args[0][0].patient_id.should.equal(patientId);
@@ -217,9 +226,12 @@ describe('registration', () => {
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
       sinon.stub(transitionUtils, 'getUniqueId').resolves('05649');
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'patient', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'patient', person: true, parents: ['place'] },
+        ]
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -261,9 +273,12 @@ describe('registration', () => {
       const configGet = sinon.stub(config, 'get');
       configGet.withArgs('outgoing_deny_list').returns('');
       configGet.returns([eventConfig]);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] },
+        ]
+      });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
 
@@ -315,9 +330,12 @@ describe('registration', () => {
       sinon.stub(transitionUtils, 'isIdUnique').resolves(false);
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] }
+        ]
+      });
 
       return transition.onMatch(change).then(() => {
         (typeof doc.patient_id).should.be.equal('undefined');
@@ -364,9 +382,12 @@ describe('registration', () => {
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
       sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] }
+        ]
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -414,9 +435,12 @@ describe('registration', () => {
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
       sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] },
+        ]
+      });
 
       return transition.onMatch(change).then(() => {
         saveDoc.callCount.should.equal(1);
@@ -461,9 +485,12 @@ describe('registration', () => {
       sinon.stub(utils, 'getRegistrations').resolves([]);
 
       sinon.stub(transitionUtils, 'getUniqueId').resolves(patientId);
-      config.get.withArgs('contact_types').returns([
-        { id: 'place' }, { id: 'person', person: true, parents: ['place'] }
-      ]);
+      sinon.stub(config, 'getAll').returns({
+        contact_types: [
+          { id: 'place' },
+          { id: 'person', person: true, parents: ['place'] },
+        ]
+      });
 
 
       return transition.onMatch(change).then(() => {
@@ -537,9 +564,8 @@ describe('registration', () => {
         { id: 'clinic', parents: ['health_center'] },
         { id: 'patient', parents: ['clinic'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -629,9 +655,8 @@ describe('registration', () => {
         { id: 'patient', parents: ['area_type_1'], person: true },
         { id: 'buddy', parents: ['area_type_2'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -714,9 +739,8 @@ describe('registration', () => {
         { id: 'area_type_2', parents: ['health_center'] },
         { id: 'patient', parents: ['area_type_1'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -793,9 +817,8 @@ describe('registration', () => {
         { id: 'area_type_2', parents: ['health_center'] },
         { id: 'patient', parents: ['area_type_1'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -880,9 +903,8 @@ describe('registration', () => {
         { id: 'area_type_2', parents: ['health_center'] },
         { id: 'patient', parents: ['area_type_2'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -972,9 +994,8 @@ describe('registration', () => {
         { id: 'clinic', parents: ['health_center'] },
         { id: 'patient', parents: ['clinic'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -1055,9 +1076,8 @@ describe('registration', () => {
         { id: 'supervisor', parents: ['health_center_1'], person: true },
         { id: 'patient', parents: ['clinic_1'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -1145,9 +1165,8 @@ describe('registration', () => {
         { id: 'supervisor', parents: ['health_center_1'], person: true },
         { id: 'patient', parents: ['clinic_1'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -1243,9 +1262,8 @@ describe('registration', () => {
         { id: 'clinic', parents: ['health_center'] },
         { id: 'patient', parents: ['clinic'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -1338,9 +1356,8 @@ describe('registration', () => {
         { id: 'clinic', parents: ['health_center'] },
         { id: 'patient', parents: ['clinic'], person: true },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
 
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
@@ -1587,9 +1604,8 @@ describe('registration', () => {
         { id: 'clinic', parents: ['health_center'] },
         { id: 'area', parents: ['local_thing'] },
       ];
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns([eventConfig])
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns([eventConfig]);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
       sinon.stub(validation, 'validate').callsArgWith(2, null);
       sinon.stub(utils, 'getRegistrations').resolves([]);
       sinon.stub(transitionUtils, 'getUniqueId').resolves(placeId);
@@ -1728,6 +1744,7 @@ describe('registration', () => {
       };
 
       transition.triggers.testparamparsing = sinon.stub();
+
 
       return transition.fireConfiguredTriggers(eventConfig, {}).then(() => {
         transition.triggers.testparamparsing.callCount.should.equal(1);
@@ -1878,9 +1895,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'known' }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init.should.throw(Error, 'Configuration error in R.add_patient: trigger would create a doc with an unknown contact type "unknown"');
     });
 
@@ -1895,9 +1912,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'place' }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init.should.throw(Error, 'Configuration error in R.add_patient: trigger would create a person with a place contact type "place"');
     });
 
@@ -1912,9 +1929,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'place' }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init.should.throw(Error, 'Configuration error in R.add_patient: trigger would create a doc with an unknown contact type "person"');
     });
 
@@ -1929,9 +1946,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'patient', person: true }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init();
       done();
     });
@@ -1947,9 +1964,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'place' }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init.should.throw(Error, 'Configuration error in R.add_place: trigger would create a place with an undefined contact type');
     });
 
@@ -1964,9 +1981,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'place' }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init.should.throw(Error, 'Configuration error in R.add_place: trigger would create a place with an unknown contact type "oh_noo"');
     });
 
@@ -1981,9 +1998,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'place' }, { id: 'person', person: true }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init.should.throw(Error, 'Configuration error in R.add_place: trigger would create a place with a person contact type "person"');
     });
 
@@ -1998,9 +2015,9 @@ describe('registration', () => {
       }];
       const contactTypes = [{ id: 'place' }, { id: 'person', person: true }];
 
-      sinon.stub(config, 'get')
-        .withArgs('registrations').returns(eventConfig)
-        .withArgs('contact_types').returns(contactTypes);
+      sinon.stub(config, 'get').returns(eventConfig);
+      sinon.stub(config, 'getAll').returns({ contact_types: contactTypes });
+
       transition.init();
     });
   });

--- a/shared-libs/transitions/test/unit/transitions/utils.js
+++ b/shared-libs/transitions/test/unit/transitions/utils.js
@@ -50,4 +50,34 @@ describe('unit transition utils', () => {
     assert.equal(addError.args[0][1].message, 'some message');
     assert.equal(addError.args[0][1].code, errorKey);
   });
+
+  it('addRejectionMessage should pass context', () => {
+    const doc = { _id: 'a', parent: { _id: 'PARENT' }, name: 'doc_name' };
+    const parent = { _id: 'PARENT', name: 'parent_name' };
+    const config = { messages: [
+        { event_type: 'notfound', recipient: 'bob' },
+        { event_type: 'found', message: '{{parent.name}} is not valid for {{doc_name}}', recipient: 'jim' }
+      ] };
+    const errorKey = 'found';
+    const addMessage = sinon.stub(messages, 'addMessage');
+    const addError = sinon.stub(messages, 'addError');
+    const getMessage = sinon.stub(messages, 'getMessage').returns('{{parent.name}} is not valid for {{doc_name}}');
+    const getLocale = sinon.stub(utils, 'getLocale').returns('xyz');
+    transitionUtils.addRejectionMessage(doc, config, errorKey,  { parent });
+    assert.equal(addMessage.callCount, 1);
+    assert.equal(addMessage.args[0][0]._id, 'a');
+    assert.equal(addMessage.args[0][1].message, '{{parent.name}} is not valid for {{doc_name}}');
+    assert.equal(addMessage.args[0][2], 'jim');
+    assert.deepEqual(addMessage.args[0][3], { parent });
+    assert.equal(getLocale.callCount, 1);
+    assert.equal(getLocale.args[0][0]._id, 'a');
+    assert.equal(getMessage.callCount, 1);
+    assert.equal(getMessage.args[0][0].event_type, 'found');
+    assert.equal(getMessage.args[0][1], 'xyz');
+    assert.equal(addError.callCount, 1);
+    assert.equal(addError.args[0][0]._id, 'a');
+    assert.equal(addError.args[0][1].message, '{{parent.name}} is not valid for {{doc_name}}');
+    assert.equal(addError.args[0][1].code, errorKey);
+    assert.deepEqual(addError.args[0][2], { parent });
+  });
 });

--- a/shared-libs/transitions/test/unit/utils.js
+++ b/shared-libs/transitions/test/unit/utils.js
@@ -60,7 +60,7 @@ describe('utils', () => {
       const given = '55998';
       const patients = [ { id: expected } ];
       const query = db.medic.query.resolves({ rows: patients });
-      return utils.getPatientContactUuid(given).then((actual) => {
+      return utils.getContactUuid(given).then((actual) => {
         assert.equal(actual, expected);
         assert.equal(query.callCount, 1);
         assert.equal(query.args[0][0], 'medic-client/contacts_by_reference');
@@ -74,7 +74,7 @@ describe('utils', () => {
       const given = '55998';
       const patients = [ ];
       const query = db.medic.query.resolves({ rows: patients });
-      return utils.getPatientContactUuid(given).then((actual) => {
+      return utils.getContactUuid(given).then((actual) => {
         assert.equal(actual, null);
         assert.equal(query.callCount, 1);
       });
@@ -82,7 +82,7 @@ describe('utils', () => {
 
     it('returns empty when no shortcode given', () => {
       const query = db.medic.query;
-      return utils.getPatientContactUuid(null).then((actual) => {
+      return utils.getContactUuid(null).then((actual) => {
         assert.equal(actual, null);
         assert.equal(query.callCount, 0);
       });
@@ -97,7 +97,7 @@ describe('utils', () => {
       const given = '55998';
       const patients = [ { id: expected, doc: { _id: expected, name: 'jim', patient_id: given } } ];
       const query = db.medic.query.resolves({ rows: patients });
-      utils.getPatientContact(given, (err, actual) => {
+      utils.getContact(given, (err, actual) => {
         assert.equal(err, null);
         assert.equal(actual.name, 'jim');
         assert.equal(query.callCount, 1);
@@ -113,7 +113,7 @@ describe('utils', () => {
       const given = '55998';
       const patients = [ ];
       const query = db.medic.query.resolves({ rows: patients });
-      utils.getPatientContact(given, (err, actual) => {
+      utils.getContact(given, (err, actual) => {
         assert.equal(err, null);
         assert.equal(actual, null);
         assert.equal(query.callCount, 1);
@@ -123,7 +123,7 @@ describe('utils', () => {
 
     it('returns empty when no shortcode given', done => {
       const query = db.medic.query;
-      utils.getPatientContact(null, (err, actual) => {
+      utils.getContact(null, (err, actual) => {
         assert.equal(err, null);
         assert.equal(actual, null);
         assert.equal(query.callCount, 0);

--- a/shared-libs/transitions/test/unit/utils.js
+++ b/shared-libs/transitions/test/unit/utils.js
@@ -53,7 +53,7 @@ describe('utils', () => {
     assert.equal(utils.translate('sms_received'), 'sms_received');
   });
 
-  describe('getPatientContactUuid', () => {
+  describe('getContactUuid', () => {
 
     it('returns the ID for the given short code', () => {
       const expected = 'abc123';
@@ -90,7 +90,7 @@ describe('utils', () => {
 
   });
 
-  describe('getPatientContact', () => {
+  describe('getContact', () => {
 
     it('returns the patient for the given short code', () => {
       const expected = 'abc123';

--- a/shared-libs/transitions/test/unit/utils.js
+++ b/shared-libs/transitions/test/unit/utils.js
@@ -92,42 +92,36 @@ describe('utils', () => {
 
   describe('getPatientContact', () => {
 
-    it('returns the patient for the given short code', done => {
+    it('returns the patient for the given short code', () => {
       const expected = 'abc123';
       const given = '55998';
       const patients = [ { id: expected, doc: { _id: expected, name: 'jim', patient_id: given } } ];
       const query = db.medic.query.resolves({ rows: patients });
-      utils.getContact(given, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getContact(given).then(actual => {
         assert.equal(actual.name, 'jim');
         assert.equal(query.callCount, 1);
         assert.equal(query.args[0][0], 'medic-client/contacts_by_reference');
         assert.equal(query.args[0][1].key[0], 'shortcode');
         assert.equal(query.args[0][1].key[1], given);
         assert.equal(query.args[0][1].include_docs, true);
-        done();
       });
     });
 
-    it('returns empty when no patient found', done => {
+    it('returns empty when no patient found', () => {
       const given = '55998';
       const patients = [ ];
       const query = db.medic.query.resolves({ rows: patients });
-      utils.getContact(given, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getContact(given).then(actual => {
         assert.equal(actual, null);
         assert.equal(query.callCount, 1);
-        done();
       });
     });
 
-    it('returns empty when no shortcode given', done => {
+    it('returns empty when no shortcode given', () => {
       const query = db.medic.query;
-      utils.getContact(null, (err, actual) => {
-        assert.equal(err, null);
+      return utils.getContact(null).then(actual => {
         assert.equal(actual, null);
         assert.equal(query.callCount, 0);
-        done();
       });
     });
   });

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const path = require('path');
 const request = require('request-promise-native');
 const utils = require('./utils');
 const constants = require('./constants');
@@ -18,7 +17,7 @@ const baseConfig = {
   },
   seleniumAddress: 'http://localhost:4444/wd/hub',
   suites: {
-    e2e:'e2e/**/*.js',
+    e2e:'e2e/**/registration.spec.js',
     performance: 'performance/**/*.js'
   },
   framework: 'jasmine2',
@@ -126,8 +125,7 @@ const login = browser => {
 };
 
 const setupSettings = () => {
-  const pathToDefaultAppSettings = path.join(__dirname, './config.default.json');
-  const defaultAppSettings = JSON.parse(fs.readFileSync(pathToDefaultAppSettings).toString());
+  const defaultAppSettings = utils.getDefaultSettings();
   defaultAppSettings.transitions = {};
 
   return utils.request({

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -17,7 +17,7 @@ const baseConfig = {
   },
   seleniumAddress: 'http://localhost:4444/wd/hub',
   suites: {
-    e2e:'e2e/**/registration.spec.js',
+    e2e:'e2e/**/*.js',
     performance: 'performance/**/*.js'
   },
   framework: 'jasmine2',

--- a/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
@@ -1,3 +1,4 @@
+const chai = require('chai');
 const utils = require('../../../utils'),
       sentinelUtils = require('../utils'),
       uuid = require('uuid');
@@ -27,11 +28,12 @@ describe('generate_patient_id_on_people', () => {
       })
       .then(() => utils.getDoc(doc._id))
       .then(person => {
-        expect(person.patient_id).not.toBeDefined();
+        chai.expect(person.patient_id).to.equal(undefined);
+        chai.expect(person.place_id).to.equal(undefined);
       });
   });
 
-  it('should be skipped when not a person', () => {
+  it('should add place_id', () => {
     const settings = {
       transitions: { generate_patient_id_on_people: true },
     };
@@ -48,11 +50,12 @@ describe('generate_patient_id_on_people', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(Object.keys(info.transitions).length).toEqual(0);
+        chai.expect(info).to.deep.nested.include({ 'transitions.generate_patient_id_on_people.ok' : true });
       })
       .then(() => utils.getDoc(doc._id))
-      .then(person => {
-        expect(person.patient_id).not.toBeDefined();
+      .then(place => {
+        chai.expect(place.patient_id).to.equal(undefined);
+        chai.expect(place.place_id).not.to.equal(undefined);
       });
   });
 
@@ -106,6 +109,31 @@ describe('generate_patient_id_on_people', () => {
       .then(() => utils.getDoc(doc._id))
       .then(person => {
         expect(person.patient_id).toBeDefined();
+      });
+  });
+
+  it('should add place_id', () => {
+    const settings = {
+      transitions: { generate_patient_id_on_people: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'health_center',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        chai.expect(info).to.deep.nested.include({ 'transitions.generate_patient_id_on_people.ok': true });
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(place => {
+        chai.expect(place.place_id).to.be.ok;
       });
   });
 });

--- a/tests/e2e/sentinel/transitions/generate_shortcode_on_contacts.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_shortcode_on_contacts.spec.js
@@ -1,0 +1,139 @@
+const chai = require('chai');
+const utils = require('../../../utils'),
+      sentinelUtils = require('../utils'),
+      uuid = require('uuid');
+
+describe('generate_shortcode_on_contacts', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertDb([], true).then(done));
+
+  it('should be skipped when transition is disabled', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: false }
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'person',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(Object.keys(info.transitions).length).toEqual(0);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        chai.expect(person.patient_id).to.equal(undefined);
+        chai.expect(person.place_id).to.equal(undefined);
+      });
+  });
+
+  it('should add place_id', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'clinic',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        chai.expect(info).to.deep.nested.include({ 'transitions.generate_shortcode_on_contacts.ok' : true });
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(place => {
+        chai.expect(place.patient_id).to.equal(undefined);
+        chai.expect(place.place_id).not.to.equal(undefined);
+      });
+  });
+
+  it('should be skipped when patient_id is filled', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'person',
+      patient_id: '1234',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(Object.keys(info.transitions).length).toEqual(0);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.patient_id).toEqual('1234');
+      });
+  });
+
+  it('should add patient_id', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'person',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(info.transitions).toBeDefined();
+        expect(info.transitions.generate_shortcode_on_contacts).toBeDefined();
+        expect(info.transitions.generate_shortcode_on_contacts.ok).toEqual(true);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.patient_id).toBeDefined();
+      });
+  });
+
+  it('should add place_id', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'health_center',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        chai.expect(info).to.deep.nested.include({ 'transitions.generate_shortcode_on_contacts.ok': true });
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(place => {
+        chai.expect(place.place_id).to.be.ok;
+      });
+  });
+});

--- a/tests/e2e/sentinel/transitions/generate_shortcode_on_contacts.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_shortcode_on_contacts.spec.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
-const utils = require('../../../utils'),
-      sentinelUtils = require('../utils'),
-      uuid = require('uuid');
+const utils = require('../../../utils');
+const sentinelUtils = require('../utils');
+const uuid = require('uuid');
 
 describe('generate_shortcode_on_contacts', () => {
   afterAll(done => utils.revertDb().then(done));
@@ -30,6 +30,44 @@ describe('generate_shortcode_on_contacts', () => {
       .then(person => {
         chai.expect(person.patient_id).to.equal(undefined);
         chai.expect(person.place_id).to.equal(undefined);
+      });
+  });
+
+  it('should be skipped when not a configured contact', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true }
+    };
+
+    const contact = {
+      _id: uuid(),
+      type: 'contact',
+      contact_type: 'something',
+      reported_date: new Date().getTime(),
+    };
+
+    const report = {
+      _id: uuid(),
+      type: 'data_record',
+      fields: { some: 'thing' },
+      reported_date: new Date().getTime(),
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDocs([contact, report]))
+      .then(() => sentinelUtils.waitForSentinel([contact._id, report._id]))
+      .then(() => sentinelUtils.getInfoDocs([contact._id, report._id]))
+      .then(([ contactInfo, reportInfo ]) => {
+        expect(Object.keys(contactInfo.transitions).length).toEqual(0);
+        expect(Object.keys(reportInfo.transitions).length).toEqual(0);
+      })
+      .then(() => utils.getDocs([contact._id, report._id]))
+      .then(([contact, report]) => {
+        chai.expect(contact.patient_id).to.equal(undefined);
+        chai.expect(contact.place_id).to.equal(undefined);
+
+        chai.expect(report.patient_id).to.equal(undefined);
+        chai.expect(report.place_id).to.equal(undefined);
       });
   });
 
@@ -82,6 +120,32 @@ describe('generate_shortcode_on_contacts', () => {
       .then(() => utils.getDoc(doc._id))
       .then(person => {
         expect(person.patient_id).toEqual('1234');
+      });
+  });
+
+  it('should be skipped when place_id is filled', () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true },
+    };
+
+    const doc = {
+      _id: uuid(),
+      type: 'clinic',
+      place_id: '1234',
+      reported_date: new Date().getTime()
+    };
+
+    return utils
+      .updateSettings(settings, true)
+      .then(() => utils.saveDoc(doc))
+      .then(() => sentinelUtils.waitForSentinel(doc._id))
+      .then(() => sentinelUtils.getInfoDoc(doc._id))
+      .then(info => {
+        expect(Object.keys(info.transitions).length).toEqual(0);
+      })
+      .then(() => utils.getDoc(doc._id))
+      .then(person => {
+        expect(person.place_id).toEqual('1234');
       });
   });
 

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -450,7 +450,7 @@ describe('registration', () => {
         }],
         messages: [{
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a person type "chw" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -480,7 +480,7 @@ describe('registration', () => {
         }],
         messages: [{
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a person type "nurse" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -611,7 +611,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[2].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a person type "chw" under parent the_clinic(contact type clinic)',
         });
         chai.expect(updated[2].tasks[0].messages[0]).to.include({
@@ -620,7 +620,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[3].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a person type "chw" under parent the_district_hospital(contact type district_hospital)',
         });
         chai.expect(updated[3].tasks[0].messages[0]).to.include({
@@ -629,7 +629,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[4].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a person type "nurse" under parent the_health_center(contact type health_center)',
         });
         chai.expect(updated[4].tasks[0].messages[0]).to.include({
@@ -1008,7 +1008,7 @@ describe('registration', () => {
         }],
         messages: [{
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -1024,7 +1024,7 @@ describe('registration', () => {
         }],
         messages: [{
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -1054,7 +1054,7 @@ describe('registration', () => {
         }],
         messages: [{
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a place type "health_center" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -1202,7 +1202,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[0].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a place type "clinic" under parent the_clinic(contact type clinic)',
         });
         chai.expect(updated[0].tasks[0].messages[0]).to.include({
@@ -1211,7 +1211,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[1].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a place type "clinic" under parent the_district_hospital(contact type district_hospital)',
         });
         chai.expect(updated[1].tasks[0].messages[0]).to.include({
@@ -1220,7 +1220,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[2].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a place type "clinic" under parent the_clinic(contact type clinic)',
         });
         chai.expect(updated[2].tasks[0].messages[0]).to.include({
@@ -1229,7 +1229,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[3].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a place type "clinic" under parent the_district_hospital(contact type district_hospital)',
         });
         chai.expect(updated[3].tasks[0].messages[0]).to.include({
@@ -1256,7 +1256,7 @@ describe('registration', () => {
         });
 
         chai.expect(updated[6].errors[0]).to.deep.equal({
-          code: 'invalid_parent',
+          code: 'parent_invalid',
           message: 'Cannot create a place type "health_center" under parent the_clinic(contact type clinic)',
         });
         chai.expect(updated[6].tasks[0].messages[0]).to.include({
@@ -1292,7 +1292,7 @@ describe('registration', () => {
           }],
         }, {
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -1316,7 +1316,7 @@ describe('registration', () => {
           }],
         }, {
           recipient: 'reporting_unit',
-          event_type: 'invalid_parent',
+          event_type: 'parent_invalid',
           message: [{
             locale: 'en',
             content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -1518,7 +1518,7 @@ describe('registration', () => {
             }],
           }, {
             recipient: 'reporting_unit',
-            event_type: 'invalid_parent',
+            event_type: 'parent_invalid',
             message: [{
               locale: 'en',
               content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
@@ -1543,7 +1543,7 @@ describe('registration', () => {
             }],
           }, {
             recipient: 'reporting_unit',
-            event_type: 'invalid_parent',
+            event_type: 'parent_invalid',
             message: [{
               locale: 'en',
               content: 'Cannot create a person type "person" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -78,6 +78,11 @@ const nurseContactType = {
   person: true
 };
 
+const nursingHomeType = {
+  id: 'nursing_home',
+  parents: ['health_center'],
+};
+
 const getContactsByReference = shortcodes => {
   const keys = shortcodes.map(shortcode => ['shortcode', shortcode]);
   const qs = { keys: JSON.stringify(keys), include_docs: true };
@@ -1299,11 +1304,11 @@ describe('registration', () => {
           }],
         }],
       }, {
-        form: 'FORM-CLINIC',
+        form: 'FORM-NURSING_HOME',
         events: [{
           name: 'on_create',
           trigger: 'add_place',
-          params: { contact_type: 'clinic', parent_id: 'parent' },
+          params: { contact_type: 'nursing_home', parent_id: 'parent' },
           bool_expr: ''
         }],
         messages: [{
@@ -1319,7 +1324,7 @@ describe('registration', () => {
           event_type: 'parent_invalid',
           message: [{
             locale: 'en',
-            content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+            content: 'Cannot create a place type "nursing_home" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
           }],
         }, {
           recipient: 'reporting_unit',
@@ -1368,7 +1373,11 @@ describe('registration', () => {
           }],
         }],
       }],
-      forms: { 'FORM-CLINIC_NO_PARENT': { }, 'FORM-CLINIC': { }, 'FORM-HEALTH_CENTER': {} },
+      forms: { 'FORM-CLINIC_NO_PARENT': { }, 'FORM-NURSING_HOME': { }, 'FORM-HEALTH_CENTER': {} },
+      contact_types: [
+        ...defaultSettings.contact_types,
+        nursingHomeType,
+      ]
     };
 
     const clinicNoParent = {
@@ -1383,10 +1392,10 @@ describe('registration', () => {
       contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
     };
 
-    const clinic = {
-      _id: 'justAClinic',
+    const nursingHome = {
+      _id: 'justANursingHome',
       type: 'data_record',
-      form: 'FORM-CLINIC',
+      form: 'FORM-NURSING_HOME',
       from: '+00000000',
       fields: {
         place_name: 'Ford',
@@ -1409,7 +1418,7 @@ describe('registration', () => {
       contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
     };
 
-    const docs = [ clinicNoParent, clinic, healthCenter ];
+    const docs = [ clinicNoParent, nursingHome, healthCenter ];
     const ids = docs.map(doc => doc._id);
     let updatedDocs;
 
@@ -1458,8 +1467,7 @@ describe('registration', () => {
 
         chai.expect(places.rows[0].doc).to.deep.include({
           name: 'Toyota',
-          type: 'contact',
-          contact_type: 'clinic',
+          type: 'clinic',
           place_id: updatedDocs[0].place_id,
           source_id: updatedDocs[0]._id,
           created_by: updatedDocs[0].contact._id,
@@ -1468,7 +1476,7 @@ describe('registration', () => {
         chai.expect(places.rows[1].doc).to.deep.include({
           name: 'Ford',
           type: 'contact',
-          contact_type: 'clinic',
+          contact_type: 'nursing_home',
           place_id: updatedDocs[1].place_id,
           source_id: updatedDocs[1]._id,
           created_by: updatedDocs[1].contact._id,
@@ -1476,8 +1484,7 @@ describe('registration', () => {
         });
         chai.expect(places.rows[2].doc).to.deep.include({
           name: 'Mazda',
-          type: 'contact',
-          contact_type: 'health_center',
+          type: 'health_center',
           place_id: updatedDocs[2].place_id,
           source_id: updatedDocs[2]._id,
           created_by: updatedDocs[2].contact._id,
@@ -1619,8 +1626,7 @@ describe('registration', () => {
 
         chai.expect(contacts.rows[0].doc).to.deep.include({
           name: 'Orbit',
-          type: 'contact',
-          contact_type: 'clinic',
+          type: 'clinic',
           place_id: updatedDocs[0].place_id,
           source_id: updatedDocs[0]._id,
           created_by: updatedDocs[0].contact._id,

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -1,26 +1,35 @@
-const utils = require('../../../utils'),
-      sentinelUtils = require('../utils'),
-      uuid = require('uuid'),
-      moment = require('moment');
+const utils = require('../../../utils');
+const sentinelUtils = require('../utils');
+const uuid = require('uuid');
+const moment = require('moment');
+const chai = require('chai');
+
+const defaultSettings = utils.getDefaultSettings();
 
 const contacts = [
   {
     _id: 'district_hospital',
     name: 'District hospital',
-    type: 'district_hospital',
+    type: 'contact',
+    contact_type: 'district_hospital',
+    place_id: 'the_district_hospital',
     reported_date: new Date().getTime()
   },
   {
     _id: 'health_center',
     name: 'Health Center',
-    type: 'health_center',
+    type: 'contact',
+    contact_type: 'health_center',
+    place_id: 'the_health_center',
     parent: { _id: 'district_hospital' },
     reported_date: new Date().getTime()
   },
   {
     _id: 'clinic',
     name: 'Clinic',
-    type: 'clinic',
+    type: 'contact',
+    contact_type: 'clinic',
+    place_id: 'the_clinic',
     parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
     contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } },
     reported_date: new Date().getTime()
@@ -28,13 +37,52 @@ const contacts = [
   {
     _id: 'person',
     name: 'Person',
-    type: 'person',
+    type: 'contact',
+    contact_type: 'person',
     patient_id: 'patient',
     parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
     phone: '+444999',
     reported_date: new Date().getTime()
+  },
+  {
+    _id: 'supervisor',
+    name: 'Supervisor',
+    type: 'contact',
+    contact_type: 'person',
+    patient_id: 'the_supervisor',
+    parent: { _id: 'district_hospital' } ,
+    phone: '+00000000',
+    reported_date: new Date().getTime()
+  },
+  {
+    _id: 'middle_man',
+    name: 'Middle man',
+    type: 'contact',
+    contact_type: 'person',
+    patient_id: 'the_middle_man',
+    parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } ,
+    phone: '+11111111',
+    reported_date: new Date().getTime()
   }
 ];
+
+const chwContactType = {
+  id: 'chw',
+  parents: ['health_center'],
+  person: true
+};
+
+const nurseContactType = {
+  id: 'nurse',
+  parents: ['district_hospital'],
+  person: true
+};
+
+const getContactsByReference = shortcodes => {
+  const keys = shortcodes.map(shortcode => ['shortcode', shortcode]);
+  const qs = { keys: JSON.stringify(keys), include_docs: true };
+  return utils.requestOnTestDb({ path: '/_design/medic-client/_view/contacts_by_reference', qs });
+};
 
 describe('registration', () => {
   beforeAll(done => utils.saveDocs(contacts).then(done));
@@ -73,7 +121,7 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(Object.keys(info.transitions).length).toEqual(0);
+        chai.expect(Object.keys(info.transitions).length).to.equal(0);
       });
   });
 
@@ -109,11 +157,11 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(Object.keys(info.transitions).length).toEqual(0);
+        chai.expect(Object.keys(info.transitions).length).to.equal(0);
       })
       .then(() => utils.getDoc(doc._id))
       .then(updated => {
-        expect(updated.tasks).not.toBeDefined();
+        chai.expect(updated.tasks).to.equal(undefined);
       });
   });
 
@@ -182,33 +230,33 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
       .then(infos => {
-        expect(infos[0].transitions).toBeDefined();
-        expect(infos[0].transitions.registration).toBeDefined();
-        expect(infos[0].transitions.registration.ok).toEqual(true);
-
-        expect(infos[1].transitions).toBeDefined();
-        expect(infos[1].transitions.registration).toBeDefined();
-        expect(infos[1].transitions.registration.ok).toEqual(true);
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
       })
       .then(() => utils.getDocs([doc1._id, doc2._id]))
       .then(updated => {
-        expect(updated[0].tasks).toBeDefined();
-        expect(updated[0].tasks.length).toEqual(1);
-        expect(updated[0].tasks[0].messages[0].message).toEqual('Count is incorrect');
-        expect(updated[0].tasks[0].messages[0].to).toEqual('+444999');
+        chai.expect(updated[0].tasks).to.be.ok;
+        chai.expect(updated[0].tasks.length).to.equal(1);
+        chai.expect(updated[0].tasks[0].messages[0]).to.include({
+          message: 'Count is incorrect',
+          to: '+444999',
+        });
 
-        expect(updated[0].errors).toBeDefined();
-        expect(updated[0].errors.length).toEqual(1);
-        expect(updated[0].errors[0].message).toEqual('Count is incorrect');
+        chai.expect(updated[0].errors).to.be.ok;
+        chai.expect(updated[0].errors.length).to.equal(1);
+        chai.expect(updated[0].errors[0].message).to.equal('Count is incorrect');
 
-        expect(updated[1].tasks).toBeDefined();
-        expect(updated[1].tasks.length).toEqual(1);
-        expect(updated[1].tasks[0].messages[0].message).toEqual('Patient not found');
-        expect(updated[1].tasks[0].messages[0].to).toEqual('+444999');
+        chai.expect(updated[1].tasks).to.be.ok;
+        chai.expect(updated[1].tasks.length).to.equal(1);
+        chai.expect(updated[1].tasks[0].messages[0]).to.include({
+          message: 'Patient not found',
+          to: '+444999',
+        });
 
-        expect(updated[1].errors).toBeDefined();
-        expect(updated[1].errors.length).toEqual(1);
-        expect(updated[1].errors[0].code).toEqual('registration_not_found');
+        chai.expect(updated[1].errors).to.be.ok;
+        chai.expect(updated[1].errors.length).to.equal(1);
+        chai.expect(updated[1].errors[0].code).to.equal('registration_not_found');
       });
   });
 
@@ -223,7 +271,14 @@ describe('registration', () => {
           params: '',
           bool_expr: ''
         }],
-        messages: [],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          message: [{
+            locale: 'en',
+            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{parent.name}}'
+          }],
+        }],
       }, {
         form: 'FORM-B',
         events: [{
@@ -232,7 +287,15 @@ describe('registration', () => {
           params: { patient_id_field: 'our_patient_id', patient_name_field: 'our_patient_name' },
           bool_expr: ''
         }],
-        messages: [],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.patient',
+          message: [{
+            locale: 'en',
+            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{parent.name}}'
+          }],
+        }],
       }],
       forms: { 'FORM-A': { }, 'FORM-B': { }}
     };
@@ -296,61 +359,459 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id, doc3._id, doc4._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id, doc3._id, doc4._id]))
       .then(infos => {
-        expect(infos[0].transitions).toBeDefined();
-        expect(infos[0].transitions.registration).toBeDefined();
-        expect(infos[0].transitions.registration.ok).toEqual(true);
-
-        expect(infos[1].transitions).toBeDefined();
-        expect(infos[1].transitions.registration).toBeDefined();
-        expect(infos[1].transitions.registration.ok).toEqual(true);
-
-        expect(infos[2].transitions).toBeDefined();
-        expect(infos[2].transitions.registration).toBeDefined();
-        expect(infos[2].transitions.registration.ok).toEqual(true);
-
-        expect(infos[3].transitions).toBeDefined();
-        expect(infos[3].transitions.registration).toBeDefined();
-        expect(infos[3].transitions.registration.ok).toEqual(true);
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
       })
       .then(() => utils.getDocs([doc1._id, doc2._id, doc3._id, doc4._id]))
       .then(updated => {
-        expect(updated[0].patient_id).toBeDefined();
+        chai.expect(updated[0].patient_id).not.to.equal(undefined);
+        chai.expect(updated[0].tasks.length).to.equal(1);
+        chai.expect(updated[0].tasks[0].messages[0]).to.include({
+          to: '+444999',
+          message: `Patient Minerva (${updated[0].patient_id}) added to Clinic`
+        });
+
         newPatientId = updated[0].patient_id;
 
-        expect(updated[1].patient_id).not.toBeDefined();
-        expect(updated[1].fields.patient_id).toEqual('person');
-        expect(updated[1].errors).toBeDefined();
-        expect(updated[1].errors.length).toEqual(1);
-        expect(updated[1].errors[0].code).toEqual('registration_not_found');
+        chai.expect(updated[1].patient_id).to.equal(undefined);
+        chai.expect(updated[1].fields.patient_id).to.equal('person');
+        chai.expect(updated[1].errors).to.be.ok;
+        chai.expect(updated[1].errors.length).to.equal(1);
+        chai.expect(updated[1].errors[0].code).to.equal('registration_not_found');
+        chai.expect(updated[1].tasks.length).to.equal(1);
 
-        expect(updated[2].patient_id).toEqual('venus');
+        chai.expect(updated[2].patient_id).to.equal('venus');
+        chai.expect(updated[2].errors).to.equal(undefined);
+        chai.expect(updated[2].tasks.length).to.equal(1);
+        chai.expect(updated[2].tasks[0].messages[0]).to.include({
+          to: '+444999',
+          message: `Patient Venus (venus) added to Clinic`
+        });
 
-        expect(updated[3].patient_id).not.toBeDefined();
-        expect(updated[3].errors).toBeDefined();
-        expect(updated[3].errors.length).toEqual(1);
-        expect(updated[3].errors[0].code).toEqual('provided_patient_id_not_unique');
+        chai.expect(updated[3].patient_id).to.equal(undefined);
+        chai.expect(updated[3].errors).to.be.ok;
+        chai.expect(updated[3].errors.length).to.equal(1);
+        chai.expect(updated[3].errors[0].code).to.equal('provided_patient_id_not_unique');
 
-        const keys = [
-          ['shortcode', newPatientId],
-          ['shortcode', 'venus']
-        ];
-
-        return utils.requestOnTestDb(
-          `/_design/medic-client/_view/contacts_by_reference?keys=${JSON.stringify(keys)}&include_docs=true`
-        );
+        return getContactsByReference([newPatientId, 'venus']);
       })
       .then(patients => {
-        expect(patients.rows.length).toEqual(2);
+        chai.expect(patients.rows.length).to.equal(2);
 
-        expect(patients.rows[0].doc.patient_id).toEqual(newPatientId);
-        expect(patients.rows[0].doc.parent._id).toEqual('clinic');
-        expect(patients.rows[0].doc.name).toEqual('Minerva');
-        expect(patients.rows[0].doc.type).toEqual('person');
+        chai.expect(patients.rows[0].doc).to.deep.include({
+          patient_id: newPatientId,
+          parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+          name: 'Minerva',
+          type: 'person',
+          created_by: 'person',
+          source_id: doc1._id,
+        });
 
-        expect(patients.rows[1].doc.patient_id).toEqual('venus');
-        expect(patients.rows[1].doc.parent._id).toEqual('clinic');
-        expect(patients.rows[1].doc.name).toEqual('Venus');
-        expect(patients.rows[1].doc.type).toEqual('person');
+        chai.expect(patients.rows[1].doc).to.deep.include({
+          patient_id: 'venus',
+          parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+          name: 'Venus',
+          type: 'person',
+          created_by: 'person',
+          source_id: doc3._id,
+        });
+      });
+  });
+
+  it('should not create people with invalid / missing parent', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM-A',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'parent' },
+          bool_expr: ''
+        }],
+        messages: [],
+      }, {
+        form: 'FORM-B',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'parent_id' },
+          bool_expr: ''
+        }],
+        messages: [],
+      }, {
+        form: 'FORM-CHW',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'parent_id', contact_type: 'chw' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a person type "chw" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [{
+            locale: 'en',
+            content: 'Parent field is required'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Parent not found'
+          }],
+        }],
+      }, {
+        form: 'FORM-NURSE',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'parent_id', contact_type: 'nurse' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a person type "nurse" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [{
+            locale: 'en',
+            content: 'Parent field is required'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Parent not found'
+          }],
+        }],
+      }],
+      forms: { 'FORM-A': { }, 'FORM-B': { }, 'FORM-CHW': {}, 'FORM-NURSE': {}},
+      contact_types: [...defaultSettings.contact_types, chwContactType, nurseContactType]
+    };
+
+    const chwNoParent = {
+      _id: 'chwNoParent',
+      type: 'data_record',
+      form: 'FORM-CHW',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Solaris',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const chwNonExistingParent = {
+      _id: 'chwNonExistingParent',
+      type: 'data_record',
+      form: 'FORM-CHW',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Lunaris',
+        parent_id: 'not_a_valid_parent',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const invalidParent1 = {
+      _id: 'invalidParent1',
+      type: 'data_record',
+      form: 'FORM-CHW',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Lunaris',
+        parent_id: 'the_clinic', // can't create a CHW under a clinic
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const invalidParent2 = {
+      _id: 'invalidParent2',
+      type: 'data_record',
+      form: 'FORM-CHW',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Kitava',
+        parent_id: 'the_district_hospital', // can't create a CHW under a district_hospital
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const invalidParent3 = {
+      _id: 'invalidParent3',
+      type: 'data_record',
+      form: 'FORM-NURSE',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Coleen',
+        parent_id: 'the_health_center', // can't create a Nurse under a health_center
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const ids = [chwNoParent._id, chwNonExistingParent._id, invalidParent1._id, invalidParent2._id, invalidParent3._id];
+
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs([chwNoParent, chwNonExistingParent, invalidParent1, invalidParent2, invalidParent3]))
+      .then(() => sentinelUtils.waitForSentinel(ids))
+      .then(() => sentinelUtils.getInfoDocs(ids))
+      .then(infos => {
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
+      })
+      .then(() => utils.getDocs(ids))
+      .then(updated => {
+        updated.forEach(doc => {
+          chai.expect(doc.patient_id).not.to.equal(undefined);
+          chai.expect(doc.errors).to.be.an('array');
+          chai.expect(doc.errors.length).to.equal(1);
+          chai.expect(doc.tasks).to.be.an('array');
+          chai.expect(doc.tasks.length).to.equal(1);
+        });
+
+        chai.expect(updated[0].errors[0]).to.deep.equal({
+          code: 'parent_field_not_provided',
+          message: 'Parent field is required',
+        });
+
+        chai.expect(updated[0].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: 'Parent field is required'
+        });
+
+        chai.expect(updated[1].errors[0]).to.deep.equal({
+          code: 'parent_not_found',
+          message: 'Parent not found',
+        });
+        chai.expect(updated[1].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: 'Parent not found'
+        });
+
+        chai.expect(updated[2].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a person type "chw" under parent the_clinic(contact type clinic)',
+        });
+        chai.expect(updated[2].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: 'Cannot create a person type "chw" under parent the_clinic(contact type clinic)'
+        });
+
+        chai.expect(updated[3].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a person type "chw" under parent the_district_hospital(contact type district_hospital)',
+        });
+        chai.expect(updated[3].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: 'Cannot create a person type "chw" under parent the_district_hospital(contact type district_hospital)'
+        });
+
+        chai.expect(updated[4].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a person type "nurse" under parent the_health_center(contact type health_center)',
+        });
+        chai.expect(updated[4].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: 'Cannot create a person type "nurse" under parent the_health_center(contact type health_center)'
+        });
+
+        return getContactsByReference(updated.map(doc => doc.patient_id));
+      })
+      .then(patients => {
+        chai.expect(patients.rows.length).to.equal(0);
+      });
+  });
+
+  it('should create people with selected parent', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM-PERSON',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'parent' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.patient',
+          message: [{
+            locale: 'en',
+            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{parent.name}}'
+          }]
+        }],
+      }, {
+        form: 'FORM-CHW',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'parent_id', contact_type: 'chw' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.patient',
+          message: [{
+            locale: 'en',
+            content: 'CHW {{patient_name}} ({{patient_id}}) added to {{parent.name}}'
+          }]
+        }],
+      }, {
+        form: 'FORM-NURSE',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_patient',
+          params: { parent_id: 'the_parent', contact_type: 'nurse', patient_name_field: 'nurse_name' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.patient',
+          message: [{
+            locale: 'en',
+            content: 'Nurse {{nurse_name}} ({{patient_id}}) added to {{parent.name}}'
+          }]
+        }],
+      }],
+      forms: { 'FORM-PERSON': { }, 'FORM-CHW': {}, 'FORM-NURSE': {}},
+      contact_types: [...defaultSettings.contact_types, chwContactType, nurseContactType]
+    };
+
+    const createPerson = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM-PERSON',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Solaris',
+        parent: 'the_clinic'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const createChw = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM-CHW',
+      from: '+00000000',
+      fields: {
+        patient_name: 'Lunaris',
+        parent_id: 'the_health_center'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const createNurse = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM-NURSE',
+      from: '+444999',
+      fields: {
+        nurse_name: 'Apollo',
+        the_parent: 'the_district_hospital'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } }
+    };
+
+    const ids = [createPerson._id, createChw._id, createNurse._id];
+    let updatedDocs;
+
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs([createPerson, createChw, createNurse]))
+      .then(() => sentinelUtils.waitForSentinel(ids))
+      .then(() => sentinelUtils.getInfoDocs(ids))
+      .then(infos => {
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
+      })
+      .then(() => utils.getDocs(ids))
+      .then(updated => {
+        updatedDocs = updated;
+        updated.forEach(doc => {
+          chai.expect(doc.patient_id).not.to.equal(undefined);
+          chai.expect(doc.errors).to.equal(undefined);
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.patient).to.equal(undefined);
+          chai.expect(doc.place).to.equal(undefined);
+        });
+
+        chai.expect(updated[0].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: `Patient Solaris (${updated[0].patient_id}) added to Clinic`
+        });
+        chai.expect(updated[1].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: `CHW Lunaris (${updated[1].patient_id}) added to Health Center`
+        });
+        chai.expect(updated[2].tasks[0].messages[0]).to.include({
+          to: '+444999',
+          message: `Nurse Apollo (${updated[2].patient_id}) added to District hospital`
+        });
+
+        return getContactsByReference(updated.map(doc => doc.patient_id));
+      })
+      .then(patients => {
+        chai.expect(patients.rows.length).to.equal(3);
+
+        chai.expect(patients.rows[0].doc).to.deep.include({
+          name: 'Solaris',
+          type: 'person',
+          parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+          created_by: 'supervisor',
+          source_id: createPerson._id,
+          patient_id: updatedDocs[0].patient_id,
+        });
+
+        chai.expect(patients.rows[1].doc).to.deep.include({
+          name: 'Lunaris',
+          type: 'contact',
+          contact_type: 'chw',
+          parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
+          created_by: 'supervisor',
+          source_id: createChw._id,
+          patient_id: updatedDocs[1].patient_id,
+        });
+
+        chai.expect(patients.rows[2].doc).to.deep.include({
+          name: 'Apollo',
+          type: 'contact',
+          contact_type: 'nurse',
+          parent: { _id: 'district_hospital' },
+          created_by: 'person',
+          source_id: createNurse._id,
+          patient_id: updatedDocs[2].patient_id,
+        });
       });
   });
 
@@ -402,23 +863,19 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
       .then(infos => {
-        expect(infos[0].transitions).toBeDefined();
-        expect(infos[0].transitions.registration).toBeDefined();
-        expect(infos[0].transitions.registration.ok).toEqual(true);
-
-        expect(infos[1].transitions).toBeDefined();
-        expect(infos[1].transitions.registration).toBeDefined();
-        expect(infos[1].transitions.registration.ok).toEqual(true);
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
       })
       .then(() => utils.getDocs([doc1._id, doc2._id]))
       .then(updated => {
-        expect(updated[0].lmp_date).toBeDefined();
-        expect(updated[0].lmp_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'weeks').toISOString());
-        expect(updated[0].expected_date).toEqual(moment().utc(false).startOf('day').add(38, 'weeks').toISOString());
+        chai.expect(updated[0].lmp_date).to.be.ok;
+        chai.expect(updated[0].lmp_date).to.equal(moment().utc(false).startOf('day').subtract(2, 'weeks').toISOString());
+        chai.expect(updated[0].expected_date).to.equal(moment().utc(false).startOf('day').add(38, 'weeks').toISOString());
 
-        expect(updated[1].lmp_date).toBeDefined();
-        expect(updated[1].lmp_date).toEqual(moment().utc(false).startOf('day').subtract(4, 'weeks').toISOString());
-        expect(updated[1].expected_date).toEqual(moment().utc(false).startOf('day').add(36, 'weeks').toISOString());
+        chai.expect(updated[1].lmp_date).to.be.ok;
+        chai.expect(updated[1].lmp_date).to.equal(moment().utc(false).startOf('day').subtract(4, 'weeks').toISOString());
+        chai.expect(updated[1].expected_date).to.equal(moment().utc(false).startOf('day').add(36, 'weeks').toISOString());
       });
   });
 
@@ -483,23 +940,554 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id, doc3._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id, doc3._id]))
       .then(infos => {
-        expect(infos[0].transitions).toBeDefined();
-        expect(infos[0].transitions.registration).toBeDefined();
-        expect(infos[0].transitions.registration.ok).toEqual(true);
-
-        expect(infos[1].transitions).toBeDefined();
-        expect(infos[1].transitions.registration).toBeDefined();
-        expect(infos[1].transitions.registration.ok).toEqual(true);
-
-        expect(infos[2].transitions).toBeDefined();
-        expect(infos[2].transitions.registration).toBeDefined();
-        expect(infos[2].transitions.registration.ok).toEqual(true);
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
       })
       .then(() => utils.getDocs([doc1._id, doc2._id, doc3._id]))
       .then(updated => {
-        expect(updated[0].birth_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'months').toISOString());
-        expect(updated[1].birth_date).toEqual(moment().utc(false).startOf('day').subtract(4, 'weeks').toISOString());
-        expect(updated[2].birth_date).toEqual(moment().utc(false).startOf('day').subtract(2, 'years').toISOString());
+        chai.expect(updated[0].birth_date).to.equal(moment().utc(false).startOf('day').subtract(2, 'months').toISOString());
+        chai.expect(updated[1].birth_date).to.equal(moment().utc(false).startOf('day').subtract(4, 'weeks').toISOString());
+        chai.expect(updated[2].birth_date).to.equal(moment().utc(false).startOf('day').subtract(2, 'years').toISOString());
+      });
+  });
+
+  it('should not create places with missing contact_type', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM-PLACE',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          bool_expr: ''
+        }],
+        messages: [],
+      }],
+      forms: { 'FORM-PLACE': { } },
+    };
+
+    const createPlace = {
+      _id: uuid(),
+      type: 'data_record',
+      form: 'FORM-PLACE',
+      from: '+00000000',
+      fields: {
+        place_name: 'Solaris',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDoc(createPlace))
+      // Sentinel won't process these, so we can't wait for a metadata update, but let's give it 5 seconds just in case
+      .then(() => utils.delayPromise(() => Promise.resolve(), 5000))
+      .then(() => sentinelUtils.getInfoDocs(createPlace._id))
+      .then(infos => {
+        chai.expect(infos[0].transitions).to.equal(undefined);
+      })
+      .then(() => utils.getDoc(createPlace._id))
+      .then(updated => {
+        chai.expect(Object.keys(updated)).to.have.members([...Object.keys(createPlace), '_rev']);
+        chai.expect(updated).to.deep.include(createPlace);
+      });
+  });
+
+  it('should not create place with invalid / missing parent', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM-CLINIC_NO_PARENT',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'clinic' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }],
+      }, {
+        form: 'FORM-CLINIC',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'clinic', parent_id: 'parent' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [{
+            locale: 'en',
+            content: 'Parent field is required'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Parent not found'
+          }],
+        }],
+      }, {
+        form: 'FORM-HEALTH_CENTER',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'health_center', parent_id: 'parent_id' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a place type "health_center" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [{
+            locale: 'en',
+            content: 'Parent field is required'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Parent not found'
+          }],
+        }],
+      }],
+      forms: { 'FORM-CLINIC_NO_PARENT': { }, 'FORM-CLINIC': { }, 'FORM-HEALTH_CENTER': {} },
+    };
+
+    const clinicNoParentUnderClinic = {
+      _id: 'clinicNoParentUnderClinic',
+      type: 'data_record',
+      form: 'FORM-CLINIC_NO_PARENT',
+      from: '+444999',
+      fields: {
+        place_name: 'Lunaris',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'person', parent:  { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } } }
+    };
+
+    const clinicNoParentUnderDistrict = {
+      _id: 'clinicNoParentUnderDistrict',
+      type: 'data_record',
+      form: 'FORM-CLINIC_NO_PARENT',
+      from: '+00000000',
+      fields: {
+        place_name: 'Lunaris',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const clinicUnderClinic = {
+      _id: 'clinicUnderClinic',
+      type: 'data_record',
+      form: 'FORM-CLINIC',
+      from: '+11111111',
+      fields: {
+        place_name: 'Lunaris',
+        parent: 'the_clinic'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
+    };
+
+    const clinicUnderDistrict = {
+      _id: 'clinicUnderDistrict',
+      type: 'data_record',
+      form: 'FORM-CLINIC',
+      from: '+11111111',
+      fields: {
+        place_name: 'Lunaris',
+        parent: 'the_district_hospital'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
+    };
+
+    const clinicNoParent = {
+      _id: 'clinicNoParent',
+      type: 'data_record',
+      form: 'FORM-CLINIC',
+      from: '+11111111',
+      fields: {
+        place_name: 'Lunaris',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
+    };
+
+    const clinicNoExistingParent = {
+      _id: 'clinicNonExistingParent',
+      type: 'data_record',
+      form: 'FORM-CLINIC',
+      from: '+11111111',
+      fields: {
+        place_name: 'Lunaris',
+        parent: 'some_parent_that_doesnt_exist'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
+    };
+
+    const healthCenterUnderClinic = {
+      _id: 'healthCenterUnderClinic',
+      type: 'data_record',
+      form: 'FORM-HEALTH_CENTER',
+      from: '+11111111',
+      fields: {
+        place_name: 'Lunaris',
+        parent_id: 'the_clinic'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
+    };
+
+    const reports = [
+      clinicNoParentUnderClinic,
+      clinicNoParentUnderDistrict,
+      clinicUnderClinic,
+      clinicUnderDistrict,
+      clinicNoParent,
+      clinicNoExistingParent,
+      healthCenterUnderClinic,
+    ];
+
+    const ids = reports.map(r => r._id);
+
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs(reports))
+      .then(() => sentinelUtils.waitForSentinel(ids))
+      .then(() => sentinelUtils.getInfoDocs(ids))
+      .then(infos => {
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
+      })
+      .then(() => utils.getDocs(ids))
+      .then(updated => {
+        updated.forEach(doc => {
+          chai.expect(doc.place_id).not.to.equal(undefined);
+          chai.expect(doc.patient_id).to.equal(undefined);
+          chai.expect(doc.errors).to.be.an('array');
+          chai.expect(doc.errors.length).to.equal(1);
+          chai.expect(doc.tasks).to.be.an('array');
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.place).to.equal(undefined);
+          chai.expect(doc.patient).to.equal(undefined);
+        });
+
+        chai.expect(updated[0].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a place type "clinic" under parent the_clinic(contact type clinic)',
+        });
+        chai.expect(updated[0].tasks[0].messages[0]).to.include({
+          to: '+444999',
+          message: 'Cannot create a place type "clinic" under parent the_clinic(contact type clinic)',
+        });
+
+        chai.expect(updated[1].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a place type "clinic" under parent the_district_hospital(contact type district_hospital)',
+        });
+        chai.expect(updated[1].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: 'Cannot create a place type "clinic" under parent the_district_hospital(contact type district_hospital)',
+        });
+
+        chai.expect(updated[2].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a place type "clinic" under parent the_clinic(contact type clinic)',
+        });
+        chai.expect(updated[2].tasks[0].messages[0]).to.include({
+          to: '+11111111',
+          message: 'Cannot create a place type "clinic" under parent the_clinic(contact type clinic)',
+        });
+
+        chai.expect(updated[3].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a place type "clinic" under parent the_district_hospital(contact type district_hospital)',
+        });
+        chai.expect(updated[3].tasks[0].messages[0]).to.include({
+          to: '+11111111',
+          message: 'Cannot create a place type "clinic" under parent the_district_hospital(contact type district_hospital)',
+        });
+
+        chai.expect(updated[4].errors[0]).to.deep.equal({
+          code: 'parent_field_not_provided',
+          message: 'Parent field is required',
+        });
+        chai.expect(updated[4].tasks[0].messages[0]).to.include({
+          to: '+11111111',
+          message: 'Parent field is required',
+        });
+
+        chai.expect(updated[5].errors[0]).to.deep.equal({
+          code: 'parent_not_found',
+          message: 'Parent not found',
+        });
+        chai.expect(updated[5].tasks[0].messages[0]).to.include({
+          to: '+11111111',
+          message: 'Parent not found',
+        });
+
+        chai.expect(updated[6].errors[0]).to.deep.equal({
+          code: 'invalid_parent',
+          message: 'Cannot create a place type "health_center" under parent the_clinic(contact type clinic)',
+        });
+        chai.expect(updated[6].tasks[0].messages[0]).to.include({
+          to: '+11111111',
+          message: 'Cannot create a place type "health_center" under parent the_clinic(contact type clinic)',
+        });
+
+        return getContactsByReference(updated.map(doc => doc.place_id));
+      })
+      .then(result => {
+        chai.expect(result.rows.length).to.equal(0);
+      });
+  });
+
+  it('should create places with correct type, name and parent', () => {
+    const settings = {
+      transitions: { registration: true },
+      registrations: [{
+        form: 'FORM-CLINIC_NO_PARENT',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'clinic', place_name_field: 'the_place_name' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [{
+            locale: 'en',
+            content: 'Place {{place.name}}({{place_id}}) added to {{parent.name}}'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }],
+      }, {
+        form: 'FORM-CLINIC',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'clinic', parent_id: 'parent' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [{
+            locale: 'en',
+            content: 'Place {{name}}({{place_id}}) added to {{parent.name}}'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'invalid_parent',
+          message: [{
+            locale: 'en',
+            content: 'Cannot create a place type "clinic" under parent {{parent.place_id}}(contact type {{parent.contact_type}})'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [{
+            locale: 'en',
+            content: 'Parent field is required'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Parent not found'
+          }],
+        }],
+      }, {
+        form: 'FORM-HEALTH_CENTER',
+        events: [{
+          name: 'on_create',
+          trigger: 'add_place',
+          params: { contact_type: 'health_center', parent_id: 'parent_id' },
+          bool_expr: ''
+        }],
+        messages: [{
+          recipient: 'reporting_unit',
+          event_type: 'report_accepted',
+          bool_expr: 'doc.place',
+          message: [{
+            locale: 'en',
+            content: 'Place {{name}}({{place_id}}) added to {{parent.name}}'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_field_not_provided',
+          message: [{
+            locale: 'en',
+            content: 'Parent field is required'
+          }],
+        }, {
+          recipient: 'reporting_unit',
+          event_type: 'parent_not_found',
+          message: [{
+            locale: 'en',
+            content: 'Parent not found'
+          }],
+        }],
+      }],
+      forms: { 'FORM-CLINIC_NO_PARENT': { }, 'FORM-CLINIC': { }, 'FORM-HEALTH_CENTER': {} },
+    };
+
+    const clinicNoParent = {
+      _id: 'clinicNoParent',
+      type: 'data_record',
+      form: 'FORM-CLINIC_NO_PARENT',
+      from: '+11111111',
+      fields: {
+        the_place_name: 'Toyota',
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'middle_man', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } }
+    };
+
+    const clinic = {
+      _id: 'justAClinic',
+      type: 'data_record',
+      form: 'FORM-CLINIC',
+      from: '+00000000',
+      fields: {
+        place_name: 'Ford',
+        parent: 'the_health_center'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const healthCenter = {
+      _id: 'newHealthCenter',
+      type: 'data_record',
+      form: 'FORM-HEALTH_CENTER',
+      from: '+00000000',
+      fields: {
+        place_name: 'Mazda',
+        parent_id: 'the_district_hospital'
+      },
+      reported_date: moment().valueOf(),
+      contact: { _id: 'supervisor', parent: { _id: 'district_hospital' } }
+    };
+
+    const docs = [ clinicNoParent, clinic, healthCenter ];
+    const ids = docs.map(doc => doc._id);
+    let updatedDocs;
+
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs(docs))
+      .then(() => sentinelUtils.waitForSentinel(ids))
+      .then(() => sentinelUtils.getInfoDocs(ids))
+      .then(infos => {
+        infos.forEach(info => {
+          chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
+        });
+      })
+      .then(() => utils.getDocs(ids))
+      .then(updated => {
+        updatedDocs = updated;
+
+        updated.forEach(doc => {
+          chai.expect(doc.patient_id).to.equal(undefined);
+          chai.expect(doc.place_id).not.to.equal(undefined);
+          chai.expect(doc.errors).to.equal(undefined);
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.patient).to.equal(undefined);
+          chai.expect(doc.place).to.equal(undefined);
+        });
+
+        chai.expect(updated[0].tasks[0].messages[0]).to.include({
+          to: '+11111111',
+          message: `Place Toyota(${updated[0].place_id}) added to Health Center`
+        });
+
+        chai.expect(updated[1].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: `Place Ford(${updated[1].place_id}) added to Health Center`
+        });
+
+        chai.expect(updated[2].tasks[0].messages[0]).to.include({
+          to: '+00000000',
+          message: `Place Mazda(${updated[2].place_id}) added to District hospital`
+        });
+
+        return getContactsByReference(updated.map(doc => doc.place_id));
+      })
+      .then(places => {
+        chai.expect(places.rows.length).to.equal(3);
+
+        chai.expect(places.rows[0].doc).to.deep.include({
+          name: 'Toyota',
+          type: 'contact',
+          contact_type: 'clinic',
+          place_id: updatedDocs[0].place_id,
+          source_id: updatedDocs[0]._id,
+          created_by: updatedDocs[0].contact._id,
+          parent: { _id: 'health_center', parent: { _id: 'district_hospital' } }
+        });
+        chai.expect(places.rows[1].doc).to.deep.include({
+          name: 'Ford',
+          type: 'contact',
+          contact_type: 'clinic',
+          place_id: updatedDocs[1].place_id,
+          source_id: updatedDocs[1]._id,
+          created_by: updatedDocs[1].contact._id,
+          parent: { _id: 'health_center', parent: { _id: 'district_hospital' } }
+        });
+        chai.expect(places.rows[2].doc).to.deep.include({
+          name: 'Mazda',
+          type: 'contact',
+          contact_type: 'health_center',
+          place_id: updatedDocs[2].place_id,
+          source_id: updatedDocs[2]._id,
+          created_by: updatedDocs[2].contact._id,
+          parent: { _id: 'district_hospital' }
+        });
+
+        places.rows.forEach(row => {
+          // no primary contact
+          chai.expect(row.doc.contact).to.equal(undefined);
+        });
       });
   });
 
@@ -606,63 +1594,59 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel(doc1._id))
       .then(() => sentinelUtils.getInfoDoc(doc1._id))
       .then(info => {
-        expect(info.transitions).toBeDefined();
-        expect(info.transitions.registration).toBeDefined();
-        expect(info.transitions.registration.ok).toEqual(true);
+        chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
       })
       .then(() => utils.getDoc(doc1._id))
       .then(updated => {
-        expect(updated.scheduled_tasks).toBeDefined();
-        expect(updated.scheduled_tasks.length).toEqual(3);
+        chai.expect(updated.scheduled_tasks).to.be.ok;
+        chai.expect(updated.scheduled_tasks.length).to.equal(3);
 
-        expect(updated.scheduled_tasks[0].type).toEqual('sch1');
-        expect(updated.scheduled_tasks[0].group).toEqual(2);
-        expect(updated.scheduled_tasks[0].state).toEqual('scheduled');
-        expect(updated.scheduled_tasks[0].messages[0].message).toEqual('message2');
+        chai.expect(updated.scheduled_tasks[0].type).to.equal('sch1');
+        chai.expect(updated.scheduled_tasks[0].group).to.equal(2);
+        chai.expect(updated.scheduled_tasks[0].state).to.equal('scheduled');
+        chai.expect(updated.scheduled_tasks[0].messages[0].message).to.equal('message2');
 
-        expect(updated.scheduled_tasks[1].type).toEqual('sch2');
-        expect(updated.scheduled_tasks[1].group).toEqual(1);
-        expect(updated.scheduled_tasks[1].state).toEqual('scheduled');
-        expect(updated.scheduled_tasks[1].messages[0].message).toEqual('message3');
+        chai.expect(updated.scheduled_tasks[1].type).to.equal('sch2');
+        chai.expect(updated.scheduled_tasks[1].group).to.equal(1);
+        chai.expect(updated.scheduled_tasks[1].state).to.equal('scheduled');
+        chai.expect(updated.scheduled_tasks[1].messages[0].message).to.equal('message3');
 
-        expect(updated.scheduled_tasks[2].type).toEqual('sch2');
-        expect(updated.scheduled_tasks[2].group).toEqual(1);
-        expect(updated.scheduled_tasks[2].state).toEqual('scheduled');
-        expect(updated.scheduled_tasks[2].messages[0].message).toEqual('message4');
+        chai.expect(updated.scheduled_tasks[2].type).to.equal('sch2');
+        chai.expect(updated.scheduled_tasks[2].group).to.equal(1);
+        chai.expect(updated.scheduled_tasks[2].state).to.equal('scheduled');
+        chai.expect(updated.scheduled_tasks[2].messages[0].message).to.equal('message4');
       })
       .then(() => utils.saveDoc(doc2))
       .then(() => sentinelUtils.waitForSentinel(doc2._id))
       .then(() => sentinelUtils.getInfoDoc(doc2._id))
       .then(info => {
-        expect(info.transitions).toBeDefined();
-        expect(info.transitions.registration).toBeDefined();
-        expect(info.transitions.registration.ok).toEqual(true);
+        chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
       })
       .then(() => utils.getDocs([doc1._id, doc2._id ]))
       .then(updated => {
         //1st doc has cleared schedules
-        expect(updated[0].scheduled_tasks).toBeDefined();
-        expect(updated[0].scheduled_tasks.length).toEqual(3);
+        chai.expect(updated[0].scheduled_tasks).to.be.ok;
+        chai.expect(updated[0].scheduled_tasks.length).to.equal(3);
         expect(updated[0].scheduled_tasks.every(task => task.state === 'cleared')).toBe(true);
 
         //2nd doc has schedules
-        expect(updated[1].scheduled_tasks).toBeDefined();
-        expect(updated[1].scheduled_tasks.length).toEqual(3);
+        chai.expect(updated[1].scheduled_tasks).to.be.ok;
+        chai.expect(updated[1].scheduled_tasks.length).to.equal(3);
 
-        expect(updated[1].scheduled_tasks[0].type).toEqual('sch1');
-        expect(updated[1].scheduled_tasks[0].group).toEqual(2);
-        expect(updated[1].scheduled_tasks[0].state).toEqual('scheduled');
-        expect(updated[1].scheduled_tasks[0].messages[0].message).toEqual('message2');
+        chai.expect(updated[1].scheduled_tasks[0].type).to.equal('sch1');
+        chai.expect(updated[1].scheduled_tasks[0].group).to.equal(2);
+        chai.expect(updated[1].scheduled_tasks[0].state).to.equal('scheduled');
+        chai.expect(updated[1].scheduled_tasks[0].messages[0].message).to.equal('message2');
 
-        expect(updated[1].scheduled_tasks[1].type).toEqual('sch2');
-        expect(updated[1].scheduled_tasks[1].group).toEqual(1);
-        expect(updated[1].scheduled_tasks[1].state).toEqual('scheduled');
-        expect(updated[1].scheduled_tasks[1].messages[0].message).toEqual('message3');
+        chai.expect(updated[1].scheduled_tasks[1].type).to.equal('sch2');
+        chai.expect(updated[1].scheduled_tasks[1].group).to.equal(1);
+        chai.expect(updated[1].scheduled_tasks[1].state).to.equal('scheduled');
+        chai.expect(updated[1].scheduled_tasks[1].messages[0].message).to.equal('message3');
 
-        expect(updated[1].scheduled_tasks[2].type).toEqual('sch2');
-        expect(updated[1].scheduled_tasks[2].group).toEqual(1);
-        expect(updated[1].scheduled_tasks[2].state).toEqual('scheduled');
-        expect(updated[1].scheduled_tasks[2].messages[0].message).toEqual('message4');
+        chai.expect(updated[1].scheduled_tasks[2].type).to.equal('sch2');
+        chai.expect(updated[1].scheduled_tasks[2].group).to.equal(1);
+        chai.expect(updated[1].scheduled_tasks[2].state).to.equal('scheduled');
+        chai.expect(updated[1].scheduled_tasks[2].messages[0].message).to.equal('message4');
       });
   });
 
@@ -725,18 +1709,16 @@ describe('registration', () => {
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
       .then(info => {
-        expect(info.transitions).toBeDefined();
-        expect(info.transitions.registration).toBeDefined();
-        expect(info.transitions.registration.ok).toEqual(true);
+        chai.expect(info).to.deep.nested.include({ 'transitions.registration.ok': true });
       })
       .then(() => utils.getDoc(doc._id))
       .then(updated => {
-        expect(updated.tasks).toBeDefined();
-        expect(updated.tasks.length).toEqual(3);
+        chai.expect(updated.tasks).to.be.ok;
+        chai.expect(updated.tasks.length).to.equal(3);
 
-        expect(updated.tasks[0].messages[0].message).toEqual('Report accepted');
-        expect(updated.tasks[1].messages[0].message).toEqual('alpha');
-        expect(updated.tasks[2].messages[0].message).toEqual('beta');
+        chai.expect(updated.tasks[0].messages[0].message).to.equal('Report accepted');
+        chai.expect(updated.tasks[1].messages[0].message).to.equal('alpha');
+        chai.expect(updated.tasks[2].messages[0].message).to.equal('beta');
       });
 
   });

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -276,7 +276,7 @@ describe('registration', () => {
           event_type: 'report_accepted',
           message: [{
             locale: 'en',
-            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{parent.name}}'
+            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{clinic.name}}'
           }],
         }],
       }, {
@@ -293,7 +293,7 @@ describe('registration', () => {
           bool_expr: 'doc.patient',
           message: [{
             locale: 'en',
-            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{parent.name}}'
+            content: 'Patient {{patient_name}} ({{patient_id}}) added to {{clinic.name}}'
           }],
         }],
       }],
@@ -1288,7 +1288,7 @@ describe('registration', () => {
           bool_expr: 'doc.place',
           message: [{
             locale: 'en',
-            content: 'Place {{place.name}}({{place_id}}) added to {{parent.name}}'
+            content: 'Place {{place.name}}({{place_id}}) added to {{health_center.name}}'
           }],
         }, {
           recipient: 'reporting_unit',
@@ -1312,7 +1312,7 @@ describe('registration', () => {
           bool_expr: 'doc.place',
           message: [{
             locale: 'en',
-            content: 'Place {{name}}({{place_id}}) added to {{parent.name}}'
+            content: 'Place {{name}}({{place_id}}) added to {{health_center.name}}'
           }],
         }, {
           recipient: 'reporting_unit',
@@ -1350,7 +1350,7 @@ describe('registration', () => {
           bool_expr: 'doc.place',
           message: [{
             locale: 'en',
-            content: 'Place {{name}}({{place_id}}) added to {{parent.name}}'
+            content: 'Place {{name}}({{place_id}}) added to {{district.name}}'
           }],
         }, {
           recipient: 'reporting_unit',

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -5,6 +5,8 @@ const _ = require('underscore'),
   rpn = require('request-promise-native'),
   htmlScreenshotReporter = require('protractor-jasmine2-screenshot-reporter');
 const specReporter = require('jasmine-spec-reporter').SpecReporter;
+const fs = require('fs');
+const path = require('path');
 
 const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
@@ -315,6 +317,11 @@ const waitForDocRev = (ids) => {
     }
     return module.exports.delayPromise(() => waitForDocRev(ids), 100);
   });
+};
+
+const getDefaultSettings = () => {
+  const pathToDefaultAppSettings = path.join(__dirname, './config.default.json');
+  return JSON.parse(fs.readFileSync(pathToDefaultAppSettings).toString());
 };
 
 module.exports = {
@@ -631,4 +638,6 @@ module.exports = {
   refreshToGetNewSettings: refreshToGetNewSettings,
 
   waitForDocRev: waitForDocRev,
+
+  getDefaultSettings: getDefaultSettings,
 };

--- a/webapp/src/js/services/contact-types.js
+++ b/webapp/src/js/services/contact-types.js
@@ -1,39 +1,30 @@
+const contactTypesUtils = require('@medic/contact-types-utils');
+
 angular.module('inboxServices').service('ContactTypes', function(
   Settings
 ) {
   'use strict';
   'ngInject';
 
-  const HARDCODED_TYPES = [
-    'district_hospital',
-    'health_center',
-    'clinic',
-    'person'
-  ];
-
-  const getConfig = () => Settings().then(config => config.contact_types || []);
-  const filterOnPerson = person => getConfig().then(types => types.filter(type => !!type.person === person));
-  const isHardcodedType = type => HARDCODED_TYPES.includes(type);
-
   return {
 
-    HARDCODED_TYPES: HARDCODED_TYPES,
+    HARDCODED_TYPES: contactTypesUtils.HARDCODED_TYPES,
 
     /**
      * Returns a Promise to resolve the configured contact type identified by the given id.
      */
-    get: id => getConfig().then(types => types.find(type => type.id === id)),
+    get: id => Settings().then(config => contactTypesUtils.getTypeById(config, id)),
 
     /**
      * Returns a Promise to resolve an array of configured contact types.
      */
-    getAll: getConfig,
+    getAll: () => Settings().then(config => contactTypesUtils.getContactTypes(config)),
 
     /**
      * Returns true if the given type is one of the contact types that
      * were hardcoded in old versions.
      */
-    isHardcodedType: isHardcodedType,
+    isHardcodedType: contactTypesUtils.isHardcodedType,
 
     /**
      * Returns true if the given doc is a contact type.
@@ -44,30 +35,23 @@ angular.module('inboxServices').service('ContactTypes', function(
         return false;
       }
       return type === 'contact' ||   // configurable hierarchy
-             isHardcodedType(type);  // hardcoded
+             contactTypesUtils.isHardcodedType(type);  // hardcoded
     },
 
     /**
      * Returns a Promise to resolve an array of child type names for the
      * given type id. If parent is falsey, returns the types with no parent.
      */
-    getChildren: parent => {
-      return getConfig().then(types => {
-        return types.filter(type => {
-          const parents = type.parents || [];
-          return (!parent && !parents.length) || parents.includes(parent);
-        });
-      });
-    },
+    getChildren: parent => Settings().then(config => contactTypesUtils.getChildren(config, parent)),
 
     /**
      * Returns a Promise to resolve all the configured place contact types
      */
-    getPlaceTypes: () => filterOnPerson(false),
+    getPlaceTypes: () => Settings().then(config => contactTypesUtils.getPlaceTypes(config)),
 
     /**
      * Returns a Promise to resolve all the configured person contact types
      */
-    getPersonTypes: () => filterOnPerson(true),
+    getPersonTypes: () => Settings().then(config => contactTypesUtils.getPersonTypes(config)),
   };
 });

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -84,7 +84,7 @@ angular.module('inboxServices').factory('RulesEngine', function(
       key: 'mark-contacts-dirty',
       filter: change => !!change.doc && (ContactTypes.includes(change.doc) || isReport(change.doc)),
       callback: change => {
-        const subjectId = isReport(change.doc) ? registrationUtils.getPatientId(change.doc) : change.id;
+        const subjectId = isReport(change.doc) ? registrationUtils.getSubjectId(change.doc) : change.id;
         RulesEngineCore.updateEmissionsFor(subjectId);
       },
     });


### PR DESCRIPTION
# Description

Adds support for creating places by SMS by adding an additional `add_place` trigger in `registration` transition. 
Adds trigger option `parent_id` for both `add_patient` and `add_place` triggers that selects the field when there parent's shortcode would be found in the form's fields. 
Adds `parent` validation based on configured contact types.
Adds `contact-type-utils` shared library. 
Updates `generate_patient_id_on_people` to add shortcodes to new places as well. 
Updates `message-utils` template context generator to use `place` context property.  

medic/cht-core#5614

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
