### PR TITLE
Set timeout on replication from server request

### DIFF
--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -57,7 +57,10 @@ angular
       },
       {
         name: 'from',
-        options: {},
+        options: {
+          heartbeat: 10000, // 10 seconds
+          timeout: 1000 * 60 * 10, // 10 minutes
+        },
         allowed: () => $q.resolve(true)
       }
     ];


### PR DESCRIPTION
# Description

Sets the timeout and heartbeat to keep the connection from the
browser alive for 10 minutes. This makes it more likely the client
will get a response if they are a long way behind the db current
seq.

medic/cht-core#6023

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
