### PR TITLE
Only hydrate contacts once

### DIFF
--- a/shared-libs/lineage/test/integration.js
+++ b/shared-libs/lineage/test/integration.js
@@ -796,7 +796,7 @@ describe('Lineage', function() {
     });
 
     it('should not recurse more than needed', () => {
-      const copy = (doc) => JSON.parse(JSON.stringify(doc));
+      const copy = (doc) => cloneDeep(doc);
       return Promise
         .all([
           lineage.hydrateDocs([circular_report]),
@@ -804,6 +804,7 @@ describe('Lineage', function() {
         ])
         .then(results => {
           expect(results[0][0]).to.deep.equal(results[1][0]);
+          expect(results[0][0]).to.deep.equal(results[1][1]);
         });
     });
 

--- a/shared-libs/lineage/test/integration.js
+++ b/shared-libs/lineage/test/integration.js
@@ -795,6 +795,18 @@ describe('Lineage', function() {
         });
     });
 
+    it('should not recurse more than needed', () => {
+      const copy = (doc) => JSON.parse(JSON.stringify(doc));
+      return Promise
+        .all([
+          lineage.hydrateDocs([circular_report]),
+          lineage.hydrateDocs([copy(circular_report), copy(circular_report)])
+        ])
+        .then(results => {
+          expect(results[0][0]).to.deep.equal(results[1][0]);
+        });
+    });
+
     it('processing a doc with itself as a parent errors out', function() {
       const docs = [ cloneDeep(child_is_parent) ];
 


### PR DESCRIPTION
# Description

Instead of performing a contact hydration for every doc-to-be-hydrated, perform the operation once, before hydrating anything else. This ensures that we never go too deep even if the docs-to-be-hydrated share some lineage.

medic/cht-core#6122

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
