### PR TITLE
Fixes basic SMS settings page

### DIFF
--- a/admin/src/js/controllers/sms-settings.js
+++ b/admin/src/js/controllers/sms-settings.js
@@ -55,7 +55,6 @@ angular.module('controllers').controller('SmsSettingsCtrl',
     $scope.submit = () => {
       $scope.model.error = {};
       if (validate()) {
-        $scope.status = { loading: true };
         const settings = {
           gateway_number: $scope.model.gateway_number,
           default_country_code: $('#default-country-code').val(),
@@ -66,9 +65,10 @@ angular.module('controllers').controller('SmsSettingsCtrl',
           schedule_evening_minutes: $scope.model.schedule_evening_minutes,
           outgoing_phone_replace: {
             match: $('#outgoing-phone-replace-match').val(),
-            replace:  $scope.model.outgoing_phone_replace.replace
+            replace: $scope.model.outgoing_phone_replace.replace
           }
         };
+        $scope.status = { loading: true };
         UpdateSettings(settings)
           .then(() => {
             $scope.status = { success: true, msg: $translate.instant('Saved') };
@@ -93,7 +93,7 @@ angular.module('controllers').controller('SmsSettingsCtrl',
           schedule_morning_minutes: res.schedule_morning_minutes,
           schedule_evening_hours: res.schedule_evening_hours,
           schedule_evening_minutes: res.schedule_evening_minutes,
-          outgoing_phone_replace: res.outgoing_phone_replace,
+          outgoing_phone_replace: res.outgoing_phone_replace || {},
           accept_messages: !res.forms_only_mode,
         };
         $('#default-country-code').select2({ width: '20em', data: countries.list });
@@ -106,7 +106,7 @@ angular.module('controllers').controller('SmsSettingsCtrl',
           placeholder: ' ',
           allowClear: true
         });
-        if (res.outgoing_phone_replace) {
+        if (res.outgoing_phone_replace.match) {
           $('#outgoing-phone-replace-match').val(res.outgoing_phone_replace.match).trigger('change');
         }
       })


### PR DESCRIPTION
# Description

We can't assume that the settings.outgoing_phone_replace is set.

medic/cht-core#6117

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
