### PR TITLE
Fix navigation (back + after contact/report deletion) 

### DIFF
--- a/tests/page-objects/contacts/contacts.po.js
+++ b/tests/page-objects/contacts/contacts.po.js
@@ -92,7 +92,6 @@ module.exports = {
   },
 
   search: async query => {
-    helper.waitUntilReady(searchBox);
     searchBox.clear();
     searchBox.sendKeys(query);
     await seachButton.click();

--- a/tests/page-objects/contacts/contacts.po.js
+++ b/tests/page-objects/contacts/contacts.po.js
@@ -92,6 +92,7 @@ module.exports = {
   },
 
   search: async query => {
+    helper.waitUntilReady(searchBox);
     searchBox.clear();
     searchBox.sendKeys(query);
     await seachButton.click();

--- a/webapp/src/js/controllers/reports-content.js
+++ b/webapp/src/js/controllers/reports-content.js
@@ -36,6 +36,7 @@ var _ = require('underscore');
         const globalActions = GlobalActions(dispatch);
         const reportsActions = ReportsActions(dispatch);
         return {
+          unsetSelected: globalActions.unsetSelected,
           clearCancelCallback: globalActions.clearCancelCallback,
           removeSelectedReport: reportsActions.removeSelectedReport,
           selectReport: reportsActions.selectReport,
@@ -47,9 +48,13 @@ var _ = require('underscore');
       };
       const unsubscribe = $ngRedux.connect(mapStateToTarget, mapDispatchToTarget)(ctrl);
 
-      ctrl.selectReport($stateParams.id);
-      ctrl.clearCancelCallback();
-      $('.tooltip').remove();
+      if ($stateParams.id) {
+        ctrl.selectReport($stateParams.id);
+        ctrl.clearCancelCallback();
+        $('.tooltip').remove();
+      } else {
+        ctrl.unsetSelected();
+      }
 
       ctrl.canMute = function(group) {
         return MessageState.any(group, 'scheduled');

--- a/webapp/src/js/directives/navigation.js
+++ b/webapp/src/js/directives/navigation.js
@@ -37,6 +37,8 @@ angular.module('inboxDirectives').directive('mmNavigation', function() {
       ctrl.navigateBack = () => {
         if ($state.current.name === 'contacts.deceased') {
           $state.go('contacts.detail', { id: $stateParams.id });
+        } else if ($stateParams.id) {
+          $state.go($state.current.name, { id: null });
         } else {
           ctrl.unsetSelected();
         }


### PR DESCRIPTION
# Description

These changes fix the navigation when
1) when the user is reviewing a report detail then navigate back to the list and then attempts to view again the detail of the same report (pre-fix the user will be stuck on the list)
2) when the user deletes a contact or a report, she will be redirected to the list (pre-fix the user will be stuck on the detail screen with an empty screen)

medic/cht-core#6118

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
