### PR TITLE
Retry replication with reducing batch size

### DIFF
--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -7,13 +7,9 @@ const MEDIC_BASIC_AUTH = 'Basic realm="Medic Mobile Web Services"';
 
 const wantsJSON = req => req.get('Accept') === 'application/json';
 
-const writeJSON = (res, code, message, details) => {
+const writeJSON = (res, code, error, details) => {
   res.status(code);
-  res.json({
-    code: code,
-    error: message,
-    details: details,
-  });
+  res.json({ code, error, details });
 };
 
 const respond = (req, res, code, message, details) => {
@@ -102,6 +98,9 @@ module.exports = {
    */
   serverError: (err, req, res) => {
     logger.error('Server error: %o', err);
+    if (err.type === 'entity.too.large') {
+      return respond(req, res, 413, 'Payload Too Large');
+    }
     respond(req, res, 500, 'Server error', err.publicMessage);
   },
 

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -214,6 +214,21 @@ describe('Server utils', () => {
       chai.expect(json.args[0][0].error).to.equal('Server error');
     });
 
+    it('handles uncaught payload size exceptions', () => {
+      const status = sinon.stub(res, 'status');
+      const json = sinon.stub(res, 'json');
+      const get = sinon.stub(req, 'get');
+      get.returns('application/json');
+      serverUtils.serverError({ foo: 'bar', type: 'entity.too.large' }, req, res);
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(get.args[0][0]).to.equal('Accept');
+      chai.expect(status.callCount).to.equal(1);
+      chai.expect(status.args[0][0]).to.equal(413);
+      chai.expect(json.callCount).to.equal(1);
+      chai.expect(json.args[0][0].code).to.equal(413);
+      chai.expect(json.args[0][0].error).to.equal('Payload Too Large');
+    });
+
   });
 
 });

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -157,11 +157,12 @@ const createReduxLoggerConfig = Selectors => ({
     $ngReduxProvider.createStoreWith(RootReducer, middlewares);
   });
 
-  // 16 million characters is gauranteed to be less than the API JSON
-  // parser limit of 32MB. It's possible to work out the exact size of
-  // the body based on the number of two byte characters but this is
-  // expensive.
-  const BODY_LENGTH_LIMIT = 16000000; // 16 million
+  // 32 million characters is gauranteed to be rejected by the API JSON
+  // parser limit of 32MB so don't even bother POSTing. If there are many
+  // 2 byte characters then a smaller body may also fail. Detecting the
+  // exact byte length of a string is too expensive so we let the request
+  // go and if it's still too long then API will respond with a 413.
+  const BODY_LENGTH_LIMIT = 32000000; // 32 million
   const POUCHDB_OPTIONS = {
     local: { auto_compaction: true },
     remote: {

--- a/webapp/src/js/app.js
+++ b/webapp/src/js/app.js
@@ -157,7 +157,7 @@ const createReduxLoggerConfig = Selectors => ({
     $ngReduxProvider.createStoreWith(RootReducer, middlewares);
   });
 
-  // 32 million characters is gauranteed to be rejected by the API JSON
+  // 32 million characters is guaranteed to be rejected by the API JSON
   // parser limit of 32MB so don't even bother POSTing. If there are many
   // 2 byte characters then a smaller body may also fail. Detecting the
   // exact byte length of a string is too expensive so we let the request

--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -49,9 +49,9 @@ angular
     const DIRECTIONS = [
       {
         name: 'to',
+        filter: true,
         options: {
           checkpoint: 'source',
-          filter: readOnlyFilter
         },
         allowed: () => Auth('can_edit').then(() => true).catch(() => false)
       },
@@ -65,34 +65,46 @@ angular
       }
     ];
 
-    const replicate = function(direction) {
-      return direction.allowed()
-        .then(allowed => {
-          if (!allowed) {
-            // not authorized to replicate - that's ok, skip silently
-            return;
+    const replicate = (direction, { batchSize=100 }={}) => {
+      const remote = DB({ remote: true });
+      const options = Object.assign({}, direction.options, { batch_size: batchSize });
+      if (direction.filter) {
+        options.filter = readOnlyFilter;
+      }
+      return DB()
+        .replicate[direction.name](remote, options)
+        .on('denied', function(err) {
+          // In theory this could be caused by 401s
+          // TODO: work out what `err` looks like and navigate to login
+          // when we detect it's a 401
+          $log.error(`Denied replicating ${direction.name} remote server`, err);
+        })
+        .on('error', function(err) {
+          $log.error(`Error replicating ${direction.name} remote server`, err);
+        })
+        .then(info => {
+          $log.debug(`Replication ${direction.name} successful`, info);
+          return;
+        })
+        .catch(err => {
+          if (err.code === 413 && direction.name === 'to' && batchSize > 1) {
+            batchSize = parseInt(batchSize / 2);
+            $log.warn(`Error attempting to replicate too much data to the server. Trying again with batch size of ${batchSize}`);
+            return replicate(direction, { batchSize });
           }
-          const remote = DB({ remote: true });
-          return DB()
-            .replicate[direction.name](remote, direction.options)
-            .on('denied', function(err) {
-              // In theory this could be caused by 401s
-              // TODO: work out what `err` looks like and navigate to login
-              // when we detect it's a 401
-              $log.error(`Denied replicating ${direction.name} remote server`, err);
-            })
-            .on('error', function(err) {
-              $log.error(`Error replicating ${direction.name} remote server`, err);
-            })
-            .then(info => {
-              $log.debug(`Replication ${direction.name} successful`, info);
-              return;
-            })
-            .catch(err => {
-              $log.error(`Error replicating ${direction.name} remote server`, err);
-              return direction.name;
-            });
+          $log.error(`Error replicating ${direction.name} remote server`, err);
+          return direction.name;
         });
+    };
+
+    const replicateIfAllowed = direction => {
+      return direction.allowed().then(allowed => {
+        if (!allowed) {
+          // not authorized to replicate - that's ok, skip silently
+          return;
+        }
+        return replicate(direction);
+      });
     };
 
     const getCurrentSeq = () => DB().info().then(info => info.update_seq + '');
@@ -108,7 +120,7 @@ angular
 
       if (!inProgressSync) {
         inProgressSync = $q
-          .all(DIRECTIONS.map(direction => replicate(direction)))
+          .all(DIRECTIONS.map(direction => replicateIfAllowed(direction)))
           .then(errs => {
             return getCurrentSeq().then(currentSeq => {
               errs = errs.filter(err => err);

--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -49,8 +49,8 @@ angular
     const DIRECTIONS = [
       {
         name: 'to',
-        filter: true,
         options: {
+          filter: readOnlyFilter,
           checkpoint: 'source',
         },
         allowed: () => Auth('can_edit').then(() => true).catch(() => false)
@@ -68,9 +68,6 @@ angular
     const replicate = (direction, { batchSize=100 }={}) => {
       const remote = DB({ remote: true });
       const options = Object.assign({}, direction.options, { batch_size: batchSize });
-      if (direction.filter) {
-        options.filter = readOnlyFilter;
-      }
       return DB()
         .replicate[direction.name](remote, options)
         .on('denied', function(err) {

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -82,6 +82,7 @@ describe('DBSync service', () => {
         expect(Auth.callCount).to.equal(1);
         expect(Auth.args[0][0]).to.equal('can_edit');
         expect(from.callCount).to.equal(1);
+        expect(from.args[0][1]).to.have.keys('heartbeat', 'timeout', 'batch_size');
         expect(from.args[0][1]).to.not.have.keys('filter', 'checkpoint');
         expect(to.callCount).to.equal(1);
         expect(to.args[0][1]).to.have.keys('filter', 'checkpoint', 'batch_size');

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -84,7 +84,7 @@ describe('DBSync service', () => {
         expect(from.callCount).to.equal(1);
         expect(from.args[0][1]).to.not.have.keys('filter', 'checkpoint');
         expect(to.callCount).to.equal(1);
-        expect(to.args[0][1]).to.have.keys('filter', 'checkpoint');
+        expect(to.args[0][1]).to.have.keys('filter', 'checkpoint', 'batch_size');
       });
     });
 
@@ -236,13 +236,85 @@ describe('DBSync service', () => {
         expect(onUpdate.args[1][0]).to.deep.eq({ to: 'success', from: 'success' });
       });
     });
+
+    describe('retries with smaller batch size', () => {
+
+      let count;
+      let retries;
+      const recursiveOnTo = sinon.stub();
+
+      const replicationResultTo = () => {
+        if (count <= retries) {
+          count++;
+          return Q.reject({ code: 413 });
+        } else {
+          return Q.resolve();
+        }
+      };
+
+      beforeEach(() => {
+        count = 0;
+
+        isOnlineOnly.returns(false);
+        Auth.resolves();
+
+        recursiveOnTo.callsFake(() => {
+          const promise = replicationResultTo();
+          promise.on = recursiveOnTo;
+          return promise;
+        });
+
+        to.callsFake(() => {
+          let promise;
+          if (count < retries) {
+            // Too big - retry
+            promise = Q.reject({ code: 413 });
+          } else {
+            // small enough - complete
+            promise = Q.resolve();
+          }
+          promise.on = recursiveOnTo;
+          return promise;
+        });
+      });
+
+      it('if request too large', () => {
+        retries = 3;
+        return service.sync().then(() => {
+          expect(Auth.callCount).to.equal(1);
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(3);
+          expect(to.args[0][1].batch_size).to.equal(100);
+          expect(to.args[1][1].batch_size).to.equal(50);
+          expect(to.args[2][1].batch_size).to.equal(25);
+        });
+      });
+
+      it('gives up once batch size is 1', () => {
+        retries = 100; // should not get this far...
+        return service.sync().then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(7);
+          expect(to.args[0][1].batch_size).to.equal(100);
+          expect(to.args[1][1].batch_size).to.equal(50);
+          expect(to.args[2][1].batch_size).to.equal(25);
+          expect(to.args[3][1].batch_size).to.equal(12);
+          expect(to.args[4][1].batch_size).to.equal(6);
+          expect(to.args[5][1].batch_size).to.equal(3);
+          expect(to.args[6][1].batch_size).to.equal(1);
+          console.log('finishing up');
+        });
+      });
+
+    });
+
   });
 
   describe('replicateTo filter', () => {
 
     let filterFunction;
 
-    before(() => {
+    beforeEach(() => {
       isOnlineOnly.returns(false);
       Auth.returns(Q.resolve());
       userCtx.returns({ name: 'mobile', roles: ['district-manager'] });

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -302,7 +302,6 @@ describe('DBSync service', () => {
           expect(to.args[4][1].batch_size).to.equal(6);
           expect(to.args[5][1].batch_size).to.equal(3);
           expect(to.args[6][1].batch_size).to.equal(1);
-          console.log('finishing up');
         });
       });
 


### PR DESCRIPTION
- Test and fail the replication to the server if the body size is
likely to be too large.
- Catch the error and retry with a smaller batch size.
- Give up when the batch size is set to 1.

medic/cht-core#6143

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
