### PR TITLE
Add defaults to restore backwards compatibility

### DIFF
--- a/api/src/controllers/changes.js
+++ b/api/src/controllers/changes.js
@@ -258,6 +258,13 @@ const getChanges = feed => {
 };
 
 const initFeed = (req, res) => {
+
+  const changesControllerConfig = config.get('changes_controller') || {
+    reiterate_changes: true,
+    changes_limit: 100,
+    debounce_interval: 200
+  };
+
   const feed = {
     id: req.id || uuid(),
     req: req,
@@ -267,13 +274,13 @@ const initFeed = (req, res) => {
     currentSeq: currentSeq,
     pendingChanges: [],
     results: [],
-    limit: req.query && req.query.limit || config.get('changes_controller').changes_limit,
-    reiterate_changes: config.get('changes_controller').reiterate_changes,
+    limit: req.query && req.query.limit || changesControllerConfig.changes_limit,
+    reiterate_changes: changesControllerConfig.reiterate_changes,
     initialReplication: req.query && req.query.initial_replication
   };
 
-  if (config.get('changes_controller').debounce_interval) {
-    feed.debounceEnd = _.debounce(() => endFeed(feed, true, true), config.get('changes_controller').debounce_interval);
+  if (changesControllerConfig.debounce_interval) {
+    feed.debounceEnd = _.debounce(() => endFeed(feed, true, true), changesControllerConfig.debounce_interval);
   }
 
   defibrillator(feed);

--- a/api/src/services/messaging.js
+++ b/api/src/services/messaging.js
@@ -11,6 +11,7 @@ const SMS_SENDING_SERVICES = {
   'africas-talking': africasTalking
   // medic-gateway -- ignored because it's a pull not a push service
 };
+const DEFAULT_CONFIG = { sms: { outgoing_service: 'medic-gateway' } };
 
 const getTaskFromMessage = (tasks, uuid) => {
   return tasks && tasks.find(task => {
@@ -59,11 +60,12 @@ const applyTaskStateChangesToDocs = (taskStateChanges, docs) => {
   }, {});
 };
 
+const getConfig = () => config.get('sms') || DEFAULT_CONFIG;
+
 const getOutgoingMessageService = () => {
-  const settings = config.get('sms') || { sms: { outgoing_service: 'medic-gateway' } };
-  return settings &&
-         settings.outgoing_service &&
-         SMS_SENDING_SERVICES[settings.outgoing_service];
+  const config = getConfig();
+  return config.outgoing_service &&
+         SMS_SENDING_SERVICES[config.outgoing_service];
 };
 
 const checkDbForMessagesToSend = () => {
@@ -301,8 +303,7 @@ module.exports = {
    * two services sending the same message.
    */
   isMedicGatewayEnabled: () => {
-    const settings = config.get('sms') || {};
-    return settings.outgoing_service === 'medic-gateway';
+    return getConfig().outgoing_service === 'medic-gateway';
   }
   
 };

--- a/api/src/services/messaging.js
+++ b/api/src/services/messaging.js
@@ -11,7 +11,7 @@ const SMS_SENDING_SERVICES = {
   'africas-talking': africasTalking
   // medic-gateway -- ignored because it's a pull not a push service
 };
-const DEFAULT_CONFIG = { sms: { outgoing_service: 'medic-gateway' } };
+const DEFAULT_CONFIG = { outgoing_service: 'medic-gateway' };
 
 const getTaskFromMessage = (tasks, uuid) => {
   return tasks && tasks.find(task => {

--- a/api/src/services/messaging.js
+++ b/api/src/services/messaging.js
@@ -60,7 +60,7 @@ const applyTaskStateChangesToDocs = (taskStateChanges, docs) => {
 };
 
 const getOutgoingMessageService = () => {
-  const settings = config.get('sms');
+  const settings = config.get('sms') || { sms: { outgoing_service: 'medic-gateway' } };
   return settings &&
          settings.outgoing_service &&
          SMS_SENDING_SERVICES[settings.outgoing_service];

--- a/api/tests/mocha/services/messaging.spec.js
+++ b/api/tests/mocha/services/messaging.spec.js
@@ -449,6 +449,15 @@ describe('messaging service', () => {
       });
     });
 
+    it('does nothing with default settings (medic-gateway)', () => {
+      sinon.stub(config, 'get').withArgs('sms').returns();
+      sinon.stub(service, 'getOutgoingMessages');
+      return service._checkDbForMessagesToSend().then(() => {
+        chai.expect(config.get.callCount).to.equal(1);
+        chai.expect(service.getOutgoingMessages.callCount).to.equal(0);
+      });
+    });
+
     it('does nothing if there are no messages to send', () => {
       sinon.stub(config, 'get').withArgs('sms').returns({ outgoing_service: 'africas-talking' });
       sinon.stub(service, 'getOutgoingMessages').resolves([]);
@@ -566,6 +575,25 @@ describe('messaging service', () => {
         ]]);
         chai.expect(actual).to.deep.equal({ saved: 3 });
       });
+    });
+
+  });
+
+  describe('isMedicGatewayEnabled', () => {
+
+    it('returns false when not configured', () => {
+      sinon.stub(config, 'get').withArgs('sms').returns({ outgoing_service: 'none' });
+      chai.expect(service.isMedicGatewayEnabled()).to.equal(false);
+    });
+
+    it('returns true when configured', () => {
+      sinon.stub(config, 'get').withArgs('sms').returns({ outgoing_service: 'medic-gateway' });
+      chai.expect(service.isMedicGatewayEnabled()).to.equal(true);
+    });
+
+    it('defaults to true', () => {
+      sinon.stub(config, 'get').withArgs('sms').returns();
+      chai.expect(service.isMedicGatewayEnabled()).to.equal(true);
     });
 
   });


### PR DESCRIPTION
# Description

When we removed config.default.json we broke the upgrade path for
projects without explicit settings for sms. This restores the defaults
in code.

medic/cht-core#6163

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
