### PR TITLE
Check types of values passed to _stats reduce

### DIFF
--- a/ddocs/medic-client/views/contacts_by_last_visited/map.js
+++ b/ddocs/medic-client/views/contacts_by_last_visited/map.js
@@ -4,10 +4,12 @@ function(doc) {
       doc.fields &&
       doc.fields.visited_contact_uuid) {
 
-    var visited_date = doc.fields.visited_date ? Date.parse(doc.fields.visited_date) : doc.reported_date;
-
+    var date = doc.fields.visited_date ? Date.parse(doc.fields.visited_date) : doc.reported_date;
+    if (typeof date !== 'number' || isNaN(date)) {
+      date = 0;
+    }
     // Is a visit report about a family
-    emit(doc.fields.visited_contact_uuid, visited_date);
+    emit(doc.fields.visited_contact_uuid, date);
   } else if (doc.type === 'contact' ||
              doc.type === 'clinic' ||
              doc.type === 'health_center' ||

--- a/ddocs/medic/views/reports_by_form_and_parent/map.js
+++ b/ddocs/medic/views/reports_by_form_and_parent/map.js
@@ -3,6 +3,7 @@ function(doc) {
       doc.form &&
       doc.contact &&
       doc.contact.parent) {
-    emit([doc.form, doc.contact.parent._id], doc.reported_date);
+    var value = typeof doc.reported_date === 'number' ? doc.reported_date : 0;
+    emit([doc.form, doc.contact.parent._id], value);
   }
 }


### PR DESCRIPTION
# Description

CouchDBs built-in _stats reduce function errors out if given anything
other than a number. Adds type checking with a fallback to 0.

medic/cht-core#6170

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
