### PR TITLE
reference the 3.7 medic-os docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   medic-os:
     container_name: medic-os
-    image: medicmobile/medic-os:3.6.1-rc.4
+    image: medicmobile/medic-os:cht-3.7.0-rc.1
     volumes:
       - medic-data:/srv
     ports:


### PR DESCRIPTION
This image includes the xsltproc dependency plus other fixes.

This is based off of the documentation here: https://github.com/medic/medic-docs/blob/master/installation/public-docker-image-setup.md#use-docker-compose.

Should we just have one place where we keep the updated compose file? cc @Hareet 
