### PR TITLE
Patch webdriver-manager maxChromedriver to 78

### DIFF
--- a/tests/patches/webdriver-manager-config.patch
+++ b/tests/patches/webdriver-manager-config.patch
@@ -13,7 +13,7 @@
     "webdriverVersions": {
       "selenium": "2.53.1",
       "chromedriver": "2.27",
-!     "maxChromedriver": "77",
+!     "maxChromedriver": "78",
       "geckodriver": "v0.13.0",
       "iedriver": "2.53.1",
       "androidsdk": "24.4.1",


### PR DESCRIPTION
# Description

E2E tests are failing due to the release of Chrome78 without a corresponding release of WebDriver. Patch maxDriverVersion

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
