### PR TITLE
Adds per-user replicated docs, tasks are per-user replicated docs (#6191)

### DIFF
--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -114,16 +114,17 @@ describe('Authorization service', () => {
       });
 
       return service
-        .getAuthorizationContext({facility_id: 'facilityId' })
+        .getAuthorizationContext({ facility_id: 'facilityId', name: 'username' })
         .then(result => {
           tombstoneUtils.extractStub.callCount.should.equal(3);
           tombstoneUtils.extractStub.args.should.deep.equal([
             ['tombstone-1'], ['tombstone-2'], ['tombstone-3']
           ]);
-          result.subjectIds.sort().should.deep.equal([
+          result.subjectIds.should.have.members([
             1, 2, 'deleted-1', 'deleted-2', 'deleted-3', '_all',
-            's1', 's2', 's3', 's4', 's5'
-          ].sort());
+            's1', 's2', 's3', 's4', 's5',
+            'org.couchdb.user:username',
+          ]);
         });
     });
 
@@ -132,9 +133,9 @@ describe('Authorization service', () => {
       config.get.returns(true);
 
       return service
-        .getAuthorizationContext({ userCtx: { facility_id: 'aaa' }})
+        .getAuthorizationContext({ facility_id: 'aaa', name: 'agatha' })
         .then(result => {
-          result.subjectIds.should.deep.equal(['_all', '_unassigned']);
+          result.subjectIds.should.have.members(['_all', '_unassigned', 'org.couchdb.user:agatha']);
         });
     });
 
@@ -146,9 +147,9 @@ describe('Authorization service', () => {
       auth.hasAllPermissions.returns(false);
       config.get.returns(false);
       return service
-        .getAuthorizationContext({ facility_id: 'aaa' })
+        .getAuthorizationContext({ facility_id: 'aaa', name: 'peter' })
         .then(result => {
-          result.subjectIds.sort().should.deep.equal([1, 2, '_all', 's1', 's2']);
+          result.subjectIds.should.have.members([1, 2, '_all', 's1', 's2', 'org.couchdb.user:peter']);
           result.contactsByDepthKeys.should.deep.equal([['aaa', 0], ['aaa', 1], ['aaa', 2]]);
         });
     });
@@ -741,19 +742,27 @@ describe('Authorization service', () => {
   });
 
   describe('getScopedAuthorizationContext', () => {
-    it('should return no subject ids if no docs provided', () => {
+    it('should return default subject ids if no docs provided', () => {
       return service
         .getScopedAuthorizationContext(userCtx, [])
         .then(result => {
-          result.should.deep.equal({ userCtx, subjectIds: [], contactsByDepthKeys: [ ['facility_id'] ] });
+          result.should.deep.equal({
+            userCtx,
+            subjectIds: ['_all', 'org.couchdb.user:user'],
+            contactsByDepthKeys: [ ['facility_id'] ]
+          });
         });
     });
 
-    it('should return no subject ids if only falsy docs are provided', () => {
+    it('should return default subject ids if only falsy docs are provided', () => {
       return service
         .getScopedAuthorizationContext(userCtx, [{ doc: false }, { doc: undefined }, { viewResults: {} }, false, undefined ])
         .then(result => {
-          result.should.deep.equal({ userCtx, subjectIds: [], contactsByDepthKeys: [ ['facility_id'] ] });
+          result.should.deep.equal({
+            userCtx,
+            subjectIds: ['_all', 'org.couchdb.user:user'],
+            contactsByDepthKeys: [ ['facility_id'] ]
+          });
         });
     });
 
@@ -768,7 +777,7 @@ describe('Authorization service', () => {
       return service
         .getScopedAuthorizationContext(userCtx, [{ doc: docs[0] }, { doc: docs[1], viewResults: {} }, { doc: docs[2] }])
         .then(result => {
-          result.subjectIds.should.deep.equal([]);
+          result.subjectIds.should.deep.equal(['_all', 'org.couchdb.user:user']);
           contactsByDepth.callCount.should.equal(2);
           contactsByDepth.args.should.deep.equal([[docs[0]], [docs[2]]]);
           docsByReplicationKey.callCount.should.equal(2);
@@ -877,7 +886,9 @@ describe('Authorization service', () => {
           docsByReplicationKey.callCount.should.equal(5);
           docsByReplicationKey.args.should.deep.equal([ [c1], [c2], [c3], [c4], [c5]]);
 
-          result.subjectIds.should.deep.equal(['c1', '123456', 'c3', 'c5', 'place5']);
+          result.subjectIds.should.have.members([
+            'c1', '123456', 'c3', 'c5', 'place5', '_all', 'org.couchdb.user:user'
+          ]);
         });
     });
 
@@ -983,7 +994,9 @@ describe('Authorization service', () => {
           contactsByDepth.callCount.should.equal(7);
           docsByReplicationKey.callCount.should.equal(7);
 
-          result.subjectIds.should.deep.equal(['c1', 'patient1doc', 'patient1', 'patient3doc']);
+          result.subjectIds.should.have.members([
+            'c1', 'patient1doc', 'patient1', 'patient3doc', '_all', 'org.couchdb.user:user'
+          ]);
         });
     });
 
@@ -1072,7 +1085,9 @@ describe('Authorization service', () => {
           contactsByDepth.callCount.should.equal(8);
           docsByReplicationKey.callCount.should.equal(8);
 
-          result.subjectIds.should.deep.equal(['c1', 'patient1doc', 'patient1', 'p1', 'facility_id']);
+          result.subjectIds.should.have.members([
+            'c1', 'patient1doc', 'patient1', 'p1', 'facility_id', '_all', 'org.couchdb.user:user'
+          ]);
         });
     });
 
@@ -1159,7 +1174,9 @@ describe('Authorization service', () => {
           contactsByDepth.callCount.should.equal(4);
           docsByReplicationKey.callCount.should.equal(4);
 
-          result.subjectIds.should.deep.equal(['c1', 'contact1', 'patient1doc', 'patient1']);
+          result.subjectIds.should.have.members([
+            'c1', 'contact1', 'patient1doc', 'patient1', '_all', 'org.couchdb.user:user'
+          ]);
         });
     });
 
@@ -1287,7 +1304,7 @@ describe('Authorization service', () => {
             contactsByDepth.callCount.should.equal(7);
             docsByReplicationKey.callCount.should.equal(7);
 
-            result.subjectIds.should.deep.equal(['c5', 'c1', 'contact1', 'c2']);
+            result.subjectIds.should.have.members(['c5', 'c1', 'contact1', 'c2', '_all', 'org.couchdb.user:user']);
           });
       });
 
@@ -1441,7 +1458,9 @@ describe('Authorization service', () => {
             contactsByDepth.callCount.should.equal(10);
             docsByReplicationKey.callCount.should.equal(10);
 
-            result.subjectIds.should.deep.equal(['patient1doc', 'patient1', 'patient5doc', 'c1', 'patient3doc']);
+            result.subjectIds.should.have.members([
+              'patient1doc', 'patient1', 'patient5doc', 'c1', 'patient3doc', '_all', 'org.couchdb.user:user'
+            ]);
           });
       });
 
@@ -1548,7 +1567,9 @@ describe('Authorization service', () => {
             contactsByDepth.callCount.should.equal(9);
             docsByReplicationKey.callCount.should.equal(9);
 
-            result.subjectIds.should.deep.equal(['patient1doc', 'patient1', 'p1', 'facility_id', 'c1']);
+            result.subjectIds.should.have.members([
+              'patient1doc', 'patient1', 'p1', 'facility_id', 'c1', '_all', 'org.couchdb.user:user'
+            ]);
           });
       });
     });

--- a/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/ddocs/medic/views/docs_by_replication_key/map.js
@@ -67,8 +67,9 @@ function (doc) {
       }
       return;
     case 'task':
-    case 'target':
       return emit(doc.user, {});
+    case 'target':
+      return emit(doc.owner, {});
     case 'contact':
     case 'clinic':
     case 'district_hospital':

--- a/shared-libs/rules-engine/src/index.js
+++ b/shared-libs/rules-engine/src/index.js
@@ -22,9 +22,10 @@ module.exports = db => {
      * @param {Object[]} settings.targets Target definitions from settings doc
      * @param {Boolean} settings.enableTasks Flag to enable tasks
      * @param {Boolean} settings.enableTargets Flag to enable targets
-     * @param {Object} userDoc User's hydrated contact document
+     * @param {Object} settings.contact User's hydrated contact document
+     * @param {Object} settings.user User's settings document
      */
-    initialize: (settings, userDoc) => wireupToProvider.initialize(provider, settings, userDoc),
+    initialize: (settings) => wireupToProvider.initialize(provider, settings),
 
     /**
      * @returns {Boolean} True if the rules engine is enabled and ready for use
@@ -68,13 +69,14 @@ module.exports = db => {
      * @param {Object[]} settings.targets Target definitions from settings doc
      * @param {Boolean} settings.enableTasks Flag to enable tasks
      * @param {Boolean} settings.enableTargets Flag to enable targets
-     * @param {Object} userDoc User's hydrated contact document
+     * @param {Object} settings.contact User's hydrated contact document
+     * @param {Object} settings.user User's user-settings document
      */
-    rulesConfigChange: (settings, userDoc) => {
-      const cacheIsReset = rulesStateStore.rulesConfigChange(settings, userDoc);
+    rulesConfigChange: (settings) => {
+      const cacheIsReset = rulesStateStore.rulesConfigChange(settings);
       if (cacheIsReset) {
         rulesEmitter.shutdown();
-        rulesEmitter.initialize(settings, userDoc);
+        rulesEmitter.initialize(settings);
       }
     },
   };

--- a/shared-libs/rules-engine/src/pouchdb-provider.js
+++ b/shared-libs/rules-engine/src/pouchdb-provider.js
@@ -21,14 +21,14 @@ const medicPouchProvider = db => {
       return docsOf(db.query('medic-client/tasks_by_contact', options));
     },
 
-    allTaskData: userDoc => {
-      const userContactId = userDoc && userDoc._id;
+    allTaskData: userSettingsDoc => {
+      const userSettingsId = userSettingsDoc && userSettingsDoc._id;
       return Promise.all([
-          docsOf(db.query('medic-client/contacts_by_type', { include_docs: true })),
-          docsOf(db.query('medic-client/reports_by_subject', { include_docs: true })),
-          self.allTasks('requester'),
-        ])
-        .then(([contactDocs, reportDocs, taskDocs]) => ({ contactDocs, reportDocs, taskDocs, userContactId }));
+        docsOf(db.query('medic-client/contacts_by_type', { include_docs: true })),
+        docsOf(db.query('medic-client/reports_by_subject', { include_docs: true })),
+        self.allTasks('requester'),
+      ])
+        .then(([contactDocs, reportDocs, taskDocs]) => ({ contactDocs, reportDocs, taskDocs, userSettingsId }));
     },
 
     contactsBySubjectId: subjectIds => (
@@ -43,13 +43,16 @@ const medicPouchProvider = db => {
 
     stateChangeCallback: docUpdateClosure(db),
 
-    commitTargetDoc: (assign, userDoc, docTag) => {
-      const userContactId = userDoc && userDoc._id;
-      const _id = `target-${docTag}-${userContactId}`;
+    commitTargetDoc: (assign, userContactDoc, userSettingsDoc, docTag) => {
+      const userContactId = userContactDoc && userContactDoc._id;
+      const userSettingsId = userSettingsDoc && userSettingsDoc._id;
+      const _id = `target~${docTag}~${userContactId}~${userSettingsId}`;
       const createNew = () => ({
         _id,
         type: 'target',
-        user: userContactId,
+        user: userSettingsId,
+        owner: userContactId,
+        reporting_period: docTag,
       });
 
       const today = moment().startOf('day').valueOf();
@@ -68,7 +71,7 @@ const medicPouchProvider = db => {
       if (!taskDocs || taskDocs.length === 0) {
         return Promise.resolve([]);
       }
-   
+
       console.debug(`Committing ${taskDocs.length} task document updates`);
       return db.bulkDocs(taskDocs)
         .catch(err => console.error('Error committing task documents', err));
@@ -81,7 +84,7 @@ const medicPouchProvider = db => {
       return docsOf(db.query('medic-client/tasks_by_contact', { keys, include_docs: true }));
     },
 
-    taskDataFor: (contactIds, userDoc) => {
+    taskDataFor: (contactIds, userSettingsDoc) => {
       if (!contactIds || contactIds.length === 0) {
         return Promise.resolve({});
       }
@@ -92,14 +95,14 @@ const medicPouchProvider = db => {
             registrationUtils.getSubjectIds(contactDoc).forEach(subjectId => agg.add(subjectId));
             return agg;
           }, new Set(contactIds));
-         
+
           const keys = Array.from(subjectIds).map(key => [key]);
           return Promise.all([
               docsOf(db.query('medic-client/reports_by_subject', { keys, include_docs: true })),
               self.tasksByRelation(contactIds, 'requester'),
             ])
             .then(([reportDocs, taskDocs]) => ({
-              userContactId: userDoc && userDoc._id,
+              userSettingsId: userSettingsDoc && userSettingsDoc._id,
               contactDocs,
               reportDocs,
               taskDocs,

--- a/shared-libs/rules-engine/src/rules-emitter.js
+++ b/shared-libs/rules-engine/src/rules-emitter.js
@@ -26,10 +26,10 @@ module.exports = {
    * @param {Object} settings Settings for the behavior of the rules emitter
    * @param {Object} settings.rules Rules code from settings doc
    * @param {Object[]} settings.taskSchedules Task schedules from settings doc
-   * @param {Object} userDoc The logged in user's contact document
+   * @param {Object} settings.contact The logged in user's contact document
    * @returns {Boolean} Success
    */
-  initialize: (settings, userDoc) => {
+  initialize: (settings) => {
     if (flow) {
       throw Error('Attempted to initialize the rules emitter multiple times.');
     }
@@ -47,7 +47,7 @@ module.exports = {
         name: 'medic',
         scope: {
           Utils: nootilsInstance,
-          user: userDoc,
+          user: settings.contact,
         },
       });
     } catch (err) {

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -1,6 +1,6 @@
 /**
  * @module rules-state-store
- * In-memory datastore containing 
+ * In-memory datastore containing
  * 1. Details on the state of each contact's rules calculations
  * 2. Target emissions @see target-state
  */
@@ -10,7 +10,8 @@ const targetState = require('./target-state');
 
 const EXPIRE_CALCULATION_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 let state;
-let currentUser;
+let currentUserContact;
+let currentUserSettings;
 let onStateChange;
 
 const self = {
@@ -19,22 +20,25 @@ const self = {
    *
    * @param {Object} existingState State object previously passed to the stateChangeCallback
    * @param {Object} settings Settings for the behavior of the rules store
-   * @param {Object} userDoc User's hydrated contact document
-   * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes. Receives the updated state as the only parameter.
+   * @param {Object} settings.contact User's hydrated contact document
+   * @param {Object} settings.user User's user-settings document
+   * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes.
+   *    Receives the updated state as the only parameter.
    */
-  load: (existingState, settings, userDoc, stateChangeCallback) => {
+  load: (existingState, settings, stateChangeCallback) => {
     if (state) {
       throw Error('Attempted to initialize the rules-state-store multiple times.');
     }
 
-    const rulesConfigHash = hashRulesConfig(settings, userDoc);
+    const rulesConfigHash = hashRulesConfig(settings);
     const useState = existingState && existingState.rulesConfigHash === rulesConfigHash;
     if (!useState) {
-      return self.build(settings, userDoc, stateChangeCallback);
+      return self.build(settings, stateChangeCallback);
     }
 
     state = existingState;
-    currentUser = userDoc;
+    currentUserContact = settings.contact;
+    currentUserSettings = settings.user;
     onStateChange = safeCallback(stateChangeCallback);
   },
 
@@ -42,20 +46,23 @@ const self = {
    * Initializes an empty rules-state-store.
    *
    * @param {Object} settings Settings for the behavior of the rules store
-   * @param {Object} userDoc User's hydrated contact document
-   * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes. Receives the updated state as the only parameter.
+   * @param {Object} settings.contact User's hydrated contact document
+   * @param {Object} settings.user User's user-settings document
+   * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes.
+   *    Receives the updated state as the only parameter.
    */
-  build: (settings, userDoc, stateChangeCallback) => {
+  build: (settings, stateChangeCallback) => {
     if (state) {
       throw Error('Attempted to initialize the rules-state-store multiple times.');
     }
 
     state = {
-      rulesConfigHash: hashRulesConfig(settings, userDoc),
+      rulesConfigHash: hashRulesConfig(settings),
       contactState: {},
       targetState: targetState.createEmptyState(settings.targets),
     };
-    currentUser = userDoc;
+    currentUserContact = settings.contact;
+    currentUserSettings = settings.user;
 
     onStateChange = safeCallback(stateChangeCallback);
     return onStateChange(state);
@@ -91,18 +98,18 @@ const self = {
    * If they have changed in a meaningful way, the calculation state of all contacts is reset
    *
    * @param {Object} settings Settings for the behavior of the rules store
-   * @param {Object} userDoc User's hydrated contact document
    * @returns {Boolean} True if the state of all contacts has been reset
    */
-  rulesConfigChange: (settings, userDoc) => {
-    const rulesConfigHash = hashRulesConfig(settings, userDoc);
+  rulesConfigChange: (settings) => {
+    const rulesConfigHash = hashRulesConfig(settings);
     if (state.rulesConfigHash !== rulesConfigHash) {
       state = {
         rulesConfigHash,
         contactState: {},
         targetState: targetState.createEmptyState(settings.targets),
       };
-      currentUser = userDoc;
+      currentUserContact = settings.contact;
+      currentUserSettings = settings.user;
 
       onStateChange(state);
       return true;
@@ -184,7 +191,12 @@ const self = {
   /**
    * @returns {string} User contact document
    */
-  currentUser: () => currentUser,
+  currentUserContact: () => currentUserContact,
+
+  /**
+   * @returns {string} User settings document
+   */
+  currentUserSettings: () => currentUserSettings,
 
   /**
    * Store a set of target emissions which were emitted by refreshing a set of contacts
@@ -214,13 +226,8 @@ const self = {
   aggregateStoredTargetEmissions: targetEmissionFilter => targetState.aggregateStoredTargetEmissions(state.targetState, targetEmissionFilter),
 };
 
-const hashRulesConfig = (settings, userDoc) => {
-  const rulesConfig = {
-    settings,
-    userDoc,
-  };
-
-  const asString = JSON.stringify(rulesConfig);
+const hashRulesConfig = (settings) => {
+  const asString = JSON.stringify(settings);
   return md5(asString);
 };
 

--- a/shared-libs/rules-engine/test/integration.spec.js
+++ b/shared-libs/rules-engine/test/integration.spec.js
@@ -15,7 +15,7 @@ chai.use(chaiExclude);
 
 let db;
 let rulesEngine;
-const userDoc = { _id: 'user' };
+
 
 const THE_FUTURE = 1500000000000;
 const patientContact = {
@@ -83,7 +83,7 @@ describe('Rules Engine Integration Tests', () => {
     sinon.useFakeTimers(THE_FUTURE);
     db = await memdownMedic('../..');
     rulesEngine = RulesEngine(db);
-    await rulesEngine.initialize(chtRulesSettings(), userDoc);
+    await rulesEngine.initialize(chtRulesSettings());
   });
 
   after(() => {
@@ -97,13 +97,13 @@ describe('Rules Engine Integration Tests', () => {
     library is created. In this case, that is the time of rulesEngine.initialize or rulesEngine.rulesConfigChange. This can lead to change behaviors with Utils.now()
     */
     sinon.useFakeTimers(THE_FUTURE);
-   
+
     db = await memdownMedic('../..');
     rulesEngine = RulesEngine(db);
 
     configHashSalt++;
     const rulesSettings = chtRulesSettings({ configHashSalt });
-    await rulesEngine.rulesConfigChange(rulesSettings, userDoc);
+    await rulesEngine.rulesConfigChange(rulesSettings);
     sinon.useFakeTimers(1);
   });
 
@@ -150,7 +150,7 @@ describe('Rules Engine Integration Tests', () => {
     expect(db.bulkDocs.callCount).to.eq(2);
     expect(db.bulkDocs.args[1][0]).to.have.property('length', 1);
     expect(db.bulkDocs.args[1][0][0]).to.deep.include({
-      _id: `task~user~report~pregnancy-facility-visit-reminder~anc.facility_reminder~${NOW}`,
+      _id: `task~org.couchdb.user:username~report~pregnancy-facility-visit-reminder~anc.facility_reminder~${NOW}`,
       requester: 'patient',
       owner: 'patient',
       state: 'Failed',
@@ -184,7 +184,7 @@ describe('Rules Engine Integration Tests', () => {
     expect(db.bulkDocs.callCount).to.eq(2);
     expect(db.bulkDocs.args[1][0]).to.have.property('length', 1);
     expect(db.bulkDocs.args[1][0][0]).to.deep.include({
-      _id: 'task~user~report~pregnancy-facility-visit-reminder~anc.facility_reminder~1',
+      _id: 'task~org.couchdb.user:username~report~pregnancy-facility-visit-reminder~anc.facility_reminder~1',
       state: 'Failed',
       stateHistory: [
         {
@@ -222,7 +222,7 @@ describe('Rules Engine Integration Tests', () => {
     expect(db.bulkDocs.callCount).to.eq(3);
     expect(db.bulkDocs.args[2][0]).to.have.property('length', 1);
     expect(db.bulkDocs.args[2][0][0]).to.deep.include({
-      _id: 'task~user~report~pregnancy-facility-visit-reminder~anc.facility_reminder~1',
+      _id: 'task~org.couchdb.user:username~report~pregnancy-facility-visit-reminder~anc.facility_reminder~1',
       state: 'Completed',
       stateHistory: [
         {
@@ -262,7 +262,7 @@ describe('Rules Engine Integration Tests', () => {
 
     const [taskDoc] = db.bulkDocs.args[2][0];
     expect(taskDoc).to.deep.include({
-      _id: 'task~user~report~pregnancy-facility-visit-reminder~anc.facility_reminder~1',
+      _id: 'task~org.couchdb.user:username~report~pregnancy-facility-visit-reminder~anc.facility_reminder~1',
       state: 'Cancelled',
       stateHistory: [
         {
@@ -290,7 +290,7 @@ describe('Rules Engine Integration Tests', () => {
     await triggerFacilityReminderInReadyState(['patient']);
 
     const updatedSettings = chtRulesSettings({ rules: noolsPartnerTemplate('const nothing = [];') });
-    await rulesEngine.rulesConfigChange(updatedSettings, userDoc);
+    await rulesEngine.rulesConfigChange(updatedSettings);
     expect(db.bulkDocs.callCount).to.eq(1);
 
     const completedTask = await rulesEngine.fetchTasksFor(['patient']);
@@ -303,12 +303,12 @@ describe('Rules Engine Integration Tests', () => {
 
     try {
       const updatedSettings = chtRulesSettings({ rules: noolsPartnerTemplate('not javascript') });
-      await rulesEngine.rulesConfigChange(updatedSettings, userDoc);
+      await rulesEngine.rulesConfigChange(updatedSettings);
       expect('throw').to.throw;
     } catch (err) {
       expect(err.message).to.include('not javascript');
     }
-    
+
     const successfulRecompile = rulesEmitter.isEnabled();
     expect(successfulRecompile).to.be.false;
     expect(rulesEngine.isEnabled()).to.be.false;
@@ -320,7 +320,7 @@ describe('Rules Engine Integration Tests', () => {
   it('reloading same config does not bust cache', async () => {
     await triggerFacilityReminderInReadyState(['patient']);
 
-    await rulesEngine.rulesConfigChange(chtRulesSettings({ configHashSalt }), userDoc);
+    await rulesEngine.rulesConfigChange(chtRulesSettings({ configHashSalt }));
     const successfulRecompile = rulesEmitter.isEnabled();
     expect(successfulRecompile).to.be.true;
     expect(rulesEngine.isEnabled()).to.be.true;
@@ -458,7 +458,7 @@ const triggerFacilityReminderInReadyState = async (selectBy, docs = [patientCont
   expect(db.query.args.map(args => args[0])).to.deep.eq(selectBy ? expectedQueriesForFreshData : [...expectedQueriesForAllFreshData, 'medic-client/tasks_by_contact']);
   expect(db.bulkDocs.callCount).to.eq(1);
   expect(tasks[0]).to.deep.include({
-    _id: `task~user~report~pregnancy-facility-visit-reminder~anc.facility_reminder~${Date.now()}`,
+    _id: `task~org.couchdb.user:username~report~pregnancy-facility-visit-reminder~anc.facility_reminder~${Date.now()}`,
     state: 'Ready',
     requester: 'patient',
     owner: 'patient',

--- a/shared-libs/rules-engine/test/mocks.js
+++ b/shared-libs/rules-engine/test/mocks.js
@@ -33,6 +33,9 @@ const chtDocs = {
   },
 };
 
+const userContactDoc = { _id: 'user' };
+const userSettingsDoc = { _id: 'org.couchdb.user:username' };
+
 module.exports = {
   MS_IN_DAY,
 
@@ -65,6 +68,8 @@ rule GenerateEvents {
       taskScedules: chtSettingsDoc.tasks.schedules,
       enableTasks: true,
       enableTargets: true,
+      user: userSettingsDoc,
+      contact: userContactDoc,
     }, assign);
   },
 

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -68,9 +68,10 @@ describe('provider-wireup integration tests', () => {
   let db;
   beforeEach(async () => {
     sinon.useFakeTimers(NOW);
-    sinon.stub(rulesStateStore, 'currentUser').returns({ _id: 'mock_user_id' });
+    sinon.stub(rulesStateStore, 'currentUserContact').returns({ _id: 'mock_user_id' });
+    sinon.stub(rulesStateStore, 'currentUserSettings').returns({ _id: 'org.couchdb.user:username' });
     wireup.__set__('rulesStateStore', rulesStateStore);
-   
+
     db = await memdownMedic('../..');
     await db.bulkDocs(fixtures);
 
@@ -141,7 +142,7 @@ describe('provider-wireup integration tests', () => {
       await wireup.updateEmissionsFor(provider, []);
       expect(rulesStateStore.markDirty.args).to.deep.eq([[[]]]);
     });
- 
+
     it('contact id', async () => {
       sinon.stub(rulesStateStore, 'markDirty').resolves();
       await wireup.updateEmissionsFor(provider, chtDocs.contact._id);
@@ -174,7 +175,7 @@ describe('provider-wireup integration tests', () => {
       sinon.stub(rulesEmitter, 'isLatestNoolsSchema').returns(true);
       sinon.spy(db, 'bulkDocs');
       await wireup.initialize(provider, settings, {});
-   
+
       const refreshRulesEmissions = sinon.stub().resolves({
         targetEmissions: [],
         taskTransforms: [],
@@ -185,7 +186,7 @@ describe('provider-wireup integration tests', () => {
         contactDocs: [],
         reportDocs: [headlessReport],
         taskDocs: [headlessTask],
-        userContactId: 'mock_user_id',
+        userSettingsId: 'org.couchdb.user:username',
       });
 
       expect(db.bulkDocs.callCount).to.eq(1);
@@ -201,20 +202,20 @@ describe('provider-wireup integration tests', () => {
       const rules = noolsPartnerTemplate('', { });
       const settings = { rules };
       await wireup.initialize(provider, settings, {});
-   
+
       const refreshRulesEmissions = sinon.stub().resolves({
         targetEmissions: [],
         taskTransforms: [],
       });
       const withMockRefresher = wireup.__with__({ refreshRulesEmissions });
-   
+
       await withMockRefresher(() => wireup.fetchTasksFor(provider));
       expect(refreshRulesEmissions.callCount).to.eq(1);
       expect(refreshRulesEmissions.args[0][0]).excludingEvery('_rev').to.deep.eq({
         contactDocs: [chtDocs.contact],
         reportDocs: [headlessReport, reportConnectedByPlace, chtDocs.pregnancyReport],
         taskDocs: [headlessTask, taskRequestedByChtContact],
-        userContactId: 'mock_user_id',
+        userSettingsId: 'org.couchdb.user:username',
       });
 
       expect(rulesStateStore.hasAllContacts()).to.be.true;
@@ -241,7 +242,7 @@ describe('provider-wireup integration tests', () => {
             timestamp: 50000,
           }]
         }],
-        userContactId: 'mock_user_id',
+        userSettingsId: 'org.couchdb.user:username',
       });
     });
 
@@ -252,7 +253,7 @@ describe('provider-wireup integration tests', () => {
       const settings = { rules };
       await wireup.initialize(provider, settings, {});
       await rulesStateStore.markFresh(Date.now(), 'fresh');
-   
+
       const actual = await wireup.fetchTasksFor(provider, ['fresh']);
       expect(actual).to.be.empty;
       expect(rulesEmitter.getEmissionsFor.callCount).to.eq(1);
@@ -281,7 +282,7 @@ describe('provider-wireup integration tests', () => {
 
     it('user rewinds system clock', async () => {
       const getWrittenTaskDoc = () => {
-        const expectedId = `task~mock_user_id~${emission._id}~${Date.now()}`;
+        const expectedId = `task~org.couchdb.user:username~${emission._id}~${Date.now()}`;
         const committedDocs = db.bulkDocs.args.reduce((agg, arg) => [...agg, ...arg[0]], []);
         const doc = committedDocs.find(doc => doc._id === expectedId);
         expect(doc).to.not.be.undefined;
@@ -358,19 +359,21 @@ describe('provider-wireup integration tests', () => {
 
     it('aggregate target doc is written (latest)', async () => {
       sinon.spy(provider, 'commitTargetDoc');
-      await wireup.initialize(provider, chtRulesSettings(), {});
+      await wireup.initialize(provider, chtRulesSettings(), {}, {});
       const actual = await wireup.fetchTargets(provider);
       expect(actual.length).to.be.gt(1);
 
       expect(provider.commitTargetDoc.callCount).to.eq(1);
       await provider.commitTargetDoc.returnValues[0];
 
-      const writtenDoc = await db.get('target-latest-mock_user_id');
+      const writtenDoc = await db.get('target~latest~mock_user_id~org.couchdb.user:username');
       expect(writtenDoc).excluding(['targets', '_rev']).to.deep.eq({
-        _id: 'target-latest-mock_user_id',
+        _id: 'target~latest~mock_user_id~org.couchdb.user:username',
         type: 'target',
         updated_date: moment(NOW).startOf('day').valueOf(),
-        user: 'mock_user_id',
+        owner: 'mock_user_id',
+        user: 'org.couchdb.user:username',
+        reporting_period: 'latest',
       });
       expect(writtenDoc.targets[0]).to.deep.eq({
         id: 'deaths-this-month',
@@ -383,7 +386,7 @@ describe('provider-wireup integration tests', () => {
 
     it('aggregate target doc is written (date)', async () => {
       sinon.spy(provider, 'commitTargetDoc');
-      await wireup.initialize(provider, chtRulesSettings(), {});
+      await wireup.initialize(provider, chtRulesSettings(), {}, {});
       const interval = { start: 1, end: 1000 };
       const actual = await wireup.fetchTargets(provider, interval);
       expect(actual.length).to.be.gt(1);
@@ -391,13 +394,15 @@ describe('provider-wireup integration tests', () => {
       expect(provider.commitTargetDoc.callCount).to.eq(1);
       await provider.commitTargetDoc.returnValues[0];
 
-      const expectedId = `target-${moment(1000).format('YYYY-MM')}-mock_user_id`;
+      const expectedId = `target~${moment(1000).format('YYYY-MM')}~mock_user_id~org.couchdb.user:username`;
       const writtenDoc = await db.get(expectedId);
       expect(writtenDoc).excluding(['targets', '_rev']).to.deep.eq({
         _id: expectedId,
         type: 'target',
         updated_date: moment(NOW).startOf('day').valueOf(),
-        user: 'mock_user_id',
+        owner: 'mock_user_id',
+        user: 'org.couchdb.user:username',
+        reporting_period: moment(1000).format('YYYY-MM'),
       });
       expect(writtenDoc.targets[0]).to.deep.eq({
         id: 'deaths-this-month',
@@ -419,7 +424,7 @@ describe('provider-wireup integration tests', () => {
         }]
       };
       await wireup.initialize(provider, settings, {});
-   
+
       const hhEmission = (day, family, patient) => {
         const date = moment(`2000-01-${day}`);
         return {
@@ -446,7 +451,7 @@ describe('provider-wireup integration tests', () => {
         ],
       });
       const withMockRefresher = wireup.__with__({ refreshRulesEmissions });
-   
+
       const interval = {
         start: moment('2000-01-01').valueOf(),
         end: moment('2000-01-31').valueOf(),

--- a/shared-libs/rules-engine/test/rules-state-store.spec.js
+++ b/shared-libs/rules-engine/test/rules-state-store.spec.js
@@ -6,7 +6,7 @@ const rulesStateStore = RestorableRulesStateStore();
 const hashRulesConfig = rulesStateStore.__get__('hashRulesConfig');
 
 const mockState = contactState => ({
-  rulesConfigHash: hashRulesConfig({}, {}),
+  rulesConfigHash: hashRulesConfig({}),
   contactState,
 });
 
@@ -18,9 +18,10 @@ describe('rules-state-store', () => {
 
   it('throw on build twice', async () => {
     const state = mockState({ 'a': { calculatedAt: 1 } });
-    await rulesStateStore.load(state, {}, {});
-    expect(() => rulesStateStore.load(state, {}, {})).to.throw('multiple times');
-    expect(rulesStateStore.currentUser()).to.deep.eq({});
+    await rulesStateStore.load(state, {});
+    expect(() => rulesStateStore.load(state, {})).to.throw('multiple times');
+    expect(rulesStateStore.currentUserContact()).to.deep.eq(undefined);
+    expect(rulesStateStore.currentUserSettings()).to.deep.eq(undefined);
   });
 
   it('throw if not initialized', async () => {
@@ -29,17 +30,20 @@ describe('rules-state-store', () => {
 
   it('load a dirty contact', async () => {
     const state = mockState({ 'a': { calculatedAt: 1 } });
-    const userDoc = { _id: 'foo' };
-    await rulesStateStore.load(state, {}, userDoc);
+    const contactDoc = { _id: 'foo' };
+    const userDoc = { _id: 'org.couchdb.user.foo' };
+
+    await rulesStateStore.load(state, { user: userDoc, contact: contactDoc });
 
     const isDirty = rulesStateStore.isDirty('a');
     expect(isDirty).to.be.true;
-    expect(rulesStateStore.currentUser()).to.eq(userDoc);
+    expect(rulesStateStore.currentUserContact()).to.eq(contactDoc);
+    expect(rulesStateStore.currentUserSettings()).to.eq(userDoc);
   });
 
   it('load a fresh contact', async () => {
     const state = mockState({ 'a': { calculatedAt: Date.now() } });
-    await rulesStateStore.load(state, {}, {});
+    await rulesStateStore.load(state, {});
 
     const isDirty = rulesStateStore.isDirty('a');
     expect(isDirty).to.be.false;
@@ -48,7 +52,7 @@ describe('rules-state-store', () => {
   it('fresh contact but dirty hash', async () => {
     const state = mockState({ 'a': { calculatedAt: Date.now() } });
     state.rulesConfigHash = 'hash';
-    await rulesStateStore.load(state, {}, {});
+    await rulesStateStore.load(state, {});
 
     const isDirty = rulesStateStore.isDirty('a');
     expect(isDirty).to.be.true;
@@ -57,7 +61,7 @@ describe('rules-state-store', () => {
   it('scenario after loading state', async () => {
     const onStateChange = sinon.stub().resolves();
     const state = mockState({ 'a': { calculatedAt: Date.now() } });
-    await rulesStateStore.load(state, {}, {}, onStateChange);
+    await rulesStateStore.load(state, {}, onStateChange);
 
     const isDirty = rulesStateStore.isDirty('a');
     expect(isDirty).to.be.false;
@@ -66,7 +70,7 @@ describe('rules-state-store', () => {
     expect(onStateChange.callCount).to.eq(1);
     expect(rulesStateStore.isDirty('b')).to.be.true;
 
-    rulesStateStore.rulesConfigChange({ });
+    rulesStateStore.rulesConfigChange({ updated: true }); // force hash to be different!
     expect(onStateChange.callCount).to.eq(2);
     expect(rulesStateStore.isDirty('a')).to.be.true;
     expect(rulesStateStore.isDirty('b')).to.be.true;
@@ -74,7 +78,7 @@ describe('rules-state-store', () => {
 
   it('scenario after building state', async () => {
     const onStateChange = sinon.stub().resolves();
-    await rulesStateStore.build({}, {}, onStateChange);
+    await rulesStateStore.build({}, onStateChange);
     expect(onStateChange.callCount).to.eq(1);
     expect(rulesStateStore.getContactIds()).to.deep.eq([]);
     expect(rulesStateStore.isDirty('a')).to.be.true;
@@ -92,7 +96,7 @@ describe('rules-state-store', () => {
     expect(onStateChange.callCount).to.eq(3);
     expect(rulesStateStore.isDirty('b')).to.be.true;
 
-    rulesStateStore.rulesConfigChange({ });
+    rulesStateStore.rulesConfigChange({ updated: true }); // force hash to be different!
     expect(onStateChange.callCount).to.eq(4);
     expect(rulesStateStore.isDirty('a')).to.be.true;
     expect(rulesStateStore.isDirty('b')).to.be.true;
@@ -102,7 +106,7 @@ describe('rules-state-store', () => {
 
   it('hasAllContacts:true scenario', async () => {
     const onStateChange = sinon.stub().resolves();
-    await rulesStateStore.build({}, {}, onStateChange);
+    await rulesStateStore.build({}, onStateChange);
     expect(onStateChange.callCount).to.eq(1);
     expect(rulesStateStore.isDirty('a')).to.be.true;
     expect(rulesStateStore.isDirty('b')).to.be.true;
@@ -120,7 +124,7 @@ describe('rules-state-store', () => {
     expect(rulesStateStore.isDirty('b')).to.be.true;
     expect(rulesStateStore.hasAllContacts()).to.be.true;
 
-    rulesStateStore.rulesConfigChange({});
+    rulesStateStore.rulesConfigChange({ updated: true }); // force hash to be different!
     expect(onStateChange.callCount).to.eq(4);
     expect(rulesStateStore.isDirty('a')).to.be.true;
     expect(rulesStateStore.isDirty('b')).to.be.true;
@@ -128,13 +132,13 @@ describe('rules-state-store', () => {
   });
 
   it('rewinding clock makes contacts dirty', async () => {
-    await rulesStateStore.build({}, {});
+    await rulesStateStore.build({});
     await rulesStateStore.markFresh(Date.now() + 1000, 'a');
     expect(rulesStateStore.isDirty('a')).to.be.true;
   });
 
   it('contact marked fresh a month ago is not fresh', async () => {
-    await rulesStateStore.build(['a'], {});
+    await rulesStateStore.build({});
     await rulesStateStore.markFresh(Date.now(), 'a');
     expect(rulesStateStore.isDirty('a')).to.be.false;
     sinon.useFakeTimers(Date.now() + 7004800000);
@@ -143,7 +147,7 @@ describe('rules-state-store', () => {
 
   it('empty targets', async () => {
     const onStateChange = sinon.stub().resolves();
-    await rulesStateStore.build({}, {}, onStateChange);
+    await rulesStateStore.build({}, onStateChange);
     rulesStateStore.storeTargetEmissions([], [{ id: 'abc', type: 'dne', contact: { _id: 'a', reported_date: 1000 } }]);
     const initialTargets = rulesStateStore.aggregateStoredTargetEmissions();
     expect(initialTargets).to.be.empty;
@@ -156,8 +160,10 @@ describe('rules-state-store', () => {
       }],
     };
     const onStateChange = sinon.stub().resolves();
-    await rulesStateStore.build(mockSettings, {}, onStateChange);
-    rulesStateStore.storeTargetEmissions([], [{ id: 'abc', type: 'target', pass: true, contact: { _id: 'a', reported_date: 1000 } }]);
+    await rulesStateStore.build(mockSettings, onStateChange);
+    rulesStateStore.storeTargetEmissions([], [{
+      id: 'abc', type: 'target', pass: true, contact: { _id: 'a', reported_date: 1000 }
+    }]);
     const initialTargets = rulesStateStore.aggregateStoredTargetEmissions();
     expect(initialTargets).to.deep.eq([{
       id: 'target',
@@ -170,13 +176,13 @@ describe('rules-state-store', () => {
 
   describe('hashRulesConfig', () => {
     it('empty objects', () => {
-      const actual = hashRulesConfig({}, {});
+      const actual = hashRulesConfig({});
       expect(actual).to.not.be.empty;
     });
 
     it('cht config', () => {
       const settings = require('../../../config/default/app_settings.json');
-      const actual = hashRulesConfig(settings, { _id: 'user' });
+      const actual = hashRulesConfig(settings);
       expect(actual).to.not.be.empty;
     });
   });

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -40,7 +40,17 @@ const users = [
       name: 'OnlineUser'
     },
     roles: ['national_admin']
-  }
+  },
+  {
+    username: 'supervisor',
+    password: password,
+    place: 'PARENT_PLACE',
+    contact: {
+      _id: 'fixture:user:supervisor',
+      name: 'Supervisor',
+    },
+    roles: ['district_admin'],
+  },
 ];
 
 let offlineRequestOptions,
@@ -112,23 +122,50 @@ describe('all_docs handler', () => {
   });
 
   it('filters offline users results', () => {
+    const supervisorRequestOptions = {
+      path: '/_all_docs',
+      auth: { username: 'supervisor', password },
+      method: 'GET'
+    };
+    const lineage = { _id: 'PARENT_PLACE' };
     const docs = [
-      { _id: 'allowed_contact', parent: { _id: 'fixture:offline'}, type: 'clinic' },
-      { _id: 'allowed_report', contact: { _id: 'fixture:offline'}, type: 'data_record', form: 'a' },
-      { _id: 'denied_contact', parent: { _id: 'fixture:online'}, type: 'clinic' },
-      { _id: 'denied_report', contact: { _id: 'fixture:online'}, type: 'data_record', form: 'a' },
+      { _id: 'allowed_contact', parent: { _id: 'fixture:offline', parent: lineage }, type: 'clinic' },
+      { _id: 'allowed_report', contact: { _id: 'fixture:offline', parent: lineage }, type: 'data_record', form: 'a' },
+      { _id: 'denied_contact', parent: { _id: 'fixture:online', parent: lineage }, type: 'clinic' },
+      { _id: 'denied_report', contact: { _id: 'fixture:online', parent: lineage }, type: 'data_record', form: 'a' },
+      { _id: 'allowed_task', user: 'org.couchdb.user:offline', type: 'task', owner: 'fixture:user:offline' },
+      { _id: 'denied_task', user: 'org.couchdb.user:online', type: 'task', owner: 'fixture:user:offline' },
+      { _id: 'allowed_target', user: 'org.couchdb.user:offline', type: 'target', owner: 'fixture:user:offline' },
+      { _id: 'denied_target', user: 'org.couchdb.user:online', type: 'target', owner: 'fixture:user:online' },
     ];
 
     return utils
       .saveDocs(docs)
-      .then(() => utils.requestOnTestDb(offlineRequestOptions)).then(result => {
+      .then(() => utils.requestOnTestDb(offlineRequestOptions))
+      .then(result => {
         expect(unrestrictedKeys.every(id => result.rows.find(row => row.id === id || row.id.match(id)))).toBe(true);
         expect(restrictedKeys.some(id => result.rows.find(row => row.id === id || row.id.match(id)))).toBe(false);
 
         expect(result.rows.findIndex(row => row.id === 'allowed_contact')).not.toEqual(-1);
         expect(result.rows.findIndex(row => row.id === 'allowed_report')).not.toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'allowed_task')).not.toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'allowed_target')).not.toEqual(-1);
         expect(result.rows.findIndex(row => row.id === 'denied_contact')).toEqual(-1);
-        expect(result.rows.findIndex(row => row.id === 'denied_contact')).toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'denied_report')).toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'denied_task')).toEqual(-1);
+        expect(result.rows.findIndex(row => row.id === 'denied_target')).toEqual(-1);
+      })
+      .then(() => utils.requestOnTestDb(supervisorRequestOptions))
+      .then(result => {
+        const resultIds = result.rows.map(row => row.id);
+        expect(resultIds).toContain('allowed_contact');
+        expect(resultIds).toContain('allowed_report');
+        expect(resultIds).not.toContain('allowed_task');
+        expect(resultIds).toContain('allowed_target');
+        expect(resultIds).toContain('denied_contact');
+        expect(resultIds).toContain('denied_report');
+        expect(resultIds).not.toContain('denied_task');
+        expect(resultIds).toContain('denied_target');
       });
   });
 
@@ -281,11 +318,28 @@ describe('all_docs handler', () => {
       { _id: '5', parent: { _id: 'fixture:online'}, type: 'clinic' }
     ];
 
+    // skip all "default" docs
+    // this includes those that emit _all or the user settings doc id,
+    // along with medic-client ddoc and the user-settings doc itself
+    const getSkip = () => {
+      const ddocAndUserSettings = 2;
+      return utils.db
+        .query('medic/docs_by_replication_key', { keys: ['_all', 'org.couchdb.user:offline'] })
+        .then(result => {
+          return result.rows && result.rows.length + ddocAndUserSettings;
+        });
+    };
+
     return utils
       .saveDocs(docs)
-      .then(() => Promise.all([
-        utils.requestOnTestDb(_.defaults({ path: `/_all_docs?limit=2&skip=2&include_docs=false` }, offlineRequestOptions)),
-        utils.requestOnTestDb(_.defaults({ path: `/_all_docs?limit=1&skip=4&include_docs=true` }, offlineRequestOptions))
+      .then(() => getSkip())
+      .then(skip => Promise.all([
+        utils.requestOnTestDb(_.defaults(
+          { path: `/_all_docs?limit=2&skip=${skip}&include_docs=false` }, offlineRequestOptions)
+        ),
+        utils.requestOnTestDb(_.defaults(
+          { path: `/_all_docs?limit=1&skip=${skip + 2}&include_docs=true` }, offlineRequestOptions)
+        )
       ]))
       .then(results => {
         expect(results[0].rows.length).toEqual(2);

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -42,9 +42,20 @@ const users = [
     },
     roles: ['national_admin'],
   },
+  {
+    username: 'supervisor',
+    password: password,
+    place: 'PARENT_PLACE',
+    contact: {
+      _id: 'fixture:user:supervisor',
+      name: 'Supervisor',
+    },
+    roles: ['district_admin'],
+  },
 ];
 
-let offlineRequestOptions, onlineRequestOptions;
+let offlineRequestOptions;
+let onlineRequestOptions;
 
 const DOCS_TO_KEEP = [
   'PARENT_PLACE',
@@ -283,6 +294,67 @@ describe('bulk-docs handler', () => {
             expect(result[6]).toBeDefined();
           });
     });
+  });
+
+  it('filters offline tasks and targets', () => {
+    const supervisorRequestOptions = {
+      path: '/_bulk_docs',
+      auth: { username: 'supervisor', password },
+      method: 'POST',
+    };
+
+    const docs = [
+      {
+        _id: 'allowed_task',
+        type: 'task',
+        user: 'org.couchdb.user:offline',
+        owner: 'fixture:user:offline',
+      },
+      {
+        _id: 'denied_task',
+        type: 'task',
+        user: 'org.couchdb.user:online',
+        owner: 'fixture:user:offline',
+      },
+      {
+        _id: 'allowed_target',
+        type: 'target',
+        user: 'org.couchdb.user:offline',
+        owner: 'fixture:user:offline',
+      },
+      {
+        _id: 'denied_target',
+        type: 'target',
+        user: 'org.couchdb.user:offline',
+        owner: 'fixture:user:online',
+      },
+    ];
+
+    offlineRequestOptions.body = { docs };
+
+    return utils
+      .requestOnTestDb(offlineRequestOptions)
+      .then(result => {
+        expect(result.length).toEqual(4);
+        expect(_.pick(result[0], 'id', 'ok')).toEqual({ id: 'allowed_task', ok: true });
+        expect(_.pick(result[2], 'id', 'ok')).toEqual({ id: 'allowed_target', ok: true });
+        expect(_.pick(result[1], 'id', 'error')).toEqual({ id: 'denied_task', error: 'forbidden' });
+        expect(_.pick(result[3], 'id', 'error')).toEqual({ id: 'denied_target', error: 'forbidden' });
+
+        docs[0]._rev = result[0].rev;
+        docs[2]._rev = result[2].rev;
+
+        supervisorRequestOptions.body = { docs };
+        return utils.requestOnTestDb(supervisorRequestOptions);
+      })
+      .then(result => {
+        expect(result.length).toEqual(4);
+        expect(_.pick(result[0], 'id', 'error')).toEqual({ id: 'allowed_task', error: 'forbidden' });
+        expect(_.pick(result[1], 'id', 'error')).toEqual({ id: 'denied_task', error: 'forbidden' });
+        expect(_.pick(result[2], 'id', 'ok')).toEqual({ id: 'allowed_target', ok: true });
+        expect(_.pick(result[3], 'id', 'ok')).toEqual({ id: 'denied_target', ok: true });
+      });
+
   });
 
   it('reiterates over docs', () => {

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -150,6 +150,19 @@ describe('view docs_by_replication_key', () => {
       contact: { _id: 'someuser' },
       fields: { patient_uuid: 'testpatient' }
     },
+    {
+      _id: 'task_created_by_user',
+      type: 'task',
+      user: 'org.couchdb.user:username',
+      requester: 'someuser',
+      owner: 'testpatient',
+    },
+    {
+      _id: 'target_created_by_user',
+      type: 'target',
+      user: 'org.couchdb.user:username',
+      owner: 'testuser',
+    },
   ];
 
   const documentsToIgnore = [
@@ -232,6 +245,19 @@ describe('view docs_by_replication_key', () => {
       type: 'data_record',
       contact: { _id: 'someuser' },
       fields: { patient_uuid: 'not_the_testpatient' }
+    },
+    {
+      _id: 'task_created_by_other_user',
+      type: 'task',
+      user: 'org.couchdb.user:not_username',
+      requester: 'someuser',
+      owner: 'testpatient',
+    },
+    {
+      _id: 'target_created_by_other_user',
+      type: 'target',
+      user: 'org.couchdb.user:not_username',
+      owner: 'not_someuser',
     },
   ];
 
@@ -319,11 +345,11 @@ describe('view docs_by_replication_key', () => {
         }
         console.log('…done');
 
-        getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace'])
+        getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username'])
           .then(docs => {
             docByPlaceIds = docs;
 
-            getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace'])
+            getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ])
               .then(docs => {
                 docByPlaceIds_unassigned = docs;
                 done();
@@ -391,6 +417,18 @@ describe('view docs_by_replication_key', () => {
       expect(docByPlaceIds).toContain('needs_signoff_within_branch');
       expect(docByPlaceIds).not.toContain('needs_signoff_within_branch_falsy');
       expect(docByPlaceIds).not.toContain('needs_signoff_outside_branch');
+    });
+
+    it('should return target docs', () => {
+      expect(docByPlaceIds).toContain('target_created_by_user');
+      expect(docByPlaceIds).not.toContain('target_created_by_other_user');
+    });
+  });
+
+  describe('Documents associated with user id', () => {
+    it('should return task docs', () => {
+      expect(docByPlaceIds).toContain('task_created_by_user');
+      expect(docByPlaceIds).not.toContain('task_created_by_other_user');
     });
   });
 


### PR DESCRIPTION
Adds a new "default" replication subject, in the form of the user's couchdb user id (org.couchdb.user:<username>). Documents that must be replicated by a specific user only should emit this value in medic/docs_by_replication_key.

Updates task documents to use this value as their user property, making uploaded tasks only available to them, and not to their supervisors or anyone who shares their lineage. Task document ids also change to use the user's doc id instead of the contact's doc id.

Updates target to also use this value as their user property (for consistency), adds the owner property that saves the contact's uuid and updates medic/docs_by_replication_key so targets emit owner - in order to make targets available for supervisors. The target doc id is updated to include the user's doc id, the value being appended, so it's still possible to search for a target document in a certain month and a certain contact, without knowing the user's id.