### PR TITLE
Registration only validates "subject" by patient_id

### DIFF
--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -13,7 +13,6 @@ const config = require('../config');
 const date = require('../date');
 const NAME = 'registration';
 
-const registrationUtils = require('@medic/registration-utils');
 const contactTypesUtils = require('@medic/contact-types-utils');
 
 const PARENT_NOT_FOUND = 'parent_not_found';
@@ -623,16 +622,16 @@ module.exports = {
           return true;
         }
 
-        const subjectId = registrationUtils.getSubjectId(doc);
+        const patientId = doc.fields && doc.fields.patient_id;
 
-        if (!subjectId) {
+        if (!patientId) {
           return fireConfiguredTriggers(registrationConfig, doc);
         }
 
         // We're attaching this registration to an existing contact, let's
         // make sure it's valid
-        return utils.getContactUuid(subjectId).then(contactId => {
-          if (!contactId) {
+        return utils.getContactUuid(patientId).then(patientContactId => {
+          if (!patientContactId) {
             transitionUtils.addRegistrationNotFoundError(doc, registrationConfig);
             return true;
           }


### PR DESCRIPTION
# Description

Reverts change that makes use of `getSubjectId` to get the report's subject.  
The function used for validation `getContactUuid` only accepts shortcodes, while `getSubjectId` might return a uuid, thus marking correct reports with `registration_not_found` when one was missing `patient_id`.

medic/cht-core#6205

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
