### PR TITLE
Updated for https with ngrok

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -150,10 +150,11 @@ This will echo a URL which you can connect to.
 ngrok sometimes fails due to connection throttling which can cause the service worker cache preload to fail. It's included here as an alternative in case serveo doesn't work for some reason.
 
 1. Create a ngrok account at https://ngrok.com/
-2. Follow instructions on downloading and linking your computer to your ngrok account.
-3. Start ngrok
-  * To connect to an API running via `grunt` or `horti`, execute `./ngrok http 5988`
-  * To connect to an API running via `Docker`, execute `./ngrok http 443`
+1. Follow instructions on downloading and linking your computer to your ngrok account.
+1. Start ngrok
+    * To connect to an API running via `grunt` or `horti`, execute `./ngrok http 5988`
+    * To connect to an API running via `Docker`, execute `./ngrok http 443`
+1. Access the app using the https address shown, eg https://123456.ngrok.io
 
 ## Data
 


### PR DESCRIPTION
# Description
Make it clearer to use https with ngrok, to avoid endless loops: medic/cht-core#6221

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
