### PR TITLE
6207 rapidpro outbound push

### DIFF
--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -160,7 +160,7 @@ const send = (payload, config) => {
     }
 
     if (authConf.type.toLowerCase() === 'header') {
-      if (authConf.name.toLowerCase() === 'authorization') {
+      if (authConf.name && authConf.name.toLowerCase() === 'authorization') {
         return fetchPassword(authConf['value_key'])
           .then(value => {
             sendOptions.headers = {

--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -159,6 +159,15 @@ const send = (payload, config) => {
         });
     }
 
+    if (authConf.type.toLowerCase() === 'rapidpro') {
+      return fetchPassword(authConf['password_key'])
+        .then(password => {
+          sendOptions.headers = {
+            'Authorization': 'Token ' + password
+          };
+        });
+    }
+
     if (authConf.type.toLowerCase() === 'muso-sih') {
       return fetchPassword(authConf['password_key'])
         .then(password => {

--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -161,7 +161,7 @@ const send = (payload, config) => {
 
     if (authConf.type.toLowerCase() === 'header') {
       if (authConf.name.toLowerCase() === 'authorization') {
-        return fetchPassword(authConf['values_key'])
+        return fetchPassword(authConf['value_key'])
           .then(value => {
             sendOptions.headers = {
               Authorization: value

--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -159,13 +159,18 @@ const send = (payload, config) => {
         });
     }
 
-    if (authConf.type.toLowerCase() === 'rapidpro') {
-      return fetchPassword(authConf['password_key'])
-        .then(password => {
-          sendOptions.headers = {
-            'Authorization': 'Token ' + password
-          };
-        });
+    if (authConf.type.toLowerCase() === 'header') {
+      if (authConf.name.toLowerCase() === 'authorization') {
+        return fetchPassword(authConf['values_key'])
+          .then(value => {
+            sendOptions.headers = {
+              Authorization: value
+            };
+          });
+      } else {
+        logger.error(`Unsupported header name '${authConf.name}'. Supported: Authorization`);
+        throw new Error(`Unsupported header name '${authConf.name}'. Supported: Authorization`);
+      }
     }
 
     if (authConf.type.toLowerCase() === 'muso-sih') {

--- a/sentinel/tests/unit/schedule/outbound.js
+++ b/sentinel/tests/unit/schedule/outbound.js
@@ -350,6 +350,40 @@ describe('outbound schedule', () => {
         });
     });
 
+    it('should support pushing via header auth', () => {
+      const payload = {
+        some: 'data'
+      };
+
+      const conf = {
+        destination: {
+          auth: {
+            type: 'Header',
+            name: 'Authorization',
+            value_key: 'test-config'
+          },
+          base_url: 'http://test',
+          path: '/foo'
+        }
+      };
+
+      sinon.stub(secureSettings, 'getCredentials').resolves('Bearer credentials');
+      sinon.stub(request, 'post').resolves();
+
+      return outbound.__get__('send')(payload, conf)
+        .then(() => {
+          assert.equal(secureSettings.getCredentials.callCount, 1);
+          assert.equal(secureSettings.getCredentials.args[0][0], 'test-config');
+          assert.equal(request.post.callCount, 1);
+          assert.equal(request.post.args[0][0].url, 'http://test/foo');
+          assert.deepEqual(request.post.args[0][0].body, {some: 'data'});
+          assert.equal(request.post.args[0][0].json, true);
+          assert.deepEqual(request.post.args[0][0].headers, {
+            Authorization: 'Bearer credentials'
+          });
+        });
+    });
+    
     it('should support Muso SIH custom auth', () => {
       const payload = {
         some: 'data'
@@ -395,7 +429,7 @@ describe('outbound schedule', () => {
         });
     });
 
-    it('should error is Muso SIH custom auth fails to return a 200', () => {
+    it('should error if Muso SIH custom auth fails to return a 200', () => {
       const payload = {
         some: 'data'
       };


### PR DESCRIPTION
# Description

Adds support for using outbound push with RapidPro, or any third party tool that does authentication via credentials in HTTP headers.

Documentation and tests have yet to be included.

medic/cht-core#6207

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
