### PR TITLE
Limits due_tasks and outbound queries to 1000 entries

### DIFF
--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -12,6 +12,7 @@ const lineage = require('@medic/lineage')(Promise, db.medic);
 
 const CONFIGURED_PUSHES = 'outbound';
 const OUTBOUND_REQ_TIMEOUT = 10 * 1000;
+const BATCH_SIZE = 1000;
 
 const fetchPassword = key => {
   return secureSettings.getCredentials(key).then(password => {
@@ -31,7 +32,8 @@ const queuedTasks = () => {
   return db.sentinel.allDocs({
     startkey: 'task:outbound:',
     endkey: 'task:outbound:\ufff0',
-    include_docs: true
+    include_docs: true,
+    limit: BATCH_SIZE,
   })
     .then(results => {
       const outboundTaskDocs = results.rows.map(r => r.doc);

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -99,8 +99,9 @@ module.exports = {
 
         let promiseChain = Promise.resolve();
         Object.values(objs).forEach(obj => {
-          promiseChain = promiseChain.then(() => {
-            return lineage.hydrateDocs([obj.doc]).then(([doc]) => {
+          promiseChain = promiseChain
+            .then(() => lineage.hydrateDocs([obj.doc]))
+            .then(([doc]) => {
               return getTemplateContext(doc).then(context => {
                 const hasUpdatedTasks = updateScheduledTasks(doc, context, obj.dueDates);
                 if (!hasUpdatedTasks) {
@@ -111,7 +112,6 @@ module.exports = {
                 return db.medic.put(doc);
               });
             });
-          });
         });
 
         return promiseChain;

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -1,6 +1,5 @@
 // TODO: this doesn't need to exist. We can just work this out dynamically when
 //       gateway queries, it's not slow or complicated.
-const async = require('async');
 const moment = require('moment');
 const utils = require('../lib/utils');
 const date = require('../date');
@@ -8,6 +7,8 @@ const config = require('../config');
 const db = require('../db');
 const lineage = require('@medic/lineage')(Promise, db.medic);
 const messageUtils = require('@medic/message-utils');
+
+const BATCH_SIZE = 1000;
 
 const getPatient = (patientShortcodeId) => {
   return utils
@@ -21,107 +22,102 @@ const getPatient = (patientShortcodeId) => {
     });
 };
 
-const getTemplateContext = (doc, callback) => {
+const getTemplateContext = (doc) => {
   const patientShortcodeId = doc.fields && doc.fields.patient_id;
   if (!patientShortcodeId) {
-    return callback();
+    return Promise.resolve();
   }
 
-  Promise
+  return Promise
     .all([
       utils.getRegistrations({ id: patientShortcodeId }),
       getPatient(patientShortcodeId)
     ])
-    .then(([ registrations, patient ]) => callback(null, { registrations, patient }))
-    .catch(callback);
+    .then(([ registrations, patient ]) => ({ registrations, patient }));
+};
+
+const updateScheduledTasks = (doc, context, dueDates) => {
+  let updatedTasks = false;
+  // set task to pending for gateway to pick up
+  doc.scheduled_tasks.forEach(task => {
+    if (dueDates.includes(task.due)) {
+      if (!task.messages) {
+        const content = {
+          translationKey: task.message_key,
+          message: task.message,
+        };
+
+        const messages = messageUtils.generate(
+          config.getAll(),
+          utils.translate,
+          doc,
+          content,
+          task.recipient,
+          context
+        );
+
+        // generated messages could have errors, such messages should not be saved
+        // an example invalid message would be generated when a registration was missing the patient
+        if (!messageUtils.hasError(messages)) {
+          task.messages = messages;
+        }
+      }
+
+      // only update task states when messages exist
+      if (task.messages) {
+        updatedTasks = true;
+        utils.setTaskState(task, 'pending');
+      }
+    }
+  });
+
+  return updatedTasks;
 };
 
 module.exports = {
   execute: callback => {
     const now = moment(date.getDate());
     const overdue = now.clone().subtract(7, 'days');
+    const opts = {
+      include_docs: true,
+      endkey: [ 'scheduled', now.valueOf() ],
+      startkey: [ 'scheduled', overdue.valueOf() ],
+      limit: BATCH_SIZE,
+    };
 
-    db.medic.query(
-      'medic/messages_by_state',
-      {
-        include_docs: true,
-        endkey: [ 'scheduled', now.valueOf() ],
-        startkey: [ 'scheduled', overdue.valueOf() ],
-      },
-      function(err, result) {
-        if (err) {
-          return callback(err);
-        }
-
-        const objs = result.rows.reduce((objs, row) => {
+    return db.medic
+      .query('medic/messages_by_state', opts)
+      .then(result => {
+        const objs = {};
+        result.rows.forEach(row => {
           if (!objs[row.id]) {
             row.dueDates = [];
             objs[row.id] = row;
           }
           objs[row.id].dueDates.push(moment(row.key[1]).toISOString());
+        });
 
-          return objs;
-        }, {});
+        let promiseChain = Promise.resolve();
+        Object.values(objs).forEach(obj => {
+          promiseChain = promiseChain.then(() => {
+            return lineage.hydrateDocs([obj.doc]).then(([doc]) => {
+              return getTemplateContext(doc).then(context => {
+                const hasUpdatedTasks = updateScheduledTasks(doc, context, obj.dueDates);
+                if (!hasUpdatedTasks) {
+                  return;
+                }
 
-        async.forEachSeries(
-          objs,
-          function(obj, cb) {
-            lineage
-              .hydrateDocs([obj.doc])
-              .then(function(docs) {
-                const doc = docs[0];
-                getTemplateContext(doc, (err, context) => {
-                  if (err) {
-                    return cb(err);
-                  }
-                  let updatedTasks = false;
-                  // set task to pending for gateway to pick up
-                  doc.scheduled_tasks.forEach(task => {
-                    if (obj.dueDates.includes(task.due)) {
-                      if (!task.messages) {
-                        const content = {
-                          translationKey: task.message_key,
-                          message: task.message,
-                        };
+                lineage.minify(doc);
+                return db.medic.put(doc);
+              });
+            });
+          });
+        });
 
-                        const messages = messageUtils.generate(
-                          config.getAll(),
-                          utils.translate,
-                          doc,
-                          content,
-                          task.recipient,
-                          context
-                        );
-
-                        // generated messages could have errors, such messages should not be saved
-                        // an example invalid message would be generated when a registration was missing the patient
-                        if (!messageUtils.hasError(messages)) {
-                          task.messages = messages;
-                        }
-                      }
-
-                      // only update task states when messages exist
-                      if (task.messages) {
-                        updatedTasks = true;
-                        utils.setTaskState(task, 'pending');
-                      }
-                    }
-                  });
-
-                  if (!updatedTasks) {
-                    return cb();
-                  }
-
-                  lineage.minify(doc);
-                  db.medic.put(doc, cb);
-                });
-              })
-              .catch(cb);
-          },
-          callback
-        );
-      }
-    );
+        return promiseChain;
+      })
+      .then(() => callback())
+      .catch(callback);
   },
   _lineage: lineage,
 };

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -4,15 +4,16 @@ const moment = require('moment');
 const utils = require('../../src/lib/utils');
 const db = require('../../src/db');
 const schedule = require('../../src/schedule/due_tasks');
+const date = require('../../src/date');
 
 describe('due tasks', () => {
   afterEach(() => sinon.restore());
 
   it('due_tasks handles view returning no rows', done => {
-    const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    const view = sinon.stub(db.medic, 'query').resolves({
       rows: [],
     });
-    const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null);
+    const saveDoc = sinon.stub(db.medic, 'put').resolves();
 
     schedule.execute(function(err) {
       assert.equal(err, undefined);
@@ -53,7 +54,7 @@ describe('due tasks', () => {
         },
       ],
     };
-    const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    const view = sinon.stub(db.medic, 'query').resolves({
       rows: [
         {
           id: id,
@@ -73,10 +74,8 @@ describe('due tasks', () => {
       ],
     });
 
-    const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
-    const hydrate = sinon
-      .stub(schedule._lineage, 'hydrateDocs')
-      .returns(Promise.resolve([doc]));
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({});
+    const hydrate = sinon.stub(schedule._lineage, 'hydrateDocs').resolves([doc]);
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
     schedule.execute(function(err) {
@@ -115,10 +114,8 @@ describe('due tasks', () => {
         },
       ],
     };
-    const hydrate = sinon
-      .stub(schedule._lineage, 'hydrateDocs')
-      .returns(Promise.resolve([doc]));
-    const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    const hydrate = sinon.stub(schedule._lineage, 'hydrateDocs').resolves([doc]);
+    const view = sinon.stub(db.medic, 'query').resolves({
       rows: [
         {
           id: id,
@@ -133,7 +130,7 @@ describe('due tasks', () => {
       ],
     });
 
-    const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({});
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
     schedule.execute(function(err) {
@@ -177,7 +174,7 @@ describe('due tasks', () => {
       ],
     };
 
-    const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    const view = sinon.stub(db.medic, 'query').resolves({
       rows: [
         {
           id: id1,
@@ -191,13 +188,10 @@ describe('due tasks', () => {
         },
       ],
     });
-    sinon
-      .stub(schedule._lineage, 'hydrateDocs')
-      .onCall(0)
-      .returns(Promise.resolve([doc1]))
-      .onCall(1)
-      .returns(Promise.resolve([doc2]));
-    const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
+    sinon.stub(schedule._lineage, 'hydrateDocs')
+      .onCall(0).resolves([doc1])
+      .onCall(1).resolves([doc2]);
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({});
 
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
@@ -284,7 +278,7 @@ describe('due tasks', () => {
         },
       ],
     };
-    const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    const view = sinon.stub(db.medic, 'query').resolves({
       rows: [
         {
           id: id,
@@ -296,7 +290,7 @@ describe('due tasks', () => {
     sinon
       .stub(schedule._lineage, 'hydrateDocs')
       .resolves([hydrated]);
-    const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({});
 
     schedule.execute(err => {
       assert.equal(err, undefined);
@@ -331,9 +325,7 @@ describe('due tasks', () => {
     const expectedMessage = 'old message';
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
     const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
-    const fetchHydratedDoc = sinon
-      .stub(schedule._lineage, 'fetchHydratedDoc')
-      .resolves({ name: 'jim' });
+    const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
     const minified = {
@@ -393,7 +385,7 @@ describe('due tasks', () => {
         },
       ],
     };
-    const view = sinon.stub(db.medic, 'query').callsArgWith(2, null, {
+    const view = sinon.stub(db.medic, 'query').resolves({
       rows: [
         {
           id: id,
@@ -402,10 +394,8 @@ describe('due tasks', () => {
         },
       ],
     });
-    sinon
-      .stub(schedule._lineage, 'hydrateDocs')
-      .returns(Promise.resolve([hydrated]));
-    const saveDoc = sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
+    sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({});
     schedule.execute(err => {
       assert.equal(err, undefined);
       assert.equal(view.callCount, 1);
@@ -486,11 +476,11 @@ describe('due tasks', () => {
       ],
     };
 
-    sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [
+    sinon.stub(db.medic, 'query').resolves({ rows: [
       { id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified }
     ]});
     sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
-    sinon.stub(db.medic, 'put');
+    sinon.stub(db.medic, 'put').resolves();
 
     schedule.execute(err => {
       assert.equal(err, undefined);
@@ -576,11 +566,11 @@ describe('due tasks', () => {
       ],
     };
 
-    sinon.stub(db.medic, 'query').callsArgWith(2, null, { rows: [
+    sinon.stub(db.medic, 'query').resolves({ rows: [
       { id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified }
     ]});
     sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
-    sinon.stub(db.medic, 'put').callsArgWith(1, null, {});
+    sinon.stub(db.medic, 'put').resolves({});
 
     schedule.execute(err => {
       assert.equal(err, undefined);
@@ -617,6 +607,27 @@ describe('due tasks', () => {
         messages: [{ message: 'visit-ad', to: phone}]
       });
 
+      done();
+    });
+  });
+
+  it('should query with a limit and correct start and end key', (done) => {
+    const now = moment('2020-02-01 00:00:00');
+    sinon.stub(date, 'getDate').returns(now);
+    const view = sinon.stub(db.medic, 'query').resolves({ rows: [] });
+
+    schedule.execute((err) => {
+      assert.equal(err, undefined);
+      assert.equal(view.callCount, 1);
+      assert.deepEqual(view.args[0], [
+        'medic/messages_by_state',
+        {
+          include_docs: true,
+          endkey: [ 'scheduled', now.valueOf() ],
+          startkey: [ 'scheduled', now.subtract(7, 'days').valueOf() ],
+          limit: 1000,
+        }
+      ]);
       done();
     });
   });

--- a/tests/e2e/sentinel/schedules/outbound.spec.js
+++ b/tests/e2e/sentinel/schedules/outbound.spec.js
@@ -1,0 +1,221 @@
+const utils = require('../../../utils');
+const sentinelUtils = require('../utils');
+const chai = require('chai');
+
+const pushes = {
+  one: {
+    destination: {
+      base_url: 'http://127.0.0.1:8888',
+      path: '/one'
+    },
+    mapping: {
+      id: 'doc._id',
+      clinic: 'doc.contact.parent._id',
+      'fields.ab': {
+        expr: 'doc.fields.a * doc.fields.b + 100',
+      },
+      'fields.cd': {
+        expr: 'doc.fields.c - doc.fields.d',
+        optional: true,
+      },
+      patient: {
+        path: 'doc.fields.patient_id',
+        optional: true
+      }
+    }
+  },
+  two: {
+    destination: {
+      base_url: 'http://127.0.0.1:8888',
+      path: '/two'
+    },
+    mapping: {
+      keys: {
+        expr: 'doc.fields && Object.keys(doc.fields).map(key => "key" + key)',
+      },
+      values: {
+        expr: 'doc.fields && Object.values(doc.fields).map(value => "value" + value)'
+      }
+    }
+  },
+};
+
+const docs = [
+  {
+    _id: 'no_clinic',
+    pushes: ['one'],
+  },
+  {
+    _id: 'no_patient_no_fields',
+    contact: { _id: 'chw_id', parent: { _id: 'clinic_id' } },
+    pushes: ['one'],
+  },
+  {
+    _id: 'no_patient_nocd',
+    contact: { _id: 'chw_id', parent: { _id: 'clinic_id' } },
+    fields: { a: 1, b: 2 },
+    pushes: ['one'],
+  },
+  {
+    _id: 'all_fields_1',
+    contact: { _id: 'other_chw', parent: { _id: 'other_clinic' } },
+    fields: { a: 5, b: 4, c: 10, d: 8, patient_id: 'alpha' },
+    pushes: ['one', 'two'],
+  },
+  {
+    _id: 'all_fields_2',
+    contact: { _id: 'some_chw', parent: { _id: 'some_clinic' } },
+    fields: { a: -5, b: 20, c: 9, d: 12, patient_id: 'beta' },
+    pushes: ['one', 'two'],
+  },
+  {
+    _id: 'for_two',
+    fields: { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 },
+    pushes: ['two'],
+  }
+];
+
+const docsToDelete = [
+  { _id: 'to_delete' }
+];
+
+const tasks = docs.concat(docsToDelete).map(doc => ({
+  _id: `task:outbound:${doc._id}`,
+  type: 'task:outbound',
+  doc_id: doc._id,
+  queue: doc.pushes,
+}));
+
+const express = require('express');
+const bodyParser = require('body-parser');
+const destinationApp = express();
+const jsonParser = bodyParser.json({ limit: '32mb' });
+const inboxes = { one: [], two: [] };
+destinationApp.use(jsonParser);
+destinationApp.post('/one', (req, res) => inboxes['one'].push(req.body) && res.send('true'));
+destinationApp.post('/two', (req, res) => inboxes['two'].push(req.body) && res.send('true'));
+let server;
+
+const waitForPushes = () => {
+  return new Promise(resolve => {
+    if (inboxes.one.length > 2) {
+      return resolve();
+    }
+
+    return utils.delayPromise(waitForPushes, 100);
+  });
+};
+
+describe('Outbound', () => {
+  beforeAll(() => {
+    server = destinationApp.listen(8888);
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  afterEach(() => utils.revertDb());
+
+  it('should send outbound tasks correctly', () => {
+    return utils
+      .updateSettings({ outbound: pushes })
+      .then(() => utils.stopSentinel())
+      .then(() => utils.saveDocs(docs.concat(docsToDelete)))
+      .then(() => utils.deleteDocs(docsToDelete.map(d => d._id)))
+      .then(() => utils.sentinelDb.bulkDocs(tasks))
+      .then(() => utils.startSentinel())
+      .then(() => sentinelUtils.waitForSentinel())
+      .then(() => waitForPushes())
+      .then(() => {
+        chai.expect(inboxes.one.length).to.equal(3);
+        chai.expect(inboxes.two.length).to.equal(3);
+
+        chai.expect(inboxes.one).to.have.deep.members([
+          {
+            id: 'no_patient_nocd',
+            clinic: 'clinic_id',
+            fields: {
+              ab: 102,
+              cd: null,
+            },
+          },
+          {
+            id: 'all_fields_1',
+            clinic: 'other_clinic',
+            fields: {
+              ab: 120,
+              cd: 2,
+            },
+            patient: 'alpha',
+          },
+          {
+            id: 'all_fields_2',
+            clinic: 'some_clinic',
+            fields: {
+              ab: 0,
+              cd: -3,
+            },
+            patient: 'beta',
+          }
+        ]);
+
+        chai.expect(inboxes.two).to.have.deep.members([
+          {
+            keys: ['keya', 'keyb', 'keyc', 'keyd', 'keypatient_id'],
+            values: ['value5', 'value4', 'value10', 'value8', 'valuealpha']
+          },
+          {
+            keys: ['keya', 'keyb', 'keyc', 'keyd', 'keypatient_id'],
+            values: ['value-5', 'value20', 'value9', 'value12', 'valuebeta']
+          },
+          {
+            keys: ['keya', 'keyb', 'keyc', 'keyd', 'keye', 'keyf'],
+            values: ['value1', 'value2', 'value3', 'value4', 'value5', 'value6']
+          }
+        ]);
+      })
+      .then(() => utils.getDocs(docs.map(doc => doc._id)))
+      .then(results => {
+        // original docs were not updated
+        results.forEach(doc => chai.expect(doc._rev.startsWith('1-')).to.equal(true));
+      })
+      .then(() => utils.sentinelDb.allDocs({ keys: tasks.map(task => task._id), include_docs: true }))
+      .then(result => {
+        // all sent task:outbound docs have been deleted, all unsent still exist unchanged
+        const sentTasks = [
+          'task:outbound:no_patient_nocd',
+          'task:outbound:all_fields_1',
+          'task:outbound:all_fields_2',
+          'task:outbound:for_two',
+          'task:outbound:to_delete'
+        ];
+        result.rows.forEach(task => {
+          if (sentTasks.includes(task.id)) {
+            chai.expect(task.doc).to.equal(null);
+          } else {
+            chai.expect(task.doc).not.to.equal(null);
+            chai.expect(task.doc).to.deep.include(tasks.find(t => t._id === task.id));
+          }
+        });
+      })
+      .then(() => sentinelUtils.getInfoDocs(docs.concat(docsToDelete).map(doc => doc._id)))
+      .then(infos => {
+        const findById = id => infos.find(info => info.doc_id === id);
+
+        // infodoc.completed_tasks filled correctly
+        chai.expect(findById('no_clinic').completed_tasks).to.equal(undefined);
+        chai.expect(findById('no_patient_no_fields').completed_tasks).to.equal(undefined);
+        chai.expect(findById('no_patient_nocd').completed_tasks.length).to.equal(1);
+        chai.expect(findById('no_patient_nocd').completed_tasks[0].name).to.equal('one');
+        chai.expect(findById('all_fields_1').completed_tasks.length).to.equal(2);
+        chai.expect(findById('all_fields_1').completed_tasks[0].name).to.equal('one');
+        chai.expect(findById('all_fields_1').completed_tasks[1].name).to.equal('two');
+        chai.expect(findById('all_fields_2').completed_tasks.length).to.equal(2);
+        chai.expect(findById('all_fields_2').completed_tasks[0].name).to.equal('one');
+        chai.expect(findById('all_fields_2').completed_tasks[1].name).to.equal('two');
+        chai.expect(findById('for_two').completed_tasks.length).to.equal(1);
+        chai.expect(findById('for_two').completed_tasks[0].name).to.equal('two');
+      });
+  });
+});


### PR DESCRIPTION
# Description

Adds a hard limit of 1000 documents to be processed by `due_tasks` and `outbound` in a single process. 
Refactors `due_tasks` to use promises.
Adds `outbound` e2e test. 

medic/cht-core#6125

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
