### PR TITLE
Allow CouchDb Admins to login in the app. 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -477,9 +477,6 @@ module.exports = function(grunt) {
       'setup-admin': {
         cmd:
           ` curl -X PUT ${couchConfig.withPath('_node/' + COUCH_NODE_NAME + '/_config/admins/admin')} -d '"${couchConfig.password}"'` +
-          ` && curl -X POST ${couchConfig.withPath('_users')} ` +
-          ' -H "Content-Type: application/json" ' +
-          ` -d '{"_id": "org.couchdb.user:${couchConfig.username}", "name": "${couchConfig.username}", "password":"${couchConfig.password}", "type":"user", "roles":[]}' ` +
           ` && curl -X PUT --data '"true"' ${couchConfig.withPath('_node/' + COUCH_NODE_NAME + '/_config/chttpd/require_valid_user')}` +
           ` && curl -X PUT --data '"4294967296"' ${couchConfig.withPath('_node/' + COUCH_NODE_NAME + '/_config/httpd/max_http_request_size')}` +
           ` && curl -X PUT ${couchConfig.withPath(couchConfig.dbName)}`

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -191,5 +191,7 @@ module.exports = {
         Object.assign(medicUser, _.pick(user, 'name', 'roles', 'facility_id'));
         return medicUser;
       });
-  }
+  },
+
+  isDbAdmin: isDbAdmin,
 };

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -65,7 +65,8 @@ module.exports = {
   isOffline: roles => {
     const configured = config.get('roles') || {};
     const configuredRole = roles.some(role => configured[role]);
-    return !configuredRole ||
+    return !isDbAdmin({ roles }) &&
+           !configuredRole ||
            roles.some(role => configured[role] && configured[role].offline);
   },
 

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -13,6 +13,7 @@ const ONE_YEAR = 31536000000;
 const logger = require('../logger');
 const db = require('../db');
 const production = process.env.NODE_ENV === 'production';
+const users = require('../services/users');
 
 let loginTemplate;
 
@@ -139,9 +140,10 @@ const setCookies = (req, res, sessionRes) => {
       return auth
         .getUserSettings(userCtx)
         .catch(err => {
-          if (err.status !== 404 || !auth.isDbAdmin(userCtx)) {
-            throw err;
+          if (err.status === 404 && auth.isDbAdmin(userCtx)) {
+            return users.createAdmin(userCtx);
           }
+          throw err;
         })
         .then(({ language }={}) => {
           if (language) {

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -141,7 +141,7 @@ const setCookies = (req, res, sessionRes) => {
         .getUserSettings(userCtx)
         .catch(err => {
           if (err.status === 404 && auth.isDbAdmin(userCtx)) {
-            return users.createAdmin(userCtx);
+            return users.createAdmin(userCtx).then(() => auth.getUserSettings(userCtx));
           }
           throw err;
         })

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -136,15 +136,22 @@ const setCookies = (req, res, sessionRes) => {
       setUserCtxCookie(res, userCtx);
       // Delete login=force cookie
       res.clearCookie('login');
-      return auth.getUserSettings(userCtx).then(({ language }={}) => {
-        if (language) {
-          setLocaleCookie(res, language);
-        }
-        res.status(302).send(getRedirectUrl(userCtx));
-      });
+      return auth
+        .getUserSettings(userCtx)
+        .catch(err => {
+          if (err.status !== 404 || !auth.isDbAdmin(userCtx)) {
+            throw err;
+          }
+        })
+        .then(({ language }={}) => {
+          if (language) {
+            setLocaleCookie(res, language);
+          }
+          res.status(302).send(getRedirectUrl(userCtx));
+        });
     })
     .catch(err => {
-      logger.error(`Error getting authCtx ${err}`);
+      logger.error(`Error getting authCtx %o`, err);
       res.status(401).json({ error: 'Error getting authCtx' });
     });
 };

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -497,6 +497,19 @@ module.exports = {
       .then(() => response);
   },
 
+  /*
+  * Take the userCtx of an admin user and create the _user doc and user-settings doc
+  */
+  createAdmin: userCtx => {
+    const response = {};
+    const data = { username: userCtx.name, roles: ['admin'] };
+    return module.exports
+      ._validateNewUsername(userCtx.name)
+      .then(() => module.exports._createUser(data, response))
+      .then(() => module.exports._createUserSettings(data, response))
+      .then(() => response);
+  },
+
   /**
    * Updates the given user.
    *

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -501,13 +501,11 @@ module.exports = {
   * Take the userCtx of an admin user and create the _user doc and user-settings doc
   */
   createAdmin: userCtx => {
-    const response = {};
     const data = { username: userCtx.name, roles: ['admin'] };
     return module.exports
       ._validateNewUsername(userCtx.name)
-      .then(() => module.exports._createUser(data, response))
-      .then(() => module.exports._createUserSettings(data, response))
-      .then(() => response);
+      .then(() => module.exports._createUser(data, {}))
+      .then(() => module.exports._createUserSettings(data, {}));
   },
 
   /**

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon');
 const config = require('../../../src/config');
 const request = require('request-promise-native');
 const fs = require('fs');
+const users = require('../../../src/services/users');
 const DB_NAME = 'lg';
 const DDOC_NAME = 'medic';
 
@@ -384,6 +385,7 @@ describe('login controller', () => {
       sinon.stub(request, 'post').resolves(postResponse);
       sinon.stub(res, 'send');
       sinon.stub(res, 'status').returns(res);
+      sinon.stub(users, 'createAdmin').returns({ _id: 'org.couchdb.user:shazza' });
       const userCtx = { name: 'shazza', roles: [ '_admin' ] };
       sinon.stub(auth, 'getUserCtx').resolves(userCtx);
       sinon.stub(auth, 'isOnlineOnly').returns(true);
@@ -397,6 +399,9 @@ describe('login controller', () => {
         chai.expect(auth.hasAllPermissions.callCount).to.equal(1);
         chai.expect(auth.isOnlineOnly.callCount).to.equal(1);
         chai.expect(auth.isDbAdmin.callCount).to.equal(1);
+        chai.expect(auth.isDbAdmin.args[0]).to.deep.equal([userCtx]);
+        chai.expect(users.createAdmin.callCount).to.equal(1);
+        chai.expect(users.createAdmin.args[0]).to.deep.equal([userCtx]);
         chai.expect(res.status.callCount).to.equal(1);
         chai.expect(res.status.args[0][0]).to.equal(302);
         chai.expect(res.send.args[0][0]).to.equal('/admin/');

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -73,7 +73,7 @@ const baseConfig = {
         });
     });
 
-    return login(browser);
+    return login(browser).then(() => runAndLog('User setup', setupUser));
   }
 };
 
@@ -87,8 +87,7 @@ const runAndLog = (msg, func) => {
 const startApi = () =>
   listenForApi()
     .then(() => runAndLog('Settings setup', setupSettings))
-    .then(() => runAndLog('User contact doc setup', utils.setUserContactDoc))
-    .then(() => runAndLog('User setup', setupUser));
+    .then(() => runAndLog('User contact doc setup', utils.setUserContactDoc));
 
 const listenForApi = () => {
   console.log('Checking API');


### PR DESCRIPTION
# Description

Catches 404s from getting `user-settings` docs and creates `user` and `user-settings` docs when logging in. 

medic/cht-core#6249

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
