### PR TITLE
Attempt (unsuccessfully) to close target doc reporting gap

### DIFF
--- a/shared-libs/rules-engine/src/pouchdb-provider.js
+++ b/shared-libs/rules-engine/src/pouchdb-provider.js
@@ -44,7 +44,7 @@ const medicPouchProvider = db => {
 
     stateChangeCallback: docUpdateClosure(db),
 
-    commitTargetDoc: (assign, userContactDoc, userSettingsDoc, docTag) => {
+    commitTargetDoc: (calculateContent, userContactDoc, userSettingsDoc, docTag) => {
       const userContactId = userContactDoc && userContactDoc._id;
       const userSettingsId = userSettingsDoc && userSettingsDoc._id;
       const _id = `target~${docTag}~${userContactId}~${userSettingsId}`;
@@ -60,8 +60,8 @@ const medicPouchProvider = db => {
       return db.get(_id)
         .catch(createNew)
         .then(existingDoc => {
-          if (existingDoc.updated_date !== today) {
-            Object.assign(existingDoc, assign);
+          if (!existingDoc.isSealed && existingDoc.updated_date !== today) {
+            Object.assign(existingDoc, calculateContent());
             existingDoc.updated_date = today;
             return db.put(existingDoc);
           }

--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -89,7 +89,7 @@ describe('pouchdb provider', () => {
 
     it('create and update a doc', async () => {
       const docTag = '2019-07';
-      await pouchdbProvider(db).commitTargetDoc({ targets }, userContactDoc, userSettingsDoc, docTag);
+      await pouchdbProvider(db).commitTargetDoc(() => ({ targets }), userContactDoc, userSettingsDoc, docTag);
 
       expect(await db.get('target~2019-07~user~org.couchdb.user:username')).excluding('_rev').to.deep.eq({
         _id: 'target~2019-07~user~org.couchdb.user:username',
@@ -102,12 +102,12 @@ describe('pouchdb provider', () => {
       });
 
       const nextTargets = [{ id: 'target', score: 1 }];
-      await pouchdbProvider(db).commitTargetDoc({ targets: nextTargets }, userContactDoc, userSettingsDoc, docTag);
+      await pouchdbProvider(db).commitTargetDoc(() => ({ targets: nextTargets }), userContactDoc, userSettingsDoc, docTag);
       const ignoredUpdate = await db.get('target~2019-07~user~org.couchdb.user:username');
       expect(ignoredUpdate._rev.startsWith('1-')).to.be.true;
 
       sinon.useFakeTimers(Date.now() + MS_IN_DAY);
-      await pouchdbProvider(db).commitTargetDoc({ targets: nextTargets }, userContactDoc, userSettingsDoc, docTag);
+      await pouchdbProvider(db).commitTargetDoc(() => ({ targets: nextTargets }), userContactDoc, userSettingsDoc, docTag);
       expect(await db.get('target~2019-07~user~org.couchdb.user:username')).excluding('_rev').to.deep.eq({
         _id: 'target~2019-07~user~org.couchdb.user:username',
         updated_date: moment().startOf('day').valueOf(),


### PR DESCRIPTION
# Description

#6209 

This is my attempt to patch this measurement gap using the method suggested in the issue.

> I'd like to update the target document for the nth reporting interval once in the n+1th reporting interval.

However, this approach is perhaps not viable since it isn't currently safe to aggregate targets for a time interval which is not the current interval. This works fine for target emissions which expicitly set their `date` attribute, but doesn't work with target emissions which leave the `date` undefined or which set it to [now](https://github.com/medic/medic-conf/blob/master/src/nools/target-emitter.js#L30) (which is the default for declarative configuration when `date: 'now'`).

While investigating, I've discovered that this same issue actually presents in a critical scenarios. See #6267. I'm publishing this PR to illustrate the problem clearly (see the failing test) as the two issues may share a common solution.


# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
