### PR TITLE
A range of styling improvements for the admin app

### DIFF
--- a/admin/src/css/theme.less
+++ b/admin/src/css/theme.less
@@ -41,7 +41,8 @@ body > div {
 }
 
 .container {
-  width: @admin-content-width;
+  width: 100%;
+  max-width: @admin-content-width;
 }
 .content {
   width: 100%;
@@ -106,6 +107,17 @@ body > div {
 ul {
   list-style-type: none;
   padding: 0;
+}
+
+.resource-icon {
+  height: @icon-large;
+  display: inline-block;
+
+  svg,
+  img {
+    width: @icon-large;
+    height: @icon-large;
+  }
 }
 
 .loader {

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -26,7 +26,7 @@ angular.module('controllers').controller('UpgradeCtrl',
     $scope.loading = true;
     $scope.versions = {};
 
-    const getCurrentDeployment = function() {
+    const getDeploymentInProgress = function() {
       return DB().get(DEPLOY_DOC_ID)
         .then(function(deployDoc) {
           $scope.deployDoc = deployDoc;
@@ -44,7 +44,7 @@ angular.module('controllers').controller('UpgradeCtrl',
         });
     };
 
-    $q.all([getCurrentDeployment(), getExistingDeployment()])
+    $q.all([getDeploymentInProgress(), getExistingDeployment()])
       .then(function() {
         if (!$scope.currentDeploy) {
           // This user has not deployed via horti, so upgrading via it (for now)
@@ -180,7 +180,7 @@ angular.module('controllers').controller('UpgradeCtrl',
       filter: change => change.id === DEPLOY_DOC_ID,
       callback: change => {
         if (!change.deleted) {
-          return getCurrentDeployment();
+          return getDeploymentInProgress();
         }
 
         if ($scope.deployDoc) {

--- a/admin/src/templates/display_translations.html
+++ b/admin/src/templates/display_translations.html
@@ -5,7 +5,8 @@
     <span translate>translation.add</span>
   </a>
 </div>
-<div class="section translations">
+<div class="loader" ng-hide="translationModels"></div>
+<div class="section translations" ng-show="translationModels">
   <div class="container-fluid">
     <div class="row selection-heading">
       <div class="col-xs-6">

--- a/admin/src/templates/forms_xml.html
+++ b/admin/src/templates/forms_xml.html
@@ -27,17 +27,17 @@
   <fieldset>
     <legend translate>Installed Forms</legend>
     <div class="row selection-heading">
-      <div class="col-sm-2" translate>icon</div>
-      <div class="col-sm-3" translate>unique.id</div>
-      <div class="col-sm-7" translate>title</div>
+      <div class="col-sm-1" translate>icon</div>
+      <div class="col-sm-5" translate>unique.id</div>
+      <div class="col-sm-6" translate>title</div>
     </div>
     <div class="container-fluid">
       <ul>
         <li ng-repeat="form in xForms | orderBy:'_id' track by form._id" class="row">
-          <div class="col-sm-2" ng-bind-html="form.icon | resourceIcon"></div>
-          <div class="col-sm-3">{{form._id}}</div>
-          <div class="col-sm-7" ng-if="form.translation_key" translate>{{form.translation_key}}</div>
-          <div class="col-sm-7" ng-if="!form.translation_key">{{form.title | translateFrom}}</div>
+          <div class="col-sm-1" ng-bind-html="form.icon | resourceIcon"></div>
+          <div class="col-sm-5">{{form._id}}</div>
+          <div class="col-sm-6" ng-if="form.translation_key" translate>{{form.translation_key}}</div>
+          <div class="col-sm-6" ng-if="!form.translation_key">{{form.title | translateFrom}}</div>
         </li>
       </ul>
     </div>

--- a/admin/src/templates/index.html
+++ b/admin/src/templates/index.html
@@ -6,8 +6,10 @@
     <title translate>admin.app.name</title>
   </head>
   <body ng-controller="MainCtrl" ng-cloak>
-    <div class="loader" ng-hide="authorized"></div>
-    <div ng-if="authorized">
+    <div ng-hide="authorized">
+      <div class="loader"></div>
+    </div>
+    <div ng-show="authorized">
       <ng-include src="'templates/header.html'"></ng-include>
       <div class="body container">
         <div class="navigation">

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -1,4 +1,3 @@
-
 <div class="upgrade-config col-sm-12" ng-hide="currentDeploy || loading" mm-auth="can_configure">
   <legend translate>instance.upgrade.no_horti</legend>
   <p translate>instance.upgrade.no_horti.detail</p>
@@ -61,60 +60,64 @@
 
     <div><p translate>upgrade.description</p></div>
 
-    <div>
-      <legend translate>instance.upgrade.releases</legend>
-      <p ng-hide="versions.releases.length" translate>instance.upgrade.no_new_releases</p>
-      <div ng-show="versions.betas.length">
-        <div class="row selection-heading">
-          <div class="col-xs-5" translate>instance.upgrade.version</div>
-          <div class="col-xs-7" translate>instance.upgrade.date</div>
-        </div>
-        <ul>
-          <li ng-repeat="release in versions.releases" class="row">
-            <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade"/>
-          </li>
-        </ul>
-      </div>
+    <div class="col-sm-12" ng-show="loading || (deployDoc && !deployDoc._deleted && (deployDoc.action !== 'stage' || !deployDoc.staging_complete))">
+      <div class="loader"></div>
     </div>
 
-    <div ng-show="allowPrereleaseBuilds">
-      <legend translate>instance.upgrade.betas</legend>
+    <div ng-hide="loading || (deployDoc && !deployDoc._deleted && (deployDoc.action !== 'stage' || !deployDoc.staging_complete))">
+
       <div>
-        <p ng-hide="versions.betas.length" translate>instance.upgrade.no_betas</p>
+        <legend translate>instance.upgrade.releases</legend>
+        <p ng-hide="versions.releases.length" translate>instance.upgrade.no_new_releases</p>
         <div ng-show="versions.betas.length">
           <div class="row selection-heading">
             <div class="col-xs-5" translate>instance.upgrade.version</div>
             <div class="col-xs-7" translate>instance.upgrade.date</div>
           </div>
           <ul>
-            <li ng-repeat="release in versions.betas" class="row">
+            <li ng-repeat="release in versions.releases" class="row">
               <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade"/>
             </li>
           </ul>
         </div>
       </div>
-    </div>
 
-    <div ng-show="allowPrereleaseBuilds">
-      <legend translate>instance.upgrade.branches</legend>
-      <div>
-        <p ng-hide="versions.branches.length" translate>instance.upgrade.no_branches</p>
-        <div ng-show="versions.branches.length">
-          <div class="row selection-heading">
-            <div class="col-xs-5" translate>instance.upgrade.version</div>
-            <div class="col-xs-7" translate>instance.upgrade.date</div>
+      <div ng-show="allowPrereleaseBuilds">
+        <legend translate>instance.upgrade.betas</legend>
+        <div>
+          <p ng-hide="versions.betas.length" translate>instance.upgrade.no_betas</p>
+          <div ng-show="versions.betas.length">
+            <div class="row selection-heading">
+              <div class="col-xs-5" translate>instance.upgrade.version</div>
+              <div class="col-xs-7" translate>instance.upgrade.date</div>
+            </div>
+            <ul>
+              <li ng-repeat="release in versions.betas" class="row">
+                <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade"/>
+              </li>
+            </ul>
           </div>
-          <ul>
-            <li ng-repeat="release in versions.branches" class="row">
-              <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade" date-format="medium" />
-            </li>
-          </ul>
+        </div>
+      </div>
+
+      <div ng-show="allowPrereleaseBuilds">
+        <legend translate>instance.upgrade.branches</legend>
+        <div>
+          <p ng-hide="versions.branches.length" translate>instance.upgrade.no_branches</p>
+          <div ng-show="versions.branches.length">
+            <div class="row selection-heading">
+              <div class="col-xs-5" translate>instance.upgrade.version</div>
+              <div class="col-xs-7" translate>instance.upgrade.date</div>
+            </div>
+            <ul>
+              <li ng-repeat="release in versions.branches" class="row">
+                <release release="release" potentially-incompatible="potentiallyIncompatible" upgrade="upgrade" date-format="medium" />
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="col-sm-12" ng-show="loading || (deployDoc && !deployDoc._deleted && (deployDoc.action !== 'stage' || !deployDoc.staging_complete))">
-    <div class="loader"></div>
-  </div>
 </div>


### PR DESCRIPTION
medic/cht-core#6270


# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
