### PR TITLE
Improvements to resource refresh notifications

### DIFF
--- a/webapp/src/js/actions/global.js
+++ b/webapp/src/js/actions/global.js
@@ -196,7 +196,6 @@ angular.module('inboxServices').factory('GlobalActions',
             templateUrl: 'templates/modals/navigation_confirm.html',
             controller: 'NavigationConfirmCtrl',
             controllerAs: 'navigationConfirmCtrl',
-            singleton: true,
           }).then(() => {
             setEnketoEditedStatus(false);
             if (transition) {
@@ -215,7 +214,6 @@ angular.module('inboxServices').factory('GlobalActions',
           templateUrl: 'templates/modals/tour_select.html',
           controller: 'TourSelectCtrl',
           controllerAs: 'tourSelectCtrl',
-          singleton: true,
         }).catch(() => {}); // modal dismissed is ok
       }
 

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -52,6 +52,7 @@ const moment = require('moment');
     Session,
     SetLanguage,
     Settings,
+    Snackbar,
     Telemetry,
     Tour,
     TranslateFrom,
@@ -525,7 +526,6 @@ const moment = require('moment');
         templateUrl: 'templates/modals/database_closed.html',
         controller: 'ReloadingModalCtrl',
         controllerAs: 'reloadingModalCtrl',
-        singleton: true,
       });
       closeDropdowns();
     });
@@ -536,7 +536,6 @@ const moment = require('moment');
         templateUrl: 'templates/modals/version_update.html',
         controller: 'ReloadingModalCtrl',
         controllerAs: 'reloadingModalCtrl',
-        singleton: true,
       }).catch(function() {
         $log.debug('Delaying update');
         $timeout(function() {
@@ -567,6 +566,7 @@ const moment = require('moment');
         if (change.id === 'service-worker-meta') {
           UpdateServiceWorker(showUpdateReady);
         } else {
+          Snackbar(`${change.id} changed`, {dev:true});
           showUpdateReady();
         }
       },

--- a/webapp/src/js/directives/header.js
+++ b/webapp/src/js/directives/header.js
@@ -34,7 +34,6 @@ angular.module('inboxDirectives').directive('mmHeader', function() {
           templateUrl: 'templates/modals/logout_confirm.html',
           controller: 'LogoutConfirmCtrl',
           controllerAs: 'logoutConfirmCtrl',
-          singleton: true,
         }).catch(() => {}); // modal dismissed is ok
       };
 

--- a/webapp/src/js/services/modal.js
+++ b/webapp/src/js/services/modal.js
@@ -5,10 +5,6 @@
  * - templateUrl    (String) The URL of the template to render
  * - controller     (String) The name of the controller to invoke
  * - model          (Object) (optional) The object to bind to the $scope
- * - singleton      (boolean) (optional) Pass true if only one of this type
- *                  of modal should be shown at a time. This will close the
- *                  previous modal so don't use it on modals that allow user
- *                  input. Defaults to false.
  *
  * In the modal template use the mm-modal directive to provide
  * the modal boilerplate.
@@ -66,14 +62,14 @@ angular.module('inboxServices').factory('Modal',
         return $q.reject('No controller speficied.');
       }
       options.scope = getScope(options.model);
-      const instance = $uibModal.open(options);
-      if (options.singleton) {
-        if (instanceCache[options.templateUrl]) {
-          instanceCache[options.templateUrl].close();
-        }
+
+      if (!instanceCache[options.templateUrl]) {
+        const instance = $uibModal.open(options);
+        instance.closed.then(() => delete instanceCache[options.templateUrl]);
         instanceCache[options.templateUrl] = instance;
       }
-      return instance.result;
+
+      return instanceCache[options.templateUrl].result;
     };
   }
 );

--- a/webapp/src/js/services/snackbar.js
+++ b/webapp/src/js/services/snackbar.js
@@ -3,7 +3,12 @@
  * Usage: Snackbar('My notification');
  */
 angular.module('inboxServices').service('Snackbar',
-  function($timeout) {
+  function(
+    $location,
+    $log,
+    $timeout
+  ) {
+
     'ngInject';
     'use strict';
 
@@ -25,15 +30,19 @@ angular.module('inboxServices').service('Snackbar',
       $('#snackbar').removeClass('active');
     };
 
-    return function(text) {
-      if (hideTimer) {
-        hide();
-        $timeout(function() {
+    return (text, {dev} = {}) => {
+      if (!dev || $location.host() === 'localhost') {
+        if (hideTimer) {
+          hide();
+          $timeout(function() {
+            show(text);
+          }, ANIMATION_DURATION);
+        } else {
           show(text);
-        }, ANIMATION_DURATION);
-      } else {
-        show(text);
+        }
       }
+
+      $log.info(text);
     };
   }
 );

--- a/webapp/src/js/services/update-service-worker.js
+++ b/webapp/src/js/services/update-service-worker.js
@@ -4,7 +4,8 @@ Handles service worker updates
 angular.module('inboxServices').factory('UpdateServiceWorker', function(
   $log,
   $timeout,
-  $window
+  $window,
+  Snackbar
 ) {
   'use strict';
   'ngInject';
@@ -32,7 +33,7 @@ angular.module('inboxServices').factory('UpdateServiceWorker', function(
           installingWorker.onstatechange = function() {
             switch (installingWorker.state) {
             case 'activated':
-              $log.info('New service worker activated');
+              Snackbar('New service worker activated', {dev: true});
               registration.onupdatefound = undefined;
               onSuccess();
               break;

--- a/webapp/tests/karma/unit/services/modal.js
+++ b/webapp/tests/karma/unit/services/modal.js
@@ -1,30 +1,33 @@
-describe('Modal service', function() {
+describe('Modal service', () => {
 
   'use strict';
 
   let service;
   let uibModalOpen;
 
-  beforeEach(function() {
+  beforeEach(() => {
     module('inboxApp');
     uibModalOpen = sinon.stub();
-    module(function ($provide) {
-      $provide.factory('$uibModal', function() {
+    module($provide => {
+      $provide.factory('$uibModal', () => {
         return { open: uibModalOpen };
       });
     });
-    inject(function(_Modal_) {
+    inject(_Modal_ => {
       service = _Modal_;
     });
   });
 
-  it('passed args to uibModal', function() {
+  it('passed args to uibModal', () => {
     const options = {
       templateUrl: 'url',
       controller: 'controller',
       model: 123
     };
-    uibModalOpen.returns({ result: 'result' });
+    uibModalOpen.returns({
+      result: 'result',
+      closed: { then: sinon.stub() }
+    });
     service(options);
 
     chai.expect(uibModalOpen.called).to.equal(true);
@@ -34,15 +37,15 @@ describe('Modal service', function() {
     chai.expect(actual.scope.model).to.equal(123);
   });
 
-  it('closes previous modal if singleton is set', function() {
+  it('second identical modal does not open', () => {
     const options = {
       templateUrl: 'url',
       controller: 'controller',
     };
-    const firstModal = { close: sinon.stub() };
-    const secondModal = { close: sinon.stub() };
-    uibModalOpen.onCall(0).returns(firstModal);
-    uibModalOpen.onCall(1).returns(secondModal);
+    uibModalOpen.onCall(0).returns({
+      result: 'result',
+      closed: { then: sinon.stub() }
+    });
 
     // first call
     service(options);
@@ -50,8 +53,73 @@ describe('Modal service', function() {
 
     // second call
     service(options);
-    chai.expect(firstModal.close.callCount).to.equal(1);
-    chai.expect(secondModal.close.callCount).to.equal(0);
+    chai.expect(uibModalOpen.callCount).to.equal(1);
+  });
+
+  it('different modal does open', () => {
+    const options1 = {
+      templateUrl: 'url1',
+      controller: 'controller',
+    };
+    const options2 = {
+      templateUrl: 'url2',
+      controller: 'controller',
+    };
+    const result1 = {
+      result: 'result1',
+      close: sinon.stub(),
+      closed: { then: sinon.stub() }
+    };
+    const result2 = {
+      result: 'result2',
+      close: sinon.stub(),
+      closed: { then: sinon.stub() }
+    };
+    uibModalOpen.onCall(0).returns(result1);
+    uibModalOpen.onCall(1).returns(result2);
+
+    // first call
+    service(options1);
+    chai.expect(uibModalOpen.callCount).to.equal(1);
+
+    // second call
+    service(options2);
+    chai.expect(uibModalOpen.callCount).to.equal(2);
+    
+    chai.expect(result1.close.callCount).to.equal(0);
+    chai.expect(result2.close.callCount).to.equal(0);
+  });
+
+  it('second identical modal opens if first modal is closed first', () => {
+    const options = {
+      templateUrl: 'url',
+      controller: 'controller',
+    };
+    let closeCallback;
+    const result1 = {
+      result: 'result1',
+      close: sinon.stub(),
+      closed: { then: cb => { closeCallback = cb; } }
+    };
+    const result2 = {
+      result: 'result2',
+      close: sinon.stub(),
+      closed: { then: sinon.stub() }
+    };
+    uibModalOpen.onCall(0).returns(result1);
+    uibModalOpen.onCall(1).returns(result2);
+
+    // first call
+    service(options);
+
+    // fire the close callback
+    closeCallback();
+
+    // second call
+    service(options);
+    chai.expect(result1.close.callCount).to.equal(0);
+    chai.expect(result2.close.callCount).to.equal(0);
     chai.expect(uibModalOpen.callCount).to.equal(2);
   });
+
 });

--- a/webapp/tests/karma/unit/services/modal.js
+++ b/webapp/tests/karma/unit/services/modal.js
@@ -38,7 +38,6 @@ describe('Modal service', function() {
     const options = {
       templateUrl: 'url',
       controller: 'controller',
-      singleton: true
     };
     const firstModal = { close: sinon.stub() };
     const secondModal = { close: sinon.stub() };


### PR DESCRIPTION
Change modals so that they are always singletons, stopping multiple
update dialogs from popping over each other.

Additionally, snackbar if dev and always log out when an important file
changes, so developers can more easily see when ddocs and the service
worker changes, hopefully making it easier to know when to refresh.

medic/cht-core#6272