### PR TITLE
Display tasks without owner in tasks list

### DIFF
--- a/ddocs/medic-client/views/tasks_by_contact/map.js
+++ b/ddocs/medic-client/views/tasks_by_contact/map.js
@@ -1,10 +1,8 @@
 function(doc) {
   if (doc.type === 'task') {
-    if (doc.owner) {
-      var isTerminalState = ['Cancelled', 'Completed', 'Failed'].indexOf(doc.state) >= 0;
-      if (!isTerminalState) {
-        emit('owner-' + doc.owner);
-      }
+    var isTerminalState = ['Cancelled', 'Completed', 'Failed'].indexOf(doc.state) >= 0;
+    if (!isTerminalState) {
+      emit('owner-' + (doc.owner || '_unassigned'));
     }
 
     if (doc.requester) {

--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -30,7 +30,7 @@ const taskOwnedByChtContact = {
   owner: 'patient',
 };
 const taskRequestedByChtContact = {
-  _id: 'taskReqiestedBy',
+  _id: 'taskRequestedBy',
   type: 'task',
   requester: 'patient',
 };
@@ -68,9 +68,10 @@ describe('pouchdb provider', () => {
 
   describe('allTasks', () => {
     it('for owner', async () => expect(await pouchdbProvider(db).allTasks('owner')).excludingEvery('_rev')
-      .to.deep.eq([headlessTask, taskOwnedByChtContact]));
+      .to.have.deep.members([headlessTask, taskOwnedByChtContact, taskRequestedByChtContact]));
+
     it('for requester', async () => expect(await pouchdbProvider(db).allTasks('requester')).excludingEvery('_rev')
-      .to.deep.eq([headlessTask, taskRequestedByChtContact]));
+      .to.have.deep.members([headlessTask, taskRequestedByChtContact]));
   });
 
   it('allTaskData', async () => {

--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -68,10 +68,9 @@ describe('pouchdb provider', () => {
 
   describe('allTasks', () => {
     it('for owner', async () => expect(await pouchdbProvider(db).allTasks('owner')).excludingEvery('_rev')
-      .to.have.deep.members([headlessTask, taskOwnedByChtContact, taskRequestedByChtContact]));
-
+      .to.deep.eq([taskRequestedByChtContact, headlessTask, taskOwnedByChtContact]));
     it('for requester', async () => expect(await pouchdbProvider(db).allTasks('requester')).excludingEvery('_rev')
-      .to.have.deep.members([headlessTask, taskRequestedByChtContact]));
+      .to.deep.eq([headlessTask, taskRequestedByChtContact]));
   });
 
   it('allTaskData', async () => {


### PR DESCRIPTION
# Description

Tasks emissions from configs that use `contactLabel` end up with an undefined `owner` property. 
Changing the `tasks_by_contact` view to emit for "unassigned" tasks ensures that ownerless tasks are displayed in the tasks list. 

medic/cht-core#6274

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
