### PR TITLE
Show correct language labels for dynamic elements and non-localized forms

### DIFF
--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -99,22 +99,20 @@ angular.module('inboxServices').service('Enketo',
 
           // TODO remove this when our enketo-core dependency is updated as the latest
           //      version uses the language passed to the constructor
-          const languages = $html
-            .find('#form-languages option')
-            .map(function() {
-              return $(this).attr('value');
-            });
-          // TODO how do we detect a non-localized form?
-          if (languages.length > 1) {
-            // for localized forms, change the selected language
+          const languages = $html.find('#form-languages option');
+          if (languages.length > 1) { // TODO how do we detect a non-localized form?
+            // for localized forms, change language to user's language
             $html
               .find('[lang]')
               .removeClass('active')
-              .filter( '[lang="' + language + '"], [lang=""]' )
-              .filter( function() {
+              .filter('[lang="' + language + '"], [lang=""]')
+              .filter(function() {
+                // localized forms can support a short and long version for labels
+                // Enketo takes this into account when switching languages
+                // https://opendatakit.github.io/xforms-spec/#languages
                 return !$(this).hasClass('or-form-short') ||
                        ($(this).hasClass('or-form-short') && $(this).siblings( '.or-form-long' ).length === 0 );
-              } )
+              })
               .addClass( 'active' );
           }
 

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -153,7 +153,6 @@ angular.module('inboxServices').service('Enketo',
           '~ .question:not(.disabled):not(.or-appearance-hidden), ~ .repeat-buttons button.repeat:not(:disabled)'
         );
         if($nextQuestion.length) {
-
           if($nextQuestion[0].tagName !== 'LABEL') {
             // The next question is something complicated, so we can't just
             // focus on it.  Next best thing is to blur the current selection
@@ -244,11 +243,13 @@ angular.module('inboxServices').service('Enketo',
       return $q.all([
         EnketoPrepopulationData(doc.model, instanceData),
         getContactSummary(doc, instanceData),
+        Language()
       ])
-        .then(([ instanceStr, contactSummary ]) => {
+        .then(([ instanceStr, contactSummary, language ]) => {
           const options = {
             modelStr: doc.model,
-            instanceStr: instanceStr
+            instanceStr: instanceStr,
+            language: language
           };
           if (contactSummary) {
             options.external = [ contactSummary ];


### PR DESCRIPTION
# Description

When switching to server-side form generation, we switched from setting the user's language directly in the xml, pre-conversion, to relying on Enketo's `lang` module.
This module contains a bug where dynamic elements would be generated using the default language instead of the one set with the module: https://github.com/enketo/enketo-core/issues/596 . 
Additionally, non-localized forms would have translation values under the `default` translation tag. 
When setting the user's language, we inadvertently stopped supporting non-localized forms that had translation labels. 

This PR attempts to detect whether the form is localized or not.
Non-localized forms are unaltered. Localized forms' html gets updated to set the user's language as active before passing them to Enketo. 

medic/cht-core#6288
medic/cht-core#6279

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
