### PR TITLE
Expose Enketo model xml via window.debugFormModel()

### DIFF
--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -341,6 +341,7 @@ angular.module('inboxServices').service('Enketo',
           .then(function(form) {
             registerEditedListener(selector, editedListener);
             registerValuechangeListener(selector, valuechangeListener);
+            $window.debugFormModel = () => form.getModel().getStr();
             return form;
           });
       });
@@ -561,6 +562,7 @@ angular.module('inboxServices').service('Enketo',
       objUrls.forEach(function(url) {
         ($window.URL || $window.webkitURL).revokeObjectURL(url);
       });
+      delete $window.debugFormModel;
       objUrls.length = 0;
     };
 

--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -341,7 +341,7 @@ angular.module('inboxServices').service('Enketo',
           .then(function(form) {
             registerEditedListener(selector, editedListener);
             registerValuechangeListener(selector, valuechangeListener);
-            $window.debugFormModel = () => form.getModel().getStr();
+            $window.debugFormModel = () => form.model.getStr();
             return form;
           });
       });


### PR DESCRIPTION
# Description

Adds a global `window.debugFormModel()` for developers to call via the developer console when debugging Enketo forms. Exposes the rendered Enketo form model as an xml string.

#4748

* Just wanting to close on naming and approach before I write a documentation PR
* Unsure if `debugFormModel` is a good name for this. Open to other suggestions.
* Opened https://github.com/medic/medic-conf-test-harness/issues/33 to also expose this data via the medic conf test harness

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
