### PR TITLE
travis-ci AWS Access Keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
     - BUILDS_SERVER=_couch/builds_testing
     - STAGING_SERVER=_couch/builds
     # AWS Access Key Id and AWS Secret Access Key encrypted by travis to access the S3 buckets where reports and screenshots are saved
-    - secure: TR1UN2r3beDtIF+VJpLF2ocTv/uxuOKyVWWhzMLre0ZrrBaIP1sLZV7Z4S/km5M92EfPgGW87BogdWE/R+kTTRiPTCbFB/U/3jFKxEZRXKST66YK5JMwsYqb17UtZtFdqEtO9GGbAVzXwpZfMMoXvlKNrors2W32xBm2uIkOSpI=
-    - secure: Q8RH65NClRBryxfvlwHQjeR4wGs+GXeUBRIBd1kspAM7Uv+5K3iP+q/TPCIrTL/OpJ5tyCYfeq5hKIFFwrY3JikNXnyHICOjXPE6zSLUm8E8NHaP/orPNWjze2x4yDSRCifqzr2ZiXVq9sxlZfNbZ9eyJxpPFTYDSpuN9T5UEE0=
+    - secure: Xpx2330cO0bn0vuotwwZaLOcnez63osHpbD3T4khUOsUxiSsJPc1eE3kY7MEyau0Pfd+M0rL8ens447BdgO2NlAXfs/Ge5AlDK0ATQJcwoBKnO8ex3wPXCelCfYjR8NWB/xN8eSHKxgW0Hv0JDFa+ruofnGkElgGVzJL7ib8iUo=
+    - secure: SZDBgH8YzCSTrbQuOFsa2VTVpFzuNTUIJmStFMVX/w304BDa2uwWnCnBTwFua7PoDQDJQt5sEbqldhHjTkkdxlLIeuDP8AGtqnFXPPpvrAyAK3VzEFfKn3W+CruG5aJ2+YqjY9lbVrXyw4LC5ywAyZzUgVqEru7usHcHxOkX7hE=
 
 before_install:
   # External contributors can't access the secured $UPLOAD_URL environment variable

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,10 +107,12 @@ after_failure:
         tail "$log"
         echo "-------------------------"
       done
+      echo "Inside loop finished"
     )
+  - echo "hiiiiiiiiii"
 
     [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
-
+    echo "Inside last after_failure -- $TRAVIS_PULL_REQUEST"
     if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then
       S3_PATH=s3://medic-e2e/PR_$TRAVIS_PULL_REQUEST
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,11 +108,9 @@ after_failure:
         echo "-------------------------"
       done
     )
-    echo "Travis build stage name - ${TRAVIS_BUILD_STAGE_NAME} - build number - ${TRAVIS_BUILD_NUMBER}"
-    echo "outside loop after_failure -- $TRAVIS_BUILD_STAGE_NAME"
 
     [[ "$TRAVIS_BUILD_STAGE_NAME" = "test" ]] || return
-    echo "Yay! We are inside now!"
+
     if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then
       S3_PATH=s3://medic-e2e/PR_$TRAVIS_PULL_REQUEST
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,8 @@ after_failure:
         echo "-------------------------"
       done
     )
-    echo "outside loop after_failure -- $TRAVIS_PULL_REQUEST"
+    echo "Travis build stage name - ${TRAVIS_BUILD_STAGE_NAME} - build number - ${TRAVIS_BUILD_NUMBER}"
+    echo "outside loop after_failure -- $TRAVIS_BUILD_STAGE_NAME"
 
     [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,8 +111,8 @@ after_failure:
     echo "Travis build stage name - ${TRAVIS_BUILD_STAGE_NAME} - build number - ${TRAVIS_BUILD_NUMBER}"
     echo "outside loop after_failure -- $TRAVIS_BUILD_STAGE_NAME"
 
-    [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
-
+    [[ "$TRAVIS_BUILD_STAGE_NAME" = "test" ]] || return
+    echo "Yay! We are inside now!"
     if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then
       S3_PATH=s3://medic-e2e/PR_$TRAVIS_PULL_REQUEST
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ after_failure:
         echo "-------------------------"
       done
     )
-  - [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
+    [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
     echo "Inside last after_failure -- $TRAVIS_PULL_REQUEST"
 
     if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,8 +108,9 @@ after_failure:
         echo "-------------------------"
       done
     )
+    echo "outside loop after_failure -- $TRAVIS_PULL_REQUEST"
+
     [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
-    echo "Inside last after_failure -- $TRAVIS_PULL_REQUEST"
 
     if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then
       S3_PATH=s3://medic-e2e/PR_$TRAVIS_PULL_REQUEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,12 +107,10 @@ after_failure:
         tail "$log"
         echo "-------------------------"
       done
-      echo "Inside loop finished"
     )
-  - echo "hiiiiiiiiii"
-
-    [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
+  - [[ "$TRAVIS_BUILD_STAGE_NAME" = "Test" ]] || return
     echo "Inside last after_failure -- $TRAVIS_PULL_REQUEST"
+
     if [[ "$TRAVIS_PULL_REQUEST" = true ]]; then
       S3_PATH=s3://medic-e2e/PR_$TRAVIS_PULL_REQUEST
     else

--- a/tests/e2e/common/common.specs.js
+++ b/tests/e2e/common/common.specs.js
@@ -6,8 +6,8 @@ describe('Navigation tests : ', () => {
 
   it('should open Messages tab', () => {
     commonElements.goToMessages();
-    expect(commonElements.isAt('message-list'));
-    expect(browser.getCurrentUrl()).toMatch(utils.getBaseUrl() + 'messages/');
+    expect(commonElements.isAt('message-list2'));
+    expect(browser.getCurrentUrl()).toMatch(utils.getBaseUrl() + 'messages2/');
   });
 
   it('should open tasks tab', () => {

--- a/tests/e2e/common/common.specs.js
+++ b/tests/e2e/common/common.specs.js
@@ -6,8 +6,8 @@ describe('Navigation tests : ', () => {
 
   it('should open Messages tab', () => {
     commonElements.goToMessages();
-    expect(commonElements.isAt('message-list2'));
-    expect(browser.getCurrentUrl()).toMatch(utils.getBaseUrl() + 'messages2/');
+    expect(commonElements.isAt('message-list'));
+    expect(browser.getCurrentUrl()).toMatch(utils.getBaseUrl() + 'messages/');
   });
 
   it('should open tasks tab', () => {


### PR DESCRIPTION

# Description

New IAM user and policies created for travis-ci: medic/medic-infrastructure/pull/139

Fixes medic/cht-core#4877

Tested access keys and limited s3 bucket access:
```
root@02:/app# export AWS_ACCESS_KEY_ID=[secure]
root@02:/app# export AWS_SECRET_ACCESS_KEY=[secure]
root@02:/app# export S3_PATH=s3://medic-e2e/A-TEST001
root@02:/app# vi hello.txt
root@02:/app# aws s3 cp hello.txt "$S3_PATH"/hello.txt
upload: ./hello.txt to s3://medic-e2e/A-TEST001/hello.txt
root@02:/app# aws ec2 describe-volumes --region eu-west-2

An error occurred (UnauthorizedOperation) when calling the DescribeVolumes operation: You are not authorized to perform this operation.
```

We still need to ensure travis is decrypting the keys correctly (that I've formatted them appropriately in .travis.yml). 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
