### PR TITLE
Creating a npm-level everything action

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,14 +232,7 @@ module.exports = function(grunt) {
             UNIT_TEST_ENV: '1',
           },
         },
-      },
-      general: {
-        options: {
-          replace: {
-            UNIT_TEST_ENV: '',
-          },
-        },
-      },
+      }
     },
     less: {
       webapp: {
@@ -1087,13 +1080,6 @@ module.exports = function(grunt) {
     'env:unit-test',
     'exec:shared-lib-unit',
     'mochaTest:unit',
-    'env:general',
-  ]);
-
-  grunt.registerTask('test', 'Run unit, integration, and e2e tests', [
-    'unit',
-    'test-api-integration',
-    'e2e',
   ]);
 
   // CI tasks

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "npm": ">=6.4.1"
   },
   "scripts": {
-    "test": "grunt test",
+    "test": "grunt eslint && grunt unit && grunt test-api-integration && grunt e2e",
     "webdriver": "webdriver-manager update && webdriver-manager start"
   },
   "devDependencies": {


### PR DESCRIPTION
doing this inside grunt doesn't work because of how our application is
architected. Specifically, places that look for UNIT_TEST_ENV only do so
once on initialisation, and grunt doesn't restart the VM between
actions.

Instead, if we run this from npm it just executes this like bash would,
with fresh vms between each run (which is way better regardless of this
issue)

#6317 
