### PR TITLE
Fixes race condition when loading a task

### DIFF
--- a/webapp/src/js/actions/actionTypes.js
+++ b/webapp/src/js/actions/actionTypes.js
@@ -57,4 +57,5 @@ module.exports = {
 
   // Tasks
   SET_SELECTED_TASK: 'SET_SELECTED_TASK',
+  SET_TASKS_LOADED: 'SET_TASKS_LOADED',
 };

--- a/webapp/src/js/actions/tasks.js
+++ b/webapp/src/js/actions/tasks.js
@@ -13,8 +13,13 @@ angular.module('inboxServices').factory('TasksActions',
         dispatch(ActionUtils.createSingleValueAction(actionTypes.SET_SELECTED_TASK, 'selected', selected));
       }
 
+      function setTasksLoaded(promise) {
+        dispatch(ActionUtils.createSingleValueAction(actionTypes.SET_TASKS_LOADED, 'loaded', promise));
+      }
+
       return {
-        setSelectedTask
+        setSelectedTask,
+        setTasksLoaded,
       };
     };
   }

--- a/webapp/src/js/controllers/tasks-content.js
+++ b/webapp/src/js/controllers/tasks-content.js
@@ -32,7 +32,8 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
         enketoStatus: Selectors.getEnketoStatus(state),
         enketoSaving: Selectors.getEnketoSavingStatus(state),
         loadingContent: Selectors.getLoadingContent(state),
-        selectedTask: Selectors.getSelectedTask(state)
+        selectedTask: Selectors.getSelectedTask(state),
+        loadTasks: Selectors.getLoadTasks(state),
       };
     };
     const mapDispatchToTarget = function(dispatch) {
@@ -71,7 +72,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
           LiveList.tasks.setSelected(hydratedTask._id);
           ctrl.setTitle(hydratedTask.title);
           ctrl.setShowContent(true);
-  
+
           if (hasOneActionAndNoFields(hydratedTask)) {
             ctrl.performAction(hydratedTask.actions[0], true);
           }
@@ -224,7 +225,7 @@ angular.module('inboxControllers').controller('TasksContentCtrl',
 
     ctrl.form = null;
     ctrl.formId = null;
-    setSelected($state.params.id);
+    ctrl.loadTasks.then(() => setSelected($state.params.id));
 
     $scope.$on('$destroy', unsubscribe);
   }

--- a/webapp/src/js/controllers/tasks.js
+++ b/webapp/src/js/controllers/tasks.js
@@ -31,6 +31,7 @@
       return {
         unsetSelected: globalActions.unsetSelected,
         setSelectedTask: tasksActions.setSelectedTask,
+        setTasksLoaded: tasksActions.setTasksLoaded,
       };
     };
     const unsubscribe = $ngRedux.connect(mapStateToTarget, mapDispatchToTarget)(ctrl);
@@ -103,6 +104,6 @@
     });
 
     const debouncedReload = Debounce(refreshTasks, 1000, 10 * 1000);
-    refreshTasks();
+    ctrl.setTasksLoaded(refreshTasks());
   });
 }());

--- a/webapp/src/js/reducers/tasks.js
+++ b/webapp/src/js/reducers/tasks.js
@@ -13,6 +13,8 @@ module.exports = function(state, action) {
     return Object.assign({}, state, { selected: null });
   case actionTypes.SET_SELECTED_TASK:
     return Object.assign({}, state, { selected: action.payload.selected });
+  case actionTypes.SET_TASKS_LOADED:
+    return Object.assign({}, state, { loaded: action.payload.loaded });
   default:
     return state;
   }

--- a/webapp/src/js/selectors/index.js
+++ b/webapp/src/js/selectors/index.js
@@ -68,6 +68,7 @@ const getLastChangedDoc = state => getServicesState(state).lastChangedDoc;
 // Tasks
 const getTasksState = state => state.tasks;
 const getSelectedTask = state => getTasksState(state).selected;
+const getLoadTasks = state => getTasksState(state).loaded;
 
 angular.module('inboxServices').constant('Selectors', {
   getGlobalState,
@@ -116,5 +117,6 @@ angular.module('inboxServices').constant('Selectors', {
   getLastChangedDoc,
 
   getTasksState,
-  getSelectedTask
+  getSelectedTask,
+  getLoadTasks,
 });

--- a/webapp/tests/karma/unit/controllers/tasks-content.js
+++ b/webapp/tests/karma/unit/controllers/tasks-content.js
@@ -10,10 +10,18 @@ describe('TasksContentCtrl', () => {
   let render;
   let get;
   let XmlForms;
+  let getList;
+  let tasksLoadedPromise;
 
   beforeEach(() => {
     module('inboxApp');
-    KarmaUtils.setupMockStore();
+    getList = sinon.stub();
+    tasksLoadedPromise = Promise.resolve().then(() => getList.returns([task]));
+    KarmaUtils.setupMockStore({
+      tasks: {
+        loaded: tasksLoadedPromise,
+      }
+    });
   });
 
   beforeEach(inject(($controller, $ngRedux, TasksActions, Selectors) => {
@@ -25,6 +33,7 @@ describe('TasksContentCtrl', () => {
       setSelected: () => tasksActions.setSelectedTask(task)
     };
     getEnketoEditedStatus = () => Selectors.getEnketoEditedStatus($ngRedux.getState());
+
     get = sinon.stub().resolves({ _id: 'contact' });
     render.resolves();
     createController = () => {
@@ -37,11 +46,11 @@ describe('TasksContentCtrl', () => {
         DB: () => ({ get }),
         XmlForms,
         Telemetry: { record: sinon.stub() },
-        LiveList: { 
+        LiveList: {
           tasks: {
             clearSelected: sinon.stub(),
             setSelected: sinon.stub(),
-            getList: sinon.stub().returns([ task ])
+            getList: getList,
           },
         }
       });
@@ -66,7 +75,7 @@ describe('TasksContentCtrl', () => {
     createController();
     setTimeout(() => {
       expect(ctrl.formId).to.equal('A');
-      
+
       expect(render.callCount).to.equal(1);
       expect(render.getCall(0).args.length).to.equal(4);
       expect(render.getCall(0).args[0]).to.equal('#task-report');
@@ -96,7 +105,7 @@ describe('TasksContentCtrl', () => {
     setTimeout(() => {
       expect(get.callCount).to.eq(1);
       expect(get.args).to.deep.eq([['contact']]);
-      
+
       expect(render.callCount).to.eq(1);
       expect(render.args[0][2]).to.deep.eq({
         contact: { _id: 'contact' },
@@ -123,7 +132,7 @@ describe('TasksContentCtrl', () => {
     setTimeout(() => {
       expect(get.callCount).to.eq(1);
       expect(get.args).to.deep.eq([['dne']]);
-      
+
       expect(render.callCount).to.eq(1);
       expect(render.args[0][2]).to.eq('nothing');
       done();
@@ -182,6 +191,36 @@ describe('TasksContentCtrl', () => {
     setTimeout(() => {
       expect(ctrl.loadingForm).to.equal(false);
       expect(ctrl.contentError).to.equal(true);
+      done();
+    });
+  });
+
+  it('should wait for the tasks to load before setting selected task', (done) => {
+    const notTask = {
+      _id: '123',
+      forId: 'contact',
+      actions: [{
+        type: 'report',
+        form: 'A',
+        content: {
+          something: 'other',
+        },
+      }]
+    };
+    const form = { _id: 'myform', title: 'My Form' };
+    XmlForms.get.resolves(form);
+    const someFn = sinon.stub();
+    tasksLoadedPromise = Promise.resolve().then(() => {
+      someFn();
+      getList.returns([notTask]);
+    });
+    createController();
+    setTimeout(() => {
+      expect(render.args[0][2]).to.deep.eq({
+        contact: { _id: 'contact' },
+        something: 'other',
+      });
+      expect(someFn.callCount).to.equal(1);
       done();
     });
   });


### PR DESCRIPTION
# Description

Fixes race condition when loading a task by saving the `refreshTasks` promise in the state and setting the selected task after tasks are refreshed.

medic/cht-core#6323

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
