### PR TITLE
Load images after rendering HTML 

### DIFF
--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -71,6 +71,29 @@ angular.module('inboxServices').service('Enketo',
       });
     };
 
+    const replaceMediaLoaders = function(selector, formDoc) {
+      const wrapper = $(selector);
+      const formContainer = wrapper.find('.container').first();
+      formContainer.find('[data-media-src]').each(function() {
+        const elem = $(this);
+        const src = elem.attr('data-media-src');
+        DB()
+          .getAttachment(formDoc._id, src)
+          .then(function(blob) {
+            const objUrl = ($window.URL || $window.webkitURL).createObjectURL(blob);
+            objUrls.push(objUrl);
+            elem
+              .attr('src', objUrl)
+              .css('visibility', '')
+              .unwrap();
+          })
+          .catch(function(err) {
+            $log.error('Error fetching media file', formDoc._id, src, err);
+            elem.closest('.loader').hide();
+          });
+      });
+    };
+
     const transformXml = function(form, language) {
       return $q.all([
         getAttachment(form._id, HTML_ATTACHMENT_NAME),
@@ -243,29 +266,6 @@ angular.module('inboxServices').service('Enketo',
           }
           return options;
         });
-    };
-
-    const replaceMediaLoaders = function(selector, formDoc) {
-      const wrapper = $(selector);
-      const formContainer = wrapper.find('.container').first();
-      formContainer.find('[data-media-src]').each(function() {
-        const elem = $(this);
-        const src = elem.attr('data-media-src');
-        DB()
-          .getAttachment(formDoc._id, src)
-          .then(function(blob) {
-            const objUrl = ($window.URL || $window.webkitURL).createObjectURL(blob);
-            objUrls.push(objUrl);
-            elem
-              .attr('src', objUrl)
-              .css('visibility', '')
-              .unwrap();
-          })
-          .catch(function(err) {
-            $log.error('Error fetching media file', formDoc._id, src, err);
-            elem.closest('.loader').hide();
-          });
-      });
     };
 
     const renderFromXmls = function(doc, selector, instanceData) {

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -231,7 +231,7 @@ describe('Enketo service', () => {
       });
     });
 
-    it('leaves img wrapped if failed to load', () => {
+    it('leaves img wrapped and hides loader if failed to load', () => {
       UserContact.resolves({ contact_id: '123' });
       dbGetAttachment
         .onFirstCall().resolves('<div><img data-media-src="myimg"></div>')
@@ -247,7 +247,9 @@ describe('Enketo service', () => {
         expect(img.attr('src')).to.equal(undefined);
         expect(img.attr('data-media-src')).to.equal('myimg');
         expect(img.css('visibility')).to.equal('hidden');
-        expect(img.closest('div').hasClass('loader')).to.equal(true);
+        const loader = img.closest('div');
+        expect(loader.hasClass('loader')).to.equal(true);
+        expect(loader.is(':hidden')).to.equal(true);
         expect(enketoInit.callCount).to.equal(1);
         expect(createObjectURL.callCount).to.equal(0);
       });


### PR DESCRIPTION
# Description

Avoids a race condition causing images to never be rendered.

medic/cht-core#6321

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
