### PR TITLE
Don't cache login redirection

### DIFF
--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -132,7 +132,14 @@ const setSessionCookie = (res, cookie) => {
 const setUserCtxCookie = (res, userCtx) => {
   const options = getCookieOptions();
   options.maxAge = ONE_YEAR;
-  res.cookie('userCtx', JSON.stringify(userCtx), options);
+  const home = getHomeUrl(userCtx);
+  let content;
+  if (home === '/') {
+    content = userCtx;
+  } else {
+    content = Object.assign({}, userCtx, { home });
+  }
+  res.cookie('userCtx', JSON.stringify(content), options);
 };
 
 const setLocaleCookie = (res, locale) => {
@@ -242,10 +249,7 @@ module.exports = {
       .getUserCtx(req)
       .then(userCtx => {
         setUserCtxCookie(res, userCtx);
-        res.send({
-          success: true,
-          url: getRedirectUrl(userCtx, req.query.redirect)
-        });
+        res.send({ success: true });
       })
       .catch(() => {
         res.status(401);

--- a/api/src/public/login/script.js
+++ b/api/src/public/login/script.js
@@ -122,27 +122,27 @@ const getRedirectUrl = function() {
   return urlParams.get('redirect');
 };
 
+const getUserCtx = function() {
+  const cookie = getCookie('userCtx');
+  if (cookie) {
+    try {
+      return JSON.parse(decodeURIComponent(cookie));
+    } catch(e) {
+      console.error('Error parsing cookie', e);
+    }
+  }
+};
+
 const checkSession = function() {
   if (getCookie('login') === 'force') {
     // require user to login regardless of session state
     return;
   }
-  const redirect = encodeURIComponent(getRedirectUrl());
-  request('GET', '/medic/login/identity?redirect=' + redirect, null, function(xmlhttp) {
-    if (xmlhttp.status === 0 || xmlhttp.status === 401) {
-      // no internet connection or not logged in - ignore
-      return;
-    }
-    if (xmlhttp.status !== 200) {
-      return console.error(`Could not determine session status. Response: ${xmlhttp.status}, ${xmlhttp.response}`);
-    }
-    try {
-      const response = JSON.parse(xmlhttp.response);
-      window.location = response.url || '/';
-    } catch (e) {
-      return console.error('Could not parse session status.', e);
-    }
-  });
+  const userCtx = getUserCtx();
+  if (userCtx && userCtx.name) {
+    // user is already logged in - redirect to app
+    window.location = getRedirectUrl() || userCtx.home || '/';
+  }
 };
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/api/src/public/login/script.js
+++ b/api/src/public/login/script.js
@@ -28,7 +28,7 @@ const submit = function(e) {
   const payload = JSON.stringify({
     user: document.getElementById('user').value.toLowerCase().trim(),
     password: document.getElementById('password').value,
-    redirect: document.getElementById('redirect').value,
+    redirect: getRedirectUrl(),
     locale: selectedLocale
   });
   request('POST', url, payload, function(xmlhttp) {
@@ -117,12 +117,9 @@ const parseTranslations = function() {
   return JSON.parse(decodeURIComponent(raw));
 };
 
-const setRedirectUrl = function() {
+const getRedirectUrl = function() {
   const urlParams = new URLSearchParams(window.location.search);
-  const redirect = urlParams.get('redirect');
-  if (redirect) {
-    document.getElementById('redirect').value = redirect;
-  }
+  return urlParams.get('redirect');
 };
 
 const checkSession = function() {
@@ -130,7 +127,7 @@ const checkSession = function() {
     // require user to login regardless of session state
     return;
   }
-  const redirect = encodeURIComponent(document.getElementById('redirect').value);
+  const redirect = encodeURIComponent(getRedirectUrl());
   request('GET', '/medic/login/identity?redirect=' + redirect, null, function(xmlhttp) {
     if (xmlhttp.status === 0 || xmlhttp.status === 401) {
       // no internet connection or not logged in - ignore
@@ -149,7 +146,6 @@ const checkSession = function() {
 };
 
 document.addEventListener('DOMContentLoaded', function() {
-  setRedirectUrl();
   checkSession();
 
   translations = parseTranslations();

--- a/api/src/templates/login/index.html
+++ b/api/src/templates/login/index.html
@@ -10,7 +10,6 @@
     <div class="center">
       <form id="form" action="/medic/login" method="POST">
         <img class="logo" src="{{ branding.logo }}" title="{{ branding.name }}">
-        <input id="redirect" type="hidden" name="redirect">
         <label for="user" translate="User Name"></label>
         <input id="user" name="user" autocomplete="off" autocorrect="off" autocapitalize="none" spellcheck="false"/>
         <label for="password" translate="Password"></label>

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -295,7 +295,6 @@ describe('login controller', () => {
         chai.expect(post.args[0][0].auth.pass).to.equal('p4ss');
         chai.expect(getUserCtx.callCount).to.equal(1);
         chai.expect(getUserCtx.args[0][0].headers.Cookie).to.equal('AuthSession=abc;');
-        chai.expect(auth.isOnlineOnly.callCount).to.equal(1);
         chai.expect(status.callCount).to.equal(1);
         chai.expect(status.args[0][0]).to.equal(302);
         chai.expect(send.args[0][0]).to.deep.equal('/');
@@ -385,7 +384,6 @@ describe('login controller', () => {
         chai.expect(getUserCtx.callCount).to.equal(1);
         chai.expect(getUserCtx.args[0][0].headers.Cookie).to.equal('AuthSession=abc;');
         chai.expect(hasAllPermissions.callCount).to.equal(0);
-        chai.expect(auth.isOnlineOnly.callCount).to.equal(1);
         chai.expect(status.callCount).to.equal(1);
         chai.expect(status.args[0][0]).to.equal(302);
         chai.expect(send.args[0][0]).to.equal('/');
@@ -402,19 +400,25 @@ describe('login controller', () => {
       const send = sinon.stub(res, 'send');
       const status = sinon.stub(res, 'status').returns(res);
       const userCtx = { name: 'shazza', roles: [ 'project-stuff' ] };
+      const cookie = sinon.stub(res, 'cookie').returns(res);
       const getUserCtx = sinon.stub(auth, 'getUserCtx').resolves(userCtx);
       auth.isOnlineOnly.returns(true);
-      const hasAllPermissions = sinon.stub(auth, 'hasAllPermissions').returns(true);
+      sinon.stub(auth, 'hasAllPermissions').returns(true);
       sinon.stub(auth, 'getUserSettings').resolves({ language: 'es' });
       return controller.post(req, res).then(() => {
         chai.expect(post.callCount).to.equal(1);
         chai.expect(getUserCtx.callCount).to.equal(1);
         chai.expect(getUserCtx.args[0][0].headers.Cookie).to.equal('AuthSession=abc;');
-        chai.expect(hasAllPermissions.callCount).to.equal(1);
-        chai.expect(auth.isOnlineOnly.callCount).to.equal(1);
         chai.expect(status.callCount).to.equal(1);
         chai.expect(status.args[0][0]).to.equal(302);
         chai.expect(send.args[0][0]).to.equal('/admin/');
+        chai.expect(cookie.callCount).to.equal(3);
+        chai.expect(cookie.args[1][0]).to.equal('userCtx');
+        chai.expect(cookie.args[1][1]).to.equal(JSON.stringify({
+          name: 'shazza',
+          roles: [ 'project-stuff' ],
+          home: '/admin/'
+        }));
       });
     });
 
@@ -440,8 +444,6 @@ describe('login controller', () => {
         chai.expect(request.post.callCount).to.equal(1);
         chai.expect(auth.getUserCtx.callCount).to.equal(1);
         chai.expect(auth.getUserCtx.args[0][0].headers.Cookie).to.equal('AuthSession=abc;');
-        chai.expect(auth.hasAllPermissions.callCount).to.equal(1);
-        chai.expect(auth.isOnlineOnly.callCount).to.equal(1);
         chai.expect(auth.isDbAdmin.callCount).to.equal(1);
         chai.expect(auth.isDbAdmin.args[0]).to.deep.equal([userCtx]);
         chai.expect(users.createAdmin.callCount).to.equal(1);
@@ -472,10 +474,7 @@ describe('login controller', () => {
         chai.expect(res.type.args[0][0]).to.equal('application/json');
         chai.expect(getUserCtx.callCount).to.equal(1);
         chai.expect(send.callCount).to.equal(1);
-        chai.expect(send.args[0][0]).to.deep.equal({
-          success: true,
-          url: '/'
-        });
+        chai.expect(send.args[0][0]).to.deep.equal({ success: true });
       });
     });
 

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -135,25 +135,7 @@ describe('login controller', () => {
 
   describe('get', () => {
 
-    it('when already logged in redirect to app', () => {
-      const getUserCtx = sinon.stub(auth, 'getUserCtx').resolves({ name: 'josh' });
-      const redirect = sinon.stub(res, 'redirect');
-      const cookie = sinon.stub(res, 'cookie').returns(res);
-      const query = sinon.stub(db, 'query');
-      return controller.get(req, res).then(() => {
-        chai.expect(getUserCtx.callCount).to.equal(1);
-        chai.expect(getUserCtx.args[0][0]).to.deep.equal(req);
-        chai.expect(cookie.callCount).to.equal(1);
-        chai.expect(cookie.args[0][0]).to.equal('userCtx');
-        chai.expect(cookie.args[0][1]).to.equal('{"name":"josh"}');
-        chai.expect(redirect.callCount).to.equal(1);
-        chai.expect(redirect.args[0][0]).to.equal('/');
-        chai.expect(query.callCount).to.equal(0);
-      });
-    });
-
-    it('when not logged in send login page', () => {
-      const getUserCtx = sinon.stub(auth, 'getUserCtx').rejects('not logged in');
+    it('send login page', () => {
       const query = sinon.stub(db, 'query').resolves({ rows: [] });
       const getDoc = sinon.stub(db, 'get').resolves({
         _id: 'branding',
@@ -172,8 +154,6 @@ describe('login controller', () => {
         .callsArgWith(2, null, 'LOGIN PAGE GOES HERE. {{ translations }}');
       sinon.stub(config, 'getTranslationValues').returns({ en: { login: 'English' } });
       return controller.get(req, res).then(() => {
-        chai.expect(getUserCtx.callCount).to.equal(1);
-        chai.expect(getUserCtx.args[0][0]).to.deep.equal(req);
         chai.expect(getDoc.callCount).to.equal(1);
         chai.expect(send.callCount).to.equal(1);
         chai.expect(send.args[0][0])
@@ -183,42 +163,20 @@ describe('login controller', () => {
       });
     });
 
-    it('when branding doc missing when not logged in send login page', () => {
-      const getUserCtx = sinon.stub(auth, 'getUserCtx').rejects('not logged in');
+    it('when branding doc missing send login page', () => {
       const getDoc = sinon.stub(db, 'get').rejects({ error: 'not_found', docId: 'branding'});
       sinon.stub(db, 'query').resolves({ rows: [] });
       const send = sinon.stub(res, 'send');
       sinon.stub(fs, 'readFile').callsArgWith(2, null, 'LOGIN PAGE GOES HERE.');
       sinon.stub(config, 'getTranslationValues').returns({});
       return controller.get(req, res).then(() => {
-        chai.expect(getUserCtx.callCount).to.equal(1);
-        chai.expect(getUserCtx.args[0][0]).to.deep.equal(req);
         chai.expect(getDoc.callCount).to.equal(1);
         chai.expect(send.callCount).to.equal(1);
         chai.expect(send.args[0][0]).to.equal('LOGIN PAGE GOES HERE.');
       });
     });
 
-    it('when already logged in and login=force cookie is present, render login', () => {
-      const getUserCtx = sinon.stub(auth, 'getUserCtx').resolves({ name: 'josh' });
-      const send = sinon.stub(res, 'send');
-      sinon.stub(db, 'get').resolves({});
-      sinon.stub(db, 'query').resolves({ rows: [] });
-      const cookie = sinon.stub(res, 'cookie').returns(res);
-      req.headers.cookie = 'login=force';
-      return controller.get(req, res).then(() => {
-        chai.expect(getUserCtx.callCount).to.equal(1);
-        chai.expect(getUserCtx.args[0][0]).to.deep.equal(req);
-        chai.expect(cookie.callCount).to.equal(1);
-        chai.expect(cookie.args[0][0]).to.equal('userCtx');
-        chai.expect(cookie.args[0][1]).to.equal('{"name":"josh"}');
-        chai.expect(send.callCount).to.equal(1);
-        chai.expect(send.args[0][0]).to.include('<form id="form" action="/medic/login" method="POST">');
-      });
-    });
-
     it('caches the login page template for performance', () => {
-      sinon.stub(auth, 'getUserCtx').rejects('not logged in');
       sinon.stub(res, 'send');
       sinon.stub(db, 'query').resolves({ rows: [] });
       sinon.stub(res, 'cookie').returns(res);
@@ -251,7 +209,6 @@ describe('login controller', () => {
     });
 
     it('hides locale selector when there is only one option', () => {
-      sinon.stub(auth, 'getUserCtx').rejects('not logged in');
       sinon.stub(db, 'query').resolves({ rows: [ { doc: { code: 'en', name: 'English' } } ] });
       sinon.stub(db, 'get').rejects({ error: 'not_found', docId: 'branding'});
       const send = sinon.stub(res, 'send');
@@ -515,7 +472,10 @@ describe('login controller', () => {
         chai.expect(res.type.args[0][0]).to.equal('application/json');
         chai.expect(getUserCtx.callCount).to.equal(1);
         chai.expect(send.callCount).to.equal(1);
-        chai.expect(send.args[0][0]).to.deep.equal({ success: true });
+        chai.expect(send.args[0][0]).to.deep.equal({
+          success: true,
+          url: '/'
+        });
       });
     });
 


### PR DESCRIPTION
# Description

If the 302 response is cached in the service worker the user is
sent to the app. If they don't have a current session then they're
sent back to the login page.

medic/cht-core#6337

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
