### PR TITLE
App forms don't default to sending SMS. 

### DIFF
--- a/webapp/src/js/services/form2sms.js
+++ b/webapp/src/js/services/form2sms.js
@@ -20,13 +20,16 @@ angular
       return DB()
         .get(`form:${doc.form}`)
         .then(form => {
-          if(form.xml2sms) {
+          if (!form.xml2sms) {
+            $log.debug('Not sending SMS. `xml2sms` form property not defined or falsy.');
+            return;
+          }
+
+          if (typeof form.xml2sms === 'string') {
             return $parse(form.xml2sms)({ doc:doc.fields, concat, spaced, match });
           } else {
-            $log.debug('No xml2sms property defined on form doc. Checking for standard odk tags in form submission...');
-
-            return GetReportContent(doc)
-              .then(odkForm2sms);
+            $log.debug('Checking for standard odk tags in form submission...');
+            return GetReportContent(doc).then(odkForm2sms);
           }
         })
         .catch(function(err) {


### PR DESCRIPTION
# Description

Updates `forms2sms` service so it requires the `xml2sms` form property to be set and truthy in order to generate SMS. If the value is Boolean, fallback to ODK standard, otherwise treat as angular expression.

medic/cht-core#6162

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
