### PR TITLE
Adds Telemetry to Rules Engine, TasksCtrl and TargetsCtrl.

### DIFF
--- a/shared-libs/rules-engine/src/index.js
+++ b/shared-libs/rules-engine/src/index.js
@@ -81,5 +81,11 @@ module.exports = db => {
         rulesEmitter.initialize(settings);
       }
     },
+
+    /**
+     * Returns a list of UUIDs of tracked contacts that are marked as dirty
+     * @returns {Array} list of dirty contacts UUIDs
+     */
+    getDirtyContacts: () => rulesStateStore.getDirtyContacts(),
   };
 };

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -243,6 +243,12 @@ const self = {
     state.targetState,
     targetEmissionFilter
   ),
+
+  /**
+   * Returns a list of UUIDs of tracked contacts that are marked as dirty
+   * @returns {Array} list of dirty contacts UUIDs
+   */
+  getDirtyContacts: () => self.getContactIds().filter(self.isDirty),
 };
 
 const hashRulesConfig = (settings) => {

--- a/shared-libs/rules-engine/test/rules-state-store.spec.js
+++ b/shared-libs/rules-engine/test/rules-state-store.spec.js
@@ -251,4 +251,23 @@ describe('rules-state-store', () => {
       expect(actual).to.not.be.empty;
     });
   });
+
+  describe('getDirtyContacts', () => {
+    it('no contacts', async () => {
+      await rulesStateStore.build({});
+      expect(rulesStateStore.getDirtyContacts()).to.deep.equal([]);
+    });
+
+    it('some contacts', async () => {
+      const now = moment();
+      clock = sinon.useFakeTimers(now.valueOf());
+      await rulesStateStore.build({});
+      await rulesStateStore.markFresh(0, ['a', 'b', 'c', 'd']);
+      const tenDays = 10 * 24 * 60 * 60 * 1000;
+      clock.tick(tenDays); // 10 days
+      expect(rulesStateStore.getDirtyContacts()).to.deep.equal(['a', 'b', 'c', 'd']);
+      await rulesStateStore.markFresh(now.add(10, 'days').valueOf(), ['a', 'b', 'c']);
+      expect(rulesStateStore.getDirtyContacts()).to.deep.equal(['d']);
+    });
+  });
 });

--- a/webapp/src/js/controllers/analytics-targets.js
+++ b/webapp/src/js/controllers/analytics-targets.js
@@ -1,6 +1,7 @@
 angular.module('inboxControllers').controller('AnalyticsTargetsCtrl', function (
   $log,
-  RulesEngine
+  RulesEngine,
+  Telemetry
 ) {
 
   'use strict';
@@ -11,6 +12,10 @@ angular.module('inboxControllers').controller('AnalyticsTargetsCtrl', function (
   ctrl.targets = [];
   ctrl.loading = true;
   ctrl.targetsDisabled = false;
+
+  const telemetryData = {
+    start: Date.now(),
+  };
 
   RulesEngine
     .isEnabled()
@@ -25,6 +30,9 @@ angular.module('inboxControllers').controller('AnalyticsTargetsCtrl', function (
     .then(targets => {
       ctrl.loading = false;
       ctrl.targets = targets.filter(target => target.visible !== false);
+
+      telemetryData.end = Date.now();
+      Telemetry.record(`analytics:targets:load`, telemetryData.end - telemetryData.start);
     });
 }
 );

--- a/webapp/tests/karma/unit/controllers/analytics-targets.spec.js
+++ b/webapp/tests/karma/unit/controllers/analytics-targets.spec.js
@@ -6,6 +6,7 @@ describe('AnalyticsTargetsCtrl controller', function() {
 
   let rulesEngine;
   let $rootScope;
+  let telemetry;
   let scope;
 
   beforeEach(() => {
@@ -18,6 +19,7 @@ describe('AnalyticsTargetsCtrl controller', function() {
       isEnabled: sinon.stub(),
       fetchTargets: sinon.stub(),
     };
+    telemetry = { record: sinon.stub() };
 
     scope = $rootScope.$new();
 
@@ -26,6 +28,7 @@ describe('AnalyticsTargetsCtrl controller', function() {
         '$scope': scope,
         '$rootScope': $rootScope,
         'RulesEngine': rulesEngine,
+        'Telemetry': telemetry,
       });
     };
   }));
@@ -54,6 +57,8 @@ describe('AnalyticsTargetsCtrl controller', function() {
       chai.expect(ctrl.targets).to.deep.equal([]);
       chai.expect(ctrl.loading).to.equal(false);
       chai.expect(ctrl.targetsDisabled).to.equal(true);
+      chai.expect(telemetry.record.callCount).to.equal(1);
+      chai.expect(telemetry.record.args[0][0]).to.equal('analytics:targets:load');
     });
   });
 
@@ -67,6 +72,8 @@ describe('AnalyticsTargetsCtrl controller', function() {
       chai.expect(ctrl.targets).to.deep.equal([{ id: 'target1' }, { id: 'target2' }]);
       chai.expect(ctrl.loading).to.equal(false);
       chai.expect(ctrl.targetsDisabled).to.equal(false);
+      chai.expect(telemetry.record.callCount).to.equal(1);
+      chai.expect(telemetry.record.args[0][0]).to.equal('analytics:targets:load');
     });
   });
 

--- a/webapp/tests/karma/unit/controllers/tasks.js
+++ b/webapp/tests/karma/unit/controllers/tasks.js
@@ -127,7 +127,6 @@ describe('Tasks controller', () => {
     expect(service.tasksDisabled).to.be.false;
     expect(service.hasTasks).to.be.true;
     expect(!!service.error).to.be.false;
-    console.log(JSON.stringify(LiveList.tasks.set.args, null, 2));
     expect(LiveList.tasks.set.args).to.deep.eq([[[{ _id: 'e1' }, { _id: 'e2' }]]]);
   });
 

--- a/webapp/tests/karma/unit/controllers/tasks.js
+++ b/webapp/tests/karma/unit/controllers/tasks.js
@@ -7,7 +7,9 @@ describe('Tasks controller', () => {
   let db;
   let LiveList;
   let RulesEngine;
+  let Telemetry;
   let Tour;
+  let Debounce;
 
   beforeEach(async () => {
     Changes = sinon.stub();
@@ -18,6 +20,12 @@ describe('Tasks controller', () => {
 
     Tour = sinon.stub();
     db = { get: sinon.stub().resolves({}) };
+    Telemetry = { record: sinon.stub() };
+    Debounce = sinon.stub().callsFake(() => {
+      const debounced = sinon.stub();
+      debounced.cancel = sinon.stub();
+      return debounced;
+    });
 
     module('inboxApp');
     module($provide => {
@@ -25,6 +33,8 @@ describe('Tasks controller', () => {
       $provide.factory('DB', KarmaUtils.mockDB(db));
       $provide.value('RulesEngine', RulesEngine);
       $provide.value('Tour', Tour);
+      $provide.value('Telemetry', Telemetry);
+      $provide.value('Debounce', Debounce);
     });
 
     inject((_$rootScope_, _$ngRedux_, _LiveList_, _LiveListConfig_, $controller) => {
@@ -37,7 +47,7 @@ describe('Tasks controller', () => {
       LiveList = _LiveList_;
 
       _LiveListConfig_($scope);
-      
+
       getService = () => {
         const result = $controller('TasksCtrl', {
           $log: { error: () => {}},
@@ -48,10 +58,11 @@ describe('Tasks controller', () => {
           LiveList,
           LiveListConfig: _LiveListConfig_,
           RulesEngine,
+          Telemetry,
           Tour,
         });
         sinon.stub(result, 'setSelectedTask');
-        
+
         return result;
       };
     });
@@ -116,6 +127,7 @@ describe('Tasks controller', () => {
     expect(service.tasksDisabled).to.be.false;
     expect(service.hasTasks).to.be.true;
     expect(!!service.error).to.be.false;
+    console.log(JSON.stringify(LiveList.tasks.set.args, null, 2));
     expect(LiveList.tasks.set.args).to.deep.eq([[[{ _id: 'e1' }, { _id: 'e2' }]]]);
   });
 
@@ -148,4 +160,34 @@ describe('Tasks controller', () => {
 
     expect(changesFeed.filter({ id: 'foo', doc: { _id: 'a', type: 'data_record', form: undefined }})).to.be.false;
   });
+
+  it('should record telemetry on initial load', async () => {
+    await new Promise(resolve => {
+      sinon.stub(LiveList.tasks, 'set').callsFake(resolve);
+      getService();
+    });
+
+    expect(RulesEngine.fetchTaskDocsForAllContacts.callCount).to.eq(1);
+    expect(Telemetry.record.callCount).to.equal(1);
+    expect(Telemetry.record.args[0][0]).to.equal('tasks:load');
+  });
+
+  it('should should record telemetry on refresh', async () => {
+    await new Promise(resolve => {
+      sinon.stub(LiveList.tasks, 'set').callsFake(resolve);
+      getService();
+    });
+
+    const changesArgs = Changes.args[0][0];
+    const change = { doc: { type: 'task' } };
+    changesArgs.callback(change);
+    const refresh = Debounce.args[0][0];
+    await refresh();
+
+    expect(RulesEngine.fetchTaskDocsForAllContacts.callCount).to.eq(2);
+    expect(Telemetry.record.callCount).to.equal(2);
+    expect(Telemetry.record.args[0][0]).to.equal('tasks:load');
+    expect(Telemetry.record.args[1][0]).to.equal('tasks:refresh');
+  });
+
 });

--- a/webapp/tests/karma/unit/services/rules-engine.js
+++ b/webapp/tests/karma/unit/services/rules-engine.js
@@ -15,6 +15,7 @@ describe(`RulesEngine service`, () => {
   let UserContact;
   let UserSettings;
   let UHCSettings;
+  let Telemetry;
 
   const settingsDoc = {
     _id: 'settings',
@@ -71,14 +72,16 @@ describe(`RulesEngine service`, () => {
     UserContact = sinon.stub().resolves(userContactDoc);
     UserSettings = sinon.stub().resolves(userSettingsDoc);
     UHCSettings = { getMonthStartDate: sinon.stub().returns(1) };
+    Telemetry = { record: sinon.stub() };
 
     RulesEngineCore = {
       initialize: sinon.stub().resolves(true),
       isEnabled: sinon.stub().returns(true),
       fetchTasksFor: sinon.stub().resolves([]),
       fetchTargets: sinon.stub().resolves([]),
-      updateEmissionsFor: sinon.stub(),
+      updateEmissionsFor: sinon.stub().resolves(),
       rulesConfigChange: sinon.stub().returns(true),
+      getDirtyContacts: sinon.stub().returns([]),
     };
 
     module('inboxApp');
@@ -93,6 +96,7 @@ describe(`RulesEngine service`, () => {
       $provide.value('RulesEngineCore', RulesEngineCore);
       $provide.value('Session', Session);
       $provide.value('Settings', Settings);
+      $provide.value('Telemetry', Telemetry);
       $provide.value('TranslateFrom', TranslateFrom);
       $provide.value('UserContact', UserContact);
       $provide.value('UserSettings', UserSettings);
@@ -125,6 +129,7 @@ describe(`RulesEngine service`, () => {
       it('disabled when user has no permissions', async () => {
         hasAuth.resolves(true);
         expectAsyncToThrow(getService().isEnabled, 'permission');
+        expect(Telemetry.record.callCount).to.equal(0);
       });
 
       it('tasks disabled', async () => {
@@ -137,6 +142,8 @@ describe(`RulesEngine service`, () => {
           user: userSettingsDoc,
           contact: userContactDoc,
         });
+        expect(Telemetry.record.callCount).to.equal(1);
+        expect(Telemetry.record.args[0][0]).to.equal('rules-engine:initialize');
       });
 
       it('targets disabled', async () => {
@@ -208,9 +215,11 @@ describe(`RulesEngine service`, () => {
           expect(await getService().isEnabled()).to.be.true;
           const change = Changes.args[0][0];
           expect(change.filter(changeFeedFormat(scenario.doc))).to.be.true;
-          change.callback(changeFeedFormat(scenario.doc));
+          await change.callback(changeFeedFormat(scenario.doc));
           expect(RulesEngineCore.updateEmissionsFor.callCount).to.eq(1);
           expect(RulesEngineCore.updateEmissionsFor.args[0][0]).to.deep.eq(scenario.expected);
+          expect(Telemetry.record.callCount).to.equal(2);
+          expect(Telemetry.record.args[1][0]).to.equal('rules-engine:update-emissions');
         });
       }
 
@@ -251,6 +260,7 @@ describe(`RulesEngine service`, () => {
 
     it('fetchTaskDocsForAllContacts', async () => {
       RulesEngineCore.fetchTasksFor.resolves([deepCopy(sampleTaskDoc)]);
+      RulesEngineCore.getDirtyContacts.returns(['a', 'b', 'c']);
       const actual = await getService().fetchTaskDocsForAllContacts();
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
       expect(RulesEngineCore.fetchTasksFor.args[0][0]).to.be.undefined;
@@ -262,11 +272,16 @@ describe(`RulesEngine service`, () => {
         'emission.priorityLabel': '$translated',
         'emission.other': true,
       });
+      expect(Telemetry.record.callCount).to.equal(4);
+      expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 3]);
+      expect(Telemetry.record.args[2][0]).to.equal('rules-engine:ensureTaskFreshness:cancel');
+      expect(Telemetry.record.args[3][0]).to.equal('rules-engine:tasks:all-contacts');
     });
 
     it('fetchTaskDocsFor', async () => {
       const contactIds = ['a', 'b', 'c'];
       RulesEngineCore.fetchTasksFor.resolves([deepCopy(sampleTaskDoc)]);
+      RulesEngineCore.getDirtyContacts.returns(['a', 'b']);
       const actual = await getService().fetchTaskDocsFor(contactIds);
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
       expect(RulesEngineCore.fetchTasksFor.args[0][0]).to.eq(contactIds);
@@ -278,6 +293,9 @@ describe(`RulesEngine service`, () => {
         'emission.priorityLabel': '$translated',
         'emission.other': true,
       });
+      expect(Telemetry.record.callCount).to.equal(3);
+      expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 2]);
+      expect(Telemetry.record.args[2][0]).to.equal('rules-engine:tasks:some-contacts');
     });
 
     it('correct range is passed when getting targets', async () => {
@@ -289,6 +307,7 @@ describe(`RulesEngine service`, () => {
     });
 
     it('ensure freshness of tasks and targets', async () => {
+      RulesEngineCore.getDirtyContacts.returns(Array.from({ length: 20 }).map(i => i));
       const service = getService();
       await service.isEnabled();
       $timeout.flush(500 * 1000);
@@ -296,6 +315,11 @@ describe(`RulesEngine service`, () => {
       await service.isEnabled(); // to resolve promises
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
       expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+
+      expect(Telemetry.record.callCount).to.equal(3);
+      expect(Telemetry.record.args[0][0]).to.equal('rules-engine:initialize');
+      expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 20]);
+      expect(Telemetry.record.args[2]).to.deep.equal(['rules-engine:targets:dirty-contacts', 20]);
     });
 
     it('ensure freshness of tasks only', async () => {
@@ -308,6 +332,11 @@ describe(`RulesEngine service`, () => {
       await service.isEnabled(); // to resolve promises
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
       expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(Telemetry.record.callCount).to.equal(5);
+      expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:targets:dirty-contacts', 0]);
+      expect(Telemetry.record.args[2][0]).to.equal('rules-engine:ensureTargetFreshness:cancel');
+      expect(Telemetry.record.args[3][0]).to.equal('rules-engine:targets');
+      expect(Telemetry.record.args[4]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 0]);
     });
 
     it('cancel all ensure freshness threads', async () => {
@@ -321,6 +350,13 @@ describe(`RulesEngine service`, () => {
       await service.isEnabled(); // to resolve promises
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
       expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(Telemetry.record.callCount).to.equal(7);
+      expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:targets:dirty-contacts', 0]);
+      expect(Telemetry.record.args[2][0]).to.equal('rules-engine:ensureTargetFreshness:cancel');
+      expect(Telemetry.record.args[3][0]).to.equal('rules-engine:targets');
+      expect(Telemetry.record.args[4]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 0]);
+      expect(Telemetry.record.args[5][0]).to.equal('rules-engine:ensureTaskFreshness:cancel');
+      expect(Telemetry.record.args[6][0]).to.equal('rules-engine:tasks:all-contacts');
     });
   });
 });


### PR DESCRIPTION
# Description

Tracks the following events:
- How long it takes to load tasks tab
- How long it takes to load targets tab
- How many contacts are "dirty" when tasks/targets refresh
- How long it takes for the "freshness" thread to run
- After how much time is the "freshness" thread canceled (when canceled)

medic/cht-core#6188

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
