### PR TITLE
Store previous month's targets on interval turnover

### DIFF
--- a/shared-libs/calendar-interval/src/index.js
+++ b/shared-libs/calendar-interval/src/index.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 
-const normalizeStartDate = function(intervalStartDate) {
+const normalizeStartDate = (intervalStartDate) => {
   intervalStartDate = parseInt(intervalStartDate);
 
   if (isNaN(intervalStartDate) || intervalStartDate <= 0 || intervalStartDate > 31) {
@@ -10,22 +10,44 @@ const normalizeStartDate = function(intervalStartDate) {
   return intervalStartDate;
 };
 
-const getMinimumStartDate = function(intervalStartDate, relativeDate) {
+const getMinimumStartDate = (intervalStartDate, relativeDate) => {
   return moment
     .min(
-      moment(relativeDate).subtract(1, 'month').date(intervalStartDate).startOf('day'),
-      moment(relativeDate).startOf('month')
+      relativeDate.clone().subtract(1, 'month').date(intervalStartDate).startOf('day'),
+      relativeDate.clone().startOf('month')
     )
     .valueOf();
 };
 
-const getMinimumEndDate = function(intervalStartDate, nextMonth, relativeDate) {
+const getMinimumEndDate = (intervalStartDate, nextMonth, relativeDate) => {
   return moment
     .min(
-      moment(relativeDate).add(nextMonth ? 1 : 0, 'month').date(intervalStartDate - 1).endOf('day'),
-      moment(relativeDate).add(nextMonth ? 1 : 0, 'month').endOf('month')
+      relativeDate.clone().add(nextMonth ? 1 : 0, 'month').date(intervalStartDate - 1).endOf('day'),
+      relativeDate.clone().add(nextMonth ? 1 : 0, 'month').endOf('month')
     )
     .valueOf();
+};
+
+const getInterval = (intervalStartDate, referenceDate = moment()) => {
+  intervalStartDate = normalizeStartDate(intervalStartDate);
+  if (intervalStartDate === 1) {
+    return {
+      start: referenceDate.startOf('month').valueOf(),
+      end: referenceDate.endOf('month').valueOf()
+    };
+  }
+
+  if (intervalStartDate <= referenceDate.date()) {
+    return {
+      start: referenceDate.date(intervalStartDate).startOf('day').valueOf(),
+      end: getMinimumEndDate(intervalStartDate, true, referenceDate)
+    };
+  }
+
+  return {
+    start: getMinimumStartDate(intervalStartDate, referenceDate),
+    end: getMinimumEndDate(intervalStartDate, false, referenceDate)
+  };
 };
 
 module.exports = {
@@ -35,26 +57,13 @@ module.exports = {
   // if `intervalStartDate` exceeds month's day count, the start/end of following/current month is returned
   // f.e. `intervalStartDate` === 31 would generate next intervals :
   // [12-31 -> 01-30], [01-31 -> 02-[28|29]], [03-01 -> 03-30], [03-31 -> 04-30], [05-01 -> 05-30], [05-31 - 06-30]
-  getCurrent: function(intervalStartDate) {
-    intervalStartDate = normalizeStartDate(intervalStartDate);
+  getCurrent: (intervalStartDate) => getInterval(intervalStartDate),
 
-    if (intervalStartDate === 1) {
-      return {
-        start: moment().startOf('month').valueOf(),
-        end: moment().endOf('month').valueOf()
-      };
-    }
-
-    if (intervalStartDate <= moment().date()) {
-      return {
-        start: moment().date(intervalStartDate).startOf('day').valueOf(),
-        end: getMinimumEndDate(intervalStartDate, true)
-      };
-    }
-
-    return {
-      start: getMinimumStartDate(intervalStartDate),
-      end: getMinimumEndDate(intervalStartDate)
-    };
-  }
+  /**
+   * Returns the timestamps of the start and end of the a calendar interval that contains a reference date
+   * @param {Number} [intervalStartDate=1] - day of month when interval starts (1 - 31)
+   * @param {Number} timestamp - the reference date the interval should include
+   * @returns { start: number, end: number } - timestamps that define the calendar interval
+   */
+  getInterval: (intervalStartDate, timestamp) => getInterval(intervalStartDate, moment(timestamp)),
 };

--- a/shared-libs/calendar-interval/test/index.js
+++ b/shared-libs/calendar-interval/test/index.js
@@ -251,4 +251,247 @@ describe('CalendarInterval', () => {
       });
     });
   });
+
+  describe('getInterval', () => {
+    it('returns 1st of current month when month start is not set or incorrect', () => {
+      let timestamp;
+      let expectedStart;
+      let expectedEnd;
+
+      timestamp = moment('2018-01-20 21:10:01').valueOf();
+      expectedStart = moment('2018-01-01 00:00:00').valueOf();
+      expectedEnd = moment('2018-01-31 23:59:59:999').valueOf();
+      chai.expect(service.getInterval(undefined, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(0, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(-1, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(false, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(100, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval('something', timestamp))
+        .to.deep.equal({ start: expectedStart, end: expectedEnd });
+
+      timestamp = moment('2018-02-10 21:10:01').valueOf();
+      expectedStart = moment('2018-02-01 00:00:00').valueOf();
+      expectedEnd = moment('2018-02-28 23:59:59:999').valueOf();
+      chai.expect(service.getInterval(undefined, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(0, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(-10, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval(false, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval({}, timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval([], timestamp)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+      chai.expect(service.getInterval('something', timestamp))
+        .to.deep.equal({ start: expectedStart, end: expectedEnd });
+    });
+
+    it('should default to current interval when missing timestamp', () => {
+      clock = sinon.useFakeTimers(moment('2018-02-10 21:10:01').valueOf());
+      const expectedStart = moment('2018-02-01 00:00:00').valueOf();
+      const expectedEnd = moment('2018-02-28 23:59:59:999').valueOf();
+      chai.expect(service.getInterval(1)).to.deep.equal({ start: expectedStart, end: expectedEnd });
+    });
+
+    it('returns 1st of requested month when month start is 1', () => {
+      let timestamp;
+
+      timestamp = moment('2018-01-20 21:10:01').valueOf();
+      chai.expect(service.getInterval(1, timestamp)).to.deep.equal({
+        start: moment('2018-01-01 00:00:00').valueOf(),
+        end: moment('2018-01-31 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-02-10 21:10:01').valueOf();
+      chai.expect(service.getInterval(1, timestamp)).to.deep.equal({
+        start: moment('2018-02-01 00:00:00').valueOf(),
+        end: moment('2018-02-28 23:59:59:999').valueOf(),
+      });
+
+      timestamp = moment('2018-03-22 11:10:01').valueOf();
+      chai.expect(service.getInterval(1, timestamp)).to.deep.equal({
+        start: moment('2018-03-01 00:00:00').valueOf(),
+        end: moment('2018-03-31 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-12-01 11:10:01').valueOf();
+      chai.expect(service.getInterval(1, timestamp)).to.deep.equal({
+        start: moment('2018-12-01 00:00:00').valueOf(),
+        end: moment('2018-12-31 23:59:59:999').valueOf()
+      });
+    });
+
+    it('returns n-th of the month when month start is n <= relative date', () => {
+      let timestamp;
+
+      timestamp = moment('2018-01-20 21:10:01').valueOf();
+      chai.expect(service.getInterval(10, timestamp)).to.deep.equal({
+        start: moment('2018-01-10 00:00:00').valueOf(),
+        end: moment('2018-02-09 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-02-22 21:10:01').valueOf();
+      chai.expect(service.getInterval(6, timestamp)).to.deep.equal({
+        start: moment('2018-02-06 00:00:00').valueOf(),
+        end: moment('2018-03-05 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-03-18 11:10:01').valueOf();
+      chai.expect(service.getInterval(18, timestamp)).to.deep.equal({
+        start: moment('2018-03-18 00:00:00').valueOf(),
+        end: moment('2018-04-17 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-04-20 11:10:01').valueOf();
+      chai.expect(service.getInterval(20, timestamp)).to.deep.equal({
+        start: moment('2018-04-20 00:00:00').valueOf(),
+        end: moment('2018-05-19 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-12-29 11:10:01').valueOf();
+      chai.expect(service.getInterval(9, timestamp)).to.deep.equal({
+        start: moment('2018-12-09 00:00:00').valueOf(),
+        end: moment('2019-01-08 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-11-30 11:10:01').valueOf();
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2018-11-30 00:00:00').valueOf(),
+        end: moment('2018-12-29 23:59:59:999').valueOf()
+      });
+    });
+
+    it('returns n-th of the previous month when month start is n > relative date', () => {
+      let timestamp;
+
+      timestamp = moment('2018-01-04 21:10:01').valueOf();
+      chai.expect(service.getInterval(10, timestamp)).to.deep.equal({
+        start: moment('2017-12-10 00:00:00').valueOf(),
+        end: moment('2018-01-09 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-02-6 21:10:01').valueOf();
+      chai.expect(service.getInterval(10, timestamp)).deep.to.equal({
+        start: moment('2018-01-10 00:00:00').valueOf(),
+        end: moment('2018-02-09 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-03-18 11:10:01').valueOf();
+      chai.expect(service.getInterval(25, timestamp)).to.deep.equal({
+        start: moment('2018-02-25 00:00:00').valueOf(),
+        end: moment('2018-03-24 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2018-12-05 11:10:01').valueOf();
+      chai.expect(service.getInterval(29, timestamp)).to.deep.equal({
+        start: moment('2018-11-29 00:00:00').valueOf(),
+        end: moment('2018-12-28 23:59:59:999').valueOf()
+      });
+    });
+
+    it('returns first day of month when start date exceeds previous month day number', () => {
+      let timestamp;
+
+      timestamp = moment('2016-03-12 16:10:10').valueOf();
+      chai.expect(service.getInterval(31, timestamp)).to.deep.equal({
+        start: moment('2016-03-01 00:00:00').valueOf(),
+        end: moment('2016-03-30 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2016-03-01 00:00:00').valueOf(),
+        end: moment('2016-03-29 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(29, timestamp)).to.deep.equal({
+        start: moment('2016-02-29 00:00:00').valueOf(),
+        end: moment('2016-03-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(28, timestamp)).to.deep.equal({
+        start: moment('2016-02-28 00:00:00').valueOf(),
+        end: moment('2016-03-27 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2017-03-12 02:02:02').valueOf();
+      chai.expect(service.getInterval(31, timestamp)).to.deep.equal({
+        start: moment('2017-03-01 00:00:00').valueOf(),
+        end: moment('2017-03-30 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2017-03-01 00:00:00').valueOf(),
+        end: moment('2017-03-29 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(29, timestamp)).to.deep.equal({
+        start: moment('2017-03-01 00:00:00').valueOf(),
+        end: moment('2017-03-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(28, timestamp)).to.deep.equal({
+        start: moment('2017-02-28 00:00:00').valueOf(),
+        end: moment('2017-03-27 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(27, timestamp)).to.deep.equal({
+        start: moment('2017-02-27 00:00:00').valueOf(),
+        end: moment('2017-03-26 23:59:59:999').valueOf()
+      });
+    });
+
+    it('returns last day of month when start date exceeds month day number', () => {
+      let timestamp;
+
+      timestamp = moment('2016-02-12 16:10:10').valueOf();
+      chai.expect(service.getInterval(31, timestamp)).to.deep.equal({
+        start: moment('2016-01-31 00:00:00').valueOf(),
+        end: moment('2016-02-29 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2016-01-30 00:00:00').valueOf(),
+        end: moment('2016-02-29 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2017-02-12 02:02:02').valueOf();
+      chai.expect(service.getInterval(31, timestamp)).to.deep.equal({
+        start: moment('2017-01-31 00:00:00').valueOf(),
+        end: moment('2017-02-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2017-01-30 00:00:00').valueOf(),
+        end: moment('2017-02-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(29, timestamp)).to.deep.equal({
+        start: moment('2017-01-29 00:00:00').valueOf(),
+        end: moment('2017-02-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(28, timestamp)).to.deep.equal({
+        start: moment('2017-01-28 00:00:00').valueOf(),
+        end: moment('2017-02-27 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2016-01-31 16:10:10').valueOf();
+      chai.expect(service.getInterval(31, timestamp)).to.deep.equal({
+        start: moment('2016-01-31 00:00:00').valueOf(),
+        end: moment('2016-02-29 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2016-01-30 00:00:00').valueOf(),
+        end: moment('2016-02-29 23:59:59:999').valueOf()
+      });
+
+      chai.expect(service.getInterval(29, timestamp)).to.deep.equal({
+        start: moment('2016-01-29 00:00:00').valueOf(),
+        end: moment('2016-02-28 23:59:59:999').valueOf()
+      });
+
+      timestamp = moment('2017-01-31 02:02:02').valueOf();
+      chai.expect(service.getInterval(31, timestamp)).to.deep.equal({
+        start: moment('2017-01-31 00:00:00').valueOf(),
+        end: moment('2017-02-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(30, timestamp)).to.deep.equal({
+        start: moment('2017-01-30 00:00:00').valueOf(),
+        end: moment('2017-02-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(29, timestamp)).to.deep.equal({
+        start: moment('2017-01-29 00:00:00').valueOf(),
+        end: moment('2017-02-28 23:59:59:999').valueOf()
+      });
+      chai.expect(service.getInterval(28, timestamp)).to.deep.equal({
+        start: moment('2017-01-28 00:00:00').valueOf(),
+        end: moment('2017-02-27 23:59:59:999').valueOf()
+      });
+    });
+  });
 });

--- a/shared-libs/rules-engine/src/pouchdb-provider.js
+++ b/shared-libs/rules-engine/src/pouchdb-provider.js
@@ -44,7 +44,7 @@ const medicPouchProvider = db => {
 
     stateChangeCallback: docUpdateClosure(db),
 
-    commitTargetDoc: (assign, userContactDoc, userSettingsDoc, docTag) => {
+    commitTargetDoc: (targets, userContactDoc, userSettingsDoc, docTag, force = false) => {
       const userContactId = userContactDoc && userContactDoc._id;
       const userSettingsId = userSettingsDoc && userSettingsDoc._id;
       const _id = `target~${docTag}~${userContactId}~${userSettingsId}`;
@@ -60,11 +60,13 @@ const medicPouchProvider = db => {
       return db.get(_id)
         .catch(createNew)
         .then(existingDoc => {
-          if (existingDoc.updated_date !== today) {
-            Object.assign(existingDoc, assign);
-            existingDoc.updated_date = today;
-            return db.put(existingDoc);
+          if (existingDoc.updated_date === today && !force) {
+            return false;
           }
+
+          existingDoc.targets = targets;
+          existingDoc.updated_date = today;
+          return db.put(existingDoc);
         });
     },
 

--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -101,8 +101,8 @@ module.exports = {
 
     const calculationTimestamp = Date.now();
     const targetEmissionFilter = filterInterval && (emission => {
-      const emissionDate = moment(emission.date);
-      return emissionDate.isAfter(filterInterval.start) && emissionDate.isBefore(filterInterval.end);
+      // 4th parameter of isBetween represents inclusivity. By default or using ( is exclusive, [ is inclusive
+      return moment(emission.date).isBetween(filterInterval.start, filterInterval.end, null, '[]');
     });
 
     return refreshRulesEmissionForContacts(provider, calculationTimestamp)
@@ -217,13 +217,15 @@ const handleIntervalTurnover = (provider, { monthStartDate }) => {
   }
 
   const currentInterval = calendarInterval.getCurrent(monthStartDate);
-  if (moment(stateCalculatedAt).isBetween(currentInterval.start, currentInterval.end)) {
+  // 4th parameter of isBetween represents inclusivity. By default or using ( is exclusive, [ is inclusive
+  if (moment(stateCalculatedAt).isBetween(currentInterval.start, currentInterval.end, null, '[]')) {
     return Promise.resolve();
   }
 
   const filterInterval = calendarInterval.getInterval(monthStartDate, stateCalculatedAt);
   const targetEmissionFilter = (emission => {
-    return moment(emission.date).isBetween(filterInterval.start, filterInterval.end);
+    // 4th parameter of isBetween represents inclusivity. By default or using ( is exclusive, [ is inclusive
+    return moment(emission.date).isBetween(filterInterval.start, filterInterval.end, null, '[]');
   });
 
   const targets = rulesStateStore.aggregateStoredTargetEmissions(targetEmissionFilter);

--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -25,6 +25,7 @@ module.exports = {
    * @param {Object[]} settings.targets Target definitions from settings doc
    * @param {Boolean} settings.enableTasks Flag to enable tasks
    * @param {Boolean} settings.enableTargets Flag to enable targets
+   * @param {number} settings.monthStartDate reporting interval start date
    * @param {Object} userDoc User's hydrated contact document
    */
   initialize: (provider, settings) => {
@@ -107,8 +108,7 @@ module.exports = {
     return refreshRulesEmissionForContacts(provider, calculationTimestamp)
       .then(() => {
         const targets = rulesStateStore.aggregateStoredTargetEmissions(targetEmissionFilter);
-        storeTargetsDoc(provider, targets, filterInterval);
-        return targets;
+        return storeTargetsDoc(provider, targets, filterInterval).then(() => targets);
       });
   },
 

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -37,7 +37,7 @@ const self = {
     setOnChangeState(stateChangeCallback);
 
     const rulesConfigHash = hashRulesConfig(settings);
-    if (existingState && existingState.rulesConfigHash !== rulesConfigHash) {
+    if (state && state.rulesConfigHash !== rulesConfigHash) {
       state.stale = true;
     }
 

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -146,6 +146,8 @@ const self = {
       };
     }
 
+    state.calculatedAt = calculatedAt;
+
     return onStateChange(state);
   },
 

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -24,22 +24,24 @@ const self = {
    * @param {Object} settings.user User's user-settings document
    * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes.
    *    Receives the updated state as the only parameter.
+   * @returns {Boolean} that represents whether or not the state needs to be rebuilt
    */
   load: (existingState, settings, stateChangeCallback) => {
     if (state) {
       throw Error('Attempted to initialize the rules-state-store multiple times.');
     }
 
-    const rulesConfigHash = hashRulesConfig(settings);
-    const useState = existingState && existingState.rulesConfigHash === rulesConfigHash;
-    if (!useState) {
-      return self.build(settings, stateChangeCallback);
-    }
-
     state = existingState;
     currentUserContact = settings.contact;
     currentUserSettings = settings.user;
-    onStateChange = safeCallback(stateChangeCallback);
+    setOnChangeState(stateChangeCallback);
+
+    const rulesConfigHash = hashRulesConfig(settings);
+    if (existingState && existingState.rulesConfigHash !== rulesConfigHash) {
+      state.stale = true;
+    }
+
+    return !state || state.stale;
   },
 
   /**
@@ -48,12 +50,12 @@ const self = {
    * @param {Object} settings Settings for the behavior of the rules store
    * @param {Object} settings.contact User's hydrated contact document
    * @param {Object} settings.user User's user-settings document
-   * @param {Object} settings.monthStartDate reporting interval start date
+   * @param {number} settings.monthStartDate reporting interval start date
    * @param {Object} stateChangeCallback Callback which is invoked whenever the state changes.
    *    Receives the updated state as the only parameter.
    */
   build: (settings, stateChangeCallback) => {
-    if (state) {
+    if (state && !state.stale) {
       throw Error('Attempted to initialize the rules-state-store multiple times.');
     }
 
@@ -66,7 +68,7 @@ const self = {
     currentUserContact = settings.contact;
     currentUserSettings = settings.user;
 
-    onStateChange = safeCallback(stateChangeCallback);
+    setOnChangeState(stateChangeCallback);
     return onStateChange(state);
   },
 
@@ -146,8 +148,6 @@ const self = {
       };
     }
 
-    state.calculatedAt = calculatedAt;
-
     return onStateChange(state);
   },
 
@@ -214,6 +214,21 @@ const self = {
   currentUserSettings: () => currentUserSettings,
 
   /**
+   * @returns {number} The timestamp when the current loaded state was last updated
+   */
+  stateLastUpdatedAt: () => state.calculatedAt,
+
+  /**
+   * @returns {number} current monthStartDate
+   */
+  getMonthStartDate: () => state.monthStartDate,
+
+  /**
+   * @returns {boolean} whether or not the state is loaded
+   */
+  isLoaded: () => !!state,
+
+  /**
    * Store a set of target emissions which were emitted by refreshing a set of contacts
    *
    * @param {string[]} contactIds An array of contact ids which produced these targetEmissions by being refreshed.
@@ -258,16 +273,20 @@ const hashRulesConfig = (settings) => {
   return md5(asString);
 };
 
-const safeCallback = callback => (...args) => {
-  if (callback && typeof callback === 'function') {
-    return callback(...args);
-  }
+const setOnChangeState = (stateChangeCallback) => {
+  onStateChange = (state) => {
+    state.calculatedAt = new Date().getTime();
+
+    if (stateChangeCallback && typeof stateChangeCallback === 'function') {
+      return stateChangeCallback(state);
+    }
+  };
 };
 
 // ensure all exported functions are only ever called after initialization
 module.exports = Object.keys(self).reduce((agg, key) => {
   agg[key] = (...args) => {
-    if (!['build', 'load'].includes(key) && (!state || !state.contactState)) {
+    if (!['build', 'load', 'isLoaded'].includes(key) && (!state || !state.contactState)) {
       throw Error(`Invalid operation: Attempted to invoke rules-state-store.${key} before call to build or load`);
     }
 

--- a/shared-libs/rules-engine/test/integration.spec.js
+++ b/shared-libs/rules-engine/test/integration.spec.js
@@ -497,7 +497,7 @@ describe('Rules Engine Integration Tests', () => {
     });
   });
 
-  it('targets on interval turnover', async () => {
+  it('targets on interval turnover only recalculates targets when interval changes', async () => {
     const targetsSaved = () => {
       const targets = [];
       db.bulkDocs.args.forEach(([docs]) => {

--- a/shared-libs/rules-engine/test/integration.spec.js
+++ b/shared-libs/rules-engine/test/integration.spec.js
@@ -471,7 +471,7 @@ describe('Rules Engine Integration Tests', () => {
       pregnancyRegistrationReport,
       { _id: 'pregReg2', fields: {
         lmp_date_8601: THE_FUTURE, patient_id: patientContact2.patient_id
-      }, reported_date: THE_FUTURE+1
+      }, reported_date: THE_FUTURE+2
       });
     await db.bulkDocs([patientContact, patientContact2, pregnancyRegistrationReport, pregnancyRegistrationReport2]);
 

--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -89,7 +89,7 @@ describe('pouchdb provider', () => {
 
     it('create and update a doc', async () => {
       const docTag = '2019-07';
-      await pouchdbProvider(db).commitTargetDoc({ targets }, userContactDoc, userSettingsDoc, docTag);
+      await pouchdbProvider(db).commitTargetDoc(targets, userContactDoc, userSettingsDoc, docTag);
 
       expect(await db.get('target~2019-07~user~org.couchdb.user:username')).excluding('_rev').to.deep.eq({
         _id: 'target~2019-07~user~org.couchdb.user:username',
@@ -102,12 +102,12 @@ describe('pouchdb provider', () => {
       });
 
       const nextTargets = [{ id: 'target', score: 1 }];
-      await pouchdbProvider(db).commitTargetDoc({ targets: nextTargets }, userContactDoc, userSettingsDoc, docTag);
+      await pouchdbProvider(db).commitTargetDoc(nextTargets, userContactDoc, userSettingsDoc, docTag);
       const ignoredUpdate = await db.get('target~2019-07~user~org.couchdb.user:username');
       expect(ignoredUpdate._rev.startsWith('1-')).to.be.true;
 
       sinon.useFakeTimers(Date.now() + MS_IN_DAY);
-      await pouchdbProvider(db).commitTargetDoc({ targets: nextTargets }, userContactDoc, userSettingsDoc, docTag);
+      await pouchdbProvider(db).commitTargetDoc(nextTargets, userContactDoc, userSettingsDoc, docTag);
       expect(await db.get('target~2019-07~user~org.couchdb.user:username')).excluding('_rev').to.deep.eq({
         _id: 'target~2019-07~user~org.couchdb.user:username',
         updated_date: moment().startOf('day').valueOf(),

--- a/webapp/src/js/controllers/analytics-targets.js
+++ b/webapp/src/js/controllers/analytics-targets.js
@@ -1,5 +1,6 @@
 angular.module('inboxControllers').controller('AnalyticsTargetsCtrl', function (
   $log,
+  $timeout,
   RulesEngine,
   Telemetry
 ) {
@@ -28,11 +29,14 @@ angular.module('inboxControllers').controller('AnalyticsTargetsCtrl', function (
       return [];
     })
     .then(targets => {
-      ctrl.loading = false;
-      ctrl.targets = targets.filter(target => target.visible !== false);
+      $timeout(() => {
+        ctrl.loading = false;
+        ctrl.targets = targets.filter(target => target.visible !== false);
+      });
 
       telemetryData.end = Date.now();
       Telemetry.record(`analytics:targets:load`, telemetryData.end - telemetryData.start);
+
     });
 }
 );

--- a/webapp/tests/karma/unit/controllers/analytics-targets.spec.js
+++ b/webapp/tests/karma/unit/controllers/analytics-targets.spec.js
@@ -54,11 +54,14 @@ describe('AnalyticsTargetsCtrl controller', function() {
     testWithTimeout(done, () => {
       chai.expect(rulesEngine.isEnabled.callCount).to.equal(1);
       chai.expect(rulesEngine.fetchTargets.callCount).to.equal(0);
-      chai.expect(ctrl.targets).to.deep.equal([]);
-      chai.expect(ctrl.loading).to.equal(false);
       chai.expect(ctrl.targetsDisabled).to.equal(true);
       chai.expect(telemetry.record.callCount).to.equal(1);
       chai.expect(telemetry.record.args[0][0]).to.equal('analytics:targets:load');
+
+      testWithTimeout(done, () => {
+        chai.expect(ctrl.targets).to.deep.equal([]);
+        chai.expect(ctrl.loading).to.equal(false);
+      });
     });
   });
 
@@ -69,11 +72,14 @@ describe('AnalyticsTargetsCtrl controller', function() {
     testWithTimeout(done, () => {
       chai.expect(rulesEngine.isEnabled.callCount).to.equal(1);
       chai.expect(rulesEngine.fetchTargets.callCount).to.equal(1);
-      chai.expect(ctrl.targets).to.deep.equal([{ id: 'target1' }, { id: 'target2' }]);
-      chai.expect(ctrl.loading).to.equal(false);
       chai.expect(ctrl.targetsDisabled).to.equal(false);
       chai.expect(telemetry.record.callCount).to.equal(1);
       chai.expect(telemetry.record.args[0][0]).to.equal('analytics:targets:load');
+
+      testWithTimeout(done, () => {
+        chai.expect(ctrl.targets).to.deep.equal([{ id: 'target1' }, { id: 'target2' }]);
+        chai.expect(ctrl.loading).to.equal(false);
+      });
     });
   });
 
@@ -91,13 +97,15 @@ describe('AnalyticsTargetsCtrl controller', function() {
     testWithTimeout(done, () => {
       chai.expect(rulesEngine.isEnabled.callCount).to.equal(1);
       chai.expect(rulesEngine.fetchTargets.callCount).to.equal(1);
-      chai.expect(ctrl.targets).to.deep.equal([
-        { id: 'target1' },
-        { id: 'target1', visible: true },
-        { id: 'target1', visible: undefined },
-        { id: 'target1', visible: 'something' },
-      ]);
-      chai.expect(ctrl.loading).to.equal(false);
+      testWithTimeout(done, () => {
+        chai.expect(ctrl.targets).to.deep.equal([
+          { id: 'target1' },
+          { id: 'target1', visible: true },
+          { id: 'target1', visible: undefined },
+          { id: 'target1', visible: 'something' },
+        ]);
+        chai.expect(ctrl.loading).to.equal(false);
+      });
     });
   });
 
@@ -107,9 +115,12 @@ describe('AnalyticsTargetsCtrl controller', function() {
     testWithTimeout(done, () => {
       chai.expect(rulesEngine.isEnabled.callCount).to.equal(1);
       chai.expect(rulesEngine.fetchTargets.callCount).to.equal(0);
-      chai.expect(ctrl.targets).to.deep.equal([]);
-      chai.expect(ctrl.loading).to.equal(false);
       chai.expect(ctrl.targetsDisabled).to.equal(false);
+
+      testWithTimeout(done, () => {
+        chai.expect(ctrl.targets).to.deep.equal([]);
+        chai.expect(ctrl.loading).to.equal(false);
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

Adds property to rules-engine state that contains a date representing the last time the state was updated. 
Upon loading a stale state during initialization and after before every state "recalculation", checks whether the state was last updated outside the current reporting interval. If yes, stores the `target` doc based on the stale state for the previous reporting interval before proceeding with initialization or recalculating the state. 
Updates `calendar-interval` library to return an interval that would include a provided timestamp. 
Updates target interval date comparison to be inclusive.

medic/cht-core#6209

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
