### PR TITLE
Make add contact menu HTML consistent

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1512,6 +1512,9 @@ a.fa:hover {
     .fa-stack {
       height: 20px;
     }
+    .dropdown-menu .fa-stack {
+      height: inherit;
+    }
     .mm-icon {
       min-height: 50px;
     }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1512,9 +1512,6 @@ a.fa:hover {
     .fa-stack {
       height: 20px;
     }
-    .dropdown-menu .fa-stack {
-      height: inherit;
-    }
     .mm-icon {
       min-height: 50px;
     }

--- a/webapp/src/templates/directives/actionbar.html
+++ b/webapp/src/templates/directives/actionbar.html
@@ -56,12 +56,12 @@
           </a>
           <ul class="dropdown-menu mm-dropdown-menu with-icon" ng-if="actionBarCtrl.actionBar.left.childPlaces.length > 1" mm-auth="can_create_places">
             <li ng-repeat="child in actionBarCtrl.actionBar.left.childPlaces | orderBy: 'id' track by child.id">
-              <a class="mm-icon mm-icon-inverse mm-icon-caption" ui-sref="contacts.addChild({ type: child.id, parent_id: actionBarCtrl.actionBar.left.userFacilityId, from: 'list' })">
+              <a ui-sref="contacts.addChild({ type: child.id, parent_id: actionBarCtrl.actionBar.left.userFacilityId, from: 'list' })">
                 <span class="fa-stack">
                   <i ng-bind-html="child.icon | resourceIcon"></i>
                   <i class="fa fa-plus fa-stack-1x"></i>
                 </span>
-                <p translate>{{child.create_key}}</p>
+                <span class="content" translate>{{child.create_key}}</span>
               </a>
             </li>
           </ul>
@@ -171,12 +171,12 @@
             </a>
             <ul class="dropdown-menu mm-dropdown-menu with-icon" ng-if="group.types.length > 1">
               <li ng-repeat="type in group.types | orderBy: 'id' track by type.id">
-                <a class="mm-icon mm-icon-caption" ui-sref="contacts.addChild({ type: type.id, parent_id: actionBarCtrl.selectedContactDoc._id })">
+                <a ui-sref="contacts.addChild({ type: type.id, parent_id: actionBarCtrl.selectedContactDoc._id })">
                   <span class="fa-stack">
                     <i ng-bind-html="type.icon | resourceIcon"></i>
                     <i class="fa fa-plus fa-stack-1x"></i>
                   </span>
-                  <p translate>{{type.create_key}}</p>
+                  <span class="content" translate>{{type.create_key}}</span>
                 </a>
               </li>
             </ul>

--- a/webapp/src/templates/directives/actionbar.html
+++ b/webapp/src/templates/directives/actionbar.html
@@ -57,10 +57,7 @@
           <ul class="dropdown-menu mm-dropdown-menu with-icon" ng-if="actionBarCtrl.actionBar.left.childPlaces.length > 1" mm-auth="can_create_places">
             <li ng-repeat="child in actionBarCtrl.actionBar.left.childPlaces | orderBy: 'id' track by child.id">
               <a ui-sref="contacts.addChild({ type: child.id, parent_id: actionBarCtrl.actionBar.left.userFacilityId, from: 'list' })">
-                <span class="fa-stack">
-                  <i ng-bind-html="child.icon | resourceIcon"></i>
-                  <i class="fa fa-plus fa-stack-1x"></i>
-                </span>
+                <span ng-bind-html="child.icon | resourceIcon"></span>
                 <span class="content" translate>{{child.create_key}}</span>
               </a>
             </li>
@@ -166,16 +163,16 @@
           <span ng-repeat="group in actionBarCtrl.actionBar.right.childTypes" mm-auth="{{group.permission}}">
 
             <a class="mm-icon mm-icon-inverse mm-icon-caption dropdown-toggle" data-toggle="dropdown" ng-if="group.types.length > 1">
-              <span class="fa {{group.menu_icon}}"></span>
+              <span class="fa-stack">
+                <i class="fa {{group.menu_icon}}"></i>
+                <i class="fa fa-plus fa-stack-1x"></i>
+              </span>
               <p translate>{{group.menu_key}}</p>
             </a>
             <ul class="dropdown-menu mm-dropdown-menu with-icon" ng-if="group.types.length > 1">
               <li ng-repeat="type in group.types | orderBy: 'id' track by type.id">
                 <a ui-sref="contacts.addChild({ type: type.id, parent_id: actionBarCtrl.selectedContactDoc._id })">
-                  <span class="fa-stack">
-                    <i ng-bind-html="type.icon | resourceIcon"></i>
-                    <i class="fa fa-plus fa-stack-1x"></i>
-                  </span>
+                  <span ng-bind-html="type.icon | resourceIcon"></span>
                   <span class="content" translate>{{type.create_key}}</span>
                 </a>
               </li>


### PR DESCRIPTION
Restructures the HTML of the add person and add place menus to
be consistent with the add report menu so they look the same.

Also modifies the height restriction on the stacked icons so
the padding is maintained.

medic/cht-core#6394

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
