### PR TITLE
Cancel "duplicate" tasks

### DIFF
--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -115,7 +115,11 @@ module.exports = {
    *
    * @returns {Promise} To complete the transaction marking the subjectIds as dirty
    */
-  updateEmissionsFor: (provider, subjectIds= []) => {
+  updateEmissionsFor: (provider, subjectIds) => {
+    if (!subjectIds) {
+      subjectIds = [];
+    }
+
     if (subjectIds && !Array.isArray(subjectIds)) {
       subjectIds = [subjectIds];
     }

--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -115,11 +115,7 @@ module.exports = {
    *
    * @returns {Promise} To complete the transaction marking the subjectIds as dirty
    */
-  updateEmissionsFor: (provider, subjectIds) => {
-    if (!subjectIds) {
-      subjectIds = [];
-    }
-
+  updateEmissionsFor: (provider, subjectIds= []) => {
     if (subjectIds && !Array.isArray(subjectIds)) {
       subjectIds = [subjectIds];
     }

--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -116,6 +116,10 @@ module.exports = {
    * @returns {Promise} To complete the transaction marking the subjectIds as dirty
    */
   updateEmissionsFor: (provider, subjectIds) => {
+    if (!subjectIds) {
+      subjectIds = [];
+    }
+
     if (subjectIds && !Array.isArray(subjectIds)) {
       subjectIds = [subjectIds];
     }

--- a/shared-libs/rules-engine/src/task-states.js
+++ b/shared-libs/rules-engine/src/task-states.js
@@ -11,7 +11,7 @@ const moment = require('moment');
  * to this rules-engine.
  * In order to purge task documents, we need to guarantee that they won't just be recreated after they are purged.
  * The two scenarios above are important for maintaining the client-side performance of the app.
- * 
+ *
  * Therefore, we only consider task emissions "timely" if they end within a fixed time period.
  * However, if this window is too short then users who don't login frequently may fail to create a task document at all.
  * Looking at time-between-reports for active projects, a time window of 60 days will ensure that 99.9% of tasks are
@@ -127,7 +127,7 @@ module.exports = {
     return endDate > moment(timestamp).add(-TIMELY_WHEN_NEWER_THAN_DAYS, 'days').format(formatString);
   },
 
-  setStateOnTaskDoc: (taskDoc, updatedState, timestamp = Date.now()) => {
+  setStateOnTaskDoc: (taskDoc, updatedState, timestamp = Date.now(), reason = '') => {
     if (!taskDoc) {
       return;
     }
@@ -137,6 +137,7 @@ module.exports = {
       taskDoc.stateReason = 'invalid';
     } else {
       taskDoc.state = updatedState;
+      taskDoc.stateReason = reason;
     }
 
     const stateHistory = taskDoc.stateHistory = taskDoc.stateHistory || [];

--- a/shared-libs/rules-engine/src/task-states.js
+++ b/shared-libs/rules-engine/src/task-states.js
@@ -72,18 +72,18 @@ const getDisplayWindow = (taskEmission) => {
   };
 };
 
+const mostReadyOrder = [States.Ready, States.Draft, States.Completed, States.Failed, States.Cancelled];
+const orderOf = state => {
+  const order = mostReadyOrder.indexOf(state);
+  return order >= 0 ? order : mostReadyOrder.length;
+};
 
 module.exports = {
   isTerminal: state => [States.Cancelled, States.Completed, States.Failed].includes(state),
 
-  isMoreReadyThan: (stateA, stateB) => {
-    const mostReadyOrder = [States.Ready, States.Draft, States.Completed, States.Failed, States.Cancelled];
-    const orderOf = state => {
-      const order = mostReadyOrder.indexOf(state);
-      return order >= 0 ? order : mostReadyOrder.length;
-    };
-    return orderOf(stateA) < orderOf(stateB);
-  },
+  isMoreReadyThan: (stateA, stateB) => orderOf(stateA) < orderOf(stateB),
+
+  compareState: (stateA, stateB) => orderOf(stateA) - orderOf(stateB),
 
   calculateState: (taskEmission, timestamp) => {
     if (!taskEmission) {
@@ -137,7 +137,9 @@ module.exports = {
       taskDoc.stateReason = 'invalid';
     } else {
       taskDoc.state = updatedState;
-      taskDoc.stateReason = reason;
+      if (reason) {
+        taskDoc.stateReason = reason;
+      }
     }
 
     const stateHistory = taskDoc.stateHistory = taskDoc.stateHistory || [];

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -175,6 +175,12 @@ describe('provider-wireup integration tests', () => {
       // dupes don't matter here
       expect(rulesStateStore.markDirty.args).to.deep.eq([[['patient', 'headless', 'patient']]]);
     });
+
+    it('none', async () => {
+      sinon.stub(rulesStateStore, 'markDirty').resolves();
+      await wireup.updateEmissionsFor(provider);
+      expect(rulesStateStore.markDirty.args).to.deep.eq([[[]]]);
+    });
   });
 
   describe('fetchTasksFor', () => {

--- a/shared-libs/rules-engine/test/refresh-rules-emissions.spec.js
+++ b/shared-libs/rules-engine/test/refresh-rules-emissions.spec.js
@@ -253,12 +253,12 @@ describe('refresh-rules-emissions', () => {
     });
   });
 
-  describe('getDedupeUpdates', () => {
+  describe('getDeduplicationUpdates', () => {
     const mockTaskDoc = (emissionId, authoredOn = 0, augment) => Object.assign(
       { emission: { _id: emissionId }, stateHistory: [], authoredOn: authoredOn || moment().valueOf() },
       augment
     );
-    const getDedupeUpdates = refreshRulesEmissionsContact.__get__('getDedupeUpdates');
+    const getDeduplicationUpdates = refreshRulesEmissionsContact.__get__('getDeduplicationUpdates');
 
     it('should add Canceled + duplicate state and reason', () => {
       const tasks = [
@@ -273,7 +273,7 @@ describe('refresh-rules-emissions', () => {
         timestamp: 2000,
       }];
 
-      const result = getDedupeUpdates(tasks, 2000);
+      const result = getDeduplicationUpdates(tasks, 2000);
       expect(result.length).to.equal(4);
       expect(result).to.have.deep.members([
         mockTaskDoc('em1', 0, { id: 1, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
@@ -296,7 +296,7 @@ describe('refresh-rules-emissions', () => {
         timestamp: 5000,
       }];
 
-      const result = getDedupeUpdates(tasks, 5000);
+      const result = getDeduplicationUpdates(tasks, 5000);
       expect(result.length).to.equal(2);
       expect(result).to.have.deep.members([
         mockTaskDoc('em2', 0, { id: 2, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),

--- a/shared-libs/rules-engine/test/refresh-rules-emissions.spec.js
+++ b/shared-libs/rules-engine/test/refresh-rules-emissions.spec.js
@@ -439,6 +439,17 @@ describe('refresh-rules-emissions', () => {
         stateReason: 'duplicate',
         'emission._id': 'pregReport~pregnancy-facility-visit-reminder~anc.facility_reminder',
       });
+
+      clock = sinon.useFakeTimers(startDate.valueOf() + 3000);
+      const thirdData = {
+        contactDocs: [chtDocs.contact],
+        reportDocs: [chtDocs.pregnancyReport],
+        taskDocs: [ ...secondResult.updatedTaskDocs, externalTask1 ],
+      };
+
+      const thirdResult = await refreshRulesEmissionsContact(thirdData);
+      // tasks are not cancelled a second time
+      expect(thirdResult.updatedTaskDocs.length).to.equal(0);
     });
   });
 });

--- a/shared-libs/rules-engine/test/refresh-rules-emissions.spec.js
+++ b/shared-libs/rules-engine/test/refresh-rules-emissions.spec.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 
 const RulesEmitter = require('../src/rules-emitter');
 const refreshRulesEmissionsContact = rewire('../src/refresh-rules-emissions');
+let clock;
 
 describe('refresh-rules-emissions', () => {
   describe('with mock emitter', () => {
@@ -17,10 +18,11 @@ describe('refresh-rules-emissions', () => {
         getEmissionsFor: sinon.stub(),
       };
       refreshRulesEmissionsContact.__set__('rulesEmitter', rulesEmitter);
-      sinon.useFakeTimers(NOW);
+      clock = sinon.useFakeTimers(NOW);
     });
 
     afterEach(() => {
+      clock.restore();
       sinon.restore();
     });
 
@@ -86,8 +88,8 @@ describe('refresh-rules-emissions', () => {
 
     it('user rewinds system clock', async () => {
       const contactDoc = { _id: 'contact' };
-      
-      sinon.useFakeTimers(moment('2000-01-01').valueOf());
+
+      clock = sinon.useFakeTimers(moment('2000-01-01').valueOf());
       const emission = mockEmission(0);
       rulesEmitter.getEmissionsFor.resolves({ tasks: [emission], targets: [] });
       const actual = await refreshRulesEmissionsContact({ contactDocs: [contactDoc] });
@@ -95,7 +97,7 @@ describe('refresh-rules-emissions', () => {
       expect(actual.updatedTaskDocs[0].authoredOn).to.eq(Date.now());
 
       // rewind one year
-      sinon.useFakeTimers(moment('1999-01-01').valueOf());
+      clock = sinon.useFakeTimers(moment('1999-01-01').valueOf());
       const earlierEmission = mockEmission(0);
       rulesEmitter.getEmissionsFor.resolves({ tasks: [earlierEmission], targets: [] });
       const earlierActual = await refreshRulesEmissionsContact(
@@ -118,7 +120,7 @@ describe('refresh-rules-emissions', () => {
       });
 
       // one day later, when viewed the reports move into the time window and become "ready"
-      sinon.useFakeTimers(NOW + MS_IN_DAY);
+      clock = sinon.useFakeTimers(NOW + MS_IN_DAY);
       const actual = await refreshRulesEmissionsContact(
         { contactDocs: [contactDoc], taskDocs: draftStateTasks.updatedTaskDocs }
       );
@@ -173,6 +175,136 @@ describe('refresh-rules-emissions', () => {
     });
   });
 
+  describe('disambiguateTaskDocs', () => {
+    const mockTaskDoc = (emissionId, authoredOn = 0, augment) => Object.assign(
+      { emission: { _id: emissionId }, stateHistory: [], authoredOn: authoredOn || moment().valueOf() },
+      augment
+    );
+    const disambiguateTaskDocs = refreshRulesEmissionsContact.__get__('disambiguateTaskDocs');
+
+    it('should map tasks to emission ids when there are no duplicates', () => {
+      const now = moment.valueOf();
+
+      const taskDoc1 = mockTaskDoc('1', now - 1000);
+      const taskDoc2 = mockTaskDoc('2', now - 2000);
+      const taskDoc3 = mockTaskDoc('3', now - 1500);
+      const taskDoc4 = mockTaskDoc('4', now - 300);
+      const taskDoc5 = mockTaskDoc('5', now - 200);
+
+      const result = disambiguateTaskDocs([taskDoc1, taskDoc2, taskDoc3, taskDoc4, taskDoc5], moment().valueOf());
+      expect(result.duplicates.length).to.equal(0);
+      expect(result.winners).to.deep.equal({
+        '1': taskDoc1,
+        '2': taskDoc2,
+        '3': taskDoc3,
+        '4': taskDoc4,
+        '5': taskDoc5,
+      });
+    });
+
+    it('should ignore tasks generated in the future', () => {
+      const now = moment.valueOf();
+
+      const taskDoc1 = mockTaskDoc('1', now - 1000);
+      const taskDoc2 = mockTaskDoc('2', now - 2000);
+      const taskDoc3 = mockTaskDoc('3', now + 1500);
+      const taskDoc4 = mockTaskDoc('4', now + 300);
+      const taskDoc5 = mockTaskDoc('5', now - 200);
+
+      const result = disambiguateTaskDocs([taskDoc1, taskDoc2, taskDoc3, taskDoc4, taskDoc5], moment().valueOf());
+      expect(result.duplicates.length).to.equal(0);
+      expect(result.winners).to.deep.equal({
+        '1': taskDoc1,
+        '2': taskDoc2,
+        '5': taskDoc5,
+      });
+    });
+
+    it('should determine winners and duplicates when duplicates are present', () => {
+      clock = sinon.useFakeTimers();
+      const now = moment().valueOf();
+
+      const tasks = [
+        mockTaskDoc('em1', now - 1000, { _id: 1, state: 'Completed' }),
+        mockTaskDoc('em1', now - 4000, { _id: 2, state: 'Draft' }),
+        mockTaskDoc('em2', now - 1000, { _id: 3, state: 'Ready' }),
+        mockTaskDoc('em1', now - 5000, { _id: 4, state: 'Draft' }),
+        mockTaskDoc('em1', now - 4000, { _id: 5, state: 'Ready' }),
+        mockTaskDoc('em2', now - 200, { _id: 6, state: 'Completed' }),
+        mockTaskDoc('em1', now - 500, { _id: 7, state: 'Ready' }),
+        mockTaskDoc('em2', now - 10, { _id: 8, state: 'Cancelled' }),
+        mockTaskDoc('em2', now + 2000, { _id: 9, state: 'Ready' }), // future doc ignored
+      ];
+
+      const result = disambiguateTaskDocs(tasks, moment().valueOf());
+      expect(result.winners).to.have.all.keys('em1', 'em2');
+      expect(result.winners['em1']).to.deep.equal(mockTaskDoc('em1', now - 500, { _id: 7, state: 'Ready' }));
+      expect(result.winners['em2']).to.deep.equal(mockTaskDoc('em2', now - 1000, { _id: 3, state: 'Ready' }));
+
+      expect(result.duplicates.length).to.equal(6);
+      expect(result.duplicates).to.have.deep.members([
+        mockTaskDoc('em1', now - 1000, { _id: 1, state: 'Completed' }),
+        mockTaskDoc('em1', now - 4000, { _id: 2, state: 'Draft' }),
+        mockTaskDoc('em1', now - 5000, { _id: 4, state: 'Draft' }),
+        mockTaskDoc('em1', now - 4000, { _id: 5, state: 'Ready' }),
+        mockTaskDoc('em2', now - 200, { _id: 6, state: 'Completed' }),
+        mockTaskDoc('em2', now - 10, { _id: 8, state: 'Cancelled' }),
+      ]);
+    });
+  });
+
+  describe('getDedupeUpdates', () => {
+    const mockTaskDoc = (emissionId, authoredOn = 0, augment) => Object.assign(
+      { emission: { _id: emissionId }, stateHistory: [], authoredOn: authoredOn || moment().valueOf() },
+      augment
+    );
+    const getDedupeUpdates = refreshRulesEmissionsContact.__get__('getDedupeUpdates');
+
+    it('should add Canceled + duplicate state and reason', () => {
+      const tasks = [
+        mockTaskDoc('em1', 0, { id: 1 }),
+        mockTaskDoc('em2', 0, { id: 2 }),
+        mockTaskDoc('em3', 0, { id: 3 }),
+        mockTaskDoc('em4', 0, { id: 4 }),
+      ];
+
+      const stateHistory = [{
+        state: 'Cancelled',
+        timestamp: 2000,
+      }];
+
+      const result = getDedupeUpdates(tasks, 2000);
+      expect(result.length).to.equal(4);
+      expect(result).to.have.deep.members([
+        mockTaskDoc('em1', 0, { id: 1, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
+        mockTaskDoc('em2', 0, { id: 2, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
+        mockTaskDoc('em3', 0, { id: 3, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
+        mockTaskDoc('em4', 0, { id: 4, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
+      ]);
+    });
+
+    it('should skip tasks in terminal states', () => {
+      const tasks = [
+        mockTaskDoc('em1', 0, { id: 1, state: 'Cancelled' }),
+        mockTaskDoc('em2', 0, { id: 2 }),
+        mockTaskDoc('em3', 0, { id: 3, state: 'Failed' }),
+        mockTaskDoc('em4', 0, { id: 4 }),
+      ];
+
+      const stateHistory = [{
+        state: 'Cancelled',
+        timestamp: 5000,
+      }];
+
+      const result = getDedupeUpdates(tasks, 5000);
+      expect(result.length).to.equal(2);
+      expect(result).to.have.deep.members([
+        mockTaskDoc('em2', 0, { id: 2, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
+        mockTaskDoc('em4', 0, { id: 4, state: 'Cancelled', stateReason: 'duplicate', stateHistory  }),
+      ]);
+    });
+  });
+
   describe('integration', () => {
     const userDoc = {};
     const NOW = 11430000000;
@@ -181,17 +313,18 @@ describe('refresh-rules-emissions', () => {
       const isInitialized = RulesEmitter.initialize(chtRulesSettings(), userDoc);
       expect(isInitialized).to.be.true;
       refreshRulesEmissionsContact.__set__('rulesEmitter', RulesEmitter);
-      sinon.useFakeTimers(NOW);
+      clock = sinon.useFakeTimers(NOW);
     });
 
     afterEach(() => {
       RulesEmitter.shutdown();
+      clock.restore();
       sinon.restore();
     });
 
     it('cht scenario', async () => {
       const startDate = moment('2000-01-01');
-      sinon.useFakeTimers(startDate.valueOf());
+      clock = sinon.useFakeTimers(startDate.valueOf());
 
       const refreshData = {
         contactDocs: [chtDocs.contact],
@@ -215,7 +348,7 @@ describe('refresh-rules-emissions', () => {
         taskDocs: firstResult.updatedTaskDocs,
       };
       firstResult.updatedTaskDocs[0]._rev = '1_';
-      sinon.useFakeTimers(startDate.valueOf() + 1000);
+      clock = sinon.useFakeTimers(startDate.valueOf() + 1000);
       const secondResult = await refreshRulesEmissionsContact(secondData);
       expect(secondResult.updatedTaskDocs.length).to.eq(1);
       expect(secondResult.updatedTaskDocs[0]).to.nested.include({
@@ -236,7 +369,7 @@ describe('refresh-rules-emissions', () => {
         })],
         taskDocs: secondResult.updatedTaskDocs,
       };
-      sinon.useFakeTimers(startDate.clone().add(1, 'year').valueOf());
+      clock = sinon.useFakeTimers(startDate.clone().add(1, 'year').valueOf());
       const thirdResult = await refreshRulesEmissionsContact(thirdData);
       expect(firstResult.updatedTaskDocs[0]._id).to.not.eq(thirdResult.updatedTaskDocs[0]._id);
       expect(thirdResult.updatedTaskDocs[0]._rev).to.be.undefined;
@@ -244,6 +377,66 @@ describe('refresh-rules-emissions', () => {
       expect(thirdResult.updatedTaskDocs[0]).to.nested.include({
         type: 'task',
         state: 'Ready',
+        'emission._id': 'pregReport~pregnancy-facility-visit-reminder~anc.facility_reminder',
+      });
+    });
+
+    it('should handle multiple device scenario', async () => {
+      const dupeTaskWithDifferntTimestamp = (task, newTimestamp) => {
+        const oldTimestamp = task.authoredOn;
+
+        const newTask = JSON.parse(JSON.stringify(task));
+        newTask._id = newTask._id.replace(oldTimestamp, newTimestamp);
+        newTask.authoredOn = newTimestamp;
+        newTask.stateHistory[0].timestamp = newTimestamp;
+
+        return newTask;
+      };
+
+      const startDate = moment('2000-01-01');
+      clock = sinon.useFakeTimers(startDate.valueOf());
+
+      const refreshData = {
+        contactDocs: [chtDocs.contact],
+        reportDocs: [chtDocs.pregnancyReport],
+      };
+
+      const firstResult = await refreshRulesEmissionsContact(refreshData);
+      expectUniqueIds(firstResult.updatedTaskDocs);
+
+      expect(firstResult.updatedTaskDocs.length).to.eq(1);
+      expect(firstResult.updatedTaskDocs[0]).to.nested.include({
+        type: 'task',
+        state: 'Ready',
+        'emission._id': 'pregReport~pregnancy-facility-visit-reminder~anc.facility_reminder',
+      });
+
+      // two seconds later, we get the same task from another device
+      clock = sinon.useFakeTimers(startDate.valueOf() + 2000);
+
+      const externalTask1 = dupeTaskWithDifferntTimestamp(firstResult.updatedTaskDocs[0], startDate.valueOf() + 1000);
+      const externalTask2 = dupeTaskWithDifferntTimestamp(firstResult.updatedTaskDocs[0], startDate.valueOf() + 200);
+
+      const secondData = {
+        contactDocs: [chtDocs.contact],
+        reportDocs: [chtDocs.pregnancyReport],
+        taskDocs: [ ...firstResult.updatedTaskDocs, externalTask1, externalTask2 ],
+      };
+      const secondResult = await refreshRulesEmissionsContact(secondData);
+      expect(secondResult.updatedTaskDocs.length).to.equal(2);
+      // first task and last task are cancelled because they are older
+      expect(secondResult.updatedTaskDocs[0]).to.deep.equal(firstResult.updatedTaskDocs[0]);
+      expect(secondResult.updatedTaskDocs[0]).to.nested.include({
+        type: 'task',
+        state: 'Cancelled',
+        stateReason: 'duplicate',
+        'emission._id': 'pregReport~pregnancy-facility-visit-reminder~anc.facility_reminder',
+      });
+      expect(secondResult.updatedTaskDocs[1]).to.deep.equal(externalTask2);
+      expect(secondResult.updatedTaskDocs[1]).to.nested.include({
+        type: 'task',
+        state: 'Cancelled',
+        stateReason: 'duplicate',
         'emission._id': 'pregReport~pregnancy-facility-visit-reminder~anc.facility_reminder',
       });
     });

--- a/shared-libs/rules-engine/test/task-states.spec.js
+++ b/shared-libs/rules-engine/test/task-states.spec.js
@@ -139,6 +139,23 @@ describe('task-states', () => {
         ]
       });
     });
+
+    it('should save reason when provided', () => {
+      const actual = TaskStates.setStateOnTaskDoc(
+        { state: 'Ready', stateHistory: [{ state: 'Ready' }] },
+        TaskStates.Cancelled,
+        4,
+        'cancel reason'
+      );
+      expect(actual).to.deep.eq({
+        state: 'Cancelled',
+        stateReason: 'cancel reason',
+        stateHistory: [
+          { state: 'Ready' },
+          { state: 'Cancelled', timestamp: 4 },
+        ],
+      });
+    });
   });
 
   describe('isTimely', () => {
@@ -169,10 +186,21 @@ describe('task-states', () => {
       .to.be.false);
   });
 
+  describe('state Comparator', () => {
+    it('should return number comparator', () => {
+      expect(TaskStates.compareState(TaskStates.Ready, 'unknown')).to.be.below(0);
+      expect(TaskStates.compareState(TaskStates.Ready, TaskStates.Draft)).to.be.below(0);
+      expect(TaskStates.compareState(TaskStates.Draft, TaskStates.Ready)).to.be.above(0);
+      expect(TaskStates.compareState(TaskStates.Draft, TaskStates.Cancelled)).to.be.below(0);
+      expect(TaskStates.compareState(TaskStates.Draft, TaskStates.Draft)).to.equal(0);
+      expect(TaskStates.compareState(TaskStates.Ready, TaskStates.Ready)).to.equal(0);
+    });
+  });
+
   it('formatString is comparable', () => {
     const formatString = TaskStates.__get__('formatString');
     expect(formatString).to.not.be.undefined;
-    
+
     const larger = moment('20000101', 'YYYYMMDD');
     const smaller = larger.clone().subtract(1, 'day');
     for (let i = 0; i < 367; i++) {

--- a/tests/e2e/target-aggregates.spec.js
+++ b/tests/e2e/target-aggregates.spec.js
@@ -102,7 +102,8 @@ const updateSettings = (targetsConfig, user, contactSummary) => {
 const clickOnTargetAggregateListItem = (contactId) => {
   element(by.css(`.aggregate-detail li[data-record-id="${contactId}"] a`)).click();
   helper.waitUntilReady(element(by.id('contacts-list')));
-  helper.waitUntilReady(element(by.css('.content-pane .meta h2')));
+  // wait until contact-summary is loaded
+  helper.waitUntilReady(element(by.css('.content-pane .meta > div > .card .action-header h3')));
 };
 
 describe('Target aggregates', () => {
@@ -455,7 +456,6 @@ describe('Target aggregates', () => {
       clickOnTargetAggregateListItem(clarissa._id);
 
       expect(element(by.css('.content-pane .meta h2')).getText()).toEqual('Clarissa');
-      helper.waitUntilReady(element(by.css('.content-pane .meta > div > .card .action-header h3')));
       // assert that the activity card exists and has the right fields.
       expect(element(by.css('.content-pane .meta > div > .card .action-header h3')).getText())
         .toBe('Activity this month');
@@ -472,7 +472,6 @@ describe('Target aggregates', () => {
       clickOnTargetAggregateListItem(prometheus._id);
 
       expect(element(by.css('.content-pane .meta h2')).getText()).toEqual('Prometheus');
-      helper.waitUntilReady(element(by.css('.content-pane .meta > div > .card .action-header h3')));
       // assert that the activity card exists and has the right fields.
       expect(element(by.css('.content-pane .meta > div > .card .action-header h3')).getText())
         .toBe('Activity this month');

--- a/tests/e2e/target-aggregates.spec.js
+++ b/tests/e2e/target-aggregates.spec.js
@@ -102,6 +102,7 @@ const updateSettings = (targetsConfig, user, contactSummary) => {
 const clickOnTargetAggregateListItem = (contactId) => {
   element(by.css(`.aggregate-detail li[data-record-id="${contactId}"] a`)).click();
   helper.waitUntilReady(element(by.id('contacts-list')));
+  helper.waitUntilReady(element(by.css('.content-pane .meta h2')));
 };
 
 describe('Target aggregates', () => {

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -241,7 +241,7 @@ const moment = require('moment');
       callback: function() {
         if (!DBSync.isSyncInProgress()) {
           ctrl.updateReplicationStatus({ current: SYNC_STATUS.required });
-          //DBSync.sync();
+          DBSync.sync();
         }
       },
     });

--- a/webapp/src/js/controllers/inbox.js
+++ b/webapp/src/js/controllers/inbox.js
@@ -241,7 +241,7 @@ const moment = require('moment');
       callback: function() {
         if (!DBSync.isSyncInProgress()) {
           ctrl.updateReplicationStatus({ current: SYNC_STATUS.required });
-          DBSync.sync();
+          //DBSync.sync();
         }
       },
     });

--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -16,6 +16,7 @@ angular
     Auth,
     DB,
     DBSyncRetry,
+    RulesEngine,
     Session
   ) {
     'use strict';
@@ -73,6 +74,9 @@ angular
       const options = Object.assign({}, direction.options, { batch_size: batchSize });
       return DB()
         .replicate[direction.name](remote, options)
+        .on('change', replicationResult => {
+          RulesEngine.monitorExternalChanges(replicationResult.docs);
+        })
         .on('denied', function(err) {
           $log.error(`Denied replicating ${direction.name} remote server`, err);
           if (direction.onDenied) {

--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -65,7 +65,8 @@ angular
           heartbeat: 10000, // 10 seconds
           timeout: 1000 * 60 * 10, // 10 minutes
         },
-        allowed: () => $q.resolve(true)
+        allowed: () => $q.resolve(true),
+        onChange: RulesEngine.monitorExternalChanges,
       }
     ];
 
@@ -75,8 +76,8 @@ angular
       return DB()
         .replicate[direction.name](remote, options)
         .on('change', replicationResult => {
-          if (replicationResult && replicationResult.docs) {
-            RulesEngine.monitorExternalChanges(replicationResult.docs);
+          if (direction.onChange) {
+            direction.onChange(replicationResult);
           }
         })
         .on('denied', function(err) {

--- a/webapp/src/js/services/db-sync.js
+++ b/webapp/src/js/services/db-sync.js
@@ -75,7 +75,9 @@ angular
       return DB()
         .replicate[direction.name](remote, options)
         .on('change', replicationResult => {
-          RulesEngine.monitorExternalChanges(replicationResult.docs);
+          if (replicationResult && replicationResult.docs) {
+            RulesEngine.monitorExternalChanges(replicationResult.docs);
+          }
         })
         .on('denied', function(err) {
           $log.error(`Denied replicating ${direction.name} remote server`, err);

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -174,8 +174,8 @@ angular.module('inboxServices').factory('RulesEngine', function(
 
   const monitorExternalChanges = (changedDocs) => {
     const isTask = doc => doc.type === 'task';
-    const contactsWithUpodatedTasks = docs.filter(isTask).map(doc => doc.requester);
-    RulesEngineCore.updateEmissionsFor(contactsWithUpodatedTasks);
+    const contactsWithUpdatedTasks = changedDocs.filter(isTask).map(doc => doc.requester);
+    RulesEngineCore.updateEmissionsFor(contactsWithUpdatedTasks);
   };
 
   const translateTaskDocs = taskDocs => {

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -172,6 +172,12 @@ angular.module('inboxServices').factory('RulesEngine', function(
     });
   };
 
+  const monitorExternalChanges = (changedDocs) => {
+    const isTask = doc => doc.type === 'task';
+    const contactsWithUpodatedTasks = docs.filter(isTask).map(doc => doc.requester);
+    RulesEngineCore.updateEmissionsFor(contactsWithUpodatedTasks);
+  };
+
   const translateTaskDocs = taskDocs => {
     const translateProperty = (property, task) => {
       if (typeof property === 'string') {
@@ -238,6 +244,10 @@ angular.module('inboxServices').factory('RulesEngine', function(
         })
         .then(telemetryData.passThrough);
     },
+
+    monitorExternalChanges: (changes) => (
+      initialized.then(() => monitorExternalChanges(changes))
+    ),
   };
 
   return self;

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -20,6 +20,7 @@ describe('DBSync service', () => {
   let getItem;
   let setItem;
   let dbSyncRetry;
+  let rulesEngine;
 
   beforeEach(() => {
     replicationResult = Q.resolve;
@@ -53,6 +54,7 @@ describe('DBSync service', () => {
     setItem = sinon.stub();
     getItem = sinon.stub();
     dbSyncRetry = sinon.stub();
+    rulesEngine = { monitorExternalChanges: sinon.stub() };
 
     module('inboxApp');
     module($provide => {
@@ -70,6 +72,7 @@ describe('DBSync service', () => {
       $provide.value('Auth', { has: hasAuth });
       $provide.value('$window', { localStorage: { setItem, getItem } });
       $provide.value('DBSyncRetry', dbSyncRetry);
+      $provide.value('RulesEngine', rulesEngine);
     });
     inject((_DBSync_, _$interval_) => {
       service = _DBSync_;
@@ -256,16 +259,6 @@ describe('DBSync service', () => {
 
       let count;
       let retries;
-      const recursiveOnTo = sinon.stub();
-
-      const replicationResultTo = () => {
-        if (count <= retries) {
-          count++;
-          return Q.reject({ code: 413 });
-        } else {
-          return Q.resolve();
-        }
-      };
 
       beforeEach(() => {
         count = 0;
@@ -273,22 +266,17 @@ describe('DBSync service', () => {
         isOnlineOnly.returns(false);
         hasAuth.resolves(true);
 
-        recursiveOnTo.callsFake(() => {
-          const promise = replicationResultTo();
-          promise.on = recursiveOnTo;
-          return promise;
-        });
-
         to.callsFake(() => {
           let promise;
           if (count < retries) {
             // Too big - retry
+            count++;
             promise = Q.reject({ code: 413 });
           } else {
             // small enough - complete
             promise = Q.resolve();
           }
-          promise.on = recursiveOnTo;
+          promise.on = () => promise;
           return promise;
         });
       });
@@ -298,10 +286,11 @@ describe('DBSync service', () => {
         return service.sync().then(() => {
           expect(hasAuth.callCount).to.equal(1);
           expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(3);
+          expect(to.callCount).to.equal(4);
           expect(to.args[0][1].batch_size).to.equal(100);
           expect(to.args[1][1].batch_size).to.equal(50);
           expect(to.args[2][1].batch_size).to.equal(25);
+          expect(to.args[3][1].batch_size).to.equal(12);
         });
       });
 
@@ -321,37 +310,69 @@ describe('DBSync service', () => {
       });
 
     });
+  });
 
-
-    describe('on denied', () => {
-      it('should have "denied" handles for every direction', () => {
-        isOnlineOnly.returns(false);
-        hasAuth.resolves(true);
-        return service.sync().then(() => {
-          expect(to.events.denied).to.be.a('function');
-          expect(from.events.denied).to.be.a('function');
-        });
+  describe('on denied', () => {
+    it('should have "denied" handles for every direction', () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      return service.sync().then(() => {
+        expect(to.events.denied).to.be.a('function');
+        expect(from.events.denied).to.be.a('function');
       });
+    });
 
-      it('"denied" from handle does nothing', () => {
-        isOnlineOnly.returns(false);
-        hasAuth.resolves(true);
-        return service.sync().then(() => {
-          from.events.denied();
-          expect(dbSyncRetry.callCount).to.equal(0);
-        });
+    it('"denied" from handle does nothing', () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      return service.sync().then(() => {
+        from.events.denied();
+        expect(dbSyncRetry.callCount).to.equal(0);
       });
+    });
 
-      it('"denied" to handle calls DBSyncRetry', () => {
-        isOnlineOnly.returns(false);
-        hasAuth.resolves(true);
-        return service.sync().then(() => {
-          to.events.denied({ some: 'err' });
-          expect(dbSyncRetry.callCount).to.equal(1);
-          expect(dbSyncRetry.args[0]).to.deep.equal([{ some: 'err' }]);
-          expect(to.callCount).to.equal(1);
-          expect(from.callCount).to.equal(1);
-        });
+    it('"denied" to handle calls DBSyncRetry', () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      return service.sync().then(() => {
+        to.events.denied({ some: 'err' });
+        expect(dbSyncRetry.callCount).to.equal(1);
+        expect(dbSyncRetry.args[0]).to.deep.equal([{ some: 'err' }]);
+        expect(to.callCount).to.equal(1);
+        expect(from.callCount).to.equal(1);
+      });
+    });
+  });
+
+  describe('on change', () => {
+    it('should have "change" handles for the "from" and "to" direction', () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      return service.sync().then(() => {
+        expect(to.events.change).to.be.a('function');
+        expect(from.events.change).to.be.a('function');
+      });
+    });
+
+    it('"changes" to handle does nothing', () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      return service.sync().then(() => {
+        to.events.change({});
+        expect(rulesEngine.monitorExternalChanges.callCount).to.equal(0);
+      });
+    });
+
+    it('"changes" from handle calls RulesEngine.monitorExternalChanges', () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      const replicationResult = { this: 'is', a: 'replication result' };
+      return service.sync().then(() => {
+        from.events.change(replicationResult);
+        expect(rulesEngine.monitorExternalChanges.callCount).to.equal(1);
+        expect(rulesEngine.monitorExternalChanges.args[0]).to.deep.equal([replicationResult]);
+        expect(to.callCount).to.equal(1);
+        expect(from.callCount).to.equal(1);
       });
     });
   });


### PR DESCRIPTION
# Description

Adds incoming changes feed listener that reacts when receiving `task` documents, by marking their corresponding "subjects" as dirty. 
When recalculating, if multiple tasks exist for a single emission, a single winner is chosen, while the rest are cancelled with a "duplicate" stateReason. The winner is the most recent, but not "future", most ready task. "Future" tasks are ignored to align with previous functionality. 

Fixes error thrown when receiving subject-less report in Rules-Engine changes listener. 

De-flakes unrelated e2e test. 

medic/cht-core#6389
medic/cht-core#6417

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
