### PR TITLE
Add missing state.duplicate translation

### DIFF
--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -1119,6 +1119,7 @@ sms_received = SMS message received; it will be reviewed shortly. If you were tr
 state.cleared = cleared
 state.delivered = delivered
 state.denied = denied
+state.duplicate = duplicate
 state.failed = failed
 state.forwarded-by-gateway = forwarded by gateway
 state.forwarded-to-gateway = forwarded to gateway


### PR DESCRIPTION
# Description

medic/cht-core#6415

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
