### PR TITLE
Db-doc now allows unassigned docs

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -230,6 +230,8 @@ const getAllTombstones = (ids) => {
 // replication keys are either contact shortcodes (`patient_id` or `place_id`) or doc ids
 // returns a list of corresponding contact docs
 const findContactsByReplicationKeys = (replicationKeys) => {
+  replicationKeys = _.without(replicationKeys, UNASSIGNED_KEY);
+
   if (!replicationKeys || !replicationKeys.length) {
     return Promise.resolve([]);
   }
@@ -320,6 +322,9 @@ const getScopedAuthorizationContext = (userCtx, scopeDocsCtx = []) => {
     });
 
     authorizationCtx.subjectIds = _.uniq(authorizationCtx.subjectIds);
+    if (hasAccessToUnassignedDocs(userCtx)) {
+      authorizationCtx.subjectIds.push(UNASSIGNED_KEY);
+    }
 
     return authorizationCtx;
   });

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -1314,6 +1314,29 @@ describe('Authorization service', () => {
         });
     });
 
+    it('adds unassigned key if the user has required permissions', () => {
+      auth.hasAllPermissions.returns(true);
+      config.get.returns(true);
+
+      const docObjs = [
+        { // unallocated
+          doc: {
+            _id: 'unallocated', type: 'data_record',
+          },
+          viewResults: {
+            contactsByDepth: [],
+            replicationKeys: [['_unassigned', {}]]
+          },
+        },
+      ];
+
+      return service
+        .getScopedAuthorizationContext(userCtx, docObjs)
+        .then(result => {
+          result.subjectIds.should.have.members(['_all', '_unassigned', 'org.couchdb.user:user']);
+        });
+    });
+
     describe('should return correct subject ids when dealing with tombstones', () => {
       it('deleted contacts', () => {
         const docObjs = [

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -1337,6 +1337,29 @@ describe('Authorization service', () => {
         });
     });
 
+    it('shold not add unassigned key if the user does not have required permissions', () => {
+      auth.hasAllPermissions.returns(false);
+      config.get.returns(true);
+
+      const docObjs = [
+        { // unallocated
+          doc: {
+            _id: 'unallocated', type: 'data_record',
+          },
+          viewResults: {
+            contactsByDepth: [],
+            replicationKeys: [['_unassigned', {}]]
+          },
+        },
+      ];
+
+      return service
+        .getScopedAuthorizationContext(userCtx, docObjs)
+        .then(result => {
+          result.subjectIds.should.have.members(['_all', 'org.couchdb.user:user']);
+        });
+    });
+
     describe('should return correct subject ids when dealing with tombstones', () => {
       it('deleted contacts', () => {
         const docObjs = [

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -1167,7 +1167,7 @@ describe('db-doc handler', () => {
         .then(() => utils.updateSettings(settings))
         .then(() => utils.requestOnTestDb(_.defaults({ path: `/${doc._id}` }, offlineRequestOptions)).catch(err => err))
         .then(result => {
-          // user can't see the unallocated report without permissions
+          // user can see the unallocated report with permissions
           chai.expect(result).to.deep.include(doc);
         });
     });

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -1136,6 +1136,42 @@ describe('db-doc handler', () => {
         });
     });
 
+    it('GET unallocated records', () => {
+      const settings = {
+        district_admins_access_unallocated_messages: true,
+        permissions: {
+          can_view_unallocated_data_records: ['district_admin'],
+        }
+      };
+      const doc = {
+        _id: uuid(),
+        type: 'data_record',
+        form: 'FORM',
+        fields: {},
+        errors: [],
+        reported_date: new Date().getTime(),
+        sms_message: {
+          message: 'FORM public',
+          form: 'FORM',
+          from: '+01232323',
+        }
+      };
+
+      return utils
+        .saveDoc(doc)
+        .then(() => utils.requestOnTestDb(_.defaults({ path: `/${doc._id}` }, offlineRequestOptions)).catch(err => err))
+        .then(result => {
+          // user can't see the unallocated report without permissions
+          chai.expect(result).to.deep.nested.include({ statusCode: 403, 'responseBody.error': 'forbidden'});
+        })
+        .then(() => utils.updateSettings(settings))
+        .then(() => utils.requestOnTestDb(_.defaults({ path: `/${doc._id}` }, offlineRequestOptions)).catch(err => err))
+        .then(result => {
+          // user can't see the unallocated report without permissions
+          chai.expect(result).to.deep.include(doc);
+        });
+    });
+
     it('POST', () => {
       offlineRequestOptions.method = 'POST';
 


### PR DESCRIPTION
# Description

Includes `_unassigned` key in db-doc subjectIds, if allowed.

medic/cht-core#6421

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
