### PR TITLE
Configurable duplicate message limit

### DIFF
--- a/shared-libs/transitions/src/lib/history.js
+++ b/shared-libs/transitions/src/lib/history.js
@@ -1,67 +1,70 @@
 /**
  * @module transitions/history
- * @description Utility to track duplicate keys in a certain period of time (periodMins).
- * Removes expired keys after threshold is reached (purgeThreshold).
+ * @description Utility to track duplicate keys in a certain period of time (30 minutes).
+ * Removes expired keys after threshold is reached (1000).
  **/
-const moment = require('moment');
+const config = require('../config');
 
-let records = {};
+const AUTO_PURGE_LENGTH = 1000;
+const TIME_TO_LIVE = 30 * 60 * 1000; // 30 minutes
+const MAXIMUM_DUPLICATES_LIMIT = 20;
+const DEFAULT_DUPLICATES_LIMIT = 5;
 
-const now = () => {
-  // Passing date to make it testable with fake timers
-  return moment(new Date());
+const getAllowedDuplicatesLimit = () => {
+  const smsConfig = config.get('sms') || {};
+  const configuredLimit = parseInt(smsConfig.allowed_duplicates_limit);
+
+  const allowedLimit =
+    (configuredLimit && !isNaN(configuredLimit) && configuredLimit > 0) ? configuredLimit : DEFAULT_DUPLICATES_LIMIT;
+
+  return Math.min(allowedLimit, MAXIMUM_DUPLICATES_LIMIT);
 };
+const records = {};
 
-const purgeIfExpired = (key, value) => {
-  if(value && value.timestamp) {
-    // Checks difference with history duration in minutes
-    const hasExpired = (now().diff(value.timestamp))/60000 >= module.exports._periodMins;
-    if(hasExpired) {
-      delete records[key];
-    }
-    return hasExpired;
+const purgeIfExpired = (key) => {
+  const value = records[key];
+  if (!value) {
+    return;
   }
-  return true;
-};
 
-const size = () => {
-  return Object.keys(records).length;
-};
-
-const purge = (force=false) => {
-  if(force || size() >= module.exports._purgeThreshold) {
-    for (const key of Object.keys(records)) {
-      purgeIfExpired(key, records[key]);
-    }
-    return true;
+  const hasExpired = (new Date().getTime() - value.timestamp) >= TIME_TO_LIVE;
+  if (hasExpired) {
+    delete records[key];
   }
-  return false;
 };
 
-const formatkey = (to, msg) => {
-  return `${to}-${msg}`;
+const purge = () => {
+  if (Object.keys(records).length < AUTO_PURGE_LENGTH) {
+    return;
+  }
+
+  Object.keys(records).forEach(purgeIfExpired);
+};
+
+const getKey = (to, msg) => `${to}-${msg}`;
+
+const touch = (key) => {
+  const value = records[key];
+
+  records[key] = {
+    timestamp: new Date().getTime(),
+    count: (value && value.count + 1) || 1,
+  };
 };
 
 module.exports = {
-
-  check: (to, msg) => { //key to track. returns true for duplicates
+  /**
+   * Returns whether the combination of message + recipient should be considered a duplicate
+   * @param {String} to - recipient phone number
+   * @param {String} msg - sms message content
+   * @returns {boolean}
+   */
+  check: (to, msg) => {
     purge();
-    const alreadyExists = module.exports._get(to, msg) !== null;
-    records[formatkey(to, msg)] = {timestamp: now()};
-    return alreadyExists;
-  },
 
-  // Exposed for testing purposes
-  _get: (to, msg) => { // returns last timestamp for given key
-    const key = formatkey(to, msg);
-    const value = records[key];
-    if(value && !purgeIfExpired(key, value)) {
-      return value;
-    }
-    return null;
+    const key = getKey(to, msg);
+    purgeIfExpired(key);
+    touch(key);
+    return records[key].count > getAllowedDuplicatesLimit();
   },
-  _size: () => size(), // returns number of expired + non-expired keys
-  _clear: () => { records = {}; },// clears history
-  _periodMins: 30, //Number of minutes to track
-  _purgeThreshold: 100 //Number of keys to keep in memory
 };

--- a/shared-libs/transitions/src/lib/history.js
+++ b/shared-libs/transitions/src/lib/history.js
@@ -14,7 +14,7 @@ const records = {};
 
 const getAllowedDuplicatesLimit = () => {
   const smsConfig = config.get('sms') || {};
-  const configuredLimit = smsConfig.allowed_duplicates_limit;
+  const configuredLimit = smsConfig.duplicate_limit;
 
   if (configuredLimit && !isNaN(configuredLimit) && configuredLimit > 0) {
     return Math.min(parseInt(configuredLimit), MAXIMUM_DUPLICATES_LIMIT);

--- a/shared-libs/transitions/test/unit/lib/history.js
+++ b/shared-libs/transitions/test/unit/lib/history.js
@@ -77,6 +77,21 @@ describe('history utility', () => {
     should.equal(history.check('to2', 'msg1'), false);
     should.equal(history.check('to2', 'msg1'), true);
 
+    config.get.returns({ allowed_duplicates_limit: '0' }); // zero, so uses default limit
+    should.equal(history.check('to3', 'msg1'), false);
+    should.equal(history.check('to3', 'msg1'), false);
+    should.equal(history.check('to3', 'msg1'), false);
+    should.equal(history.check('to3', 'msg1'), false);
+    should.equal(history.check('to3', 'msg1'), false);
+    should.equal(history.check('to3', 'msg1'), true);
+
+    config.get.returns({ allowed_duplicates_limit: '-20' }); // lower than 0, so uses default limit
+    should.equal(history.check('to4', 'msg1'), false);
+    should.equal(history.check('to4', 'msg1'), false);
+    should.equal(history.check('to4', 'msg1'), false);
+    should.equal(history.check('to4', 'msg1'), false);
+    should.equal(history.check('to4', 'msg1'), false);
+    should.equal(history.check('to4', 'msg1'), true);
   });
 
   it('tracks keys', () => {

--- a/shared-libs/transitions/test/unit/lib/history.js
+++ b/shared-libs/transitions/test/unit/lib/history.js
@@ -26,7 +26,7 @@ describe('history utility', () => {
     should.equal(history.check('to2', 'msg2'), false);
   });
 
-  it('should return false when duplicate with default limit', () => {
+  it('should return false when not duplicate with default limit', () => {
     // not stubbing config.get cause, let's presume we have no config at all
     // default limit is 5
     should.equal(history.check('to1', 'msg1'), false);
@@ -68,6 +68,15 @@ describe('history utility', () => {
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), true);
+
+    config.get.returns({ allowed_duplicates_limit: '25 dolars' }); // not a number, so uses default limit
+    should.equal(history.check('to2', 'msg1'), false);
+    should.equal(history.check('to2', 'msg1'), false);
+    should.equal(history.check('to2', 'msg1'), false);
+    should.equal(history.check('to2', 'msg1'), false);
+    should.equal(history.check('to2', 'msg1'), false);
+    should.equal(history.check('to2', 'msg1'), true);
+
   });
 
   it('tracks keys', () => {

--- a/shared-libs/transitions/test/unit/lib/history.js
+++ b/shared-libs/transitions/test/unit/lib/history.js
@@ -41,7 +41,7 @@ describe('history utility', () => {
   });
 
   it('should return false when duplicate with configured limit', () => {
-    sinon.stub(config, 'get').returns({ allowed_duplicates_limit: 3 });
+    sinon.stub(config, 'get').returns({ duplicate_limit: 3 });
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), false);
@@ -53,7 +53,7 @@ describe('history utility', () => {
   });
 
   it('should use default maximum limit when configured limit is too high', () => {
-    sinon.stub(config, 'get').returns({ allowed_duplicates_limit: 300 });
+    sinon.stub(config, 'get').returns({ duplicate_limit: 300 });
     for (let i = 0; i < 20; i++) {
       should.equal(history.check('to1', 'msg1'), false);
     }
@@ -61,7 +61,7 @@ describe('history utility', () => {
   });
 
   it('should normalize limit', () => {
-    sinon.stub(config, 'get').returns({ allowed_duplicates_limit: 'not a number' });
+    sinon.stub(config, 'get').returns({ duplicate_limit: 'not a number' });
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), false);
@@ -69,7 +69,7 @@ describe('history utility', () => {
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), true);
 
-    config.get.returns({ allowed_duplicates_limit: '25 dolars' }); // not a number, so uses default limit
+    config.get.returns({ duplicate_limit: '25 dolars' }); // not a number, so uses default limit
     should.equal(history.check('to2', 'msg1'), false);
     should.equal(history.check('to2', 'msg1'), false);
     should.equal(history.check('to2', 'msg1'), false);
@@ -77,7 +77,7 @@ describe('history utility', () => {
     should.equal(history.check('to2', 'msg1'), false);
     should.equal(history.check('to2', 'msg1'), true);
 
-    config.get.returns({ allowed_duplicates_limit: '0' }); // zero, so uses default limit
+    config.get.returns({ duplicate_limit: '0' }); // zero, so uses default limit
     should.equal(history.check('to3', 'msg1'), false);
     should.equal(history.check('to3', 'msg1'), false);
     should.equal(history.check('to3', 'msg1'), false);
@@ -85,7 +85,7 @@ describe('history utility', () => {
     should.equal(history.check('to3', 'msg1'), false);
     should.equal(history.check('to3', 'msg1'), true);
 
-    config.get.returns({ allowed_duplicates_limit: '-20' }); // lower than 0, so uses default limit
+    config.get.returns({ duplicate_limit: '-20' }); // lower than 0, so uses default limit
     should.equal(history.check('to4', 'msg1'), false);
     should.equal(history.check('to4', 'msg1'), false);
     should.equal(history.check('to4', 'msg1'), false);
@@ -95,7 +95,7 @@ describe('history utility', () => {
   });
 
   it('tracks keys', () => {
-    sinon.stub(config, 'get').returns({ allowed_duplicates_limit: 1 });
+    sinon.stub(config, 'get').returns({ duplicate_limit: 1 });
     should.equal(history.check('to1', 'msg1'), false);
     should.equal(history.check('to1', 'msg1'), true); // duplicate
 

--- a/shared-libs/transitions/test/unit/messages.js
+++ b/shared-libs/transitions/test/unit/messages.js
@@ -152,6 +152,7 @@ describe('messages', () => {
   });
 
   it('addMessage detects duplicate messages', () => {
+    sinon.stub(config, 'get').returns({ allowed_duplicates_limit: 1 });
     const doc = {to: '+1234567'};
     messages.addMessage(doc, { message: 'Thank you.' }, '123', {});
     assert.equal(doc.tasks.length, 1);
@@ -329,7 +330,7 @@ describe('messages', () => {
         ['5', 'ABCD', false],
         ['5', ' ABCD ', false],
         ['5.9', 'ABCD', false],
-        
+
         // allowed
         [0, '+123', true],
         ['5', '12345', true],

--- a/shared-libs/transitions/test/unit/messages.js
+++ b/shared-libs/transitions/test/unit/messages.js
@@ -152,7 +152,7 @@ describe('messages', () => {
   });
 
   it('addMessage detects duplicate messages', () => {
-    sinon.stub(config, 'get').returns({ allowed_duplicates_limit: 1 });
+    sinon.stub(config, 'get').returns({ duplicate_limit: 1 });
     const doc = {to: '+1234567'};
     messages.addMessage(doc, { message: 'Thank you.' }, '123', {});
     assert.equal(doc.tasks.length, 1);

--- a/tests/e2e/transitions/message_duplicates.spec.js
+++ b/tests/e2e/transitions/message_duplicates.spec.js
@@ -1,0 +1,185 @@
+const chai = require('chai');
+const uuid = require('uuid');
+const utils = require('../../utils');
+const apiUtils = require('./utils');
+
+const settings = {
+  transitions: {
+    registration: true,
+  },
+  forms: {
+    SICK: {
+      meta: {
+        code: 'SICK',
+        icon: '',
+        translation_key: 'Im sick',
+      },
+      fields: {},
+      public_form: true,
+    }
+  },
+  registrations: [{
+    form: 'SICK',
+    events: [],
+    messages: [{
+      message: 'Await further instructions',
+      event_type: 'report_accepted',
+      recipient: 'reporting_unit',
+    }]
+  }]
+};
+
+const getPostOpts = (path, body) => ({
+  path: path,
+  method: 'POST',
+  headers: { 'Content-Type':'application/json' },
+  body: body
+});
+
+const postMessages = (messages) => {
+  return Promise
+    .all([
+      apiUtils.getApiSmsChanges(messages),
+      utils.request(getPostOpts('/api/sms', { messages: messages }))
+    ])
+    .then(([changes]) => changes.map(change => change.id));
+};
+
+const getRecipient = doc => doc.tasks[0].messages[0].to;
+
+describe('message duplicates', () => {
+  afterAll(done => utils.revertDb().then(done));
+  afterEach(done => utils.revertSettings(true).then(done));
+
+  it('should mark as duplicate after 5 retries by default', () => {
+    const message1 = {
+      from: 'duplicate-phone',
+      content: 'SICK'
+    };
+
+    const message2 = {
+      from: 'other-phone',
+      content: 'SICK'
+    };
+
+    const firstMessages = [
+      Object.assign({ id: uuid() }, message1),
+      Object.assign({ id: uuid() }, message2),
+      Object.assign({ id: uuid() }, message1),
+      Object.assign({ id: uuid() }, message1),
+    ];
+
+    const secondMessages = [
+      Object.assign({ id: uuid() }, message1),
+      Object.assign({ id: uuid() }, message2),
+      Object.assign({ id: uuid() }, message1),
+    ];
+
+    const thirdMessages = [
+      Object.assign({ id: uuid() }, message1),
+      Object.assign({ id: uuid() }, message2),
+      Object.assign({ id: uuid() }, message1),
+    ];
+
+    return utils
+      .updateSettings(settings)
+      .then(() => postMessages(firstMessages))
+      .then(ids => utils.getDocs(ids))
+      .then(docs => {
+        docs.forEach(doc => {
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.tasks[0].messages.length).to.equal(1);
+
+          const task = doc.tasks[0];
+          chai.expect(task.messages[0]).to.include({ message: 'Await further instructions' });
+          // we have no duplicate, 3x message1 + 1x message2
+          chai.expect(task.state).to.equal('forwarded-to-gateway');
+          chai.expect(task.state_history.length).to.equal(2);
+        });
+      })
+      .then(() => postMessages(secondMessages))
+      .then(ids => utils.getDocs(ids))
+      .then(docs => {
+        docs.forEach(doc => {
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.tasks[0].messages.length).to.equal(1);
+
+          const task = doc.tasks[0];
+          chai.expect(task.messages[0]).to.include({ message: 'Await further instructions' });
+          // still no duplicates, 5x message1, 2x message2
+          chai.expect(task.state).to.equal('forwarded-to-gateway');
+          chai.expect(task.state_history.length).to.equal(2);
+        });
+      })
+      .then(() => postMessages(thirdMessages))
+      .then(ids => utils.getDocs(ids))
+      .then(docs => {
+        docs.forEach(doc => {
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.tasks[0].messages.length).to.equal(1);
+
+          const recipient = getRecipient(doc);
+          const task = doc.tasks[0];
+          // message1 is duplicated (7x), message2 not duplicate (3x)
+          if (recipient === message1.from) {
+            chai.expect(task.messages[0]).to.include({ message: 'Await further instructions' });
+            chai.expect(task.state).to.equal('duplicate');
+            chai.expect(task.state_history.length).to.equal(1);
+          } else {
+            chai.expect(task.state).to.equal('forwarded-to-gateway');
+            chai.expect(task.state_history.length).to.equal(2);
+          }
+        });
+      });
+  });
+
+  it('should mark as duplicate using configured limit', () => {
+    Object.assign(settings, { sms: { allowed_duplicates_limit: 3, outgoing_service: 'medic-gateway' } });
+    const message = {
+      from: 'new-duplicate-phone',
+      content: 'SICK'
+    };
+
+    const firstMessages = [
+      Object.assign({ id: uuid() }, message),
+      Object.assign({ id: uuid() }, message),
+      Object.assign({ id: uuid() }, message),
+    ];
+
+    const secondMessages = [
+      Object.assign({ id: uuid() }, message),
+      Object.assign({ id: uuid() }, message),
+    ];
+
+    return utils
+      .updateSettings(settings)
+      .then(() => postMessages(firstMessages))
+      .then(ids => utils.getDocs(ids))
+      .then(docs => {
+        docs.forEach(doc => {
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.tasks[0].messages.length).to.equal(1);
+
+          const task = doc.tasks[0];
+          chai.expect(task.messages[0]).to.include({ message: 'Await further instructions' });
+          // we have no duplicate, 3x message1
+          chai.expect(task.state).to.equal('forwarded-to-gateway');
+          chai.expect(task.state_history.length).to.equal(2);
+        });
+      })
+      .then(() => postMessages(secondMessages))
+      .then(ids => utils.getDocs(ids))
+      .then(docs => {
+        docs.forEach(doc => {
+          chai.expect(doc.tasks.length).to.equal(1);
+          chai.expect(doc.tasks[0].messages.length).to.equal(1);
+
+          const task = doc.tasks[0];
+          // message1 is duplicated (5x)
+          chai.expect(task.messages[0]).to.include({ message: 'Await further instructions' });
+          chai.expect(task.state).to.equal('duplicate');
+          chai.expect(task.state_history.length).to.equal(1);
+        });
+      });
+  });
+});

--- a/tests/e2e/transitions/message_duplicates.spec.js
+++ b/tests/e2e/transitions/message_duplicates.spec.js
@@ -134,7 +134,7 @@ describe('message duplicates', () => {
   });
 
   it('should mark as duplicate using configured limit', () => {
-    Object.assign(settings, { sms: { allowed_duplicates_limit: 3, outgoing_service: 'medic-gateway' } });
+    Object.assign(settings, { sms: { duplicate_limit: 3, outgoing_service: 'medic-gateway' } });
     const message = {
       from: 'new-duplicate-phone',
       content: 'SICK'

--- a/tests/e2e/transitions/utils.js
+++ b/tests/e2e/transitions/utils.js
@@ -1,7 +1,7 @@
 const utils = require('../../utils');
 
 const getApiSmsChanges = (messages) => {
-  const expectedMessages = messages.map(message => message.message);
+  const expectedMessages = messages.map(message => message.content);
   const changes = [];
   const ids = [];
   const listener = utils.db.changes({
@@ -19,6 +19,7 @@ const getApiSmsChanges = (messages) => {
         const idx = expectedMessages.findIndex(message => message === change.doc.sms_message.message);
         changes.push(change);
         expectedMessages.splice(idx, 1);
+
         ids.push(change.id);
         if (!expectedMessages.length) {
           listener.cancel();


### PR DESCRIPTION
# Description

Adds `app_settings.sms.allowed_duplicates_limit` property to define maximum number of duplicate messages to send. Defaults to 5. Maximum allowed value is 20. 

medic/cht-core#6094

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
