### PR TITLE
Stop storing last_seq and null-check before cancel.

### DIFF
--- a/sentinel/server.js
+++ b/sentinel/server.js
@@ -9,10 +9,16 @@ if (process.env.TEST_ENV) {
   process.exit(1);
 }
 
-process.on('unhandledRejection', reason => {
-  logger.error('Unhandled Rejection:');
-  logger.error('%o',reason);
-});
+process
+  .on('unhandledRejection', reason => {
+    logger.error('Unhandled Rejection:');
+    logger.error('%o',reason);
+  })
+  .on('uncaughtException', err => {
+    logger.error('UNCAUGHT EXCEPTION!');
+    logger.error('  Error: %o', err);
+    process.exit(1);
+  });
 
 const waitForApi = () =>
   new Promise(resolve => {

--- a/sentinel/src/lib/feed.js
+++ b/sentinel/src/lib/feed.js
@@ -14,7 +14,6 @@ const MAX_QUEUE_SIZE = 100;
 
 let request;
 let processed = 0;
-let lastSeq;
 
 const enqueue = change => changeQueue.push(change);
 
@@ -42,16 +41,14 @@ const registerFeed = seq => {
     .on('change', change => {
       if (!change.id.match(IDS_TO_IGNORE) &&
           !tombstoneUtils.isTombstoneId(change.id)) {
+        enqueue(change);
 
         const queueSize = changeQueue.length();
-        if (queueSize >= MAX_QUEUE_SIZE) {
+        if (queueSize >= MAX_QUEUE_SIZE && request) {
           logger.debug(`transitions: queue size ${queueSize} greater than ${MAX_QUEUE_SIZE}, we stop listening`);
-          lastSeq = change.seq;
           request.cancel();
           request = null;
         }
-
-        enqueue(change);
       }
     })
     .on('error', err => {
@@ -144,11 +141,8 @@ changeQueue.drain(() => {
 
 const listen = () => {
   if (!request) {
-    if (lastSeq) {
-      return registerFeed(lastSeq);
-    } else {
-      return getProcessedSeq().then(seq => registerFeed(seq));
-    }
+    logger.info('transitions: processing enabled');
+    return getProcessedSeq().then(seq => registerFeed(seq));
   }
 };
 
@@ -157,12 +151,8 @@ module.exports = {
   /**
    * Start listening from the last processed seq. Will restart
    * automatically on error.
-   * @param {Function} callback Called with a change Object.
    */
-  listen: () => {
-    logger.info('transitions: processing enabled');
-    return listen();
-  },
+  listen,
 
   /**
    * Stops listening for changes. Must be restarted manually

--- a/sentinel/src/lib/feed.js
+++ b/sentinel/src/lib/feed.js
@@ -140,6 +140,7 @@ changeQueue.drain(() => {
 });
 
 const listen = () => {
+  changeQueue.resume();
   if (!request) {
     logger.info('transitions: processing enabled');
     return getProcessedSeq().then(seq => registerFeed(seq));
@@ -159,7 +160,7 @@ module.exports = {
    * by calling listen.
    */
   cancel: () => {
-    changeQueue.kill();
+    changeQueue.pause();
     if (request) {
       request.cancel();
       request = null;

--- a/sentinel/tests/unit/lib/feed.js
+++ b/sentinel/tests/unit/lib/feed.js
@@ -22,10 +22,10 @@ describe('feed', () => {
     handler.catch = sinon.stub().returns(handler);
     handler.on = sinon.stub().returns(handler);
     sinon.stub(db.medic, 'changes').returns(handler);
+    feed._changeQueue.resume();
   });
 
   afterEach(() => {
-    feed._changeQueue.kill();
     feed.cancel();
     sinon.restore();
   });

--- a/sentinel/tests/unit/lib/feed.js
+++ b/sentinel/tests/unit/lib/feed.js
@@ -60,15 +60,15 @@ describe('feed', () => {
         });
     });
 
-    it('restarts listener after db error', done => {
+    it('restarts listener after db error', () => {
       const clock = sinon.useFakeTimers();
       const change = { id: 'some-uuid' };
       sinon.stub(metadata, 'getProcessedSeq')
         .onCall(0).resolves('123')
         .onCall(1).resolves('456');
-      sinon.stub(feed._changeQueue, 'length').returns(0);
+
       const push = sinon.stub(feed._changeQueue, 'push');
-      feed
+      return feed
         .listen()
         .then(() => {
           chai.expect(db.medic.changes.callCount).to.equal(1);
@@ -93,7 +93,6 @@ describe('feed', () => {
         .then(() => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(change);
-          done();
         });
     });
 
@@ -121,14 +120,14 @@ describe('feed', () => {
         });
     });
 
-    it('ignores ddocs', done => {
+    it('ignores ddocs', () => {
       const ddoc = { id: '_design/medic' };
       const edoc = { id: 'some-uuid' };
       sinon.stub(metadata, 'getProcessedSeq').resolves('123');
       sinon.stub(tombstoneUtils, 'isTombstoneId').returns(false);
       sinon.stub(feed._changeQueue, 'length').returns(0);
       const push = sinon.stub(feed._changeQueue, 'push');
-      feed
+      return feed
         .listen()
         .then(() => {
           const callbackFn = handler.on.args[0][1];
@@ -138,18 +137,17 @@ describe('feed', () => {
         .then(() => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(edoc);
-          done();
         });
     });
 
-    it('ignores info docs', done => {
+    it('ignores info docs', () => {
       const infodoc = { id: 'some-uuid-info' };
       const doc = { id: 'some-uuid' };
       sinon.stub(metadata, 'getProcessedSeq').resolves('123');
       sinon.stub(tombstoneUtils, 'isTombstoneId').returns(false);
-      sinon.stub(feed._changeQueue, 'length').returns(0);
+
       const push = sinon.stub(feed._changeQueue, 'push');
-      feed
+      return feed
         .listen()
         .then(() => {
           const callbackFn = handler.on.args[0][1];
@@ -159,20 +157,19 @@ describe('feed', () => {
         .then(() => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(doc);
-          done();
         });
     });
 
-    it('ignores tombstones', done => {
+    it('ignores tombstones', () => {
       const tombstone = { id: 'tombstone' };
       const doc = { id: 'some-uuid' };
       sinon.stub(metadata, 'getProcessedSeq').resolves('123');
       sinon.stub(tombstoneUtils, 'isTombstoneId')
         .withArgs(tombstone.id).returns(true)
         .withArgs(doc.id).returns(false);
-      sinon.stub(feed._changeQueue, 'length').returns(0);
+
       const push = sinon.stub(feed._changeQueue, 'push');
-      feed
+      return feed
         .listen()
         .then(() => {
           const callbackFn = handler.on.args[0][1];
@@ -183,18 +180,18 @@ describe('feed', () => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(doc);
           chai.expect(tombstoneUtils.isTombstoneId.callCount).to.equal(2);
-          done();
         });
     });
 
-    it('stops listening when the number of changes in the queue is above the limit', done => {
+    it('stops listening when the number of changes in the queue is above the limit', () => {
       const change = { id: 'some-uuid' };
       sinon.stub(metadata, 'getProcessedSeq').resolves('123');
       sinon.stub(tombstoneUtils, 'isTombstoneId').returns(false);
+
       sinon.stub(feed._changeQueue, 'length').returns(101);
       const push = sinon.stub(feed._changeQueue, 'push');
 
-      feed
+      return feed
         .listen()
         .then(() => {
           const callbackFn = handler.on.args[0][1];
@@ -204,7 +201,6 @@ describe('feed', () => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(change);
           chai.expect(handler.cancel.callCount).to.equal(1);
-          done();
         });
     });
 
@@ -212,29 +208,27 @@ describe('feed', () => {
 
   describe('cancel', () => {
 
-    it('cancels the couch request', done => {
+    it('cancels the couch request', () => {
       sinon.stub(metadata, 'getProcessedSeq').resolves('123');
-      sinon.stub(feed._changeQueue, 'length').returns(0);
+
       const push = sinon.stub(feed._changeQueue, 'push');
-      feed
+      const change = { id: 'some-uuid' };
+
+      return feed
         .listen()
         .then(() => feed.cancel())
         .then(() => {
           chai.expect(handler.cancel.callCount).to.equal(1);
-
           // resume listening
-          const change = { id: 'some-uuid' };
-          feed
-            .listen()
-            .then(() => {
-              const callbackFn = handler.on.args[0][1];
-              callbackFn(change);
-            })
-            .then(() => {
-              chai.expect(push.callCount).to.equal(1);
-              chai.expect(push.args[0][0]).to.deep.equal(change);
-              done();
-            });
+          return feed.listen();
+        })
+        .then(() => {
+          const callbackFn = handler.on.args[0][1];
+          callbackFn(change);
+        })
+        .then(() => {
+          chai.expect(push.callCount).to.equal(1);
+          chai.expect(push.args[0][0]).to.deep.equal(change);
         });
     });
 
@@ -334,7 +328,7 @@ describe('feed', () => {
       sinon.stub(metadata, 'update').resolves();
       sinon.stub(infodoc, 'delete').resolves();
       sinon.stub(db, 'allDbs').resolves([]);
-      
+
       feed._enqueue({ id: 'somechange', seq: 55, deleted: true });
 
       feed._changeQueue.drain(() => {


### PR DESCRIPTION
# Description

Always restart the feed from the `sentinel-meta-data.processed_seq`.
Awalys equeue first, then stop the feed. 
Always null-check before stopping the feed. 
Switches from `async.queue.kill` to `async.queue.pause` + `async.queue.resume` because 
https://caolan.github.io/async/v3/docs.html#QueueObject
Crash on unhandled exception.

medic/cht-core#6440

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
