### PR TITLE
Tighten relation between report "primary" subject and tasks

### DIFF
--- a/shared-libs/rules-engine/src/pouchdb-provider.js
+++ b/shared-libs/rules-engine/src/pouchdb-provider.js
@@ -109,12 +109,21 @@ const medicPouchProvider = db => {
             docsOf(db.query('medic-client/reports_by_subject', { keys, include_docs: true })),
             self.tasksByRelation(contactIds, 'requester'),
           ])
-            .then(([reportDocs, taskDocs]) => ({
-              userSettingsId: userSettingsDoc && userSettingsDoc._id,
-              contactDocs,
-              reportDocs,
-              taskDocs,
-            }));
+            .then(([reportDocs, taskDocs]) => {
+              // tighten the connection between reports and contacts
+              // a report will only be allowed to generate tasks for a single contact!
+              reportDocs = reportDocs.filter(report => {
+                const subjectId = registrationUtils.getSubjectId(report);
+                return subjectIds.has(subjectId);
+              });
+
+              return {
+                userSettingsId: userSettingsDoc && userSettingsDoc._id,
+                contactDocs,
+                reportDocs,
+                taskDocs,
+              };
+            });
         });
     },
   };

--- a/shared-libs/rules-engine/src/rules-emitter.js
+++ b/shared-libs/rules-engine/src/rules-emitter.js
@@ -180,11 +180,9 @@ const marshalDocsIntoNoolsFacts = (contactDocs, reportDocs, taskDocs) => {
   };
 
   for (const report of reportDocs) {
-    const subjectIdsInReport = registrationUtils.getSubjectIds(report);
-    for (const subjectId of subjectIdsInReport) {
-      const factOfPatient = factBySubjectId[subjectId] || addHeadlessContact(subjectId);
-      factOfPatient.reports.push(report);
-    }
+    const subjectIdInReport = registrationUtils.getSubjectId(report);
+    const factOfPatient = factBySubjectId[subjectIdInReport] || addHeadlessContact(subjectIdInReport);
+    factOfPatient.reports.push(report);
   }
 
   if (Object.hasOwnProperty.call(Contact.prototype, 'tasks')) {

--- a/shared-libs/rules-engine/test/mocks.js
+++ b/shared-libs/rules-engine/test/mocks.js
@@ -12,6 +12,13 @@ const chtDocs = {
     patient_id: 'patient_id',
   },
 
+  place: {
+    _id: 'place',
+    name: 'cht_mock_place',
+    type: 'health_center',
+    place_id: 'place_id',
+  },
+
   pregnancyReport: {
     _id: 'pregReport',
     type: 'data_record',

--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -24,6 +24,23 @@ const headlessReport = {
   patient_id: 'headless',
   reported_date: 1000,
 };
+const reportConnectedByPatientAndPlaceUuid = {
+  _id: 'reportByPatientAndPlaceUuid',
+  type: 'data_record',
+  form: 'form',
+  fields: {
+    place_uuid: 'place',
+  },
+  patient_id: 'patient',
+};
+const reportConnectedByPlaceUuid = {
+  _id: 'reportByPlaceUuid',
+  type: 'data_record',
+  form: 'form',
+  fields: {
+    place_uuid: 'place',
+  },
+};
 const taskOwnedByChtContact = {
   _id: 'taskOwnedBy',
   type: 'task',
@@ -34,6 +51,11 @@ const taskRequestedByChtContact = {
   type: 'task',
   requester: 'patient',
 };
+const taskRequestedByChtPlace = {
+  _id: 'taskRequestedByPlace',
+  type: 'task',
+  requester: 'place',
+};
 const headlessTask = {
   _id: 'headlessTask',
   type: 'task',
@@ -43,14 +65,18 @@ const headlessTask = {
 
 const fixtures = [
   chtDocs.contact,
+  chtDocs.place,
 
   chtDocs.pregnancyReport,
   headlessReport,
   reportConnectedByPlace,
+  reportConnectedByPatientAndPlaceUuid,
+  reportConnectedByPlaceUuid,
 
   taskOwnedByChtContact,
   taskRequestedByChtContact,
   headlessTask,
+  taskRequestedByChtPlace,
 ];
 
 describe('pouchdb provider', () => {
@@ -68,16 +94,22 @@ describe('pouchdb provider', () => {
 
   describe('allTasks', () => {
     it('for owner', async () => expect(await pouchdbProvider(db).allTasks('owner')).excludingEvery('_rev')
-      .to.deep.eq([taskRequestedByChtContact, headlessTask, taskOwnedByChtContact]));
+      .to.deep.eq([taskRequestedByChtContact, taskRequestedByChtPlace, headlessTask, taskOwnedByChtContact]));
     it('for requester', async () => expect(await pouchdbProvider(db).allTasks('requester')).excludingEvery('_rev')
-      .to.deep.eq([headlessTask, taskRequestedByChtContact]));
+      .to.deep.eq([headlessTask, taskRequestedByChtContact, taskRequestedByChtPlace]));
   });
 
   it('allTaskData', async () => {
     expect(await pouchdbProvider(db).allTaskData(mockUserSettingsDoc)).excludingEvery('_rev').to.deep.eq({
-      contactDocs: [chtDocs.contact],
-      reportDocs: [headlessReport, chtDocs.pregnancyReport, reportConnectedByPlace],
-      taskDocs: [headlessTask, taskRequestedByChtContact], // not owner
+      contactDocs: [chtDocs.place, chtDocs.contact],
+      reportDocs: [
+        headlessReport,
+        chtDocs.pregnancyReport,
+        reportConnectedByPatientAndPlaceUuid,
+        reportConnectedByPlace,
+        reportConnectedByPlaceUuid,
+      ],
+      taskDocs: [headlessTask, taskRequestedByChtContact, taskRequestedByChtPlace], // not owner
       userSettingsId: mockUserSettingsDoc._id,
     });
   });
@@ -180,8 +212,44 @@ describe('pouchdb provider', () => {
       const actual = await pouchdbProvider(db).taskDataFor([chtDocs.contact._id, 'abc'], mockUserSettingsDoc);
       expect(actual).excludingEvery('_rev').to.deep.eq({
         contactDocs: [chtDocs.contact],
-        reportDocs: [chtDocs.pregnancyReport, reportConnectedByPlace],
+        reportDocs: [chtDocs.pregnancyReport, reportConnectedByPatientAndPlaceUuid, reportConnectedByPlace ],
         taskDocs: [taskRequestedByChtContact],
+        userSettingsId: 'org.couchdb.user:username',
+      });
+    });
+
+    it('should exclude multi-subject reports who have other "primary" subjects for contact', async () => {
+      const forContact = await pouchdbProvider(db).taskDataFor([chtDocs.contact._id], mockUserSettingsDoc);
+      expect(forContact).excludingEvery('_rev').to.deep.eq({
+        contactDocs: [chtDocs.contact],
+        reportDocs: [chtDocs.pregnancyReport, reportConnectedByPatientAndPlaceUuid, reportConnectedByPlace, ],
+        taskDocs: [taskRequestedByChtContact],
+        userSettingsId: 'org.couchdb.user:username',
+      });
+    });
+
+    it('should exclude multi-subject reports who have other "primary" subjects for place', async () => {
+      const forPlace = await pouchdbProvider(db).taskDataFor([chtDocs.place._id], mockUserSettingsDoc);
+      chai.expect(forPlace).excludingEvery('_rev').to.deep.eq({
+        contactDocs: [chtDocs.place],
+        reportDocs: [reportConnectedByPlaceUuid],
+        taskDocs: [taskRequestedByChtPlace],
+        userSettingsId: 'org.couchdb.user:username',
+      });
+    });
+
+    it('should include all for both', async () => {
+      const forPlace = await pouchdbProvider(db)
+        .taskDataFor([chtDocs.place._id, chtDocs.contact._id], mockUserSettingsDoc);
+      chai.expect(forPlace).excludingEvery('_rev').to.deep.eq({
+        contactDocs: [chtDocs.place, chtDocs.contact],
+        reportDocs: [
+          reportConnectedByPatientAndPlaceUuid,
+          reportConnectedByPlaceUuid,
+          chtDocs.pregnancyReport,
+          reportConnectedByPlace,
+        ],
+        taskDocs: [taskRequestedByChtPlace, taskRequestedByChtContact],
         userSettingsId: 'org.couchdb.user:username',
       });
     });

--- a/shared-libs/rules-engine/test/rules-emitter.spec.js
+++ b/shared-libs/rules-engine/test/rules-emitter.spec.js
@@ -182,7 +182,7 @@ describe('rules-emitter', () => {
       expect(initialized).to.be.true;
 
       const { tasks, targets } = await rulesEmitter.getEmissionsFor([chtDocs.contact], [chtDocs.pregnancyReport]);
-      expect(tasks.length).to.eq(2);
+      expect(tasks.length).to.eq(1);
       expect(targets.length).to.eq(1);
     });
   });

--- a/shared-libs/rules-engine/test/transform-task-emission-to-doc.spec.js
+++ b/shared-libs/rules-engine/test/transform-task-emission-to-doc.spec.js
@@ -223,7 +223,7 @@ describe('transform-task-emission-to-doc', () => {
       expect(initialized).to.be.true;
 
       const { tasks } = await rulesEmitter.getEmissionsFor([chtDocs.contact], [chtDocs.pregnancyReport]);
-      expect(tasks.length).to.eq(2);
+      expect(tasks.length).to.eq(1);
 
       const copyOfTaskEmission = deepCopy(tasks[0]);
       copyOfTaskEmission.date = new Date(copyOfTaskEmission.date);

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -130,7 +130,7 @@ angular.module('inboxServices').factory('RulesEngine', function(
       key: 'mark-contacts-dirty',
       filter: change => !!change.doc && (ContactTypes.includes(change.doc) || isReport(change.doc)),
       callback: change => {
-        const subjectIds = isReport(change.doc) ? registrationUtils.getSubjectIds(change.doc) : [ change.id ];
+        const subjectIds = isReport(change.doc) ? registrationUtils.getSubjectId(change.doc) : change.id;
         const telemetryData = telemetryEntry('rules-engine:update-emissions', true);
         return RulesEngineCore
           .updateEmissionsFor(subjectIds)

--- a/webapp/tests/karma/unit/services/rules-engine.js
+++ b/webapp/tests/karma/unit/services/rules-engine.js
@@ -217,7 +217,7 @@ describe(`RulesEngine service`, () => {
           expect(change.filter(changeFeedFormat(scenario.doc))).to.be.true;
           await change.callback(changeFeedFormat(scenario.doc));
           expect(RulesEngineCore.updateEmissionsFor.callCount).to.eq(1);
-          expect(RulesEngineCore.updateEmissionsFor.args[0][0]).to.deep.eq([scenario.expected]);
+          expect(RulesEngineCore.updateEmissionsFor.args[0][0]).to.deep.eq(scenario.expected);
           expect(Telemetry.record.callCount).to.equal(2);
           expect(Telemetry.record.args[1][0]).to.equal('rules-engine:update-emissions');
         });


### PR DESCRIPTION
Makes that a report will only be allowed to generate tasks for one contact!

So, instead of broadening the scope when calculating (which would have been a deep rabbit-hole), i'm tightening it. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
