### PR TITLE
Removing unneeded test target

### DIFF
--- a/tests/e2e/sentinel/schedules/purging.spec.js
+++ b/tests/e2e/sentinel/schedules/purging.spec.js
@@ -224,14 +224,6 @@ const tasks = [
 const latestTargetInterval = moment().subtract(7, 'months').format('YYYY-MM');
 const targets = [
   {
-    _id: `target~${moment().subtract(8, 'months').format('YYYY-MM')}~org.couchdb.user:user2`,
-    type: 'target',
-    user: 'org.couchdb.user:user2',
-    owner: 'fixture:user:user2',
-    reporting_period: moment().subtract(8, 'months').format('YYYY-MM'),
-    targets: [],
-  },
-  {
     _id: `target~${moment().subtract(9, 'months').format('YYYY-MM')}~org.couchdb.user:user2`,
     type: 'target',
     user: 'org.couchdb.user:user2',


### PR DESCRIPTION
Which causes tests to spuriously fail on the 1st and 2nd of the month