### PR TITLE
Replace images loaders on addrepeat

### DIFF
--- a/demo-forms/multimedia-repeats.xml
+++ b/demo-forms/multimedia-repeats.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>Repeat with image</h:title>
+    <model>
+      <itext>
+        <translation lang="en">
+          <text id="/repeat/image_out:label">
+            <value>Image outside repeat group</value>
+            <value form="image">jr://mark.png</value>
+          </text>
+          <text id="/repeat/num_repeat:label">
+            <value>Repeat for how many times?</value>
+          </text>
+          <text id="/repeat/repeat/image_in:label">
+            <value>Image inside repeat group</value>
+            <value form="image">jr://mark.png</value>
+          </text>
+          <text id="/repeat/repeat:label">
+            <value>REPEAT</value>
+          </text>
+        </translation>
+        <translation lang="fr">
+          <text id="/repeat/image_out:label">
+            <value>Image outside repeat group</value>
+            <value form="image">jr://mark.png</value>
+          </text>
+          <text id="/repeat/num_repeat:label">
+            <value>Repeat for how many times?</value>
+          </text>
+          <text id="/repeat/repeat/image_in:label">
+            <value>Image inside repeat group</value>
+            <value form="image">jr://mark.png</value>
+          </text>
+          <text id="/repeat/repeat:label">
+            <value>REPEAT</value>
+          </text>
+        </translation>
+      </itext>
+      <instance>
+        <repeat delimiter="#" id="repeat" prefix="J1!repeat!" version="2020-05-28 18:22:41">
+          <image_out/>
+          <num_repeat/>
+          <repeat_count/>
+          <repeat jr:template="">
+            <image_in/>
+          </repeat>
+          <meta tag="hidden">
+            <instanceID/>
+          </meta>
+        </repeat>
+      </instance>
+      <instance id="contact-summary"/>
+      <bind nodeset="/repeat/image_out" readonly="true()" type="string"/>
+      <bind nodeset="/repeat/num_repeat" type="int"/>
+      <bind calculate=" /repeat/num_repeat " nodeset="/repeat/repeat_count" readonly="true()" type="string"/>
+      <bind nodeset="/repeat/repeat/image_in" readonly="true()" type="string"/>
+      <bind calculate="concat('uuid:', uuid())" nodeset="/repeat/meta/instanceID" readonly="true()" type="string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input accuracyThreshold="1.5" ref="/repeat/image_out">
+      <label ref="jr:itext('/repeat/image_out:label')"/>
+    </input>
+    <input ref="/repeat/num_repeat">
+      <label ref="jr:itext('/repeat/num_repeat:label')"/>
+    </input>
+    <group ref="/repeat/repeat">
+      <label ref="jr:itext('/repeat/repeat:label')"/>
+      <repeat jr:count=" /repeat/repeat_count " nodeset="/repeat/repeat">
+        <input ref="/repeat/repeat/image_in">
+          <label ref="jr:itext('/repeat/repeat/image_in:label')"/>
+        </input>
+      </repeat>
+    </group>
+  </h:body>
+</h:html>


### PR DESCRIPTION
When Enketo fires the addrepeat event it inits the widgets on the
new HTML so we should replace the image loaders at the same time.

medic/cht-core#6450

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
