### PR TITLE
Adds report replication depth

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -54,14 +54,13 @@ const hasAccessToUnassignedDocs = (userCtx) => {
 const includeSubjects = (authorizationContext, newSubjects, depth) => {
   const initialSubjectsCount = authorizationContext.subjectIds.length;
   newSubjects.forEach(subject => {
-    if (!subject) {
+    if (!subject || authorizationContext.subjectIds.includes(subject)) {
       return;
     }
 
     authorizationContext.subjectsDepth[subject] = depth;
     authorizationContext.subjectIds.push(subject);
   });
-  authorizationContext.subjectIds = _.uniq(authorizationContext.subjectIds);
 
   return authorizationContext.subjectIds.length !== initialSubjectsCount;
 };

--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -15,34 +15,55 @@ const couchDbUser = doc => doc.type === 'user-settings';
 const getUserSettingsId = username => `org.couchdb.user:${username}`;
 
 const getDepth = (userCtx) => {
+  const depth = {
+    contactDepth: -1,
+    reportDepth: -1,
+  };
+
   if (!userCtx.roles || !userCtx.roles.length) {
-    return -1;
+    return depth;
   }
 
   const settings = config.get('replication_depth');
   if (!settings) {
-    return -1;
+    return depth;
   }
-  let depth = -1;
+
   userCtx.roles.forEach(function(role) {
     // find the role with the deepest depth
     const setting = settings.find(setting => setting.role === role);
     const settingDepth = setting && parseInt(setting.depth, 10);
-    if (!isNaN(settingDepth) && settingDepth > depth) {
-      depth = settingDepth;
+    const settingsReportDepth = setting && parseInt(setting.report_depth);
+    if (!isNaN(depth.contactDepth) && settingDepth > depth.contactDepth) {
+      depth.contactDepth = settingDepth;
+      depth.reportDepth = !isNaN(settingsReportDepth) ? settingsReportDepth : -1;
     }
   });
+
   return depth;
 };
+
+const usesReportDepth = (authorizationContext) => authorizationContext.reportDepth >= 0;
 
 const hasAccessToUnassignedDocs = (userCtx) => {
   return config.get('district_admins_access_unallocated_messages') &&
          auth.hasAllPermissions(userCtx, 'can_view_unallocated_data_records');
 };
 
-const include = (array, ...values) => {
+const include = ({ subjectIds, subjectsDepth }, values, valueDepth) => {
   let newValues = 0;
-  values.forEach(value => value && array.indexOf(value) === -1 && array.push(value) && newValues++);
+  values.forEach(value => {
+    if (!value) {
+      return;
+    }
+
+    subjectsDepth[value] = valueDepth;
+    if (!subjectIds.includes(value)) {
+      subjectIds.push(value);
+      newValues++;
+    }
+  });
+
   return newValues;
 };
 
@@ -50,9 +71,19 @@ const exclude = (array, ...values) => {
   return array.filter(value => values.indexOf(value) === -1);
 };
 
+// gets the depth of a contact, relative to the user's facility
+const getContactDepth = (authorizationContext, contactsByDepth) => {
+  const depthEntry = contactsByDepth.find(entry =>
+    entry[0].length === 2 &&
+    entry[0][0] === authorizationContext.userCtx.facility_id
+  );
+  return depthEntry && depthEntry[0][1];
+};
+
 // Updates authorizationContext.subjectIds, including or excluding tested contact `subjectId` and `docId`
 // @param   {Boolean} allowed - whether subjects should be included or excluded
 // @param   {Array}   authorizationContext.subjectIds - allowed subjectIds.
+// @param   {Object}  authorizationContext.subjectsByDepth
 // @param   {Array}   viewValues.contactsByDepth - results of `medic/contacts_by_depth` view against doc
 // @returns {Boolean} whether new subjectIds were added to authorizationContext
 const updateContext = (allowed, authorizationContext, { contactsByDepth }) => {
@@ -61,10 +92,11 @@ const updateContext = (allowed, authorizationContext, { contactsByDepth }) => {
     const [[[ docId ], subjectId ]] = contactsByDepth;
 
     if (allowed) {
-      return !!include(authorizationContext.subjectIds, subjectId, docId);
+      const contactDepth = getContactDepth(authorizationContext, contactsByDepth);
+      return !!include(authorizationContext, [subjectId, docId], contactDepth);
     }
 
-    authorizationContext.subjectIds = exclude(authorizationContext.subjectIds, subjectId, docId );
+    authorizationContext.subjectIds = exclude(authorizationContext.subjectIds, subjectId, docId);
     return false;
   }
 
@@ -98,6 +130,7 @@ const allowedDoc = (docId, authorizationContext, { replicationKeys, contactsByDe
   }
 
   //it's a report, task or target
+  const allowedDepth = isAllowedDepth(authorizationContext, replicationKeys);
   return replicationKeys.some(replicationKey => {
     const [ subjectId, { submitter: submitterId } ] = replicationKey;
     const allowedSubmitter = submitterId && authorizationContext.subjectIds.indexOf(submitterId) !== -1;
@@ -105,7 +138,9 @@ const allowedDoc = (docId, authorizationContext, { replicationKeys, contactsByDe
       return true;
     }
     const allowedSubject = subjectId && authorizationContext.subjectIds.indexOf(subjectId) !== -1;
-    return allowedSubject && !isSensitive(authorizationContext.userCtx, subjectId, submitterId, allowedSubmitter);
+    return allowedSubject &&
+           !isSensitive(authorizationContext.userCtx, subjectId, submitterId, allowedSubmitter) &&
+           allowedDepth;
   });
 };
 
@@ -166,30 +201,53 @@ const allowedContact = (contactsByDepth, userContactsByDepthKeys) => {
   return viewResultKeys.some(viewResult => userContactsByDepthKeys.some(generated => _.isEqual(viewResult, generated)));
 };
 
-const getContextObject = (userCtx) => ({
-  userCtx,
-  contactsByDepthKeys: getContactsByDepthKeys(userCtx, module.exports.getDepth(userCtx)),
-  subjectIds: [ ALL_KEY, getUserSettingsId(userCtx.name) ]
-});
+const getContextObject = (userCtx) => {
+  const { contactDepth, reportDepth } = getDepth(userCtx);
+  const subjectsDepth = {};
+  return {
+    userCtx,
+    contactsByDepthKeys: getContactsByDepthKeys(userCtx, contactDepth),
+    subjectIds: [ ALL_KEY, getUserSettingsId(userCtx.name) ],
+    contactDepth,
+    reportDepth,
+    subjectsDepth,
+  };
+};
+
+const getContactSubjects = (row) => {
+  const subjects = [];
+
+  if (tombstoneUtils.isTombstoneId(row.id)) {
+    subjects.push(tombstoneUtils.extractStub(row.id).id);
+  } else {
+    subjects.push(row.id);
+  }
+
+  if (row.value) {
+    subjects.push(row.value);
+  }
+
+  return subjects;
+};
 
 const getAuthorizationContext = (userCtx) => {
   const authorizationCtx = getContextObject(userCtx);
 
   return db.medic.query('medic/contacts_by_depth', { keys: authorizationCtx.contactsByDepthKeys }).then(results => {
     results.rows.forEach(row => {
-      if (tombstoneUtils.isTombstoneId(row.id)) {
-        authorizationCtx.subjectIds.push(tombstoneUtils.extractStub(row.id).id);
-      } else {
-        authorizationCtx.subjectIds.push(row.id);
-      }
-      if (row.value) {
-        authorizationCtx.subjectIds.push(row.value);
+      const subjects = getContactSubjects(row);
+      authorizationCtx.subjectIds.push(...subjects);
+
+      if (authorizationCtx.reportDepth >= 0) {
+        const subjectDepth = row.key[1];
+        subjects.forEach(subject => authorizationCtx.subjectsDepth[subject] = subjectDepth);
       }
     });
 
     authorizationCtx.subjectIds = _.uniq(authorizationCtx.subjectIds);
     if (hasAccessToUnassignedDocs(userCtx)) {
       authorizationCtx.subjectIds.push(UNASSIGNED_KEY);
+      authorizationCtx.subjectsDepth[UNASSIGNED_KEY] = 0;
     }
     return authorizationCtx;
   });
@@ -314,10 +372,14 @@ const getScopedAuthorizationContext = (userCtx, scopeDocsCtx = []) => {
         return;
       }
 
-      authorizationCtx.subjectIds.push(getContactUuid(viewResults));
+      const contactDepth = getContactDepth(authorizationCtx, viewResults.contactsByDepth);
+      const contactUuid = getContactUuid(viewResults);
+      authorizationCtx.subjectIds.push(contactUuid);
+      authorizationCtx.subjectsDepth[contactUuid] = contactDepth;
       const shortcode = getContactShortcode(viewResults);
       if (shortcode) {
         authorizationCtx.subjectIds.push(shortcode);
+        authorizationCtx.subjectsDepth[shortcode] = contactDepth;
       }
     });
 
@@ -344,10 +406,62 @@ const isSensitive = function(userCtx, subject, submitter, allowedSubmitter) {
   return !allowedSubmitter;
 };
 
+/**
+ * Returns whether a doc should be visible, depending on configured replication_depth.report_depth.
+ * We're receiving all relevant replication keys to check whether at least one is of valid depth.
+ * In cases of reports with `needs_signoff`, the replication key of valid depth might be at facility level, but that
+ * key would be marked as sensitive.
+ * @param {Object} authorizationContext
+ * @param {Object} authorizationContext.subjectsDepth
+ * @param {number} authorizationContext.subjectsDepth.subject - relative depth of every contact the user can see
+ * @param {Object} authorizationContext.reportDepth - the maximum allowed depth for replicated reports
+ * @param {Array[]} replicationKeys - array of pairs of subject + value, emitted by docs_by_replication_keys view
+ * @returns {boolean}
+ */
+const isAllowedDepth = (authorizationContext, replicationKeys) => {
+  if (!usesReportDepth(authorizationContext)) {
+    // no depth limitation
+    return true;
+  }
+
+  const docType = replicationKeys[0][1].type;
+  if (docType !== 'data_record') {
+    // allow everything that's not a data_record through (f.e. targets)
+    return true;
+  }
+
+  return replicationKeys.some(replicationKey => {
+    const [ subject, { submitter } ] = replicationKey;
+    if (submitter === authorizationContext.userCtx.contact_id) {
+      // current user is the submitter
+      return true;
+    }
+
+    return authorizationContext.subjectsDepth[subject] <= authorizationContext.reportDepth;
+  });
+};
+
+const getViewResultsById = (viewResult) => {
+  const mapById = {};
+  viewResult.rows.forEach(row => {
+    if (!mapById[row.id]) {
+      mapById[row.id] = [];
+    }
+
+    mapById[row.id].push([row.key, row.value]);
+  });
+  return mapById;
+};
+
 const getAllowedDocIds = (feed, { includeTombstones = true } = {}) => {
   return db.medic.query('medic/docs_by_replication_key', { keys: feed.subjectIds }).then(results => {
     const validatedIds = [MEDIC_CLIENT_DDOC, getUserSettingsId(feed.userCtx.name)];
     const tombstoneIds = [];
+
+    let viewResultsById = {};
+    if (usesReportDepth(feed)) {
+      viewResultsById = getViewResultsById(results);
+    }
 
     results.rows.forEach(row => {
       if (isSensitive(feed.userCtx, row.key, row.value.submitter, feed.subjectIds.includes(row.value.submitter))) {
@@ -358,7 +472,9 @@ const getAllowedDocIds = (feed, { includeTombstones = true } = {}) => {
         return includeTombstones && tombstoneIds.push(row.id);
       }
 
-      validatedIds.push(row.id);
+      if (!usesReportDepth(feed) || isAllowedDepth(feed, viewResultsById[row.id])) {
+        validatedIds.push(row.id);
+      }
     });
 
     // only include tombstones if the winning rev of the document is deleted
@@ -396,7 +512,6 @@ const isAuthChange = (docId, userCtx, { couchDbUser }) => {
 module.exports = {
   isAuthChange: isAuthChange,
   allowedDoc: allowedDoc,
-  getDepth: getDepth,
   getViewResults: getViewResults,
   getAuthorizationContext: getAuthorizationContext,
   getAllowedDocIds: getAllowedDocIds,

--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -90,7 +90,7 @@ const updateContext = (allowed, authorizationContext, { contactsByDepth }) => {
   }
 
   //first element of `contactsByDepth` contains both `subjectId` and `docID`
-  const { key: [ docId ], value: subjectId } = contactsByDepth[0];
+  const [{ key: [ docId ], value: subjectId }] = contactsByDepth;
 
   if (allowed) {
     const contactDepth = getContactDepth(authorizationContext, contactsByDepth);
@@ -417,7 +417,7 @@ const isAllowedDepth = (authorizationContext, replicationKeys) => {
     return true;
   }
 
-  const docType = replicationKeys[0].value.type;
+  const [{ value: { type: docType } = {} }] = replicationKeys;
   if (docType !== 'data_record') {
     // allow everything that's not a data_record through (f.e. targets)
     return true;

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -66,7 +66,6 @@ describe('Changes controller', () => {
 
     sinon.stub(authorization, 'getViewResults').returns({});
     sinon.stub(authorization, 'allowedDoc');
-    sinon.stub(authorization, 'getDepth').returns(1);
     sinon.stub(authorization, 'getAuthorizationContext').resolves({ userCtx });
     sinon.stub(authorization, 'getAllowedDocIds').resolves({});
     sinon.stub(authorization, 'isAuthChange').returns(false);

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -496,13 +496,18 @@ describe('Authorization service', () => {
     });
 
     it('returns true for `allowed for all` docs', () => {
-      service.allowedDoc(null, { userCtx }, { replicationKeys: [['_all', {}]], contactsByDepth: null })
+      service
+        .allowedDoc(null, { userCtx }, { replicationKeys: [{ key: '_all', value: null }], contactsByDepth: null })
         .should.equal(true);
     });
 
     it('returns true when it is main ddoc or user contact', () => {
       service
-        .allowedDoc('_design/medic-client', { userCtx }, { replicationKeys: [['_all', {}]], contactsByDepth: null })
+        .allowedDoc(
+          '_design/medic-client',
+          { userCtx },
+          { replicationKeys: [{ key: '_all', value: null}], contactsByDepth: null}
+        )
         .should.equal(true);
       service
         .allowedDoc('org.couchdb.user:' + userCtx.name, { userCtx }, { replicationKeys: null, contactsByDepth: null })
@@ -511,7 +516,10 @@ describe('Authorization service', () => {
 
     describe('allowedContact', () => {
       beforeEach(() => {
-        viewResults = { replicationKeys: [[['a', {}]]], contactsByDepth: [['parent1'], 'patient_id'] };
+        viewResults = {
+          replicationKeys: [{ key: 'a', value: {} }],
+          contactsByDepth: [{ key: ['parent1'], value: 'patient_id' }],
+        };
         feed = { userCtx, contactsByDepthKeys: [[userCtx.facility_id]], subjectIds };
         keysByDepth = {
           0: [[userCtx.facility_id, 0]],
@@ -524,56 +532,56 @@ describe('Authorization service', () => {
 
       it('returns true for valid contacts', () => {
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 2], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 2], value: 'patient_id' }
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [[userCtx.facility_id], null], [[userCtx.facility_id, 0], null]
+          { key: [userCtx.facility_id], value: null }, { key: [userCtx.facility_id, 0], value: null }
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 1], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 1], value: 'patient_id' }
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [['parent2'], 'patient_id'], [['parent2', 2], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 3], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: ['parent2'], value: 'patient_id' }, { key: ['parent2', 2], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 3], value: 'patient_id' }
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
       });
 
       it('returns false for not allowed contacts', () => {
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [['parent2'], 'patient_id'], [['parent2', 2], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: ['parent2'], value: 'patient_id' }, { key: ['parent2', 2], value: 'patient_id' }
         ];
         service.allowedDoc(contact, feed, viewResults).should.equal(false);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
         ];
         service.allowedDoc(contact, feed, viewResults).should.equal(false);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
         ];
         service.allowedDoc(contact, feed, viewResults).should.equal(false);
       });
 
       it('respects depth', () => {
         viewResults.contactsByDepth = [
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id']
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' }
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
         service
@@ -584,9 +592,9 @@ describe('Authorization service', () => {
           .should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact_id'], 'patient_id'], [['contact_id', 0], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 1], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 2], 'patient_id']
+          { key: ['contact_id'], value: 'patient_id' }, { key: ['contact_id', 0], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 1], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 2], value: 'patient_id' }
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
         service
@@ -597,9 +605,9 @@ describe('Authorization service', () => {
           .should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 2], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 2], value: 'patient_id' },
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
         service
@@ -613,10 +621,10 @@ describe('Authorization service', () => {
           .should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [['parent2'], 'patient_id'], [['parent2', 2], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 3], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: ['parent2'], value: 'patient_id' }, { key: ['parent2', 2], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 3], value: 'patient_id' },
         ];
         service.allowedDoc(contact, feed, viewResults).should.deep.equal(true);
         service
@@ -635,8 +643,8 @@ describe('Authorization service', () => {
 
       it('should ignore report depth', () => {
         viewResults.contactsByDepth = [
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
         ];
         const ctx = { userCtx, subjectIds, contactsByDepthKeys: [[userCtx.facility_id]], reportDepth: 0 };
 
@@ -648,9 +656,9 @@ describe('Authorization service', () => {
         service.allowedDoc(contact, ctx, viewResults).should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact_id'], 'patient_id'], [['contact_id', 0], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 1], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 2], 'patient_id'],
+          { key: ['contact_id'], value: 'patient_id' }, { key: ['contact_id', 0], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 1], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 2], value: 'patient_id' },
         ];
 
         ctx.contactsByDepthKeys = keysByDepth[0];
@@ -661,9 +669,9 @@ describe('Authorization service', () => {
         service.allowedDoc(contact, ctx, viewResults).should.deep.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 2], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 2], value: 'patient_id' },
         ];
 
         ctx.contactsByDepthKeys = keysByDepth[0];
@@ -684,7 +692,7 @@ describe('Authorization service', () => {
       it('returns true for reports with unknown subject and allowed submitter', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', 'submitter' ];
         viewResults = {
-          replicationKeys: [[false, { submitter: 'submitter', type: 'data_record' }]],
+          replicationKeys: [{ key: false, value:  { submitter: 'submitter', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -693,7 +701,7 @@ describe('Authorization service', () => {
       it('returns false for reports with unknown subject and denied submitter', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact' ];
         viewResults = {
-          replicationKeys: [[false, { submitter: 'submitter', type: 'data_record' }]],
+          replicationKeys: [{ key: false, value: { submitter: 'submitter', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
@@ -701,14 +709,17 @@ describe('Authorization service', () => {
 
       it('returns false for reports with denied subject and unknown submitter', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact' ];
-        viewResults = { replicationKeys: [['subject2', { type: 'data_record' }]], contactsByDepth: [] };
+        viewResults = {
+          replicationKeys: [{ key: 'subject2', value: { type: 'data_record' }}],
+          contactsByDepth: []
+        };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
       });
 
       it('returns false for reports with denied subject and allowed submitter', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact' ];
         viewResults = {
-          replicationKeys: [['subject2', { submitter: 'contact', type: 'data_record' }]],
+          replicationKeys: [{ key: 'subject2', value: { submitter: 'contact', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
@@ -717,7 +728,7 @@ describe('Authorization service', () => {
       it('returns true for reports with allowed subject and unknown submitter', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact' ];
         viewResults = {
-          replicationKeys: [['subject', { type: 'data_record' }]],
+          replicationKeys: [{ key: 'subject', value: { type: 'data_record' }}],
           contactsByDepth: false,
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -726,7 +737,7 @@ describe('Authorization service', () => {
       it('returns true for reports with allowed subject, denied submitter and not sensitive', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact' ];
         viewResults = {
-          replicationKeys: [['subject', { submitter: 'submitter', type: 'data_record' }]],
+          replicationKeys: [{ key: 'subject', value: { submitter: 'submitter', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -735,7 +746,7 @@ describe('Authorization service', () => {
       it('returns true for reports with allowed subject, allowed submitter and not sensitive', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact' ];
         viewResults = {
-          replicationKeys: [['subject', { submitter: 'contact', type: 'data_record' }]],
+          replicationKeys: [{ key: 'subject', value: { submitter: 'contact', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -744,14 +755,14 @@ describe('Authorization service', () => {
       it('returns false for reports with allowed subject, denied submitter and sensitive', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.contact_id ];
         viewResults = {
-          replicationKeys: [[userCtx.contact_id, { submitter: 'submitter', type: 'data_record' }]],
+          replicationKeys: [{ key: userCtx.contact_id, value: { submitter: 'submitter', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
 
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.facility_id ];
         viewResults = {
-          replicationKeys: [[userCtx.facility_id, { submitter: 'submitter', type: 'data_record' }]],
+          replicationKeys: [{ key: userCtx.facility_id, value: { submitter: 'submitter', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
@@ -760,14 +771,14 @@ describe('Authorization service', () => {
       it('returns true for reports with allowed subject, allowed submitter and about user`s contact or place', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.contact_id ];
         viewResults = {
-          replicationKeys: [[userCtx.contact_id, { submitter: 'contact', type: 'data_record' }]],
+          replicationKeys: [{ key: userCtx.contact_id, value: { submitter: 'contact', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
 
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.facility_id ];
         viewResults = {
-          replicationKeys: [[userCtx.facility_id, { submitter: 'contact', type: 'data_record' }]],
+          replicationKeys: [{ key: userCtx.facility_id, value: { submitter: 'contact', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -779,19 +790,21 @@ describe('Authorization service', () => {
         feed.subjectsDepth = { parent: 0, contact: 1, place: 1, chw: 2, patient: 3 };
 
         viewResults = {
-          replicationKeys: [[userCtx.facility_id, { submitter: 'contact_id', type: 'data_record' }]], // depth 0
+          // depth 0
+          replicationKeys: [{ key: userCtx.facility_id, value: { submitter: 'contact_id', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
 
         viewResults = {
-          replicationKeys: [['place', { submitter: 'submitter', type: 'data_record' }]], // depth 1
+          // depth 1
+          replicationKeys: [{ key: 'place', value: { submitter: 'submitter', type: 'data_record' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
 
         viewResults = {
-          replicationKeys: [['chw', { submitter: 'submitter', type: 'data_record' }]], // depth 2
+          replicationKeys: [{ key: 'chw', value: { submitter: 'submitter', type: 'data_record' }}], // depth 2
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -803,7 +816,7 @@ describe('Authorization service', () => {
         feed.subjectsDepth = { facility_id: 0, contact_id: 1, place: 1, chw: 2, patient: 3 };
 
         viewResults = {
-          replicationKeys: [['patient', { submitter: 'submitter', type: 'data_record' }]], // depth 3
+          replicationKeys: [{ key: 'patient', value: { submitter: 'submitter', type: 'data_record' }}], // depth 3
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
@@ -815,7 +828,7 @@ describe('Authorization service', () => {
         feed.subjectsDepth = { facility_id: 0, contact_id: 1, place: 1, chw: 2, patient: 3 };
 
         viewResults = {
-          replicationKeys: [['patient', { submitter: 'contact_id', type: 'data_record' }]], // depth 3
+          replicationKeys: [{ key: 'patient', value: { submitter: 'contact_id', type: 'data_record' }}], // depth 3
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -828,8 +841,10 @@ describe('Authorization service', () => {
 
         viewResults = {
           replicationKeys: [
-            ['place', { submitter: 'some_submitter', type: 'data_record' }], // depth 1
-            ['facility_id', { submitter: 'some_submitter', type: 'data_record' }], // depth 0 but "sensitive"
+            // depth 1
+            { key: 'place', value: { submitter: 'some_submitter', type: 'data_record' }},
+            // depth 0 but "sensitive"
+            { key: 'facility_id', value: { submitter: 'some_submitter', type: 'data_record' }},
           ],
           contactsByDepth: [],
         };
@@ -842,7 +857,7 @@ describe('Authorization service', () => {
       it('should return true for own task', () => {
         feed.subjectIds = [ 'facility_id', 'contact_id', 'org.couchdb.user:user' ];
         viewResults = {
-          replicationKeys: [['org.couchdb.user:user', { type: 'task' }]],
+          replicationKeys: [{ key: 'org.couchdb.user:user', value: { type: 'task' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
@@ -851,7 +866,7 @@ describe('Authorization service', () => {
       it('should return false for unowned task', () => {
         feed.subjectIds = [ 'facility_id', 'contact_id', 'org.couchdb.user:user' ];
         viewResults = {
-          replicationKeys: [['org.couchdb.user:otheruser', { type: 'task' }]],
+          replicationKeys: [{ key: 'org.couchdb.user:otheruser', value: { type: 'task' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
@@ -860,19 +875,19 @@ describe('Authorization service', () => {
       it('should return true for known contacts targets', () => {
         feed.subjectIds = [ 'facility_id', 'contact_id', 'org.couchdb.user:user', 'chw1', 'chw2' ];
         viewResults = {
-          replicationKeys: [['contact_id', { type: 'target' }]],
+          replicationKeys: [{ key: 'contact_id', value: { type: 'target' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
 
         viewResults = {
-          replicationKeys: [['chw1', { type: 'target' }]],
+          replicationKeys: [{ key: 'chw1', value: { type: 'target' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(true);
 
         viewResults = {
-          replicationKeys: [['chw2', { type: 'target' }]],
+          replicationKeys: [{ key: 'chw2', value: { type: 'target' }}],
           contactsByDepth: [],
         };
         const ctx = Object.assign(
@@ -885,13 +900,13 @@ describe('Authorization service', () => {
       it('should return false for unknown contacts targets', () => {
         feed.subjectIds = [ 'facility_id', 'contact_id', 'org.couchdb.user:user', 'chw1', 'chw2' ];
         viewResults = {
-          replicationKeys: [['omg1', { type: 'target' }]],
+          replicationKeys: [{ key: 'omg1', value: { type: 'target' }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
 
         viewResults = {
-          replicationKeys: [['omg2', { type: 'target' }]],
+          replicationKeys: [{ key: 'omg2', value: { type: 'target' }}],
           contactsByDepth: [],
         };
         const ctx = Object.assign(
@@ -904,7 +919,7 @@ describe('Authorization service', () => {
 
     describe('updateContext', () => {
       beforeEach(() => {
-        viewResults = { contactsByDepth: [['parent1'], 'patient_id'] };
+        viewResults = { contactsByDepth: [{ key: ['parent1'], value: 'patient_id'}] };
         feed = { userCtx, contactsByDepthKeys: [[userCtx.facility_id]], subjectIds, subjectsDepth: {} };
         keysByDepth = {
           0: [[userCtx.facility_id, 0]],
@@ -917,48 +932,49 @@ describe('Authorization service', () => {
 
       it('returns nbr of new subjects for allowed contacts', () => {
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 2], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 2], value: 'patient_id' },
         ];
         service.updateContext(true, feed, viewResults).should.equal(true);
 
         viewResults.contactsByDepth = [
-          [[userCtx.facility_id], null], [[userCtx.facility_id, 0], null]
+          { key: [userCtx.facility_id], value: null },
+          { key: [userCtx.facility_id, 0], value: null },
         ];
         service.updateContext(true, feed, viewResults).should.equal(true);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 1], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id'}, { key: [userCtx.facility_id, 1], value: 'patient_id' },
         ];
         service.updateContext(true, feed, viewResults).should.equal(false);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [['parent2'], 'patient_id'], [['parent2', 2], 'patient_id'],
-          [[userCtx.facility_id], 'patient_id'], [[userCtx.facility_id, 3], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: ['parent2'], value: 'patient_id' }, { key: ['parent2', 2], value: 'patient_id' },
+          { key: [userCtx.facility_id], value: 'patient_id' }, { key: [userCtx.facility_id, 3], value: 'patient_id' },
         ];
         service.updateContext(true, feed, viewResults).should.equal(false);
       });
 
       it('returns false for not allowed contacts', () => {
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
-          [['parent2'], 'patient_id'], [['parent2', 2], 'patient_id']
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
+          { key: ['parent2'], value: 'patient_id' }, { key: ['parent2', 2], value: 'patient_id' },
         ];
         service.updateContext(false, feed, viewResults).should.equal(false);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
         ];
         service.updateContext(false, feed, viewResults).should.equal(false);
 
         viewResults.contactsByDepth = [
-          [['contact'], 'patient_id'], [['contact', 0], 'patient_id'],
-          [['parent1'], 'patient_id'], [['parent1', 1], 'patient_id'],
+          { key: ['contact'], value: 'patient_id' }, { key: ['contact', 0], value: 'patient_id' },
+          { key: ['parent1'], value: 'patient_id' }, { key: ['parent1', 1], value: 'patient_id' },
         ];
         service.updateContext(false, feed, viewResults).should.equal(false);
       });
@@ -966,8 +982,10 @@ describe('Authorization service', () => {
       it('adds valid contact _id and reference to subjects list, while keeping them unique', () => {
         feed.subjectIds = [];
         viewResults.contactsByDepth = [
-          [['new_contact_id'], 'new_patient_id'], [['new_contact_id', 0], 'new_patient_id'],
-          [[userCtx.facility_id], 'new_patient_id'], [[userCtx.facility_id, 1], 'new_patient_id']
+          { key: ['new_contact_id'], value: 'new_patient_id' },
+          { key: ['new_contact_id', 0], value: 'new_patient_id' },
+          { key: [userCtx.facility_id], value: 'new_patient_id' },
+          { key: [userCtx.facility_id, 1], value:  'new_patient_id' }
         ];
 
         service.updateContext(true, feed, viewResults).should.equal(true);
@@ -979,8 +997,10 @@ describe('Authorization service', () => {
         feed.subjectsDepth.should.deep.equal({ new_patient_id: 1, new_contact_id: 1 });
 
         viewResults.contactsByDepth = [
-          [['second_new_contact_id'], 'second_patient_id'], [['second_new_contact_id', 0], 'second_patient_id'],
-          [['parent1'], 'second_patient_id'], [['parent1', 1], 'second_patient_id']
+          { key: ['second_new_contact_id'], value: 'second_patient_id' },
+          { key: ['second_new_contact_id', 0], value: 'second_patient_id' },
+          { key: ['parent1'], value: 'second_patient_id' },
+          { key: ['parent1', 1], value: 'second_patient_id' },
         ];
         service.updateContext(false, feed, viewResults).should.equal(false);
         feed.subjectIds.should.deep.equal(['new_patient_id', 'new_contact_id']);
@@ -991,8 +1011,10 @@ describe('Authorization service', () => {
         feed.subjectIds = ['person_id', 'person_id', 'contact_id', 'person_ref', 'contact_id', 'person_ref', 's'];
 
         viewResults.contactsByDepth = [
-          [['person_id'], 'person_ref'], [['person_id', 0], 'person_ref'],
-          [['parent1'], 'person_ref'], [['parent1', 1], 'person_ref']
+          { key: ['person_id'], value: 'person_ref' },
+          { key: ['person_id', 0], value: 'person_ref' },
+          { key: ['parent1'], value: 'person_ref' },
+          { key: ['parent1', 1], value: 'person_ref' },
         ];
 
         service.updateContext(false, feed, viewResults).should.equal(false);
@@ -1003,19 +1025,26 @@ describe('Authorization service', () => {
         feed.subjectIds = [];
 
         viewResults.contactsByDepth = [
-          [['person_id'], 'person_ref'], [['person_id', 0], 'person_ref'],
-          [['clinic_id'], 'person_ref'], [['clinic_id', 1], 'person_ref'],
-          [['hc_id'], 'person_ref'], [['hc_id', 2], 'person_ref'],
-          [['facility_id'], 'person_ref'], [['facility_id', 3], 'person_ref'],
+          { key: ['person_id'], value: 'person_ref' },
+          { key: ['person_id', 0], value: 'person_ref' },
+          { key: ['clinic_id'], value: 'person_ref' },
+          { key: ['clinic_id', 1], value: 'person_ref' },
+          { key: ['hc_id'], value: 'person_ref' },
+          { key: ['hc_id', 2], value: 'person_ref' },
+          { key: ['facility_id'], value: 'person_ref' },
+          { key: ['facility_id', 3], value: 'person_ref' },
         ];
         service.updateContext(true, feed, viewResults).should.equal(true);
         feed.subjectIds.should.have.deep.members(['person_id', 'person_ref']);
         feed.subjectsDepth.should.deep.equal({ person_id: 3, person_ref: 3 });
 
         viewResults.contactsByDepth = [
-          [['clinic_id'], 'clinic_ref'], [['clinic_id', 0], 'clinic_ref'],
-          [['hc_id'], 'clinic_ref'], [['hc_id', 1], 'clinic_ref'],
-          [['facility_id'], 'clinic_ref'], [['facility_id', 2], 'clinic_ref'],
+          { key: ['clinic_id'], value: 'clinic_ref' },
+          { key: ['clinic_id', 0], value: 'clinic_ref' },
+          { key: ['hc_id'], value: 'clinic_ref' },
+          { key: ['hc_id', 1], value: 'clinic_ref' },
+          { key: ['facility_id'], value: 'clinic_ref' },
+          { key: ['facility_id', 2], value: 'clinic_ref' },
         ];
         service.updateContext(true, feed, viewResults).should.equal(true);
         feed.subjectIds.should.have.deep.members(['person_id', 'person_ref', 'clinic_id', 'clinic_ref']);
@@ -1025,8 +1054,10 @@ describe('Authorization service', () => {
         });
 
         viewResults.contactsByDepth = [
-          [['hc_id'], 'hc_ref'], [['hc_id', 0], 'hc_ref'],
-          [['facility_id'], 'hc_ref'], [['facility_id', 1], 'hc_ref'],
+          { key: ['hc_id'], value: 'hc_ref' },
+          { key: ['hc_id', 0], value: 'hc_ref' },
+          { key: ['facility_id'], value: 'hc_ref' },
+          { key: ['facility_id', 1], value: 'hc_ref' },
         ];
         service.updateContext(true, feed, viewResults).should.equal(true);
         feed.subjectIds.should.have.deep.members([
@@ -1080,20 +1111,20 @@ describe('Authorization service', () => {
     it('returns only allowed docs', () => {
 
       const docs = [
-        { id: 1, viewResults: { replicationKeys: [['_all']] } },
-        { id: 2, viewResults: { replicationKeys: [['_all']] } },
+        { id: 1, viewResults: { replicationKeys: [{ key: '_all' }] } },
+        { id: 2, viewResults: { replicationKeys: [{ key: '_all' }] } },
         { id: 3, viewResults: {} },
         { id: 4, viewResults: {} },
-        { id: 5, viewResults: { replicationKeys: [['_all']] } }
+        { id: 5, viewResults: { replicationKeys: [{ key: '_all' }] } }
       ];
 
       const results = service.filterAllowedDocs({ userCtx: {}, subjectIds: [ 1 ] }, docs);
 
       results.length.should.equal(3);
       results.should.deep.equal([
-        { id: 1, viewResults: { replicationKeys: [['_all']] } },
-        { id: 2, viewResults: { replicationKeys: [['_all']] } },
-        { id: 5, viewResults: { replicationKeys: [['_all']] } }
+        { id: 1, viewResults: { replicationKeys: [{ key: '_all' }] } },
+        { id: 2, viewResults: { replicationKeys: [{ key: '_all' }] } },
+        { id: 5, viewResults: { replicationKeys: [{ key: '_all' }] } }
       ]);
     });
 
@@ -1107,14 +1138,44 @@ describe('Authorization service', () => {
       const docs = [
         { id: 6, viewResults: {} },
         { id: 7, viewResults: {} },
-        { id: 8, viewResults: { replicationKeys: [['subject2', { submitter: 'a' }]], contactsByDepth: false } },
-        { id: 4, viewResults: { replicationKeys: [[1, { submitter: 'b' }]], contactsByDepth: false } },
+        {
+          id: 8,
+          viewResults: {
+            replicationKeys: [{ key: 'subject2', value: { submitter: 'a' }}],
+            contactsByDepth: false,
+          },
+        },
+        {
+          id: 4,
+          viewResults: {
+            replicationKeys: [{ key: 1, value: { submitter: 'b' }}],
+            contactsByDepth: false,
+          },
+        },
         { id: 5, viewResults: {} },
-        { id: 2, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[2, 0], 'subject2'], [['a']]] } },
-        { id: 3, viewResults: { replicationKeys: [[ '_all' ]]} },
-        { id: 1, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[1], 'subject1'], [['a']]] } },
+        {
+          id: 2,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [2, 0], value: 'subject2' }, { key: ['a'], value: null }],
+          },
+        },
+        { id: 3, viewResults: { replicationKeys: [{ key: '_all', value: null }] } },
+        {
+          id: 1,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject1' }, { key: ['a'], value: null }],
+          },
+        },
         { id: 9, viewResults: {}, allowed: true },
-        { id: 11, viewResults: { replicationKeys: [['subject2', { submitter: 'a' }]], contactsByDepth: false } },
+        {
+          id: 11,
+          viewResults: {
+            replicationKeys: [{ key: 'subject2', value: { submitter: 'a' }}],
+            contactsByDepth: false,
+          },
+        },
         { id: 10, viewResults: {} }
       ];
 
@@ -1122,13 +1183,43 @@ describe('Authorization service', () => {
 
       results.length.should.equal(7);
       results.should.deep.equal([
-        { id: 2, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[2, 0], 'subject2'], [['a']]] } },
-        { id: 3, viewResults: { replicationKeys: [[ '_all' ]]} },
-        { id: 1, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[1], 'subject1'], [['a']]] } },
+        {
+          id: 2,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [2, 0], value: 'subject2'}, { key: ['a'], value: null }],
+          },
+        },
+        { id: 3, viewResults: { replicationKeys: [{ key: '_all', value: null }]} },
+        {
+          id: 1,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject1' }, { key: ['a'], value: null }],
+          },
+        },
         { id: 9, viewResults: {}, allowed: true },
-        { id: 11, viewResults: { replicationKeys: [['subject2', { submitter: 'a' }]], contactsByDepth: false } },
-        { id: 8, viewResults: { replicationKeys: [['subject2', { submitter: 'a' }]], contactsByDepth: false } },
-        { id: 4, viewResults: { replicationKeys: [[1, { submitter: 'b' }]], contactsByDepth: false } }
+        {
+          id: 11,
+          viewResults: {
+            replicationKeys: [{ key: 'subject2', value: { submitter: 'a' }}],
+            contactsByDepth: false,
+          },
+        },
+        {
+          id: 8,
+          viewResults: {
+            replicationKeys: [{ key: 'subject2', value: { submitter: 'a' }}],
+            contactsByDepth: false,
+          },
+        },
+        {
+          id: 4,
+          viewResults: {
+            replicationKeys: [{ key: 1, value: { submitter: 'b' }}],
+            contactsByDepth: false,
+          },
+        },
       ]);
 
       authzContext.subjectIds.should.deep.equal([ 'subject2', 2, 'subject1', 1 ]);
@@ -1143,11 +1234,29 @@ describe('Authorization service', () => {
       };
 
       const docs = [
-        { id: 4, viewResults: { replicationKeys: [[ '_all' ]] } },
+        { id: 4, viewResults: { replicationKeys: [{ key: '_all' }] } },
         { id: 5, viewResults: {} },
-        { id: 2, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[1], 'subject1']] } },
-        { id: 3, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[1], 'subject2']] } },
-        { id: 1, viewResults: { replicationKeys: [['subject2', { submitter: 'a' }]], contactsByDepth: false } }
+        {
+          id: 2,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject1' }],
+          },
+        },
+        {
+          id: 3,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject2' }],
+          },
+        },
+        {
+          id: 1,
+          viewResults: {
+            replicationKeys: [{ key: 'subject2', value: { submitter: 'a' }}],
+            contactsByDepth: false,
+          },
+        },
       ];
 
 
@@ -1155,10 +1264,28 @@ describe('Authorization service', () => {
 
       results.length.should.equal(4);
       results.should.deep.equal([
-        { id: 4, viewResults: { replicationKeys: [[ '_all' ]] } },
-        { id: 2, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[1], 'subject1']] } },
-        { id: 3, viewResults: { replicationKeys: [['something']], contactsByDepth: [[[1], 'subject2']] } },
-        { id: 1, viewResults: { replicationKeys: [['subject2', { submitter: 'a' }]], contactsByDepth: false } }
+        { id: 4, viewResults: { replicationKeys: [{ key: '_all' }] } },
+        {
+          id: 2,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject1' }],
+          },
+        },
+        {
+          id: 3,
+          viewResults: {
+            replicationKeys: [{ key: 'something', value: null, }],
+            contactsByDepth: [{ key: [1], value: 'subject2' }],
+          },
+        },
+        {
+          id: 1,
+          viewResults: {
+            replicationKeys: [{ key: 'subject2', value: { submitter: 'a' }}],
+            contactsByDepth: false,
+          },
+        },
       ]);
     });
 
@@ -1173,7 +1300,14 @@ describe('Authorization service', () => {
       const docs = [
         { id: 4, viewResults: {} },
         { id: 5, viewResults: {}, allowed: true },
-        { id: 2, viewResults: { replicationKeys: [['a']], contactsByDepth: [[[1], 'subject2']] }, allowed: false },
+        {
+          id: 2,
+          viewResults: {
+            replicationKeys: [{ key: 'a', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject2' }]
+          },
+          allowed: false
+        },
         { id: 3, viewResults: {} },
         { id: 1, viewResults: {}, allowed: true }
       ];
@@ -1183,7 +1317,14 @@ describe('Authorization service', () => {
       results.length.should.equal(3);
       results.should.deep.equal([
         { id: 5, viewResults: {}, allowed: true },
-        { id: 2, viewResults: { replicationKeys: [['a']], contactsByDepth: [[[1], 'subject2']] }, allowed: false },
+        {
+          id: 2,
+          viewResults: {
+            replicationKeys: [{ key: 'a', value: null }],
+            contactsByDepth: [{ key: [1], value: 'subject2' }],
+          },
+          allowed: false,
+        },
         { id: 1, viewResults: {}, allowed: true }
       ]);
     });
@@ -1266,37 +1407,57 @@ describe('Authorization service', () => {
         {
           doc: c1, // allowed
           viewResults: {
-            contactsByDepth: [[['c1'], '123456'], [['p1'], '123456'], [['facility_id'], '123456']],
-            replicationKeys: [['c1', { type: 'contact' }]]
+            contactsByDepth: [
+              { key: ['c1'], value: '123456' },
+              { key: ['p1'], value : '123456' },
+              { key: ['facility_id'], value: '123456' },
+            ],
+            replicationKeys: [{ key: 'c1', value: { type: 'contact' }}],
           }
         },
         {
           doc: c2, // denied
           viewResults: {
-            contactsByDepth: [[['c2'], 'place1'], [['p3'], 'place1'], [['p4'], 'place1']],
-            replicationKeys: [['c2', { type: 'contact' }]]
+            contactsByDepth: [
+              { key: ['c2'], value: 'place1' },
+              { key: ['p3'], value: 'place1' },
+              { key: ['p4'], value: 'place1' },
+            ],
+            replicationKeys: [{ key: 'c2', value: { type: 'contact' }}],
           }
         },
         {
           doc: c3, // allowed
           viewResults: {
-            contactsByDepth: [[['c3'], null], [['p1'], null], [['facility_id'], null]],
-            replicationKeys: [['c3', { type: 'contact' }]]
-          }
+            contactsByDepth: [
+              { key: ['c3'], value: null },
+              { key: ['p1'], value: null },
+              { key: ['facility_id'], value: null },
+            ],
+            replicationKeys: [{ key: 'c3', value: { type: 'contact' }}]
+          },
         },
         {
           doc: c4, // denied
           viewResults: {
-            contactsByDepth: [[['c4'], null], [['p3'], null], [['p4'], null]],
-            replicationKeys: [['c4', { type: 'contact' }]]
-          }
+            contactsByDepth: [
+              { key: ['c4'], value: null },
+              { key: ['p3'], value: null },
+              { key: ['p4'], value: null },
+            ],
+            replicationKeys: [{ key: 'c4', value: { type: 'contact' }}],
+          },
         },
         {
           doc: c5, // allowed
           viewResults: {
-            contactsByDepth: [[['c5'], 'place5'], [['p2'], 'place5'], [['facility_id'], 'place5']],
-            replicationKeys: [['c5', { type: 'contact' }]]
-          }
+            contactsByDepth: [
+              { key: ['c5'], value: 'place5' },
+              { key: ['p2'], value: 'place5' },
+              { key: ['facility_id'], value: 'place5' },
+            ],
+            replicationKeys: [{ key: 'c5', value: { type: 'contact' }}],
+          },
         },
       ];
 
@@ -1316,17 +1477,37 @@ describe('Authorization service', () => {
         ] });
 
       const contactsByDepth = sinon.stub();
-      contactsByDepth.withArgs(c1).returns([[['c1'], '123456'], [['p1'], '123456'], [['facility_id'], '123456']]);
-      contactsByDepth.withArgs(c2).returns([[['c2'], 'place1'], [['p3'], 'place1'], [['p4'], 'place1']]);
-      contactsByDepth.withArgs(c3).returns([[['c3'], null], [['p1'], null], [['facility_id'], null]]);
-      contactsByDepth.withArgs(c4).returns([[['c4'], null], [['p3'], null], [['p4'], null]]);
-      contactsByDepth.withArgs(c5).returns([[['c5'], 'place5'], [['p2'], 'place5'], [['facility_id'], 'place5']]);
+      contactsByDepth.withArgs(c1).returns([
+        { key: ['c1'], value: '123456' },
+        { key: ['p1'], value: '123456' },
+        { key: ['facility_id'], value: '123456' },
+      ]);
+      contactsByDepth.withArgs(c2).returns([
+        { key: ['c2'], value: 'place1' },
+        { key: ['p3'], value: 'place1' },
+        { key: ['p4'], value: 'place1' },
+      ]);
+      contactsByDepth.withArgs(c3).returns([
+        { key: ['c3'], value: null },
+        { key: ['p1'], value: null },
+        { key: ['facility_id'], value: null },
+      ]);
+      contactsByDepth.withArgs(c4).returns([
+        { key: ['c4'], value: null },
+        { key: ['p3'], value: null },
+        { key: ['p4'], value: null },
+      ]);
+      contactsByDepth.withArgs(c5).returns([
+        { key: ['c5'], value: 'place5' },
+        { key: ['p2'], value: 'place5' },
+        { key: ['facility_id'], value: 'place5' },
+      ]);
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(c1).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(c2).returns([['c2', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(c3).returns([['c3', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(c4).returns([['c4', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(c5).returns([['c5', { type: 'contact' }]]);
+      docsByReplicationKey.withArgs(c1).returns([{ key: 'c1', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(c2).returns([{ key: 'c2', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(c3).returns([{ key: 'c3', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(c4).returns([{ key: 'c4', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(c5).returns([{ key: 'c5', value: {  type: 'contact'  }}]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -1374,7 +1555,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient1', { submitter: 'c1' }]]
+            replicationKeys: [{ key: 'patient1', value: {  submitter: 'c1'  }}]
           }
         },
         { // denied
@@ -1384,7 +1565,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient2', { submitter: 'c2', type: 'data_record' }]]
+            replicationKeys: [{ key: 'patient2', value: {  submitter: 'c2', type: 'data_record'  }}]
           }
         },
         { // allowed
@@ -1394,7 +1575,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient1', { submitter: 'c2', type: 'data_record' }]]
+            replicationKeys: [{ key: 'patient1', value: {  submitter: 'c2', type: 'data_record'  }}]
           }
         },
         { // allowed
@@ -1404,7 +1585,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient3doc', { submitter: 'c1', type: 'data_record' }]]
+            replicationKeys: [{ key: 'patient3doc', value: {  submitter: 'c1', type: 'data_record'  }}]
           }
         },
         { // denied
@@ -1414,7 +1595,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient4doc', { submitter: 'c3', type: 'data_record' }]]
+            replicationKeys: [{ key: 'patient4doc', value: {  submitter: 'c3', type: 'data_record'  }}]
           }
         },
       ];
@@ -1453,28 +1634,51 @@ describe('Authorization service', () => {
         ]});
 
       const contactsByDepth = sinon.stub();
-      contactsByDepth.withArgs(sinon.match({ _id: 'c1' }))
-        .returns([[['c1'], null], [['p1'], null], [['facility_id'], null]]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc' }))
-        .returns([[['patient1doc'], 'patient1'], [['p1'], 'patient1'], [['facility_id'], 'patient1']]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'c2' }))
-        .returns([[['c2'], null], [['p2'], null], [['p3'], null]]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' }))
-        .returns([[['patient2doc'], 'patient1'], [['p2'], 'patient2'], [['p3'], 'patient2']]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'c3' }))
-        .returns([[['c3'], null], [['p2'], null], [['p3'], null]]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'patient3doc' }))
-        .returns([[['patient3doc'], null], [['facility_id'], null]]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'patient4doc' }))
-        .returns([[['patient4doc'], null], [['p3'], null]]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'c1' })).returns([
+        { key: ['c1'], value: null }, { key: ['p1'], value: null }, { key: ['facility_id'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc' })).returns([
+        { key: ['patient1doc'], value: 'patient1' },
+        { key: ['p1'], value: 'patient1' },
+        { key: ['facility_id'], value: 'patient1' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'c2' })).returns([
+        { key: ['c2'], value: null }, { key: ['p2'], value: null }, { key: ['p3'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+        { key: ['patient2doc'], value: 'patient1' },
+        { key: ['p2'], value: 'patient2' },
+        { key: ['p3'], value: 'patient2' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'c3' })).returns([
+        { key: ['c3'], value: null }, { key: ['p2'], value: null }, { key: ['p3'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient3doc' })).returns([
+        { key: ['patient3doc'], value: null }, { key: ['facility_id'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient4doc' })).returns([
+        { key: ['patient4doc'], value: null }, { key: ['p3'], value: null },
+      ]);
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([['patient1doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' })).returns([['c2', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' })).returns([['patient2doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c3' })).returns([['c3', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient3doc' })).returns([['patient3doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient4doc' })).returns([['patient4doc', {type: 'contact'}]]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([
+        { key: 'c1', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([
+        { key: 'patient1doc', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' })).returns([
+        { key: 'c2', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+        { key: 'patient2doc', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c3' })).returns([{ key: 'c3', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient3doc' })).returns([
+        { key: 'patient3doc', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient4doc' })).returns([
+        { key: 'patient4doc', value: { type: 'contact' }},
+      ]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -1525,10 +1729,10 @@ describe('Authorization service', () => {
           viewResults: {
             contactsByDepth: [],
             replicationKeys: [
-              ['patient1', { submitter: 'c1', type: 'data_record' }],
-              ['c1', { submitter: 'c1', type: 'data_record' }],
-              ['p1', { submitter: 'c1', type: 'data_record' }],
-              ['facility_id', { submitter: 'c1', type: 'data_record' }],
+              { key: 'patient1', value: {  submitter: 'c1', type: 'data_record'  }},
+              { key: 'c1', value: {  submitter: 'c1', type: 'data_record'  }},
+              { key: 'p1', value: {  submitter: 'c1', type: 'data_record'  }},
+              { key: 'facility_id', value: {  submitter: 'c1', type: 'data_record'  }},
             ]
           }
         },
@@ -1540,10 +1744,10 @@ describe('Authorization service', () => {
           viewResults: {
             contactsByDepth: [],
             replicationKeys: [
-              ['patient2', { submitter: 'c2', type: 'data_record' }],
-              ['c2', { submitter: 'c2', type: 'data_record' }],
-              ['p2', { submitter: 'c2', type: 'data_record' }],
-              ['p3', { submitter: 'c2', type: 'data_record' }]
+              { key: 'patient2', value: {  submitter: 'c2', type: 'data_record'  }},
+              { key: 'c2', value: {  submitter: 'c2', type: 'data_record'  }},
+              { key: 'p2', value: {  submitter: 'c2', type: 'data_record'  }},
+              { key: 'p3', value: {  submitter: 'c2', type: 'data_record'  }}
             ]
           }
         },
@@ -1575,41 +1779,46 @@ describe('Authorization service', () => {
         ]});
 
       const contactsByDepth = sinon.stub();
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'c1' })).returns([[['c1'], null], [['p1'], null], [['facility_id'], null]]
-      );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'patient1doc' }))
-        .returns([[['patient1doc'], 'patient1'], [['p1'], 'patient1'], [['facility_id'], 'patient1']]
-        );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'c2' })).returns([[['c2'], null], [['p2'], null], [['p3'], null]]
-      );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'patient2doc' }))
-        .returns([[['patient2doc'], 'patient2'], [['p2'], 'patient2'], [['p3'], 'patient2']]
-        );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'p1' })).returns([[['p1'], null], [['facility_id'], null]]
-      );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'facility_id' })).returns([[['facility_id'], null]]
-      );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'p2' })).returns([[['p2'], null], [['p3'], null]]
-      );
-      contactsByDepth.withArgs(
-        sinon.match({ _id: 'p3' })).returns([[['p3'], null]]
-      );
+      contactsByDepth.withArgs(sinon.match({ _id: 'c1' })).returns([
+        { key: ['c1'], value: null }, { key: ['p1'], value: null }, { key: ['facility_id'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc' })).returns([
+        { key: ['patient1doc'], value: 'patient1' },
+        { key: ['p1'], value: 'patient1' },
+        { key: ['facility_id'], value: 'patient1' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'c2' })).returns([
+        { key: ['c2'], value: null }, { key: ['p2'], value: null }, { key: ['p3'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+        { key: ['patient2doc'], value: 'patient2' },
+        { key: ['p2'], value: 'patient2' },
+        { key: ['p3'], value: 'patient2' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'p1' })).returns([
+        { key: ['p1'], value: null }, { key: ['facility_id'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'facility_id' })).returns([{ key: ['facility_id'], value: null }]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'p2' })).returns([
+        { key: ['p2'], value: null }, { key: ['p3'], value: null },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'p3' })).returns([{ key: ['p3'], value: null }]);
+
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([['patient1doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' })).returns([['c2', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' })).returns([['patient2doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'p1' })).returns([['p1', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'facility_id' })).returns([['facility_id', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'p2' })).returns([['p2', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'p3' })).returns([['p3', {type: 'contact'}]]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([{ key: 'c1', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([
+        { key: 'patient1doc', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' })).returns([{ key: 'c2', value: { type: 'contact' }}]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+        { key: 'patient2doc', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'p1' })).returns([{ key: 'p1', value: { type: 'contact' }}]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'facility_id' })).returns([
+        { key: 'facility_id', value: { type: 'contact' }},
+      ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'p2' })).returns([{ key: 'p2', value: { type: 'contact' }}]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'p3' })).returns([{ key: 'p3', value: { type: 'contact' }}]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -1657,15 +1866,23 @@ describe('Authorization service', () => {
             _id: 'c1', type: 'person', parent: { _id: 'p1', parent: { _id: 'facility_id' } }, patient_id: 'contact1'
           },
           viewResults: {
-            contactsByDepth: [[['c1'], 'contact1'], [['p1'], 'contact1'], [['facility_id'], 'contact1']],
-            replicationKeys: [['c1', { type: 'contact' }]]
+            contactsByDepth: [
+              { key: ['c1'], value: 'contact1' },
+              { key: ['p1'], value: 'contact1' },
+              { key: ['facility_id'], value: 'contact1' },
+            ],
+            replicationKeys: [{ key: 'c1', value: {  type: 'contact'  }}]
           },
         },
         { // denied
           doc: { _id: 'c2', type: 'person', parent: { _id: 'p2', parent: { _id: 'p3' } }, patient_id: 'contact2' },
           viewResults: {
-            contactsByDepth: [[['c2'], 'contact2'], [['p2'], 'contact2'], [['p3'], 'contact2']],
-            replicationKeys: [['c2', { type: 'contact' }]]
+            contactsByDepth: [
+              { key: ['c2'], value: 'contact2' },
+              { key: ['p2'], value: 'contact2' },
+              { key: ['p3'], value: 'contact2' },
+            ],
+            replicationKeys: [{ key: 'c2', value: {  type: 'contact'  }}]
           },
         },
         { // allowed
@@ -1675,7 +1892,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient1', { submitter: 'c1', type: 'data_record' }]]
+            replicationKeys: [{ key: 'patient1', value: {  submitter: 'c1', type: 'data_record'  }}]
           }
         },
         { // denied
@@ -1685,7 +1902,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['patient2', { submitter: 'c2', type: 'data_record' }]]
+            replicationKeys: [{ key: 'patient2', value: {  submitter: 'c2', type: 'data_record'  }}]
           }
         },
       ];
@@ -1718,19 +1935,35 @@ describe('Authorization service', () => {
         ]});
 
       const contactsByDepth = sinon.stub();
-      contactsByDepth.withArgs(sinon.match({ _id: 'c1' }))
-        .returns([[['c1'], 'contact1'], [['p1'], 'contact1'], [['facility_id'], 'contact1']]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc' }))
-        .returns([[['patient1doc'], 'patient1'], [['p1'], 'patient1'], [['facility_id'], 'patient1']]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'c2' }))
-        .returns([[['c2'], 'contact2'], [['p2'], 'contact2'], [['p3'], 'contact2']]);
-      contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' }))
-        .returns([[['patient2doc'], 'patient2'], [['p2'], 'patient2'], [['p3'], 'patient2']]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'c1' })).returns([
+        { key: ['c1'], value: 'contact1' },
+        { key: ['p1'], value: 'contact1' },
+        { key: ['facility_id'], value: 'contact1' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc' })).returns([
+        { key: ['patient1doc'], value: 'patient1' },
+        { key: ['p1'], value: 'patient1' },
+        { key: ['facility_id'], value: 'patient1' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'c2' })).returns([
+        { key: ['c2'], value: 'contact2' },
+        { key: ['p2'], value: 'contact2' },
+        { key: ['p3'], value: 'contact2' },
+      ]);
+      contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+        { key: ['patient2doc'], value: 'patient2' },
+        { key: ['p2'], value: 'patient2' },
+        { key: ['p3'], value: 'patient2' },
+      ]);
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([['patient1doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' })).returns([['c2', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' })).returns([['patient2doc', {type: 'contact'}]]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([{ key: 'c1', value: {  type: 'contact'  }}]);
+      docsByReplicationKey
+        .withArgs(sinon.match({ _id: 'patient1doc' }))
+        .returns([{ key: 'patient1doc', value: { type: 'contact' }}, ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' })).returns([{ key: 'c2', value: { type: 'contact' }}]);
+      docsByReplicationKey
+        .withArgs(sinon.match({ _id: 'patient2doc' }))
+        .returns([{ key: 'patient2doc', value: { type: 'contact' }}]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -1776,7 +2009,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['_unassigned', { type: 'data_record' }]]
+            replicationKeys: [{ key: '_unassigned', value: {  type: 'data_record'  }}]
           },
         },
       ];
@@ -1799,7 +2032,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [['_unassigned', { type: 'data_record' }]]
+            replicationKeys: [{ key: '_unassigned', value: {  type: 'data_record'  }}]
           },
         },
       ];
@@ -1821,7 +2054,7 @@ describe('Authorization service', () => {
           },
           viewResults: {
             contactsByDepth: [],
-            replicationKeys: [ ['patient1', { submitter: 'c1' }] ]
+            replicationKeys: [ { key: 'patient1', value: {  submitter: 'c1'  }} ]
           }
         },
       ];
@@ -1848,24 +2081,26 @@ describe('Authorization service', () => {
       contactsByDepth
         .withArgs(sinon.match({ _id: 'c1' }))
         .returns([
-          [['c1'], null],
-          [['c1', 0], null],
-          [['facility_id'], null],
-          [['facility_id', 1], null],
+          { key: ['c1'], value: null },
+          { key: ['c1', 0], value: null },
+          { key: ['facility_id'], value: null },
+          { key: ['facility_id', 1], value: null },
         ]);
       contactsByDepth
         .withArgs(sinon.match({ _id: 'patient1doc' }))
         .returns([
-          [['patient1doc'], 'patient1'],
-          [['patient1doc', 0], 'patient1'],
-          [['p1'], 'patient1'],
-          [['p1', 1], 'patient1'],
-          [['facility_id'], 'patient1'],
-          [['facility_id', 2], 'patient1']
+          { key: ['patient1doc'], value: 'patient1' },
+          { key: ['patient1doc', 0], value: 'patient1' },
+          { key: ['p1'], value: 'patient1' },
+          { key: ['p1', 1], value: 'patient1' },
+          { key: ['facility_id'], value: 'patient1' },
+          { key: ['facility_id', 2], value: 'patient1' }
         ]);
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([['patient1doc', {type: 'contact'}]]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([{ key: 'c1', value: {  type: 'contact'  }}]);
+      docsByReplicationKey
+        .withArgs(sinon.match({ _id: 'patient1doc' }))
+        .returns([ { key: 'patient1doc', value: { type: 'contact' }}, ]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -1916,10 +2151,10 @@ describe('Authorization service', () => {
           viewResults: {
             contactsByDepth: [],
             replicationKeys: [
-              ['patient1', { submitter: 'c1', type: 'data_record' }],
-              ['c1', { submitter: 'c1', type: 'data_record' }],
-              ['p1', { submitter: 'c1', type: 'data_record' }],
-              ['facility_id', { submitter: 'c1', type: 'data_record' }],
+              { key: 'patient1', value: {  submitter: 'c1', type: 'data_record'  }},
+              { key: 'c1', value: {  submitter: 'c1', type: 'data_record'  }},
+              { key: 'p1', value: {  submitter: 'c1', type: 'data_record'  }},
+              { key: 'facility_id', value: {  submitter: 'c1', type: 'data_record'  }},
             ]
           }
         },
@@ -1947,40 +2182,44 @@ describe('Authorization service', () => {
       contactsByDepth
         .withArgs(sinon.match({ _id: 'c1' }))
         .returns([
-          [['c1'], null],
-          [['c1', 0], null],
-          [['facility_id'], null],
-          [['facility_id', 1], null],
+          { key: ['c1'], value: null },
+          { key: ['c1', 0], value: null },
+          { key: ['facility_id'], value: null },
+          { key: ['facility_id', 1], value: null },
         ]);
       contactsByDepth
         .withArgs(sinon.match({ _id: 'patient1doc' }))
         .returns([
-          [['patient1doc'], 'patient1'],
-          [['patient1doc', 0], 'patient1'],
-          [['p1'], 'patient1'],
-          [['p1', 1], 'patient1'],
-          [['facility_id'], 'patient1'],
-          [['facility_id', 2], 'patient1']
+          { key: ['patient1doc'], value: 'patient1' },
+          { key: ['patient1doc', 0], value: 'patient1' },
+          { key: ['p1'], value: 'patient1' },
+          { key: ['p1', 1], value: 'patient1' },
+          { key: ['facility_id'], value: 'patient1' },
+          { key: ['facility_id', 2], value: 'patient1' }
         ]);
       contactsByDepth
         .withArgs(sinon.match({ _id: 'p1' }))
         .returns([
-          [['p1'], null],
-          [['p1', 0], null],
-          [['facility_id'], null],
-          [['facility_id', 1], null]
+          { key: ['p1'], value: null },
+          { key: ['p1', 0], value: null },
+          { key: ['facility_id'], value: null },
+          { key: ['facility_id', 1], value: null }
         ]);
       contactsByDepth
         .withArgs(sinon.match({ _id: 'facility_id' }))
         .returns([
-          [['facility_id'], null],
-          [['facility_id', 0], null]
+          { key: ['facility_id'], value: null },
+          { key: ['facility_id', 0], value: null }
         ]);
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc' })).returns([['patient1doc', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'p1' })).returns([['p1', {type: 'contact'}]]);
-      docsByReplicationKey.withArgs(sinon.match({ _id: 'facility_id' })).returns([['facility_id', {type: 'contact'}]]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'c1' })).returns([{ key: 'c1', value: {  type: 'contact'  }}]);
+      docsByReplicationKey
+        .withArgs(sinon.match({ _id: 'patient1doc' }))
+        .returns([ { key: 'patient1doc', value: { type: 'contact' }}, ]);
+      docsByReplicationKey.withArgs(sinon.match({ _id: 'p1' })).returns([{ key: 'p1', value: { type: 'contact' }}]);
+      docsByReplicationKey
+        .withArgs(sinon.match({ _id: 'facility_id' }))
+        .returns([ { key: 'facility_id', value: { type: 'contact' }}, ]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -2038,28 +2277,28 @@ describe('Authorization service', () => {
           doc: c1, // allowed
           viewResults: {
             contactsByDepth: [
-              [['c1'], '123456'],
-              [['c1', 0], '123456'],
-              [['p1'], '123456'],
-              [['p1', 1], '123456'],
-              [['facility_id'], '123456'],
-              [['facility_id', 2], '123456']
+              { key: ['c1'], value: '123456' },
+              { key: ['c1', 0], value: '123456' },
+              { key: ['p1'], value: '123456' },
+              { key: ['p1', 1], value: '123456' },
+              { key: ['facility_id'], value: '123456' },
+              { key: ['facility_id', 2], value: '123456' }
             ],
-            replicationKeys: [['c1', { type: 'contact' }]]
+            replicationKeys: [{ key: 'c1', value: {  type: 'contact'  }}]
           }
         },
         {
           doc: c2, // denied
           viewResults: {
             contactsByDepth: [
-              [['c2'], 'place1'],
-              [['c2', 0], 'place1'],
-              [['p3'], 'place1'],
-              [['p3', 1], 'place1'],
-              [['p4'], 'place1'],
-              [['p4', 2], 'place1'],
+              { key: ['c2'], value: 'place1' },
+              { key: ['c2', 0], value: 'place1' },
+              { key: ['p3'], value: 'place1' },
+              { key: ['p3', 1], value: 'place1' },
+              { key: ['p4'], value: 'place1' },
+              { key: ['p4', 2], value: 'place1' },
             ],
-            replicationKeys: [['c2', { type: 'contact' }]]
+            replicationKeys: [{ key: 'c2', value: {  type: 'contact'  }}]
           }
         },
       ];
@@ -2075,24 +2314,24 @@ describe('Authorization service', () => {
 
       const contactsByDepth = sinon.stub();
       contactsByDepth.withArgs(c1).returns([
-        [['c1'], '123456'],
-        [['c1', 0], '123456'],
-        [['p1'], '123456'],
-        [['p1', 1], '123456'],
-        [['facility_id'], '123456'],
-        [['facility_id', 2], '123456'],
+        { key: ['c1'], value: '123456' },
+        { key: ['c1', 0], value: '123456' },
+        { key: ['p1'], value: '123456' },
+        { key: ['p1', 1], value: '123456' },
+        { key: ['facility_id'], value: '123456' },
+        { key: ['facility_id', 2], value: '123456' },
       ]);
       contactsByDepth.withArgs(c2).returns([
-        [['c2'], 'place1'],
-        [['c2', 0], 'place1'],
-        [['p3'], 'place1'],
-        [['p3', 1], 'place1'],
-        [['p4'], 'place1'],
-        [['p4', 2], 'place1'],
+        { key: ['c2'], value: 'place1' },
+        { key: ['c2', 0], value: 'place1' },
+        { key: ['p3'], value: 'place1' },
+        { key: ['p3', 1], value: 'place1' },
+        { key: ['p4'], value: 'place1' },
+        { key: ['p4', 2], value: 'place1' },
       ]);
       const docsByReplicationKey = sinon.stub();
-      docsByReplicationKey.withArgs(c1).returns([['c1', { type: 'contact' }]]);
-      docsByReplicationKey.withArgs(c2).returns([['c2', { type: 'contact' }]]);
+      docsByReplicationKey.withArgs(c1).returns([{ key: 'c1', value: {  type: 'contact'  }}]);
+      docsByReplicationKey.withArgs(c2).returns([{ key: 'c2', value: {  type: 'contact'  }}]);
 
       viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
       viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -2138,15 +2377,23 @@ describe('Authorization service', () => {
               patient_id: 'contact1', _deleted: true
             },
             viewResults: {
-              contactsByDepth: [[['c1'], 'contact1'], [['p1'], 'contact1'], [['facility_id'], 'contact1']],
-              replicationKeys: [['c1', {}]]
+              contactsByDepth: [
+                { key: ['c1'], value: 'contact1' },
+                { key: ['p1'], value: 'contact1' },
+                { key: ['facility_id'], value: 'contact1' },
+              ],
+              replicationKeys: [{ key: 'c1', value: {  }}]
             },
           },
           { // allowed without shortcode
             doc: { _id: 'c2', type: 'clinic', parent: { _id: 'p2', parent: { _id: 'facility_id' } }, _deleted: true },
             viewResults: {
-              contactsByDepth: [[['c2'], undefined], [['p1'], undefined], [['facility_id'], undefined]],
-              replicationKeys: [['c2', {}]]
+              contactsByDepth: [
+                { key: ['c2'], value: undefined },
+                { key: ['p1'], value: undefined },
+                { key: ['facility_id'], value: undefined },
+              ],
+              replicationKeys: [{ key: 'c2', value: {  }}]
             },
           },
           { // denied with shortcode
@@ -2155,22 +2402,34 @@ describe('Authorization service', () => {
               parent: { _id: 'p4', parent: { _id: 'p3' } }, patient_id: 'contact3', _deleted: true
             },
             viewResults: {
-              contactsByDepth: [[['c3'], 'contact3'], [['p2'], 'contact3'], [['p3'], 'contact3']],
-              replicationKeys: [['c3', {}]]
+              contactsByDepth: [
+                { key: ['c3'], value: 'contact3' },
+                { key: ['p2'], value: 'contact3' },
+                { key: ['p3'], value: 'contact3' },
+              ],
+              replicationKeys: [{ key: 'c3', value: {  }}]
             },
           },
           { // denied without shortcode
             doc: { _id: 'c4', type: 'person', parent: { _id: 'p5', parent: { _id: 'p3' } }, _deleted: true },
             viewResults: {
-              contactsByDepth: [[['c4'], undefined], [['p2'], undefined], [['p3'], undefined]],
-              replicationKeys: [['c4', {}]]
+              contactsByDepth: [
+                { key: ['c4'], value: undefined },
+                { key: ['p2'], value: undefined },
+                { key: ['p3'], value: undefined },
+              ],
+              replicationKeys: [{ key: 'c4', value: {  }}]
             },
           },
           { // not deleted allowed
             doc: { _id: 'c5', type: 'person', parent: { _id: 'p1', parent: { _id: 'facility_id' } }, },
             viewResults: {
-              contactsByDepth: [[['c5'], undefined], [['p1'], undefined], [['facility_id'], undefined]],
-              replicationKeys: [['c5', {}]]
+              contactsByDepth: [
+                { key: ['c5'], value: undefined },
+                { key: ['p1'], value: undefined },
+                { key: ['facility_id'], value: undefined },
+              ],
+              replicationKeys: [{ key: 'c5', value: {  }}]
             },
           },
         ];
@@ -2240,29 +2499,64 @@ describe('Authorization service', () => {
           ]});
 
         const contactsByDepth = sinon.stub();
-        contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev____tombstone' }))
-          .returns([[['c1'], 'contact1'], [['p1'], 'contact1'], [['facility_id'], 'contact1']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c2____rev____tombstone' }))
-          .returns([[['c2'], undefined], [['p1'], undefined], [['facility_id'], undefined]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c2____rev2____tombstone' }))
-          .returns([[['c2'], undefined], [['p1'], undefined], [['facility_id'], undefined]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c3____rev____tombstone' }))
-          .returns([[['c3'], 'contact3'], [['p2'], 'contact3'], [['p3'], 'contact3']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c3____rev2____tombstone' }))
-          .returns([[['c3'], 'contact3'], [['p2'], 'contact3'], [['p3'], 'contact3']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c4____rev____tombstone' }))
-          .returns([[['c4'], undefined], [['p2'], undefined], [['p3'], undefined]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c5' }))
-          .returns([[['c5'], undefined], [['p1'], undefined], [['facility_id'], undefined]]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev____tombstone' })).returns([
+          { key: ['c1'], value: 'contact1' },
+          { key: ['p1'], value: 'contact1' },
+          { key: ['facility_id'], value: 'contact1' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c2____rev____tombstone' })).returns([
+          { key: ['c2'], value: undefined },
+          { key: ['p1'], value: undefined },
+          { key: ['facility_id'], value: undefined },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c2____rev2____tombstone' })).returns([
+          { key: ['c2'], value: undefined },
+          { key: ['p1'], value: undefined },
+          { key: ['facility_id'], value: undefined },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c3____rev____tombstone' })).returns([
+          { key: ['c3'], value: 'contact3' },
+          { key: ['p2'], value: 'contact3' },
+          { key: ['p3'], value: 'contact3' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c3____rev2____tombstone' })).returns([
+          { key: ['c3'], value: 'contact3' },
+          { key: ['p2'], value: 'contact3' },
+          { key: ['p3'], value: 'contact3' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c4____rev____tombstone' })).returns([
+          { key: ['c4'], value: undefined },
+          { key: ['p2'], value: undefined },
+          { key: ['p3'], value: undefined },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c5' })).returns([
+          { key: ['c5'], value: undefined },
+          { key: ['p1'], value: undefined },
+          { key: ['facility_id'], value: undefined },
+        ]);
 
         const docsByReplicationKey = sinon.stub();
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c1____rev____tombstone' })).returns([['c1', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c2____rev____tombstone' })).returns([['c2', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c2____rev2____tombstone' })).returns([['c2', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c3____rev____tombstone' })).returns([['c3', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c3____rev2____tombstone' })).returns([['c3', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c4____rev____tombstone' })).returns([['c4', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c5' })).returns([['c5', {}]]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c1____rev____tombstone' }))
+          .returns([{ key: 'c1', value: {}}]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c2____rev____tombstone' }))
+          .returns([{ key: 'c2', value: {}}]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c2____rev2____tombstone' }))
+          .returns([{ key: 'c2', value: {}}]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c3____rev____tombstone' }))
+          .returns([{ key: 'c3', value: {}}]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c3____rev2____tombstone' }))
+          .returns([{ key: 'c3', value: {}}]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c4____rev____tombstone' }))
+          .returns([{ key: 'c4', value: {}}]);
+        docsByReplicationKey
+          .withArgs(sinon.match({ _id: 'c5' }))
+          .returns([{ key: 'c5', value: {  }}]);
 
         viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
         viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -2307,7 +2601,7 @@ describe('Authorization service', () => {
             },
             viewResults: {
               contactsByDepth: [],
-              replicationKeys: [['patient1', { submitter: 'c1' }]]
+              replicationKeys: [{ key: 'patient1', value: {  submitter: 'c1'  }}]
             }
           },
           { // denied
@@ -2317,7 +2611,7 @@ describe('Authorization service', () => {
             },
             viewResults: {
               contactsByDepth: [],
-              replicationKeys: [['patient2', { submitter: 'c2' }]]
+              replicationKeys: [{ key: 'patient2', value: {  submitter: 'c2'  }}]
             }
           },
           { // allowed
@@ -2327,7 +2621,7 @@ describe('Authorization service', () => {
             },
             viewResults: {
               contactsByDepth: [],
-              replicationKeys: [['patient1', { submitter: 'c2' }]]
+              replicationKeys: [{ key: 'patient1', value: {  submitter: 'c2'  }}]
             }
           },
           { // allowed
@@ -2337,7 +2631,7 @@ describe('Authorization service', () => {
             },
             viewResults: {
               contactsByDepth: [],
-              replicationKeys: [['patient3doc', { submitter: 'c1' }]]
+              replicationKeys: [{ key: 'patient3doc', value: {  submitter: 'c1'  }}]
             }
           },
           { // denied
@@ -2347,7 +2641,7 @@ describe('Authorization service', () => {
             },
             viewResults: {
               contactsByDepth: [],
-              replicationKeys: [['patient4doc', { submitter: 'c3' }]]
+              replicationKeys: [{ key: 'patient4doc', value: {  submitter: 'c3'  }}]
             }
           },
           { // allowed
@@ -2357,7 +2651,7 @@ describe('Authorization service', () => {
             },
             viewResults: {
               contactsByDepth: [],
-              replicationKeys: [['patient5', { submitter: 'c3' }]]
+              replicationKeys: [{ key: 'patient5', value: {  submitter: 'c3'  }}]
             }
           },
         ];
@@ -2440,46 +2734,58 @@ describe('Authorization service', () => {
 
         const contactsByDepth = sinon.stub();
         contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev____tombstone' }))
-          .returns([[['c1'], null], [['p1'], null], [['facility_id'], null]]);
+          .returns([{ key: ['c1'], value: null }, { key: ['p1'], value: null }, { key: ['facility_id'], value: null }]);
         contactsByDepth.withArgs(sinon.match({ _id: 'c2' }))
-          .returns([[['c2'], null], [['p2'], null], [['p3'], null]]);
+          .returns([{ key: ['c2'], value: null }, { key: ['p2'], value: null }, { key: ['p3'], value: null }]);
         contactsByDepth.withArgs(sinon.match({ _id: 'c3____rev____tombstone' }))
-          .returns([[['c3'], null], [['p2'], null], [['p3'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' }))
-          .returns([[['patient1doc'], 'patient1'], [['p1'], 'patient1'], [['facility_id'], 'patient1']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc____rev2____tombstone' }))
-          .returns([[['patient1doc'], 'patient1'], [['p1'], 'patient1'], [['facility_id'], 'patient1']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc____rev____tombstone' }))
-          .returns([[['patient2doc'], 'patient1'], [['p2'], 'patient2'], [['p3'], 'patient2']]);
+          .returns([{ key: ['c3'], value: null }, { key: ['p2'], value: null }, { key: ['p3'], value: null }]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' })).returns([
+          { key: ['patient1doc'], value: 'patient1' },
+          { key: ['p1'], value: 'patient1' },
+          { key: ['facility_id'], value: 'patient1' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc____rev2____tombstone' })).returns([
+          { key: ['patient1doc'], value: 'patient1' },
+          { key: ['p1'], value: 'patient1' },
+          { key: ['facility_id'], value: 'patient1' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc____rev____tombstone' })).returns([
+          { key: ['patient2doc'], value: 'patient1' },
+          { key: ['p2'], value: 'patient2' },
+          { key: ['p3'], value: 'patient2' },
+        ]);
         contactsByDepth.withArgs(sinon.match({ _id: 'patient3doc____rev____tombstone' }))
-          .returns([[['patient3doc'], null], [['facility_id'], null]]);
+          .returns([{ key: ['patient3doc'], value: null }, { key: ['facility_id'], value: null }]);
         contactsByDepth.withArgs(sinon.match({ _id: 'patient3doc____rev2____tombstone' }))
-          .returns([[['patient3doc'], null], [['facility_id'], null]]);
+          .returns([{ key: ['patient3doc'], value: null }, { key: ['facility_id'], value: null }]);
         contactsByDepth.withArgs(sinon.match({ _id: 'patient4doc____rev____tombstone' }))
-          .returns([[['patient4doc'], null], [['p3'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'patient5doc' }))
-          .returns([[['patient5doc'], null], [['p1'], null], [['facility_id'], null]]);
+          .returns([{ key: ['patient4doc'], value: null }, { key: ['p3'], value: null }]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'patient5doc' })).returns([
+          { key: ['patient5doc'], value: null },
+          { key: ['p1'], value: null },
+          { key: ['facility_id'], value: null },
+        ]);
         const docsByReplicationKey = sinon.stub();
         docsByReplicationKey.withArgs(sinon.match({ _id: 'c1____rev____tombstone' }))
-          .returns([['c1', {}]]);
+          .returns([{ key: 'c1', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'c2' }))
-          .returns([['c2', {}]]);
+          .returns([{ key: 'c2', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'c3____rev____tombstone' }))
-          .returns([['c3', {}]]);
+          .returns([{ key: 'c3', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' }))
-          .returns([['patient1doc', {}]]);
+          .returns([{ key: 'patient1doc', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc____rev2____tombstone' }))
-          .returns([['patient1doc', {}]]);
+          .returns([{ key: 'patient1doc', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc____rev____tombstone' }))
-          .returns([['patient2doc', {}]]);
+          .returns([{ key: 'patient2doc', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient3doc____rev____tombstone' }))
-          .returns([['patient3doc', {}]]);
+          .returns([{ key: 'patient3doc', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient3doc____rev2____tombstone' }))
-          .returns([['patient3doc', {}]]);
+          .returns([{ key: 'patient3doc', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient4doc____rev____tombstone' }))
-          .returns([['patient4doc', {}]]);
+          .returns([{ key: 'patient4doc', value: {  }}]);
         docsByReplicationKey.withArgs(sinon.match({ _id: 'patient5doc' }))
-          .returns([['patient5doc', {}]]);
+          .returns([{ key: 'patient5doc', value: {  }}]);
 
         viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth')
           .returns(contactsByDepth);
@@ -2545,8 +2851,8 @@ describe('Authorization service', () => {
             viewResults: {
               contactsByDepth: [],
               replicationKeys: [
-                [ 'patient1', { submitter: 'c1' }], ['c1', { submitter: 'c1' }],
-                ['p1', { submitter: 'c1' }], ['facility_id', { submitter: 'c1' }]
+                { key: 'patient1', value: { submitter: 'c1' }}, { key: 'c1', value: {  submitter: 'c1'  }},
+                { key: 'p1', value: {  submitter: 'c1'  }}, { key: 'facility_id', value: {  submitter: 'c1'  }}
               ]
             }
           },
@@ -2559,8 +2865,8 @@ describe('Authorization service', () => {
             viewResults: {
               contactsByDepth: [],
               replicationKeys: [
-                ['patient2', { submitter: 'c2' }], ['c2', { submitter: 'c2' }],
-                ['p2', { submitter: 'c2' }], ['p3', { submitter: 'c2' }]
+                { key: 'patient2', value: {  submitter: 'c2'  }}, { key: 'c2', value: {  submitter: 'c2'  }},
+                { key: 'p2', value: {  submitter: 'c2'  }}, { key: 'p3', value: {  submitter: 'c2'  }}
               ]
             }
           },
@@ -2620,43 +2926,58 @@ describe('Authorization service', () => {
           ]});
 
         const contactsByDepth = sinon.stub();
-        contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev____tombstone' }))
-          .returns([[['c1'], null], [['p1'], null], [['facility_id'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev2____tombstone' }))
-          .returns([[['c1'], null], [['p1'], null], [['facility_id'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' }))
-          .returns([[['patient1doc'], 'patient1'], [['p1'], 'patient1'], [['facility_id'], 'patient1']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'c2____rev____tombstone' }))
-          .returns([[['c2'], null], [['p2'], null], [['p3'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' }))
-          .returns([[['patient2doc'], 'patient2'], [['p2'], 'patient2'], [['p3'], 'patient2']]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'p1' }))
-          .returns([[['p1'], null], [['facility_id'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'facility_id' }))
-          .returns([[['facility_id'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'p2____rev____tombstone' }))
-          .returns([[['p2'], null], [['p3'], null]]);
-        contactsByDepth.withArgs(sinon.match({ _id: 'p3' }))
-          .returns([[['p3'], null]]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev____tombstone' })).returns([
+          { key: ['c1'], value: null }, { key: ['p1'], value: null }, { key: ['facility_id'], value: null },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c1____rev2____tombstone' })).returns([
+          { key: ['c1'], value: null }, { key: ['p1'], value: null }, { key: ['facility_id'], value: null },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' })).returns([
+          { key: ['patient1doc'], value: 'patient1' },
+          { key: ['p1'], value: 'patient1' },
+          { key: ['facility_id'], value: 'patient1' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'c2____rev____tombstone' })).returns([
+          { key: ['c2'], value: null }, { key: ['p2'], value: null }, { key: ['p3'], value: null },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+          { key: ['patient2doc'], value: 'patient2' },
+          { key: ['p2'], value: 'patient2' },
+          { key: ['p3'], value: 'patient2' },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'p1' })).returns([
+          { key: ['p1'], value: null }, { key: ['facility_id'], value: null },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'facility_id' })).returns([{ key: ['facility_id'], value: null }]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'p2____rev____tombstone' })).returns([
+          { key: ['p2'], value: null }, { key: ['p3'], value: null },
+        ]);
+        contactsByDepth.withArgs(sinon.match({ _id: 'p3' })).returns([{ key: ['p3'], value: null }]);
+
         const docsByReplicationKey = sinon.stub();
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c1____rev____tombstone' }))
-          .returns([['c1', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c1____rev2____tombstone' }))
-          .returns([['c1', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' }))
-          .returns([['patient1doc', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'c2____rev____tombstone' }))
-          .returns([['c2', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' }))
-          .returns([['patient2doc', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'p1' }))
-          .returns([['p1', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'facility_id' }))
-          .returns([['facility_id', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'p2____rev____tombstone' }))
-          .returns([['p2', {}]]);
-        docsByReplicationKey.withArgs(sinon.match({ _id: 'p3' }))
-          .returns([['p3', {}]]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'c1____rev____tombstone' })).returns([
+          { key: 'c1', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'c1____rev2____tombstone' })).returns([
+          { key: 'c1', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'patient1doc____rev____tombstone' })).returns([
+          { key: 'patient1doc', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'c2____rev____tombstone' })).returns([
+          { key: 'c2', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'patient2doc' })).returns([
+          { key: 'patient2doc', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'p1' })).returns([{ key: 'p1', value: { type: 'contact' }}]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'facility_id' })).returns([
+          { key: 'facility_id', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'p2____rev____tombstone' })).returns([
+          { key: 'p2', value: { type: 'contact' }},
+        ]);
+        docsByReplicationKey.withArgs(sinon.match({ _id: 'p3' })).returns([{ key: 'p3', value: { type: 'contact' }}]);
 
         viewMapUtils.getViewMapFn.withArgs('medic', 'contacts_by_depth').returns(contactsByDepth);
         viewMapUtils.getViewMapFn.withArgs('medic', 'docs_by_replication_key').returns(docsByReplicationKey);
@@ -2712,13 +3033,13 @@ describe('Authorization service', () => {
       });
 
       it('should return all emitted keys and values', () => {
-        getReplicationKeys({ replicationKeys: [['patient_id', {}]] }).should.deep.equal(['patient_id']);
-        getReplicationKeys({ replicationKeys: [['patient', { submitter: 'contact' }]] })
+        getReplicationKeys({ replicationKeys: [{ key: 'patient_id', value: {  }}] }).should.deep.equal(['patient_id']);
+        getReplicationKeys({ replicationKeys: [{ key: 'patient', value: {  submitter: 'contact'  }}] })
           .should.deep.equal(['patient', 'contact']);
         const manyReplicationKeys = [
-          ['patient1', { submitter: 'contact1' }],
-          ['patient2', { submitter: 'contact2' }],
-          ['patient3', { submitter: 'contact3' }],
+          { key: 'patient1', value: {  submitter: 'contact1'  }},
+          { key: 'patient2', value: {  submitter: 'contact2'  }},
+          { key: 'patient3', value: {  submitter: 'contact3'  }},
         ];
         getReplicationKeys({ replicationKeys: manyReplicationKeys })
           .should.deep.equal(['patient1', 'contact1', 'patient2', 'contact2', 'patient3', 'contact3']);
@@ -2896,9 +3217,10 @@ describe('Authorization service', () => {
       });
 
       it('should return patient_id', () => {
-        getContactShortcode({ contactsByDepth: [[['parent'], 'patient']] }).should.equal('patient');
-        getContactShortcode({ contactsByDepth: [[['parent'], 'patient'], [['parent', 0], 'patient']] })
-          .should.equal('patient');
+        getContactShortcode({ contactsByDepth: [{ key: ['parent'], value: 'patient' }] }).should.equal('patient');
+        getContactShortcode(
+          { contactsByDepth: [{ key: ['parent'], value: 'patient' }, { key: ['parent', 0], value: 'patient' }] }
+        ).should.equal('patient');
       });
     });
   });
@@ -2910,16 +3232,16 @@ describe('Authorization service', () => {
     });
 
     it('should return true when docType is not data_record', () => {
-      let replicationKeys = [[ 'contact_id', { type: 'contact' } ]];
+      let replicationKeys = [{ key: 'contact_id', value: { type: 'contact'  }}];
       service.__get__('isAllowedDepth')({ reportDepth: 1 }, replicationKeys).should.equal(true);
 
-      replicationKeys = [[ 'targetID', { type: 'target' } ]];
+      replicationKeys = [{ key: 'targetID', value: { type: 'target'  }}];
       service.__get__('isAllowedDepth')({ reportDepth: 2 }, replicationKeys).should.equal(true);
 
-      replicationKeys = [[ 'taskID', { type: 'task' } ]];
+      replicationKeys = [{ key: 'taskID', value: { type: 'task'  }}];
       service.__get__('isAllowedDepth')({ reportDepth: 3 }, replicationKeys).should.equal(true);
 
-      replicationKeys = [[ 'anyid', { type: 'anything' } ]];
+      replicationKeys = [{ key: 'anyid', value: { type: 'anything'  }}];
       service.__get__('isAllowedDepth')({ reportDepth: 0 }, replicationKeys).should.equal(true);
     });
 
@@ -2930,13 +3252,13 @@ describe('Authorization service', () => {
         reportDepth: 2
       };
 
-      let replicationKeys = [[ 'patient', { type: 'data_record', submitter: 'chw' } ]];
+      let replicationKeys = [{ key: 'patient', value: { type: 'data_record', submitter: 'chw'  }}];
       service.__get__('isAllowedDepth')(authCtx, replicationKeys).should.equal(true);
 
       authCtx.reportDepth = 1;
       service.__get__('isAllowedDepth')(authCtx, replicationKeys).should.equal(true);
 
-      replicationKeys = [[ 'clinic', { type: 'data_record', submitter: 'chw' } ]];
+      replicationKeys = [{ key: 'clinic', value: { type: 'data_record', submitter: 'chw'  }}];
       service.__get__('isAllowedDepth')(authCtx, replicationKeys).should.equal(true);
     });
 
@@ -2947,13 +3269,13 @@ describe('Authorization service', () => {
         userCtx: { contact_id: 'chw' }
       };
 
-      let replicationKeys = [[ 'patient', { type: 'data_record', submitter: 'chw' } ]];
+      let replicationKeys = [{ key: 'patient', value: { type: 'data_record', submitter: 'chw'  }}];
       service.__get__('isAllowedDepth')(authCtx, replicationKeys).should.equal(true);
 
       replicationKeys = [
-        [ 'unknown', { type: 'data_record', submitter: 'chw' } ],
-        [ 'chw', { type: 'data_record', submitter: 'chw' } ],
-        [ 'facility', { type: 'data_record', submitter: 'chw' } ],
+        { key: 'unknown', value: { type: 'data_record', submitter: 'chw'  }},
+        { key: 'chw', value: { type: 'data_record', submitter: 'chw'  }},
+        { key: 'facility', value: { type: 'data_record', submitter: 'chw'  }},
       ];
       authCtx.reportDepth = 0;
       service.__get__('isAllowedDepth')(authCtx, replicationKeys).should.equal(true);
@@ -2965,7 +3287,7 @@ describe('Authorization service', () => {
         reportDepth: 1,
         userCtx: { contact_id: 'chw' }
       };
-      const replicationKeys = [[ 'patient', { type: 'data_record', submitter: 'other' } ]];
+      const replicationKeys = [{ key: 'patient', value: { type: 'data_record', submitter: 'other'  }}];
       service.__get__('isAllowedDepth')(authCtx, replicationKeys).should.equal(false);
 
       authCtx.reportDepth = 0;

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -452,10 +452,6 @@ describe('Authorization service', () => {
     });
   });
 
-  describe('allowedDepth', () => {
-    // todo
-  });
-
   describe('getViewResults', () => {
     it('initializes view map functions if needed and returns view results', () => {
       const contactsByDepthStub = sinon.stub().returns('contactsByDepthStubResult');

--- a/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/ddocs/medic/views/docs_by_replication_key/map.js
@@ -45,10 +45,10 @@ function (doc) {
              doc.tasks[0].messages[0].contact._id;
     }
   };
+  var value = { type: doc.type };
   switch (doc.type) {
     case 'data_record':
       var subject = getSubject() || '_unassigned';
-      var value = {};
       if (doc.form && doc.contact) {
         value.submitter = doc.contact._id;
       }
@@ -67,14 +67,14 @@ function (doc) {
       }
       return;
     case 'task':
-      return emit(doc.user, {});
+      return emit(doc.user, value);
     case 'target':
-      return emit(doc.owner, {});
+      return emit(doc.owner, value);
     case 'contact':
     case 'clinic':
     case 'district_hospital':
     case 'health_center':
     case 'person':
-      return emit(doc._id, {});
+      return emit(doc._id, value);
   }
 }

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -1,3 +1,6 @@
+const chai = require('chai');
+const chaiExclude = require('chai-exclude');
+chai.use(chaiExclude);
 const _ = require('lodash');
 const utils = require('../../../utils');
 const constants = require('../../../constants');
@@ -470,5 +473,145 @@ describe('all_docs handler', () => {
           }
         })).toBe(true);
       });
+  });
+
+  describe('replication depth', () => {
+    it('should respect replication_depth', () => {
+      const docs = [
+        {
+          // depth = 1
+          _id: 'the_clinic',
+          type: 'clinic',
+          parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+        },
+        {
+          // depth = 2
+          _id: 'the_person',
+          type: 'person',
+          parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+        },
+        {
+          // depth = 3
+          _id: 'the_patient',
+          type: 'person',
+          parent: { _id: 'the_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+        },
+        {
+          // depth = 1
+          _id: 'report_about_place',
+          type: 'data_record',
+          form: 'form',
+          fields: {
+            place_id: 'fixture:offline',
+          },
+          contact: { _id: 'irrelevant' },
+        },
+        {
+          // depth = 2, own report
+          _id: 'allowed_report_about_the_person_1',
+          type: 'data_record',
+          form: 'form',
+          fields: {
+            patient_id: 'the_person',
+          },
+          contact: { _id: 'fixture:user:supervisor' },
+        },
+        {
+          // depth = 2, has needs_signoff
+          _id: 'allowed_report_about_the_person_2',
+          type: 'data_record',
+          form: 'form',
+          fields: {
+            patient_id: 'the_person',
+            needs_signoff: true,
+          },
+          contact: { _id: 'fixture:user:offline', parent: { _id: 'fixture:offline' } },
+        },
+        {
+          // depth = 2, no needs_signoff
+          _id: 'denied_report_about_the_person',
+          type: 'data_record',
+          form: 'form',
+          fields: {
+            patient_id: 'the_person',
+          },
+          contact: { _id: 'fixture:user:offline' },
+        },
+        {
+          // depth = 3, has needs_signoff
+          _id: 'allowed_report_about_the_patient',
+          type: 'data_record',
+          form: 'form',
+          fields: {
+            patient_id: 'the_patient',
+            needs_signoff: true,
+          },
+          contact: { _id: 'fixture:user:offline', parent: { _id: 'fixture:offline' } },
+        },
+        {
+          // depth = 3, no needs_signoff
+          _id: 'denied_report_about_the_patient',
+          type: 'data_record',
+          form: 'form',
+          fields: {
+            patient_id: 'the_patient',
+          },
+          contact: { _id: 'fixture:user:offline', parent: { _id: 'fixture:offline' } },
+        },
+        {
+          // depth = 2
+          _id: 'target~offline',
+          type: 'target',
+          owner: 'fixture:user:offline',
+        },
+        {
+          _id: 'task~supervisor',
+          type: 'task',
+          user: 'org.couchdb.user:supervisor',
+        },
+        {
+          _id: 'task~offline',
+          type: 'task',
+          user: 'org.couchdb.user:offline',
+        }
+      ];
+
+      const supervisorRequestOptions = {
+        path: '/_all_docs',
+        auth: { username: 'supervisor', password },
+        method: 'GET'
+      };
+
+      const keys = docs.map(doc => doc._id);
+
+      const settings = { replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] };
+      return utils
+        .updateSettings(settings)
+        .then(() => utils.saveDocs(docs))
+        .then(() => Promise.all([
+          utils.requestOnMedicDb(Object.assign({ qs: { keys: keys  } }, supervisorRequestOptions)),
+          utils.requestOnMedicDb(supervisorRequestOptions),
+        ]))
+        .then(([withKeys, withoutKeys]) => {
+          const expectedRowsWithKeys = [
+            { id: 'the_clinic', key: 'the_clinic', value: {} },
+            { id: 'the_person', key: 'the_person', value: {} },
+            { id: 'the_patient', error: 'forbidden' },
+            { id: 'report_about_place', key: 'report_about_place', value: {} },
+            { id: 'allowed_report_about_the_person_1', key: 'allowed_report_about_the_person_1', value: {} },
+            { id: 'allowed_report_about_the_person_2', key: 'allowed_report_about_the_person_2', value: {} },
+            { id: 'denied_report_about_the_person', error: 'forbidden' },
+            { id: 'allowed_report_about_the_patient', key: 'allowed_report_about_the_patient', value: {} },
+            { id: 'denied_report_about_the_patient', error: 'forbidden' },
+            { id: 'target~offline', key: 'target~offline', value: {} },
+            { id: 'task~supervisor', key: 'task~supervisor', value: {} },
+            { id: 'task~offline', error: 'forbidden' },
+          ];
+          const expectedRowsWithoutKeys = expectedRowsWithKeys.filter(row => !row.error);
+
+          chai.expect(withKeys.rows).excludingEvery('rev').to.deep.equal(expectedRowsWithKeys);
+          chai.expect(withoutKeys.rows).excludingEvery('rev').to.deep.include.members(expectedRowsWithoutKeys);
+        });
+    });
   });
 });

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -1,3 +1,6 @@
+const chai = require('chai');
+const chaiExclude = require('chai-exclude');
+chai.use(chaiExclude);
 const _ = require('lodash');
 const utils = require('../../../utils');
 const sUtils = require('../../sentinel/utils');
@@ -718,6 +721,301 @@ describe('bulk-docs handler', () => {
 
         expect(results[1].content).toEqual('feedback2');
         expect(results[1]._rev).toEqual(docs[1]._rev);
+      });
+  });
+
+
+  it('should work with replication_depth', () => {
+    const existentDocs = [
+      {
+        _id: 'existing_clinic',
+        type: 'clinic',
+        parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+      },
+      {
+        _id: 'report_about_existing_clinic',
+        type: 'data_record',
+        form: 'form',
+        fields: { place_id: 'existing_clinic' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'existing_person',
+        type: 'person',
+        parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } }
+      },
+      {
+        _id: 'denied_report_about_existing_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'existing_person' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'allowed_report_about_existing_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'existing_person', needs_signoff: true },
+        contact: {
+          _id: 'existing_person',
+          parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+        },
+      },
+      {
+        _id: 'allowed_task',
+        type: 'task',
+        user: 'org.couchdb.user:offline',
+      },
+      {
+        _id: 'denied_task',
+        type: 'task',
+        user: 'org.couchdb.user:other',
+      },
+      {
+        _id: 'allowed_target',
+        type: 'target',
+        owner: 'fixture:user:offline',
+      },
+      {
+        _id: 'denied_target',
+        type: 'target',
+        owner: 'existing_person',
+      },
+    ];
+
+    const newDocs = [
+      {
+        _id: 'allowed_new_clinic',
+        type: 'clinic',
+        parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+      },
+      {
+        _id: 'denied_new_person',
+        type: 'person',
+        parent: { _id: 'allowed_new_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+      },
+      {
+        _id: 'allowed_report_about_new_clinic',
+        type: 'data_record',
+        form: 'form',
+        fields: { place_id: 'allowed_new_clinic' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'denied_report_about_new_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'denied_new_person' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'allowed_report_about_new_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'denied_new_person', needs_signoff: true },
+        contact: {
+          _id: 'new_person',
+          parent: { _id: 'allowed_new_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } }
+        },
+      },
+      {
+        _id: 'new_allowed_task',
+        type: 'task',
+        user: 'org.couchdb.user:offline',
+      },
+      {
+        _id: 'new_denied_task',
+        type: 'task',
+        user: 'org.couchdb.user:other',
+      },
+      {
+        _id: 'new_allowed_target',
+        type: 'target',
+        owner: 'fixture:user:offline',
+      },
+      {
+        _id: 'new_denied_target',
+        type: 'target',
+        owner: 'existing_person',
+      },
+    ];
+
+    const settings = { replication_depth: [{ role: 'district_admin', depth: 1 }] };
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs(existentDocs))
+      .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
+      .then(() => {
+        offlineRequestOptions.body = { docs: [...newDocs, ...existentDocs], new_edits: true };
+        return utils.requestOnMedicDb(offlineRequestOptions);
+      })
+      .then(results => {
+        chai.expect(results).excludingEvery('rev').to.deep.equal([
+          { id: 'allowed_new_clinic', ok: true },
+          { id: 'denied_new_person', error: 'forbidden' },
+          { id: 'allowed_report_about_new_clinic', ok: true },
+          { id: 'denied_report_about_new_person', error: 'forbidden' },
+          { id: 'allowed_report_about_new_person', ok: true },
+          { id: 'new_allowed_task', ok: true },
+          { id: 'new_denied_task', error: 'forbidden' },
+          { id: 'new_allowed_target', ok: true },
+          { id: 'new_denied_target', error: 'forbidden' },
+          { id: 'existing_clinic', ok: true },
+          { id: 'report_about_existing_clinic', ok: true },
+          { id: 'existing_person', error: 'forbidden' },
+          { id: 'denied_report_about_existing_person', error: 'forbidden' },
+          { id: 'allowed_report_about_existing_person', ok: true },
+          { id: 'allowed_task', ok: true },
+          { id: 'denied_task', error: 'forbidden' },
+          { id: 'allowed_target', ok: true },
+          { id: 'denied_target', error: 'forbidden' },
+        ]);
+      });
+  });
+
+  it('should work with report replication depth', () => {
+    const existentDocs = [
+      {
+        _id: 'existing_clinic',
+        type: 'clinic',
+        parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+      },
+      {
+        _id: 'report_about_existing_clinic',
+        type: 'data_record',
+        form: 'form',
+        fields: { place_id: 'existing_clinic' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'existing_person',
+        type: 'person',
+        parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } }
+      },
+      {
+        _id: 'denied_report_about_existing_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'existing_person' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'allowed_report_about_existing_person1',
+        type: 'data_record',
+        fields: { patient_id: 'existing_person' },
+        form: 'form',
+        contact: {
+          _id: 'fixture:user:offline',
+          parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+        },
+      },
+      {
+        _id: 'allowed_report_about_existing_person2',
+        type: 'data_record',
+        fields: { patient_id: 'existing_person', needs_signoff: true },
+        form: 'form',
+        contact: {
+          _id: 'existing_person',
+          parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+        },
+      },
+      {
+        _id: 'allowed_target',
+        type: 'target',
+        owner: 'existing_person',
+      },
+      {
+        _id: 'denied_target',
+        type: 'target',
+        owner: 'whoever',
+      },
+    ];
+
+    const newDocs = [
+      {
+        _id: 'new_clinic',
+        type: 'clinic',
+        parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+      },
+      {
+        _id: 'new_person',
+        type: 'person',
+        parent: { _id: 'new_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+      },
+      {
+        _id: 'allowed_report_about_new_clinic',
+        type: 'data_record',
+        form: 'form',
+        fields: { place_id: 'new_clinic' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'denied_report_about_new_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'new_person' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'allowed_report_about_new_person1',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'new_person', needs_signoff: true },
+        contact: {
+          _id: 'new_person',
+          parent: { _id: 'new_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } }
+        },
+      },
+      {
+        _id: 'allowed_report_about_new_person2',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'new_person' },
+        contact: {
+          _id: 'fixture:user:offline',
+          parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+        },
+      },
+      {
+        _id: 'new_allowed_target',
+        type: 'target',
+        owner: 'new_person',
+      },
+      {
+        _id: 'new_denied_target',
+        type: 'target',
+        owner: 'whoever',
+      },
+    ];
+
+    const settings = { replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] };
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs(existentDocs))
+      .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
+      .then(() => {
+        offlineRequestOptions.body = { docs: [...newDocs, ...existentDocs], new_edits: true };
+        return utils.requestOnMedicDb(offlineRequestOptions);
+      })
+      .then(results => {
+        chai.expect(results).excludingEvery('rev').to.deep.equal([
+          { id: 'new_clinic', ok: true },
+          { id: 'new_person', ok: true },
+          { id: 'allowed_report_about_new_clinic', ok: true },
+          { id: 'denied_report_about_new_person', error: 'forbidden' },
+          { id: 'allowed_report_about_new_person1', ok: true },
+          { id: 'allowed_report_about_new_person2', ok: true },
+          { id: 'new_allowed_target', ok: true },
+          { id: 'new_denied_target', error: 'forbidden' },
+          { id: 'existing_clinic', ok: true },
+          { id: 'report_about_existing_clinic', ok: true },
+          { id: 'existing_person', ok: true },
+          { id: 'denied_report_about_existing_person', error: 'forbidden' },
+          { id: 'allowed_report_about_existing_person1', ok: true },
+          { id: 'allowed_report_about_existing_person2', ok: true },
+          { id: 'allowed_target', ok: true },
+          { id: 'denied_target', error: 'forbidden' },
+        ]);
       });
   });
 });

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -1,3 +1,6 @@
+const chai = require('chai');
+const chaiExclude = require('chai-exclude');
+chai.use(chaiExclude);
 const _ = require('lodash');
 const utils = require('../../../utils');
 const constants = require('../../../constants');
@@ -474,6 +477,180 @@ describe('bulk-get handler', () => {
 
           return result.responseBody === 'Server error';
         })).toBe(true);
+      });
+  });
+
+  it('should work with replication depth', () => {
+    const existentDocs = [
+      {
+        _id: 'existing_clinic',
+        type: 'clinic',
+        parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+      },
+      {
+        _id: 'report_about_existing_clinic',
+        type: 'data_record',
+        form: 'form',
+        fields: { place_id: 'existing_clinic' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'existing_person',
+        type: 'person',
+        parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } }
+      },
+      {
+        _id: 'denied_report_about_existing_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'existing_person' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'allowed_report_about_existing_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'existing_person', needs_signoff: true },
+        contact: {
+          _id: 'existing_person',
+          parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+        },
+      },
+      {
+        _id: 'allowed_task',
+        type: 'task',
+        user: 'org.couchdb.user:offline',
+      },
+      {
+        _id: 'denied_task',
+        type: 'task',
+        user: 'org.couchdb.user:other',
+      },
+      {
+        _id: 'allowed_target',
+        type: 'target',
+        owner: 'fixture:user:offline',
+      },
+      {
+        _id: 'denied_target',
+        type: 'target',
+        owner: 'existing_person',
+      },
+    ];
+
+    const settings = { replication_depth: [{ role: 'district_admin', depth: 1 }] };
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs(existentDocs))
+      .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
+      .then(() => {
+        const docs = existentDocs.map(doc => ({ id: doc._id, rev: doc._rev }));
+        offlineRequestOptions.body = { docs };
+        return utils.requestOnMedicDb(offlineRequestOptions);
+      })
+      .then(result => {
+        const allowedIds = [
+          'existing_clinic',
+          'report_about_existing_clinic',
+          'allowed_report_about_existing_person',
+          'allowed_task',
+          'allowed_target',
+        ];
+        const expected = existentDocs
+          .filter(doc => allowedIds.includes(doc._id))
+          .map(doc => ({
+            id: doc._id,
+            docs: [{ ok: doc }]
+          }));
+        chai.expect(result.results).to.deep.equal(expected);
+      });
+  });
+
+  it('should work with report replication depth', () => {
+    const existentDocs = [
+      {
+        _id: 'existing_clinic',
+        type: 'clinic',
+        parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+      },
+      {
+        _id: 'report_about_existing_clinic',
+        type: 'data_record',
+        form: 'form',
+        fields: { place_id: 'existing_clinic' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'existing_person',
+        type: 'person',
+        parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } }
+      },
+      {
+        _id: 'denied_report_about_existing_person',
+        type: 'data_record',
+        form: 'form',
+        fields: { patient_id: 'existing_person' },
+        contact: { _id: 'nevermind' },
+      },
+      {
+        _id: 'allowed_report_about_existing_person1',
+        type: 'data_record',
+        fields: { patient_id: 'existing_person' },
+        form: 'form',
+        contact: {
+          _id: 'fixture:user:offline',
+          parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } },
+        },
+      },
+      {
+        _id: 'allowed_report_about_existing_person2',
+        type: 'data_record',
+        fields: { patient_id: 'existing_person', needs_signoff: true },
+        form: 'form',
+        contact: {
+          _id: 'existing_person',
+          parent: { _id: 'existing_clinic', parent: { _id: 'fixture:offline', parent: { _id: 'PARENT_PLACE' } } },
+        },
+      },
+      {
+        _id: 'allowed_target',
+        type: 'target',
+        owner: 'existing_person',
+      },
+      {
+        _id: 'denied_target',
+        type: 'target',
+        owner: 'whoever',
+      },
+    ];
+
+    const settings = { replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] };
+    return utils
+      .updateSettings(settings)
+      .then(() => utils.saveDocs(existentDocs))
+      .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
+      .then(() => {
+        const docs = existentDocs.map(doc => ({ id: doc._id, rev: doc._rev }));
+        offlineRequestOptions.body = { docs };
+        return utils.requestOnMedicDb(offlineRequestOptions);
+      })
+      .then(result => {
+        const allowedIds = [
+          'existing_clinic',
+          'report_about_existing_clinic',
+          'existing_person',
+          'allowed_report_about_existing_person1',
+          'allowed_report_about_existing_person2',
+          'allowed_target',
+        ];
+
+        const expected = existentDocs
+          .filter(doc => allowedIds.includes(doc._id))
+          .map(doc => ({
+            id: doc._id,
+            docs: [{ ok: doc }]
+          }));
+        chai.expect(result.results).to.deep.equal(expected);
       });
   });
 });

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -462,6 +462,44 @@ describe('db-doc handler', () => {
         });
     });
 
+    it('GET many types of reports with report replication depth and needs_signoff', () => {
+      const reportScenarios = [
+        { doc: reportForPatient('fixture:offline:patient', null, ['patient_uuid']), allowed: true },
+        { doc: reportForPatient('fixture:offline:patient', 'offline', ['patient_id']), allowed: true },
+        { doc: reportForPatient('fixture:offline:clinic:patient', null, ['patient_uuid']), allowed: false },
+        { doc: reportForPatient('fixture:offline:clinic:patient', 'offline', ['patient_id']), allowed: true },
+        { doc: reportForPatient('fixture:offline:clinic:patient', null, ['patient_uuid'], true), allowed: false },
+        { doc: reportForPatient('fixture:offline:clinic:patient', 'offline', ['patient_id'], true), allowed: true },
+
+        { doc: reportForPatient('fixture:online:patient', null, ['patient_uuid']), allowed: false },
+        { doc: reportForPatient('fixture:online:patient', 'online', ['patient_id']), allowed: false },
+        { doc: reportForPatient('fixture:online:clinic:patient', null, ['patient_uuid']), allowed: false },
+        { doc: reportForPatient('fixture:online:clinic:patient', 'online', ['patient_id']), allowed: false },
+        { doc: reportForPatient('fixture:online:clinic:patient', null, ['patient_uuid'], true), allowed: false },
+        { doc: reportForPatient('fixture:online:clinic:patient', 'online', ['patient_id'], true), allowed: false },
+      ];
+
+      const docs = reportScenarios.map(scenario => scenario.doc);
+      return utils
+        .updateSettings({replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }]})
+        .then(() => utils.saveDocs(docs))
+        .then(() => Promise.all(
+          reportScenarios.map(scenario =>
+            utils
+              .requestOnTestDb(_.defaults({ path: `/${scenario.doc._id}` }, offlineRequestOptions))
+              .catch(err => err)))
+        )
+        .then(results => {
+          results.forEach((result, idx) => {
+            if (reportScenarios[idx].allowed) {
+              chai.expect(result).to.deep.include(reportScenarios[idx].doc);
+            } else {
+              chai.expect(result).to.deep.nested.include({ statusCode: 403, 'responseBody.error': 'forbidden'});
+            }
+          });
+        });
+    });
+
     describe('GET with deletes', () => {
       const patientsToDelete = [
         {


### PR DESCRIPTION
# Description

Adds a new property to `replication_depth`, called `report_depth` that reduces the depth of report replication, with the exception of reports that are submitted by the authenticated user. 
Only works in conjunction with regular replication depth, and the selected report depth is the one paired with the selected contact depth. 
Reports with `needs_signoff` work as before. 

medic/cht-core#6352

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
