### PR TITLE
Outbound will send multiple requests for the same record

### DIFF
--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -101,12 +101,6 @@ const singlePush = (taskDoc, medicDoc, infoDoc, config, key) => Promise.resolve(
       return removeConfigKeyFromTask(taskDoc, key);
     }
 
-    if (outbound.alreadySent(key, infoDoc)) {
-      // Don't send "duplicate" outbound pushes
-      logger.debug(`Skipping ${medicDoc._id} for ${key} because we've pushed this combination before`);
-      return removeConfigKeyFromTask(taskDoc, key);
-    }
-
     return outbound.send(config, key, medicDoc, infoDoc)
       .then(() => {
         // Worked, remove entry from queue and store infodoc that outbound service has updated

--- a/sentinel/tests/unit/schedule/outbound.js
+++ b/sentinel/tests/unit/schedule/outbound.js
@@ -211,7 +211,6 @@ describe('outbound schedule', () => {
     let sentinelPut;
     let sentinelGet;
     let send;
-    let alreadySent;
 
     const restores = [];
 
@@ -225,8 +224,7 @@ describe('outbound schedule', () => {
       restores.push(outbound.__set__('mapDocumentToPayload', mapDocumentToPayload));
 
       send = sinon.stub();
-      alreadySent = sinon.stub();
-      restores.push(outbound.__set__('outbound', { send: send, alreadySent: alreadySent }));
+      restores.push(outbound.__set__('outbound', { send: send }));
 
       sentinelPut = sinon.stub(db.sentinel, 'put');
       sentinelGet = sinon.stub(db.sentinel, 'get');
@@ -255,7 +253,6 @@ describe('outbound schedule', () => {
       };
 
       mapDocumentToPayload.returns({map: 'called'});
-      alreadySent.returns(false);
       send.resolves();
       sentinelPut.onFirstCall().resolves({rev: '1-abc'});
       sentinelPut.resolves();
@@ -323,45 +320,6 @@ describe('outbound schedule', () => {
           assert.equal(task._deleted, true);
           assert.equal(task._rev, '1-abc');
           assert.equal(send.callCount, 0);
-        });
-    });
-
-    it('should remove queue entries that refer to already sent config items', () => {
-      const config = {
-        some: 'config'
-      };
-
-      const task = {
-        _id: 'task:outbound:test-doc-1',
-        doc_id: 'test-doc-1',
-        queue: ['test-push-1']
-      };
-
-      const doc = {
-        _id: 'test-doc-1', some: 'data-1'
-      };
-
-      const infoDoc = {
-        _id: 'test-doc-1-info',
-        type: 'info',
-        completed_tasks: [{
-          type: 'outbound',
-          key: 'test-push-1'
-        }]
-      };
-
-      mapDocumentToPayload.returns({map: 'called'});
-      alreadySent.returns(true);
-      send.resolves();
-      sentinelPut.onFirstCall().resolves({rev: '1-abc'});
-      sentinelPut.resolves();
-
-      return outbound.__get__('singlePush')(task, doc, infoDoc, config, 'some')
-        .then(() => {
-          assert.equal(task._deleted, true);
-          assert.equal(task._rev, '1-abc');
-          assert.equal(send.callCount, 0);
-          assert.equal(sentinelPut.callCount, 1);
         });
     });
 

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -196,9 +196,9 @@ const orderedStringify = thing => {
     }
 
     return `{${output.join(',')}}`;
-  } else {
-    return JSON.stringify(thing);
   }
+
+  return JSON.stringify(thing);
 };
 
 // Never change this hashing algorithm or how we stringify, otherwise you will invalidate all existing hashes
@@ -301,12 +301,12 @@ module.exports = theLogger => {
           if (alreadySent(payload, configName, recordInfo)) {
             logger.info(`Not pushing ${record._id} to ${configName} as payload is identical to previous push`);
             return false;
-          } else {
-            return sendPayload(payload, config)
-              .then(() => updateInfo(payload, recordInfo, configName))
-              .then(() => logger.info(`Pushed ${record._id} to ${configName}`))
-              .then(() => true);
           }
+
+          return sendPayload(payload, config)
+            .then(() => updateInfo(payload, recordInfo, configName))
+            .then(() => logger.info(`Pushed ${record._id} to ${configName}`))
+            .then(() => true);
         })
         .catch(err => {
           logSendError(configName, record._id, err);


### PR DESCRIPTION
Adds a hash into completed_tasks so we can correctly detect when to
re-send a record.

This changes the sending semantics for outbound to be that we send an
outbound request whenever we have a configuration with a truthy
relevant_to, and where the prior send (if any) for that configuration
sent a different payload.

This is not a perfect system. If your mapping function is not idempotent
outbound may fire requests when you do not intend it to, e.g., if a user
doesn't actually edit the document meaningfully, or if sentinel or
another process writes to the document.

medic/cht-core#6419