### PR TITLE
Adds `private` sensitive property

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -449,8 +449,8 @@ const getAllowedDocIds = (feed, { includeTombstones = true } = {}) => {
     const viewResultsById = groupViewResultsById(feed, results);
 
     results.rows.forEach(row => {
-      const { key: subject, value:{ submitter, private } } = row;
-      if (isSensitive(feed.userCtx, subject, submitter, private, feed.subjectIds.includes(row.value.submitter))) {
+      const { key: subject, value: { submitter, private } = {} } = row;
+      if (isSensitive(feed.userCtx, subject, submitter, private, feed.subjectIds.includes(submitter))) {
         return;
       }
 

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -278,24 +278,25 @@ describe('Authorization service', () => {
           { id: 'r4', key: null, value: { submitter: 'c2' } },
           { id: 'r5', key: 'facility_id', value: {} },
           { id: 'r6', key: 'contact_id', value: {} },
-          { id: 'r7', key: 'facility_id', value: { submitter: 'c-unknown' } }, //sensitive
-          { id: 'r8', key: 'contact_id', value: { submitter: 'c-unknown' } }, //sensitive
+          { id: 'r7', key: 'facility_id', value: { submitter: 'c-unknown', private: true } }, //sensitive
+          { id: 'r8', key: 'contact_id', value: { submitter: 'c-unknown', private: 'something' } }, //sensitive
           { id: 'r9', key: 'facility_id', value: { submitter: 'c3' } },
           { id: 'r10', key: 'contact_id', value: { submitter: 'c4' } },
           { id: 'r11', key: 'sbj3', value: { } },
           { id: 'r12', key: 'sbj4', value: { submitter: 'someone' } },
-          { id: 'r13', key: false, value: { submitter: 'someone else' } }
+          { id: 'r13', key: false, value: { submitter: 'someone else' } },
+          { id: 'r14', key: 'contact_id', value: { submitter: 'c-unknown', private: false } }, // not sensitive
         ]});
 
       return service
         .getAllowedDocIds({subjectIds, userCtx: { name: 'user', facility_id: 'facility_id', contact_id: 'contact_id' }})
         .then(result => {
-          result.length.should.equal(13);
+          result.length.should.equal(14);
           result.should.deep.equal([
             '_design/medic-client', 'org.couchdb.user:user',
             'r1', 'r2', 'r3', 'r4',
             'r5', 'r6', 'r9', 'r10',
-            'r11', 'r12', 'r13'
+            'r11', 'r12', 'r13', 'r14'
           ]);
         });
     });
@@ -755,14 +756,14 @@ describe('Authorization service', () => {
       it('returns false for reports with allowed subject, denied submitter and sensitive', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.contact_id ];
         viewResults = {
-          replicationKeys: [{ key: userCtx.contact_id, value: { submitter: 'submitter', type: 'data_record' }}],
+          replicationKeys: [{ key: userCtx.contact_id, value: { submitter: 'submitter', type: 'data_record', private: true }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
 
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.facility_id ];
         viewResults = {
-          replicationKeys: [{ key: userCtx.facility_id, value: { submitter: 'submitter', type: 'data_record' }}],
+          replicationKeys: [{ key: userCtx.facility_id, value: { submitter: 'submitter', type: 'data_record', private: true }}],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);

--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -756,14 +756,20 @@ describe('Authorization service', () => {
       it('returns false for reports with allowed subject, denied submitter and sensitive', () => {
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.contact_id ];
         viewResults = {
-          replicationKeys: [{ key: userCtx.contact_id, value: { submitter: 'submitter', type: 'data_record', private: true }}],
+          replicationKeys: [{
+            key: userCtx.contact_id,
+            value: { submitter: 'submitter', type: 'data_record', private: true }}
+          ],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);
 
         feed.subjectIds = [ 'subject1', 'contact1', 'subject', 'contact', userCtx.facility_id ];
         viewResults = {
-          replicationKeys: [{ key: userCtx.facility_id, value: { submitter: 'submitter', type: 'data_record', private: true }}],
+          replicationKeys: [{
+            key: userCtx.facility_id,
+            value: { submitter: 'submitter', type: 'data_record', private: true }
+          }],
           contactsByDepth: [],
         };
         service.allowedDoc(report, feed, viewResults).should.equal(false);

--- a/ddocs/medic/views/docs_by_replication_key/map.js
+++ b/ddocs/medic/views/docs_by_replication_key/map.js
@@ -52,6 +52,9 @@ function (doc) {
       if (doc.form && doc.contact) {
         value.submitter = doc.contact._id;
       }
+      if (doc.fields && doc.fields.private) {
+        value.private = true;
+      }
       emit(subject, value);
       if (doc.fields &&
           doc.fields.needs_signoff &&

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1544,23 +1544,57 @@ describe('changes handler', () => {
     });
   });
 
-  it('should not return reports about your place by someone above you in the hierarchy', () =>
-    utils
-      .saveDoc({
-        type:'data_record', _id:'chw-report', place_id:'fixture:chwville',
-        contact:{ _id:'fixture:user:chw' }, form:'some-form'
-      })
-      .then(() => utils.saveDoc({
-        type:'data_record', _id:'chw-boss-report', place_id:'fixture:chwville',
-        contact:{ _id:'fixture:user:chw-boss' }, form:'some-form'
-      }))
+  it('should not return reports about your place by someone above you in the hierarchy', () => {
+    const docs = [
+      {
+        // report about home place submitted by logged in user
+        _id: 'chw-report-1',
+        type: 'data_record',
+        place_id: 'fixture:chwville',
+        contact: { _id: 'fixture:user:chw' },
+        form: 'form',
+      },
+      {
+        // private report about place submitted by logged in user
+        _id: 'chw-report-2',
+        type: 'data_record',
+        place_id: 'fixture:chwville',
+        contact: { _id: 'fixture:user:chw' },
+        form: 'form',
+        fields: { private: true },
+      },
+      {
+        // report about place submitted by someone else
+        _id: 'chw-report-3',
+        type: 'data_record',
+        place_id: 'fixture:chwville',
+        contact: { _id: 'someone_else' },
+        form: 'form',
+      },
+      {
+        // private report about place submitted by someone else
+        _id: 'chw-report-4',
+        type: 'data_record',
+        place_id: 'fixture:chwville',
+        contact: { _id: 'someone_else' },
+        form: 'form',
+        fields: { private: true },
+      },
+    ];
+    return utils
+      .saveDocs(docs)
       .then(() => requestChanges('chw'))
-      .then(changes =>
+      .then(changes => {
         assertChangeIds(changes,
           'org.couchdb.user:chw',
           'fixture:chwville',
           'fixture:user:chw',
-          'chw-report')));
+          'chw-report-1',
+          'chw-report-2',
+          'chw-report-3',
+        );
+      });
+  });
 
   it('should update the feed when the doc is updated', () => {
     let seq_number;

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -435,6 +435,58 @@ describe('all_docs handler', () => {
       });
   });
 
+  it('should not return sensitive documents', () => {
+    const docs = [
+      {
+        _id: 'insensitive_report_1',
+        type: 'data_record',
+        form: 'a',
+        contact: { _id: 'fixture:offline'},
+        patient_id: 'fixture:offline'
+      },
+      {
+        _id: 'insensitive_report_2',
+        type: 'data_record',
+        form: 'a',
+        contact: { _id: 'fixture:offline'},
+        patient_id: 'fixture:offline',
+        fields: { private: true },
+      },
+      {
+        _id: 'insensitive_report_3',
+        type: 'data_record',
+        form: 'a',
+        contact: { _id: 'fixture:online'},
+        patient_id: 'fixture:offline',
+        fields: { private: false },
+      },
+      {
+        _id: 'sensitive_report',
+        type: 'data_record',
+        form: 'a',
+        contact: { _id: 'fixture:online'},
+        patient_id: 'fixture:offline',
+        fields: { private: true },
+      },
+    ];
+
+    const keys = docs.map(doc => doc._id);
+    const opts = _.defaults({ path: '/_all_docs?keys=' + JSON.stringify(keys) }, offlineRequestOptions);
+
+    return utils
+      .saveDocs(docs)
+      .then(result => result.forEach((r, idx) => docs[idx]._rev = r.rev))
+      .then(() => utils.requestOnMedicDb(opts))
+      .then(result => {
+        chai.expect(result.rows).to.deep.equal([
+          { id: 'insensitive_report_1', key: 'insensitive_report_1', value: { rev: docs[0]._rev }},
+          { id: 'insensitive_report_2', key: 'insensitive_report_2', value: { rev: docs[1]._rev }},
+          { id: 'insensitive_report_3', key: 'insensitive_report_3', value: { rev: docs[2]._rev }},
+          { id: 'sensitive_report', error: 'forbidden' },
+        ]);
+      });
+  });
+
   it('filters offline users results when db name is not medic', () => {
     const docs = [
       { _id: 'allowed_contact', parent: { _id: 'fixture:offline'}, type: 'clinic' },

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 const chai = require('chai');
+const chaiExclude = require('chai-exclude');
+chai.use(chaiExclude);
 const utils = require('../../../utils');
 const sUtils = require('../../sentinel/utils');
 const constants = require('../../../constants');
@@ -1206,6 +1208,56 @@ describe('db-doc handler', () => {
         .then(result => {
           // user can see the unallocated report with permissions
           chai.expect(result).to.deep.include(doc);
+        });
+    });
+
+    it('GET sensitive documents', () => {
+      const docs = [
+        {
+          _id: 'insensitive_report_1',
+          type: 'data_record',
+          form: 'a',
+          contact: { _id: 'fixture:offline'},
+          patient_id: 'fixture:offline'
+        },
+        {
+          _id: 'insensitive_report_2',
+          type: 'data_record',
+          form: 'a',
+          contact: { _id: 'fixture:offline'},
+          patient_id: 'fixture:offline',
+          fields: { private: true },
+        },
+        {
+          _id: 'insensitive_report_3',
+          type: 'data_record',
+          form: 'a',
+          contact: { _id: 'fixture:online'},
+          patient_id: 'fixture:offline',
+          fields: { private: false },
+        },
+        {
+          _id: 'sensitive_report',
+          type: 'data_record',
+          form: 'a',
+          contact: { _id: 'fixture:online'},
+          patient_id: 'fixture:offline',
+          fields: { private: true },
+        },
+      ];
+
+      return utils
+        .saveDocs(docs)
+        .then(() => Promise.all(
+          docs.map(doc =>
+            utils.requestOnTestDb(_.defaults({ path: `/${doc._id}` }, offlineRequestOptions)).catch(err => err)
+          )
+        ))
+        .then(results => {
+          chai.expect(results[0]).excluding('_rev').to.deep.equal(docs[0]);
+          chai.expect(results[1]).excluding('_rev').to.deep.equal(docs[1]);
+          chai.expect(results[2]).excluding('_rev').to.deep.equal(docs[2]);
+          chai.expect(results[3]).to.deep.nested.include({ statusCode: 403, 'responseBody.error': 'forbidden'});
         });
     });
 


### PR DESCRIPTION
# Description

Changes the definition of a "sensitive" report, so it needs to:
1. be about the user's contact or the user's place
2. be submitted by someone the user can't see
3. have a field called `private` with a truthy value. 

medic/cht-core#6370

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
