### PR TITLE
Turn off the autocomplete on user name field.

### DIFF
--- a/admin/src/templates/edit_user.html
+++ b/admin/src/templates/edit_user.html
@@ -11,7 +11,7 @@
 
     <div class="form-group required" ng-class="{'has-error': errors.username}">
       <label for="username" translate>User Name</label>
-      <input id="username" type="text" class="form-control" ng-model="editUserModel.username" ng-disabled="editUserModel.id" />
+      <input id="username" type="text" class="form-control" autocomplete="off" ng-model="editUserModel.username" ng-disabled="editUserModel.id" />
       <span class="help-block" translate>user.username.help</span>
       <span class="help-block">{{errors.username}}</span>
     </div>

--- a/admin/src/templates/edit_user.html
+++ b/admin/src/templates/edit_user.html
@@ -10,8 +10,8 @@
   <form action="" method="POST">
 
     <div class="form-group required" ng-class="{'has-error': errors.username}">
-      <label for="username" translate>User Name</label>
-      <input id="username" type="text" class="form-control" autocomplete="off" ng-model="editUserModel.username" ng-disabled="editUserModel.id" />
+      <label for="edit-username" translate>User Name</label>
+      <input id="edit-username" name="edit-username" type="text" class="form-control" autocomplete="off" ng-model="editUserModel.username" ng-disabled="editUserModel.id" />
       <span class="help-block" translate>user.username.help</span>
       <span class="help-block">{{errors.username}}</span>
     </div>
@@ -65,14 +65,14 @@
     </div>
 
     <div class="form-group" ng-class="{'has-error': errors.password, 'required': !editUserModel.id}">
-      <label for="password" translate>Password</label>
-      <input id="password" type="password" class="form-control" ng-model="editUserModel.password" autocomplete="off" ng-disabled="editUserModel.role === '_admin'"/>
+      <label for="edit-password" translate>Password</label>
+      <input id="edit-password" name="edit-password" type="password" class="form-control" ng-model="editUserModel.password" autocomplete="new-password" ng-disabled="editUserModel.role === '_admin'"/>
       <span class="help-block">{{errors.password}}</span>
     </div>
 
     <div class="form-group" ng-class="{'required': !editUserModel.id}">
-      <label for="password-confirm" translate>Confirm Password</label>
-      <input id="password-confirm" type="password" class="form-control" ng-model="editUserModel.passwordConfirm" autocomplete="off" ng-disabled="editUserModel.role === '_admin'"/>
+      <label for="edit-password-confirm" translate>Confirm Password</label>
+      <input id="edit-password-confirm" name="edit-password-confirm" type="password" class="form-control" ng-model="editUserModel.passwordConfirm" autocomplete="new-password" ng-disabled="editUserModel.role === '_admin'"/>
     </div>
 
   </form>

--- a/tests/e2e/users/add-user.specs.js
+++ b/tests/e2e/users/add-user.specs.js
@@ -5,7 +5,7 @@ const addUserModal = require('../../page-objects/users/add-user-modal.po.js');
 
 const addedUser = 'fulltester' + new Date().getTime();
 const fullName = 'Bede Ngaruko';
-const errorMessagePassword = element(by.css('#password ~ .help-block'));
+const errorMessagePassword = element(by.css('#edit-password ~ .help-block'));
 
 describe('Add user  : ', () => {
 
@@ -54,7 +54,7 @@ describe('Add user  : ', () => {
   it('should reject non-matching passwords', () => {
     usersPage.openAddUserModal();
     addUserModal.fillForm('user0', 'Not Saved', '%4wbbygxkgdwvdwT65');
-    element(by.id('password-confirm')).sendKeys('abc');
+    element(by.id('edit-password-confirm')).sendKeys('abc');
     addUserModal.submit();
     expect(errorMessagePassword.getText()).toMatch('Passwords must match');
     element(by.css('button.cancel.close')).click();

--- a/tests/page-objects/users/add-user-modal.po.js
+++ b/tests/page-objects/users/add-user-modal.po.js
@@ -1,7 +1,7 @@
 const helper = require('../../helper');
 
 const getUsernameField = () => {
-  return element(by.id('username'));
+  return element(by.id('edit-username'));
 };
 
 const getFullNameField = () => {
@@ -24,11 +24,11 @@ const getRoleField = () => {
 };
 
 const getPasswordField = () => {
-  return element(by.id('password'));
+  return element(by.id('edit-password'));
 };
 
 const getConfirmPasswordField = () => {
-  return element(by.id('password-confirm'));
+  return element(by.id('edit-password-confirm'));
 };
 const getSubmitButton = () => {
   return element(by.css('.btn.submit.btn-primary:not(.ng-hide)'));


### PR DESCRIPTION
# Description

The User name field should be blank when adding a new user, this PR adds the autocomplete="off" property to the input field in admin/user. 
I checked password and confirm password fields as well as login fields and all of them has the property correctly. Just this one was missing.

medic/cht-core#6404

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
