### PR TITLE
Add a sentance deliniating INSTALL.md vs DEVELOPMENT.md per #6508

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Local Installation
 
-The following are instructions on how to install the Core Framework on your local machine, allowing you to develop or edit applications using the Core Framework. These are not instructions for a production-ready deployment.
+The following are instructions on how to install the Core Framework on your local machine, allowing you to easily develop or edit applications using the Core Framework. If you are looking to do development on the Core Framework directly, please see [Development Setup](./DEVELOPMENT.md). These are not instructions for a production-ready deployment.
 
 These instructions should work on Windows, MacOS and Linux.
 


### PR DESCRIPTION
# Description

Add a sentence delineating  [DEVELOPMENT.md](https://github.com/medic/cht-core/blob/master/DEVELOPMENT.md) vs [INSTALL.md](https://github.com/medic/cht-core/blob/master/INSTALL.md)

medic/cht-core#6508

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
