### PR TITLE
Increase width and wrap text in dropdown selects

### DIFF
--- a/webapp/src/css/dropdown.less
+++ b/webapp/src/css/dropdown.less
@@ -259,8 +259,8 @@
 @media (max-width: 767px) {
   .open .mm-dropdown-menu {
     top: 111px;
-    left: 20px;
-    right: 20px;
+    left: 10px;
+    right: 10px;
     .mm-dropdown-menu-modal
   }
 

--- a/webapp/src/css/dropdown.less
+++ b/webapp/src/css/dropdown.less
@@ -81,7 +81,7 @@
   display: inline-block;
 
   .dropdown-menu {
-    min-width: 220px;
+    min-width: 240px;
     a:before {
       // copied from .fa-fw
       display: inline-block;
@@ -96,6 +96,7 @@
   }
 
   &.multidropdown .dropdown-menu {
+    min-width: 260px;
     padding-bottom: 50px;
     > ul {
       max-height: 300px;
@@ -106,6 +107,26 @@
       content: none;
     }
     li {
+      > a[role="menuitem"] {
+        padding: 5px 20px 3px 35px;
+        text-indent: -20px;
+
+        &.indent-1 {
+          padding-left: 50px;
+        }
+
+        &.indent-2 {
+          padding-left: 60px;
+        }
+
+        &.indent-3 {
+          padding-left: 70px;
+        }
+
+        &.indent-4 {
+          padding-left: 80px;
+        }
+      }
       a,
       &.dropdown-header {
         padding-left: 10px;
@@ -226,28 +247,25 @@
   }
   li > a {
     display: block;
-    padding: 3px 20px;
+    padding: 5px 20px;
     clear: both;
     font-weight: normal;
     line-height: 1.42857;
     color: #333;
-    white-space: nowrap;
+    white-space: normal;
+
     &.indent-1 {
       padding-left: 20px;
     }
-
     &.indent-2 {
       padding-left: 30px;
     }
-
     &.indent-3 {
       padding-left: 40px;
     }
-
     &.indent-4 {
       padding-left: 50px;
     }
-
     &.indent-5 {
       padding-left: 60px;
     }

--- a/webapp/src/css/dropdown.less
+++ b/webapp/src/css/dropdown.less
@@ -81,7 +81,7 @@
   display: inline-block;
 
   .dropdown-menu {
-    min-width: 240px;
+    min-width: 260px;
     a:before {
       // copied from .fa-fw
       display: inline-block;
@@ -96,7 +96,6 @@
   }
 
   &.multidropdown .dropdown-menu {
-    min-width: 260px;
     padding-bottom: 50px;
     > ul {
       max-height: 300px;
@@ -114,15 +113,12 @@
         &.indent-1 {
           padding-left: 50px;
         }
-
         &.indent-2 {
           padding-left: 60px;
         }
-
         &.indent-3 {
           padding-left: 70px;
         }
-
         &.indent-4 {
           padding-left: 80px;
         }
@@ -253,22 +249,6 @@
     line-height: 1.42857;
     color: #333;
     white-space: normal;
-
-    &.indent-1 {
-      padding-left: 20px;
-    }
-    &.indent-2 {
-      padding-left: 30px;
-    }
-    &.indent-3 {
-      padding-left: 40px;
-    }
-    &.indent-4 {
-      padding-left: 50px;
-    }
-    &.indent-5 {
-      padding-left: 60px;
-    }
 
     &:hover, &:focus {
       text-decoration: none;


### PR DESCRIPTION
# Description

Issue: medic/cht-core#6481

Increase the width of the component a bit and wrap the text instead of hide it when overflow.

Here is how it looks now:

![6481-space-filter-box-fixed](https://user-images.githubusercontent.com/1608415/86055071-a2759480-ba31-11ea-8d14-fad84feab500.png)

In **mobile** the new size is ignored as expected taking the full width, but the wrapping is applied:

![6481-space-filter-box-fixed mobile](https://user-images.githubusercontent.com/1608415/86055162-c33dea00-ba31-11ea-955a-8114da00d9a8.png)

The PR also takes into account **nested bullets** with long texts:

![6481-space-filter-box-fixed-multi-indent](https://user-images.githubusercontent.com/1608415/86055264-dd77c800-ba31-11ea-86be-e0f0beefaa62.png)

And finally, the changes also place nicely with **scrolls** when the list is too largem and **Firefox**:

![6481-space-filter-box-fixed-and-scroll](https://user-images.githubusercontent.com/1608415/86055311-f1232e80-ba31-11ea-9493-79ccf413fa9a.png)

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
