### PR TITLE
Patch for Nools parser regex

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -351,7 +351,8 @@ module.exports = function(grunt) {
           'enketo-core/**',
           'font-awesome/**',
           'messageformat/**',
-          'moment/**'
+          'moment/**',
+          'nools/**'
         ],
         dest: 'webapp/node_modules_backup',
       },
@@ -537,6 +538,7 @@ module.exports = function(grunt) {
             'enketo-core',
             'font-awesome',
             'moment',
+            'nools',
           ];
           return modulesToPatch.map(module => {
             const backupPath = 'webapp/node_modules_backup/' + module;
@@ -621,6 +623,10 @@ module.exports = function(grunt) {
 
             // patch messageformat to add a default plural function for languages not yet supported by make-plural #5705
             'patch webapp/node_modules/messageformat/lib/plurals.js < webapp/patches/messageformat-default-plurals.patch',
+
+            // patch to update the nools parser regex to ignore urls and only remove comments
+            // https://github.com/medic/cht-core/issues/6506
+            'patch shared-libs/rules-engine/node_modules/nools/lib/parser/nools/nool.parser.js < webapp/patches/nools-parser-regex-url-update.patch',
           ];
           return patches.join(' && ');
         },

--- a/webapp/patches/nools-parser-regex-url-update.patch
+++ b/webapp/patches/nools-parser-regex-url-update.patch
@@ -1,5 +1,5 @@
-*** nool.parser.js	Mon Jul  6 12:01:37 2020
---- nool.parser-copy.js	Mon Jul  6 11:52:27 2020
+*** nool.parser.js	Wed Jul  8 13:05:00 2020
+--- nool.parser-copy.js	Wed Jul  8 13:06:01 2020
 ***************
 *** 7,13 ****
   
@@ -9,13 +9,11 @@
   
       var blockTypes = new RegExp("^(" + keys(keywords).join("|") + ")"), index;
       while (src && (index = utils.findNextTokenIndex(src)) !== -1) {
---- 7,15 ----
+--- 7,13 ----
   
   var parse = function (src, keywords, context) {
       var orig = src;
-!     src = src.replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, " "+/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm)
-!     .replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, " ")
-!     .replace(/\r\n|\r|\n/g, " ");
+!     src = src.replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, " ").replace(/\r\n|\r|\n/g, " ");
   
       var blockTypes = new RegExp("^(" + keys(keywords).join("|") + ")"), index;
       while (src && (index = utils.findNextTokenIndex(src)) !== -1) {

--- a/webapp/patches/nools-parser-regex-url-update.patch
+++ b/webapp/patches/nools-parser-regex-url-update.patch
@@ -1,0 +1,21 @@
+*** nool.parser.js	Mon Jul  6 12:01:37 2020
+--- nool.parser-copy.js	Mon Jul  6 11:52:27 2020
+***************
+*** 7,13 ****
+  
+  var parse = function (src, keywords, context) {
+      var orig = src;
+!     src = src.replace(/\/\/(.*)/g, "").replace(/\r\n|\r|\n/g, " ");
+  
+      var blockTypes = new RegExp("^(" + keys(keywords).join("|") + ")"), index;
+      while (src && (index = utils.findNextTokenIndex(src)) !== -1) {
+--- 7,15 ----
+  
+  var parse = function (src, keywords, context) {
+      var orig = src;
+!     src = src.replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, " "+/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm)
+!     .replace(/\/\*[\s\S]*?\*\/|([^:]|^)\/\/.*$/gm, " ")
+!     .replace(/\r\n|\r|\n/g, " ");
+  
+      var blockTypes = new RegExp("^(" + keys(keywords).join("|") + ")"), index;
+      while (src && (index = utils.findNextTokenIndex(src)) !== -1) {


### PR DESCRIPTION
# Description

Regex patch to exclude comments(double and single line) but ignore urls

medic/cht-core#6506

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
