### PR TITLE
6369 unhandled rejections unit tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,5 +18,9 @@
         "no-var": "off"
       }
     }
-  ]
+  ],
+  "plugins": ["promise"],
+  "rules": {
+    "promise/catch-or-return": "error"
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "parserOptions": {
     "ecmaVersion": 6
   },
+  "plugins": ["promise"],
   "overrides": [
     {
       "files": [ "Gruntfile.js", "grunt/service-worker.js" ],
@@ -17,10 +18,12 @@
         "no-console": "off",
         "no-var": "off"
       }
+    },
+    {
+      "files": [ "**/tests/**" ],
+      "rules": {
+        "promise/catch-or-return": "error"
+      }
     }
-  ],
-  "plugins": ["promise"],
-  "rules": {
-    "promise/catch-or-return": "error"
-  }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
       }
     },
     {
-      "files": [ "**/tests/**" ],
+      "files": [ "**/test/**", "**/tests/**" ],
       "rules": {
         "promise/catch-or-return": "error"
       }

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -122,7 +122,11 @@ describe('Changes controller', () => {
 
       this.then = promise.then.bind(promise);
       this['catch'] = promise['catch'].bind(promise);
-      this.then(result => complete(null, result), complete);
+      this.then(
+        result => complete(null, result), complete
+      ).catch(() => {
+        process.exit(1);
+      });
     };
     inherits(ChangesEmitter, EventEmitter);
 

--- a/api/tests/mocha/controllers/changes.js
+++ b/api/tests/mocha/controllers/changes.js
@@ -122,11 +122,9 @@ describe('Changes controller', () => {
 
       this.then = promise.then.bind(promise);
       this['catch'] = promise['catch'].bind(promise);
-      this.then(
-        result => complete(null, result), complete
-      ).catch(() => {
-        process.exit(1);
-      });
+      this
+        .then(result => complete(null, result), complete)
+        .catch(err => complete(err));
     };
     inherits(ChangesEmitter, EventEmitter);
 

--- a/api/tests/mocha/controllers/export-data.spec.js
+++ b/api/tests/mocha/controllers/export-data.spec.js
@@ -87,7 +87,7 @@ describe('Export Data controller', () => {
     // NB: This is actually an integration test so we can test that
     // errors from the underlying mapper are handled correctly in
     // the controller.
-    it('catches error from service.exportStream', done => {
+    it('catches error from service.exportStream', () => {
       const req = {
         params: {
           type: 'feedback'
@@ -112,7 +112,6 @@ describe('Export Data controller', () => {
           res.write.args[0][0].toString().should.equal('id,reported_date,user,app_version,url,info\n');
           res.end.callCount.should.equal(1);
           res.end.args[0][0].should.equal('--ERROR--\nError exporting data: db not found\n');
-          done();
         });
       });
     });

--- a/api/tests/mocha/controllers/export-data.spec.js
+++ b/api/tests/mocha/controllers/export-data.spec.js
@@ -114,6 +114,8 @@ describe('Export Data controller', () => {
           res.end.args[0][0].should.equal('--ERROR--\nError exporting data: db not found\n');
           done();
         });
+      }).catch(() => {
+        process.exit(1);
       });
     });
   });

--- a/api/tests/mocha/controllers/export-data.spec.js
+++ b/api/tests/mocha/controllers/export-data.spec.js
@@ -105,7 +105,7 @@ describe('Export Data controller', () => {
       auth.isOnlineOnly.returns(true);
       sinon.stub(db.medicUsersMeta, 'allDocs').returns(Promise.reject(new Error('db not found')));
       
-      controller.get(req, res).then(() => {
+      return controller.get(req, res).then(() => {
         // defer execution to allow the stream to write first
         setTimeout(() => {
           res.write.callCount.should.equal(1);
@@ -114,8 +114,6 @@ describe('Export Data controller', () => {
           res.end.args[0][0].should.equal('--ERROR--\nError exporting data: db not found\n');
           done();
         });
-      }).catch(() => {
-        process.exit(1);
       });
     });
   });

--- a/api/tests/mocha/controllers/forms.spec.js
+++ b/api/tests/mocha/controllers/forms.spec.js
@@ -21,7 +21,7 @@ describe('forms controller', () => {
   });
 
   describe('get', () => {
-    it('returns error from view query', done => {
+    it('returns error from view query', () => {
       const req = { params: { form: 'a.xml' } };
       const query = sinon
         .stub(db.medic, 'query')
@@ -30,7 +30,6 @@ describe('forms controller', () => {
       return controller.get(req, res).then(() => {
         chai.expect(error.args[0][0]).to.equal('icky');
         chai.expect(query.callCount).to.equal(1);
-        done();
       });
     });
 
@@ -65,14 +64,13 @@ describe('forms controller', () => {
   });
 
   describe('list', () => {
-    it('returns error from view query', done => {
+    it('returns error from view query', () => {
       const req = {};
       const get = sinon.stub(db.medic, 'query').returns(Promise.reject('icky'));
       const error = sinon.stub(serverUtils, 'error');
       return controller.list(req, res).then(() => {
         chai.expect(error.args[0][0]).to.equal('icky');
         chai.expect(get.callCount).to.equal(1);
-        done();
       });
     });
 

--- a/api/tests/mocha/controllers/forms.spec.js
+++ b/api/tests/mocha/controllers/forms.spec.js
@@ -27,12 +27,10 @@ describe('forms controller', () => {
         .stub(db.medic, 'query')
         .returns(Promise.reject('icky'));
       const error = sinon.stub(serverUtils, 'error');
-      controller.get(req, res).then(() => {
+      return controller.get(req, res).then(() => {
         chai.expect(error.args[0][0]).to.equal('icky');
         chai.expect(query.callCount).to.equal(1);
         done();
-      }).catch(() => {
-        process.exit(1);
       });
     });
 
@@ -71,12 +69,10 @@ describe('forms controller', () => {
       const req = {};
       const get = sinon.stub(db.medic, 'query').returns(Promise.reject('icky'));
       const error = sinon.stub(serverUtils, 'error');
-      controller.list(req, res).then(() => {
+      return controller.list(req, res).then(() => {
         chai.expect(error.args[0][0]).to.equal('icky');
         chai.expect(get.callCount).to.equal(1);
         done();
-      }).catch(() => {
-        process.exit(1);
       });
     });
 

--- a/api/tests/mocha/controllers/forms.spec.js
+++ b/api/tests/mocha/controllers/forms.spec.js
@@ -31,6 +31,8 @@ describe('forms controller', () => {
         chai.expect(error.args[0][0]).to.equal('icky');
         chai.expect(query.callCount).to.equal(1);
         done();
+      }).catch(() => {
+        process.exit(1);
       });
     });
 
@@ -73,6 +75,8 @@ describe('forms controller', () => {
         chai.expect(error.args[0][0]).to.equal('icky');
         chai.expect(get.callCount).to.equal(1);
         done();
+      }).catch(() => {
+        process.exit(1);
       });
     });
 

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -35,22 +35,20 @@ describe('Resource Extraction', () => {
   it('attachments written to disk', done => {
     const expected = { content: { toString: () => 'foo' } };
     doMocking(expected);
-    resourceExtraction.run().then(() => {
+    return resourceExtraction.run().then(() => {
       expect(mockFs.writeFile.callCount).to.eq(1);
 
       const [actualOutputPath, actualContent] = mockFs.writeFile.args[0];
       expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
       expect(actualContent).to.include(expected.content);
       done();
-    }).catch(() => {
-      process.exit(1);
     });
   });
 
   it('unchanged files get written once', done => {
     const expected = { content: 'foo' };
     doMocking(expected);
-    resourceExtraction.run()
+    return resourceExtraction.run()
       .then(resourceExtraction.run)
       .then(() => {
         expect(mockFs.writeFile.callCount).to.eq(1);
@@ -59,15 +57,13 @@ describe('Resource Extraction', () => {
         expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
         expect(actualContent).to.include(expected.content);
         done();
-      }).catch(() => {
-        process.exit(1);
       });
   });
 
   it('changed files get written again', done => {
     const expected = { content: 'foo' };
     doMocking(expected);
-    resourceExtraction.run()
+    return resourceExtraction.run()
       .then(() => {
         fakeDdoc._attachments['js/attached.js'].digest = 'update';
         return resourceExtraction.run();
@@ -79,18 +75,14 @@ describe('Resource Extraction', () => {
         expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
         expect(actualContent).to.include(expected.content);
         done();
-      }).catch(() => {
-        process.exit(1);
       });
   });
 
   it('non-cacheable attachments not written to disk', done => {
     doMocking({ attachments: { 'skip/me.js': {} }});
-    resourceExtraction.run().then(() => {
+    return resourceExtraction.run().then(() => {
       expect(mockFs.writeFile.callCount).to.eq(0);
       done();
-    }).catch(() => {
-      process.exit(1);
     });
   });
 
@@ -109,13 +101,11 @@ describe('Resource Extraction', () => {
     doMocking();
     mockFs.existsSync.returns(false);
     mockFs.mkdirSync = sinon.stub().returns(true);
-    resourceExtraction.run().then(() => {
+    return resourceExtraction.run().then(() => {
       expect(mockFs.mkdirSync.callCount).to.eq(2);
       expect(mockFs.mkdirSync.args[0][0]).to.include('src/extracted-resources');
       expect(mockFs.mkdirSync.args[1][0]).to.include('src/extracted-resources/js');
       done();
-    }).catch(() => {
-      process.exit(1);
     });
   });
 });

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -32,7 +32,7 @@ function doMocking(overwrites = {}) {
 }
 
 describe('Resource Extraction', () => {
-  it('attachments written to disk', done => {
+  it('attachments written to disk', () => {
     const expected = { content: { toString: () => 'foo' } };
     doMocking(expected);
     return resourceExtraction.run().then(() => {
@@ -41,11 +41,10 @@ describe('Resource Extraction', () => {
       const [actualOutputPath, actualContent] = mockFs.writeFile.args[0];
       expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
       expect(actualContent).to.include(expected.content);
-      done();
     });
   });
 
-  it('unchanged files get written once', done => {
+  it('unchanged files get written once', () => {
     const expected = { content: 'foo' };
     doMocking(expected);
     return resourceExtraction.run()
@@ -56,11 +55,10 @@ describe('Resource Extraction', () => {
         const [actualOutputPath, actualContent] = mockFs.writeFile.args[0];
         expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
         expect(actualContent).to.include(expected.content);
-        done();
       });
   });
 
-  it('changed files get written again', done => {
+  it('changed files get written again', () => {
     const expected = { content: 'foo' };
     doMocking(expected);
     return resourceExtraction.run()
@@ -74,15 +72,13 @@ describe('Resource Extraction', () => {
         const [actualOutputPath, actualContent] = mockFs.writeFile.args[1];
         expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
         expect(actualContent).to.include(expected.content);
-        done();
       });
   });
 
-  it('non-cacheable attachments not written to disk', done => {
+  it('non-cacheable attachments not written to disk', () => {
     doMocking({ attachments: { 'skip/me.js': {} }});
     return resourceExtraction.run().then(() => {
       expect(mockFs.writeFile.callCount).to.eq(0);
-      done();
     });
   });
 
@@ -97,7 +93,7 @@ describe('Resource Extraction', () => {
     expect(isAttachmentExtractable('translations/messages-en.properties')).to.eq(false);
   });
 
-  it('creates destination folder as necessary', done => {
+  it('creates destination folder as necessary', () => {
     doMocking();
     mockFs.existsSync.returns(false);
     mockFs.mkdirSync = sinon.stub().returns(true);
@@ -105,7 +101,6 @@ describe('Resource Extraction', () => {
       expect(mockFs.mkdirSync.callCount).to.eq(2);
       expect(mockFs.mkdirSync.args[0][0]).to.include('src/extracted-resources');
       expect(mockFs.mkdirSync.args[1][0]).to.include('src/extracted-resources/js');
-      done();
     });
   });
 });

--- a/api/tests/mocha/resource-extraction.spec.js
+++ b/api/tests/mocha/resource-extraction.spec.js
@@ -42,6 +42,8 @@ describe('Resource Extraction', () => {
       expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
       expect(actualContent).to.include(expected.content);
       done();
+    }).catch(() => {
+      process.exit(1);
     });
   });
 
@@ -57,6 +59,8 @@ describe('Resource Extraction', () => {
         expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
         expect(actualContent).to.include(expected.content);
         done();
+      }).catch(() => {
+        process.exit(1);
       });
   });
 
@@ -75,6 +79,8 @@ describe('Resource Extraction', () => {
         expect(actualOutputPath).to.include('src/extracted-resources/js/attached.js');
         expect(actualContent).to.include(expected.content);
         done();
+      }).catch(() => {
+        process.exit(1);
       });
   });
 
@@ -83,6 +89,8 @@ describe('Resource Extraction', () => {
     resourceExtraction.run().then(() => {
       expect(mockFs.writeFile.callCount).to.eq(0);
       done();
+    }).catch(() => {
+      process.exit(1);
     });
   });
 
@@ -106,6 +114,8 @@ describe('Resource Extraction', () => {
       expect(mockFs.mkdirSync.args[0][0]).to.include('src/extracted-resources');
       expect(mockFs.mkdirSync.args[1][0]).to.include('src/extracted-resources/js');
       done();
+    }).catch(() => {
+      process.exit(1);
     });
   });
 });

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -319,7 +319,7 @@ describe('Users service', () => {
         }
       ]);
       sinon.stub(service, '_getAllUserSettings').resolves([]);
-      service.getList().then(data => {
+      return service.getList().then(data => {
         chai.expect(data.length).to.equal(1);
         const lucas = data[0];
         chai.expect(lucas.id).to.equal('org.couchdb.user:x');
@@ -329,8 +329,6 @@ describe('Users service', () => {
         chai.expect(lucas.phone).to.equal(undefined);
         chai.expect(lucas.facility).to.equal(undefined);
         chai.expect(lucas.type).to.equal('unknown');
-      }).catch(() => {
-        process.exit(1);
       });
     });
 
@@ -436,10 +434,8 @@ describe('Users service', () => {
   describe('createPlace', () => {
     it('assigns new place', () => {
       sinon.stub(places, 'getOrCreatePlace').resolves({ _id: 'santos' });
-      service._createPlace(userData).then(() => {
+      return service._createPlace(userData).then(() => {
         chai.expect(userData.place._id).to.equal('santos');
-      }).catch(() => {
-        process.exit(1);
       });
     });
   });

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -329,6 +329,8 @@ describe('Users service', () => {
         chai.expect(lucas.phone).to.equal(undefined);
         chai.expect(lucas.facility).to.equal(undefined);
         chai.expect(lucas.type).to.equal('unknown');
+      }).catch(() => {
+        process.exit(1);
       });
     });
 
@@ -436,6 +438,8 @@ describe('Users service', () => {
       sinon.stub(places, 'getOrCreatePlace').resolves({ _id: 'santos' });
       service._createPlace(userData).then(() => {
         chai.expect(userData.place._id).to.equal('santos');
+      }).catch(() => {
+        process.exit(1);
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,7 +1003,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -3637,6 +3638,12 @@
       "integrity": "sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==",
       "dev": true
     },
+    "eslint-plugin-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
+      "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
+      "dev": true
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -4102,7 +4109,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -12182,7 +12190,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-jasmine": "^4.1.1",
     "eslint-plugin-json": "^2.1.1",
     "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-promise": "^4.2.1",
     "express": "^4.17.1",
     "grunt": "^1.1.0",
     "grunt-angular-templates": "^1.2.0",

--- a/sentinel/tests/unit/lib/feed.js
+++ b/sentinel/tests/unit/lib/feed.js
@@ -109,7 +109,7 @@ describe('feed', () => {
       sinon.stub(feed._changeQueue, 'length').returns(0);
       const push = sinon.stub(feed._changeQueue, 'push');
 
-      feed
+      return feed
         .listen()
         .then(() => {
           const callbackFn = handler.on.args[0][1];
@@ -119,8 +119,6 @@ describe('feed', () => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(change);
           done();
-        }).catch(() => {
-          process.exit(1);
         });
     });
 

--- a/sentinel/tests/unit/lib/feed.js
+++ b/sentinel/tests/unit/lib/feed.js
@@ -119,6 +119,8 @@ describe('feed', () => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(change);
           done();
+        }).catch(() => {
+          process.exit(1);
         });
     });
 

--- a/sentinel/tests/unit/lib/feed.js
+++ b/sentinel/tests/unit/lib/feed.js
@@ -102,7 +102,7 @@ describe('feed', () => {
 
   describe('listener', () => {
 
-    it('invokes listener with changes', done => {
+    it('invokes listener with changes', () => {
       const change = { id: 'some-uuid' };
       sinon.stub(metadata, 'getProcessedSeq').resolves('123');
       sinon.stub(tombstoneUtils, 'isTombstoneId').returns(false);
@@ -118,7 +118,6 @@ describe('feed', () => {
         .then(() => {
           chai.expect(push.callCount).to.equal(1);
           chai.expect(push.args[0][0]).to.deep.equal(change);
-          done();
         });
     });
 

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -60,7 +60,7 @@ const baseConfig = {
     browser.driver.wait(prepServices(), 135 * 1000, 'API took too long to start up');
 
     afterEach(() => {
-      browser
+      return browser
         .manage()
         .logs()
         .get('browser')
@@ -69,8 +69,6 @@ const baseConfig = {
             .map(log => `[${log.level.name_}] ${log.message}\n`)
             .forEach(log => browserLogStream.write(log));
           browserLogStream.write('\n~~~~~~~~~~~~~~~~~~~~~\n\n');
-        }).catch(() => {
-          process.exit(1);
         });
     });
 

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -69,6 +69,8 @@ const baseConfig = {
             .map(log => `[${log.level.name_}] ${log.message}\n`)
             .forEach(log => browserLogStream.write(log));
           browserLogStream.write('\n~~~~~~~~~~~~~~~~~~~~~\n\n');
+        }).catch(() => {
+          process.exit(1);
         });
     });
 

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1077,11 +1077,7 @@ describe('changes handler', () => {
           reported_date: 1,
           parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
         };
-        utils.saveDocs([patient, healthCenterPatient])
-          .then(done)
-          .catch(() => {
-            process.exit(1);
-          });
+        return utils.saveDocs([patient, healthCenterPatient]).then(done);
       });
 
       it('should do nothing when not truthy or not present', () => {

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1077,7 +1077,11 @@ describe('changes handler', () => {
           reported_date: 1,
           parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
         };
-        utils.saveDocs([patient, healthCenterPatient]).then(done);
+        utils.saveDocs([patient, healthCenterPatient])
+          .then(done)
+          .catch(() => {
+            process.exit(1);
+          });
       });
 
       it('should do nothing when not truthy or not present', () => {

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1064,7 +1064,7 @@ describe('changes handler', () => {
             'should-also-be-visible')));
 
     describe('Needs signoff', () => {
-      beforeEach(done => {
+      beforeEach(() => {
         const patient = {
           _id: 'clinic_patient',
           type: 'person',
@@ -1077,7 +1077,7 @@ describe('changes handler', () => {
           reported_date: 1,
           parent: { _id:'fixture:chw-bossville', parent: { _id: parentPlace._id }}
         };
-        return utils.saveDocs([patient, healthCenterPatient]).then(done);
+        return utils.saveDocs([patient, healthCenterPatient]);
       });
 
       it('should do nothing when not truthy or not present', () => {

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -90,11 +90,10 @@ const hasMatchingRow = (rows, id, exact = true) => {
 };
 
 describe('all_docs handler', () => {
-  beforeAll(done => {
+  beforeAll(() => {
     return utils
       .saveDoc(parentPlace)
-      .then(() => utils.createUsers(users))
-      .then(done);
+      .then(() => utils.createUsers(users));
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -91,13 +91,10 @@ const hasMatchingRow = (rows, id, exact = true) => {
 
 describe('all_docs handler', () => {
   beforeAll(done => {
-    utils
+    return utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+      .then(done);
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -94,7 +94,10 @@ describe('all_docs handler', () => {
     utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done);
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -72,7 +72,10 @@ describe('bulk-docs handler', () => {
     utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done);
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -68,11 +68,10 @@ const DOCS_TO_KEEP = [
 ];
 
 describe('bulk-docs handler', () => {
-  beforeAll(done => {
+  beforeAll(() => {
     return utils
       .saveDoc(parentPlace)
-      .then(() => utils.createUsers(users))
-      .then(done);
+      .then(() => utils.createUsers(users));
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -69,13 +69,10 @@ const DOCS_TO_KEEP = [
 
 describe('bulk-docs handler', () => {
   beforeAll(done => {
-    utils
+    return utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+      .then(done);
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -71,7 +71,10 @@ describe('bulk-get handler', () => {
     utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done);
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -68,13 +68,10 @@ const DOCS_TO_KEEP = [
 
 describe('bulk-get handler', () => {
   beforeAll(done => {
-    utils
+    return utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+      .then(done);
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -67,11 +67,10 @@ const DOCS_TO_KEEP = [
 ];
 
 describe('bulk-get handler', () => {
-  beforeAll(done => {
+  beforeAll(() => {
     return utils
       .saveDoc(parentPlace)
-      .then(() => utils.createUsers(users))
-      .then(done);
+      .then(() => utils.createUsers(users));
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -160,7 +160,10 @@ describe('db-doc handler', () => {
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
       .then(() => utils.saveDocs([...clinics, ...patients]))
-      .then(done);
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -155,12 +155,11 @@ const reportForPatient = (patientUuid, username, fields = [], needs_signoff = fa
 };
 
 describe('db-doc handler', () => {
-  beforeAll(done => {
+  beforeAll(() => {
     return utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(() => utils.saveDocs([...clinics, ...patients]))
-      .then(done);
+      .then(() => utils.saveDocs([...clinics, ...patients]));
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -156,14 +156,11 @@ const reportForPatient = (patientUuid, username, fields = [], needs_signoff = fa
 
 describe('db-doc handler', () => {
   beforeAll(done => {
-    utils
+    return utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
       .then(() => utils.saveDocs([...clinics, ...patients]))
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+      .then(done);
   });
 
   afterAll(done =>

--- a/tests/e2e/api/controllers/sms-gateway.spec.js
+++ b/tests/e2e/api/controllers/sms-gateway.spec.js
@@ -56,11 +56,8 @@ describe('/sms', function() {
       });
 
       it('should not reject bad message content', function() {
-        api.postMessage({ missing_fields:true })
-          .then(assert.response({ messages:[] }))
-          .catch(() => {
-            process.exit(1);
-          });
+        return api.postMessage({ missing_fields:true })
+          .then(assert.response({ messages:[] }));
       });
 
       it('should save all good messages in a request containing some good and some bad', function() {

--- a/tests/e2e/api/controllers/sms-gateway.spec.js
+++ b/tests/e2e/api/controllers/sms-gateway.spec.js
@@ -57,7 +57,10 @@ describe('/sms', function() {
 
       it('should not reject bad message content', function() {
         api.postMessage({ missing_fields:true })
-          .then(assert.response({ messages:[] }));
+          .then(assert.response({ messages:[] }))
+          .catch(() => {
+            process.exit(1);
+          });
       });
 
       it('should save all good messages in a request containing some good and some bad', function() {

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -346,7 +346,10 @@ describe('Users API', () => {
           docsForAll = resp.rows.length + 2; // _design/medic-client + org.couchdb.user:doc
           expectedNbrDocs += resp.rows.length;
         })
-        .then(done);
+        .then(done)
+        .catch(() => {
+          process.exit(1);
+        });
     });
 
     afterAll(done =>

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -330,7 +330,7 @@ describe('Users API', () => {
     let docsForAll;
 
     beforeAll(done => {
-      utils
+      return utils
         .saveDoc(parentPlace)
         .then(() => utils.createUsers(users))
         .then(() => {
@@ -346,10 +346,7 @@ describe('Users API', () => {
           docsForAll = resp.rows.length + 2; // _design/medic-client + org.couchdb.user:doc
           expectedNbrDocs += resp.rows.length;
         })
-        .then(done)
-        .catch(() => {
-          process.exit(1);
-        });
+        .then(done);
     });
 
     afterAll(done =>

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -67,13 +67,10 @@ const DOCS_TO_KEEP = [
 
 describe('routing', () => {
   beforeAll(done => {
-    utils
+    return utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+      .then(done);
   });
 
   afterAll(done =>

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -70,7 +70,10 @@ describe('routing', () => {
     utils
       .saveDoc(parentPlace)
       .then(() => utils.createUsers(users))
-      .then(done);
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
 
   afterAll(done =>

--- a/tests/e2e/content-security-policy.js
+++ b/tests/e2e/content-security-policy.js
@@ -13,9 +13,13 @@ describe('Content Security Policy', () => {
   it('Telemetry script is not blocked by CSP', done => {
     browser.manage()
       .logs()
-      .get('browser').then(function(logEntries) {
+      .get('browser')
+      .then(function(logEntries) {
         logEntries.forEach(entry => expect(entry.message).to.not.include('Refused to execute inline script'));
         done();
+      })
+      .catch(() => {
+        process.exit(1);
       });
   });
 });

--- a/tests/e2e/content-security-policy.js
+++ b/tests/e2e/content-security-policy.js
@@ -11,15 +11,12 @@ describe('Content Security Policy', () => {
   // If the change is intentional, take the hash recommended in this error and replace the telemetry hash in the
   // API helmet configuration
   it('Telemetry script is not blocked by CSP', done => {
-    browser.manage()
+    return browser.manage()
       .logs()
       .get('browser')
       .then(function(logEntries) {
         logEntries.forEach(entry => expect(entry.message).to.not.include('Refused to execute inline script'));
         done();
-      })
-      .catch(() => {
-        process.exit(1);
       });
   });
 });

--- a/tests/e2e/content-security-policy.js
+++ b/tests/e2e/content-security-policy.js
@@ -10,13 +10,12 @@ describe('Content Security Policy', () => {
   // If this test fails, you've probably changed the inline telemetry script
   // If the change is intentional, take the hash recommended in this error and replace the telemetry hash in the
   // API helmet configuration
-  it('Telemetry script is not blocked by CSP', done => {
+  it('Telemetry script is not blocked by CSP', () => {
     return browser.manage()
       .logs()
       .get('browser')
       .then(function(logEntries) {
         logEntries.forEach(entry => expect(entry.message).to.not.include('Refused to execute inline script'));
-        done();
       });
   });
 });

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -331,13 +331,17 @@ describe('view docs_by_replication_key', () => {
     console.log(`Pushing ${alldocs.length} documents for testing…`);
     return utils.saveDocs(alldocs)
       .then(() => {
-        getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']);
+        return getChanges(
+          ['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']
+        );
       })
       .then((docs) => {
         docByPlaceIds = docs;
         return getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);
       })
-      .then(docs => docByPlaceIds_unassigned = docs)
+      .then((docs) => {
+        docByPlaceIds_unassigned = docs;
+      })
       .catch(err => {
         throw err;
       });

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -345,22 +345,17 @@ describe('view docs_by_replication_key', () => {
         }
         console.log('…done');
 
-        getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username'])
-          .then(docs => {
-            docByPlaceIds = docs;
+        return getChanges(
+          ['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']
+        ).then(docs => {
+          docByPlaceIds = docs;
 
-            getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ])
-              .then(docs => {
-                docByPlaceIds_unassigned = docs;
-                done();
-              })
-              .catch(() => {
-                process.exit(1);
-              });
-          })
-          .catch(() => {
-            process.exit(1);
-          });
+          return getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ])
+            .then(docs => {
+              docByPlaceIds_unassigned = docs;
+              done();
+            });
+        });
       });
   }, 5 * 60 * 1000);
 

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -353,7 +353,13 @@ describe('view docs_by_replication_key', () => {
               .then(docs => {
                 docByPlaceIds_unassigned = docs;
                 done();
+              })
+              .catch(() => {
+                process.exit(1);
               });
+          })
+          .catch(() => {
+            process.exit(1);
           });
       });
   }, 5 * 60 * 1000);

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -333,7 +333,7 @@ describe('view docs_by_replication_key', () => {
       .then(() => {
         getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']);
       })
-      .then(docs => {
+      .then((docs) => {
         docByPlaceIds = docs;
         return getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);
       })

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -330,32 +330,15 @@ describe('view docs_by_replication_key', () => {
     };
 
     console.log(`Pushing ${alldocs.length} documents for testing…`);
-    async.each(alldocs,
-      (testDoc, callback) => {
-        utils.saveDoc(testDoc)
-          .then(() => {
-            callback();
-          })
-          .catch(callback);
-      },
-      err => {
-        if (err) {
-          console.error(err);
-          return done.fail(err);
-        }
-        console.log('…done');
-
-        return getChanges(
-          ['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']
-        ).then(docs => {
-          docByPlaceIds = docs;
-
-          return getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ])
-            .then(docs => {
-              docByPlaceIds_unassigned = docs;
-              done();
-            });
-        });
+    return utils.saveDocs(alldocs)
+      .then(getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']))
+      .then(docs => {
+        docByPlaceIds = docs;
+        getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);
+      })
+      .then(docs => docByPlaceIds_unassigned = docs)
+      .catch(err => {
+        throw err;
       });
   }, 5 * 60 * 1000);
 

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -309,7 +309,7 @@ describe('view docs_by_replication_key', () => {
   let docByPlaceIds;
   let docByPlaceIds_unassigned;
 
-  beforeAll(done => {
+  beforeAll(() => {
     const alldocs = documentsToReturn.concat(documentsToIgnore, documentsToIgnoreSometimes);
 
     const getChanges = keys => {

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -335,7 +335,7 @@ describe('view docs_by_replication_key', () => {
       })
       .then(docs => {
         docByPlaceIds = docs;
-        getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);
+        return getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);
       })
       .then(docs => docByPlaceIds_unassigned = docs)
       .catch(err => {

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -1,5 +1,4 @@
 const utils = require('../utils');
-const async = require('async');
 
 describe('view docs_by_replication_key', () => {
 

--- a/tests/e2e/docs-by-replication-key-view.js
+++ b/tests/e2e/docs-by-replication-key-view.js
@@ -330,7 +330,9 @@ describe('view docs_by_replication_key', () => {
 
     console.log(`Pushing ${alldocs.length} documents for testing…`);
     return utils.saveDocs(alldocs)
-      .then(getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']))
+      .then(() => {
+        getChanges(['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']);
+      })
       .then(docs => {
         docByPlaceIds = docs;
         getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -237,10 +237,8 @@ describe('Purging on login', () => {
       const callback = arguments[arguments.length - 1];
       const db = window.PouchDB('medic-user-e2e_restricted');
       db.get('_local/purgelog')
-        .then(doc => callback(doc), err => callback(err))
-        .catch(() => {
-          process.exit(1);
-        });
+        .then(doc => callback(null, doc))
+        .catch(err => callback(err));
     }));
   };
 

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -237,14 +237,14 @@ describe('Purging on login', () => {
       const callback = arguments[arguments.length - 1];
       const db = window.PouchDB('medic-user-e2e_restricted');
       db.get('_local/purgelog')
-        .then(doc => callback(null, doc))
+        .then(doc => callback(doc), err => callback(err))
         .catch(err => callback(err));
     }));
   };
 
   const restartSentinel = () => utils.stopSentinel().then(() => utils.startSentinel());
 
-  it('Logging in as a restricted user with configured purge rules should not download purged docs', () => {
+  it('Logging in as a restricted user with configured purge rules should not download purged docs', (done) => {
     utils.resetBrowser();
     commonElements.goToLoginPage();
     loginPage.login(restrictedUserName, restrictedPass);
@@ -271,9 +271,7 @@ describe('Purging on login', () => {
         date: result.date
       });
       purgeDate = result.date;
-    }).catch(() => {
-      process.exit(1);
-    });
+    }).catch(err => done(err));
 
     utils.resetBrowser();
     commonElements.calm();
@@ -283,9 +281,7 @@ describe('Purging on login', () => {
       // purge didn't run again on next refresh
       chai.expect(result._rev).to.equal('0-1');
       chai.expect(result.date).to.equal(purgeDate);
-    }).catch(() => {
-      process.exit(1);
-    });
+    }).catch(err => done(err));
 
     browser.wait(() => utils.saveDocs(subsequentReports).then(() => true));
     commonElements.sync();
@@ -325,12 +321,11 @@ describe('Purging on login', () => {
         roles: result.roles,
         date: result.date
       });
-    }).catch(() => {
-      process.exit(1);
-    });
+    }).catch(err => done(err));
     commonElements.goToReports();
     reports.expectReportsToExist([goodFormId, goodFormId2]);
     reports.expectReportsToNotExist([badFormId, badFormId2]);
+    done();
   });
 
 });

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -331,5 +331,4 @@ describe('Purging on login', () => {
         reports.expectReportsToNotExist([badFormId, badFormId2]);
       });
   });
-
 });

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -237,7 +237,7 @@ describe('Purging on login', () => {
       const callback = arguments[arguments.length - 1];
       const db = window.PouchDB('medic-user-e2e_restricted');
       db.get('_local/purgelog')
-        .then(doc => callback(doc), err => callback(err))
+        .then(doc => callback(doc))
         .catch(err => callback(err));
     }));
   };
@@ -259,73 +259,77 @@ describe('Purging on login', () => {
     reports.expectReportsToNotExist([badFormId]);
 
     let purgeDate;
-    getPurgeLog().then(result => {
-      // purge ran but after initial replication, nothing to purge
-      chai.expect(result._rev).to.equal('0-1');
-      chai.expect(result.roles).to.equal(JSON.stringify(restrictedUser.roles.sort()));
-      chai.expect(result.history.length).to.equal(1);
-      chai.expect(result.count).to.equal(0);
-      chai.expect(result.history[0]).to.deep.equal({
-        count: 0,
-        roles: result.roles,
-        date: result.date
+    return getPurgeLog()
+      .then(result => {
+        // purge ran but after initial replication, nothing to purge
+        chai.expect(result._rev).to.equal('0-1');
+        chai.expect(result.roles).to.equal(JSON.stringify(restrictedUser.roles.sort()));
+        chai.expect(result.history.length).to.equal(1);
+        chai.expect(result.count).to.equal(0);
+        chai.expect(result.history[0]).to.deep.equal({
+          count: 0,
+          roles: result.roles,
+          date: result.date
+        });
+        purgeDate = result.date;
+      })
+      .then(() => {
+        utils.resetBrowser();
+        commonElements.calm();
+        helper.waitForAngularComplete();
+        return getPurgeLog();
+      })
+      .then(result => {
+        // purge didn't run again on next refresh
+        chai.expect(result._rev).to.equal('0-1');
+        chai.expect(result.date).to.equal(purgeDate);
+      })
+      .then(() => {
+        browser.wait(() => utils.saveDocs(subsequentReports).then(() => true));
+        commonElements.sync();
+        commonElements.goToReports();
+        reports.expectReportsToExist([goodFormId, goodFormId2, badFormId2]);
+
+        browser.wait(() => {
+          let seq;
+          const purgeSettings = {
+            fn: purgeFn.toString(),
+            text_expression: 'every 1 seconds',
+            run_every_days: '0'
+          };
+          return utils.revertSettings(true)
+            .then(() => sentinelUtils.getCurrentSeq())
+            .then(result => seq = result)
+            .then(() => utils.updateSettings({ purge: purgeSettings}, true))
+            .then(() => restartSentinel())
+            .then(() => sentinelUtils.waitForPurgeCompletion(seq))
+            .then(() => true);
+        });
+
+        // get new settings that say to purge on every boot!
+        commonElements.sync();
+        utils.refreshToGetNewSettings();
+        commonElements.calm();
+        return getPurgeLog();
+      })
+      .then(result => {
+        // purge ran again and it purged the bad form
+        chai.expect(result._rev).to.equal('0-2');
+        chai.expect(result.roles).to.equal(JSON.stringify(restrictedUser.roles.sort()));
+        chai.expect(result.history.length).to.equal(2);
+        chai.expect(result.count).to.equal(1);
+        chai.expect(result.history[1].date).to.equal(purgeDate);
+        chai.expect(result.history[0]).to.deep.equal({
+          count: 1,
+          roles: result.roles,
+          date: result.date
+        });
+      })
+      .then(() => {
+        commonElements.goToReports();
+        reports.expectReportsToExist([goodFormId, goodFormId2]);
+        reports.expectReportsToNotExist([badFormId, badFormId2]);
       });
-      purgeDate = result.date;
-    }).catch(err => done(err));
-
-    utils.resetBrowser();
-    commonElements.calm();
-    helper.waitForAngularComplete();
-
-    getPurgeLog().then(result => {
-      // purge didn't run again on next refresh
-      chai.expect(result._rev).to.equal('0-1');
-      chai.expect(result.date).to.equal(purgeDate);
-    }).catch(err => done(err));
-
-    browser.wait(() => utils.saveDocs(subsequentReports).then(() => true));
-    commonElements.sync();
-    commonElements.goToReports();
-    reports.expectReportsToExist([goodFormId, goodFormId2, badFormId2]);
-
-    browser.wait(() => {
-      let seq;
-      const purgeSettings = {
-        fn: purgeFn.toString(),
-        text_expression: 'every 1 seconds',
-        run_every_days: '0'
-      };
-      return utils.revertSettings(true)
-        .then(() => sentinelUtils.getCurrentSeq())
-        .then(result => seq = result)
-        .then(() => utils.updateSettings({ purge: purgeSettings}, true))
-        .then(() => restartSentinel())
-        .then(() => sentinelUtils.waitForPurgeCompletion(seq))
-        .then(() => true);
-    });
-
-    // get new settings that say to purge on every boot!
-    commonElements.sync();
-    utils.refreshToGetNewSettings();
-    commonElements.calm();
-
-    getPurgeLog().then(result => {
-      // purge ran again and it purged the bad form
-      chai.expect(result._rev).to.equal('0-2');
-      chai.expect(result.roles).to.equal(JSON.stringify(restrictedUser.roles.sort()));
-      chai.expect(result.history.length).to.equal(2);
-      chai.expect(result.count).to.equal(1);
-      chai.expect(result.history[1].date).to.equal(purgeDate);
-      chai.expect(result.history[0]).to.deep.equal({
-        count: 1,
-        roles: result.roles,
-        date: result.date
-      });
-    }).catch(err => done(err));
-    commonElements.goToReports();
-    reports.expectReportsToExist([goodFormId, goodFormId2]);
-    reports.expectReportsToNotExist([badFormId, badFormId2]);
-    done();
   });
 
 });

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -306,7 +306,6 @@ describe('Purging on login', () => {
             .then(() => sentinelUtils.waitForPurgeCompletion(seq))
             .then(() => true);
         });
-
         // get new settings that say to purge on every boot!
         commonElements.sync();
         utils.refreshToGetNewSettings();

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -236,7 +236,11 @@ describe('Purging on login', () => {
     return browser.executeAsyncScript((() => {
       const callback = arguments[arguments.length - 1];
       const db = window.PouchDB('medic-user-e2e_restricted');
-      db.get('_local/purgelog').then(doc => callback(doc), err => callback(err));
+      db.get('_local/purgelog')
+        .then(doc => callback(doc), err => callback(err))
+        .catch(() => {
+          process.exit(1);
+        });
     }));
   };
 
@@ -269,6 +273,8 @@ describe('Purging on login', () => {
         date: result.date
       });
       purgeDate = result.date;
+    }).catch(() => {
+      process.exit(1);
     });
 
     utils.resetBrowser();
@@ -279,6 +285,8 @@ describe('Purging on login', () => {
       // purge didn't run again on next refresh
       chai.expect(result._rev).to.equal('0-1');
       chai.expect(result.date).to.equal(purgeDate);
+    }).catch(() => {
+      process.exit(1);
     });
 
     browser.wait(() => utils.saveDocs(subsequentReports).then(() => true));
@@ -319,6 +327,8 @@ describe('Purging on login', () => {
         roles: result.roles,
         date: result.date
       });
+    }).catch(() => {
+      process.exit(1);
     });
     commonElements.goToReports();
     reports.expectReportsToExist([goodFormId, goodFormId2]);

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -244,7 +244,7 @@ describe('Purging on login', () => {
 
   const restartSentinel = () => utils.stopSentinel().then(() => utils.startSentinel());
 
-  it('Logging in as a restricted user with configured purge rules should not download purged docs', (done) => {
+  it('Logging in as a restricted user with configured purge rules should not download purged docs', () => {
     utils.resetBrowser();
     commonElements.goToLoginPage();
     loginPage.login(restrictedUserName, restrictedPass);

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -259,6 +259,7 @@ describe('Purging on login', () => {
     reports.expectReportsToNotExist([badFormId]);
 
     let purgeDate;
+
     return getPurgeLog()
       .then(result => {
         // purge ran but after initial replication, nothing to purge

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -257,7 +257,6 @@ describe('Purging on login', () => {
     );
     reports.expectReportsToExist([goodFormId]);
     reports.expectReportsToNotExist([badFormId]);
-
     let purgeDate;
 
     return getPurgeLog()

--- a/tests/e2e/reports-subject.js
+++ b/tests/e2e/reports-subject.js
@@ -286,7 +286,10 @@ describe('Reports Summary', () => {
   afterEach((done) => {
     utils
       .deleteAllDocs(CONTACTS.map(contact => contact._id)) // deletes all except these docs
-      .then(done);
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
 
   describe('Displays correct LHS and RHS summary', () => {

--- a/tests/e2e/reports-subject.js
+++ b/tests/e2e/reports-subject.js
@@ -284,12 +284,9 @@ describe('Reports Summary', () => {
   afterAll(utils.afterEach);
 
   afterEach((done) => {
-    utils
+    return utils
       .deleteAllDocs(CONTACTS.map(contact => contact._id)) // deletes all except these docs
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+      .then(done);
   });
 
   describe('Displays correct LHS and RHS summary', () => {

--- a/tests/e2e/reports-subject.js
+++ b/tests/e2e/reports-subject.js
@@ -283,10 +283,8 @@ describe('Reports Summary', () => {
 
   afterAll(utils.afterEach);
 
-  afterEach((done) => {
-    return utils
-      .deleteAllDocs(CONTACTS.map(contact => contact._id)) // deletes all except these docs
-      .then(done);
+  afterEach(() => {
+    return utils.deleteAllDocs(CONTACTS.map(contact => contact._id)); // deletes all except these docs
   });
 
   describe('Displays correct LHS and RHS summary', () => {

--- a/tests/e2e/sentinel/queue.spec.js
+++ b/tests/e2e/sentinel/queue.spec.js
@@ -62,19 +62,13 @@ describe('Sentinel queue drain', () => {
   beforeAll(done => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
-    utils.saveDocs(contacts)
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+    return utils.saveDocs(contacts)
+      .then(done);
   });
   afterAll(done => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-    utils.revertDb()
-      .then(done)
-      .catch(() => {
-        process.exit(1);
-      });
+    return utils.revertDb()
+      .then(done);
   });
   afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
 

--- a/tests/e2e/sentinel/queue.spec.js
+++ b/tests/e2e/sentinel/queue.spec.js
@@ -59,16 +59,14 @@ const report = {
 let originalTimeout;
 
 describe('Sentinel queue drain', () => {
-  beforeAll(done => {
+  beforeAll(() => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
-    return utils.saveDocs(contacts)
-      .then(done);
+    return utils.saveDocs(contacts);
   });
-  afterAll(done => {
+  afterAll(() => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-    return utils.revertDb()
-      .then(done);
+    return utils.revertDb();
   });
   afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
 

--- a/tests/e2e/sentinel/queue.spec.js
+++ b/tests/e2e/sentinel/queue.spec.js
@@ -62,11 +62,19 @@ describe('Sentinel queue drain', () => {
   beforeAll(done => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
-    utils.saveDocs(contacts).then(done);
+    utils.saveDocs(contacts)
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
   afterAll(done => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-    utils.revertDb().then(done);
+    utils.revertDb()
+      .then(done)
+      .catch(() => {
+        process.exit(1);
+      });
   });
   afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
 

--- a/tests/e2e/submit-enketo-form.js
+++ b/tests/e2e/submit-enketo-form.js
@@ -133,13 +133,8 @@ describe('Submit Enketo form', () => {
       by.css('#reports-content .details ul li:first-child p')
     );
     helper.waitElementToBeVisible(detail);
-    return detail.getText().then(
-      name => {
-        expect(name).toBe('Jones');
-      },
-      err => {
-        console.log(err); // eslint-disable-line no-console
-      }
-    );
+    return detail.getText().then(name => {
+      expect(name).toBe('Jones');
+    });
   });
 });

--- a/tests/e2e/submit-enketo-form.js
+++ b/tests/e2e/submit-enketo-form.js
@@ -140,6 +140,8 @@ describe('Submit Enketo form', () => {
       err => {
         console.log(err); // eslint-disable-line no-console
       }
-    );
+    ).catch(() => {
+      process.exit(1);
+    });
   });
 });

--- a/tests/e2e/submit-enketo-form.js
+++ b/tests/e2e/submit-enketo-form.js
@@ -133,15 +133,13 @@ describe('Submit Enketo form', () => {
       by.css('#reports-content .details ul li:first-child p')
     );
     helper.waitElementToBeVisible(detail);
-    detail.getText().then(
+    return detail.getText().then(
       name => {
         expect(name).toBe('Jones');
       },
       err => {
         console.log(err); // eslint-disable-line no-console
       }
-    ).catch(() => {
-      process.exit(1);
-    });
+    );
   });
 });

--- a/tests/e2e/target-aggregates.spec.js
+++ b/tests/e2e/target-aggregates.spec.js
@@ -78,10 +78,8 @@ const expectContacts = (contacts, target) => {
     if (!target.goal) {
       expect(lineItem.all(by.css('.goal')).count()).toEqual(0);
     } else {
-      lineItem.all(by.css('.goal')).first().getText().then(text => {
+      return lineItem.all(by.css('.goal')).first().getText().then(text => {
         expect(text.indexOf(target.goal)).not.toEqual(-1);
-      }).catch(() => {
-        process.exit(1);
       });
     }
   });

--- a/tests/e2e/target-aggregates.spec.js
+++ b/tests/e2e/target-aggregates.spec.js
@@ -78,9 +78,11 @@ const expectContacts = (contacts, target) => {
     if (!target.goal) {
       expect(lineItem.all(by.css('.goal')).count()).toEqual(0);
     } else {
-      return lineItem.all(by.css('.goal')).first().getText().then(text => {
-        expect(text.indexOf(target.goal)).not.toEqual(-1);
-      });
+      lineItem.all(by.css('.goal')).first().getText()
+        .then(text => expect(text.indexOf(target.goal)).not.toEqual(-1))
+        .catch(err => {
+          throw err;
+        });
     }
   });
 };

--- a/tests/e2e/target-aggregates.spec.js
+++ b/tests/e2e/target-aggregates.spec.js
@@ -80,6 +80,8 @@ const expectContacts = (contacts, target) => {
     } else {
       lineItem.all(by.css('.goal')).first().getText().then(text => {
         expect(text.indexOf(target.goal)).not.toEqual(-1);
+      }).catch(() => {
+        process.exit(1);
       });
     }
   });

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -49,16 +49,20 @@ module.exports = {
       )
       .then(() => {
         elements.each(element => {
-          return element.getText().then(text => {
-            if (
-              text
-                .toLowerCase()
-                .trim()
-                .includes(expectedText)
-            ) {
-              element.click();
-            }
-          });
+          element.getText()
+            .then(text => {
+              if (
+                text
+                  .toLowerCase()
+                  .trim()
+                  .includes(expectedText)
+              ) {
+                element.click();
+              }
+            })
+            .catch(err => {
+              throw err;
+            });
         });
       });
   },
@@ -101,9 +105,13 @@ module.exports = {
       )
       .then(() => {
         elements.each(element => {
-          return element.getText().then(text => {
-            textFromElements.push(text.trim());
-          });
+          element.getText()
+            .then(text => {
+              textFromElements.push(text.trim());
+            })
+            .catch(err => {
+              throw err;
+            });
         });
         return textFromElements;
       });
@@ -148,8 +156,8 @@ module.exports = {
   selectDropdownByNumber: (element, index, milliseconds) => {
     element.findElements(by.tagName('option')).then(options => {
       options[index].click();
-    }).catch(() => {
-      process.exit(1);
+    }).catch(err => {
+      throw err;
     });
     if (milliseconds) {
       browser.sleep(milliseconds);
@@ -164,14 +172,18 @@ module.exports = {
   selectDropdownByText: (element, item, milliseconds) => {
     element.all(by.tagName('option')).then(options => {
       options.some(option => {
-        return option.getText().then(text => {
-          if (text.indexOf(item) !== -1) {
-            option.click();
-          }
-        });
+        option.getText()
+          .then(text => {
+            if (text.indexOf(item) !== -1) {
+              option.click();
+            }
+          })
+          .catch(err => {
+            throw err;
+          });
       });
-    }).catch(() => {
-      process.exit(1);
+    }).catch(err => {
+      throw err;
     });
     if (milliseconds) {
       browser.sleep(milliseconds);
@@ -183,8 +195,8 @@ module.exports = {
       if (options[0]) {
         options[0].click();
       }
-    }).catch(() => {
-      process.exit(1);
+    }).catch(err => {
+      throw err;
     });
     if (milliseconds) {
       browser.sleep(milliseconds);
@@ -201,8 +213,8 @@ module.exports = {
   takeScreenshot: filename => {
     browser.takeScreenshot().then(png => {
       writeScreenShot(png, filename);
-    }).catch(() => {
-      process.exit(1);
+    }).catch(err => {
+      throw err;
     });
   },
 

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -58,8 +58,13 @@ module.exports = {
             ) {
               element.click();
             }
+          }).catch(() => {
+            process.exit(1);
           });
         });
+      })
+      .catch(() => {
+        process.exit(1);
       });
   },
 
@@ -103,6 +108,8 @@ module.exports = {
         elements.each(element => {
           element.getText().then(text => {
             textFromElements.push(text.trim());
+          }).catch(() => {
+            process.exit(1);
           });
         });
         return textFromElements;
@@ -135,6 +142,9 @@ module.exports = {
             );
           }
         });
+      })
+      .catch(() => {
+        process.exit(1);
       });
   },
 
@@ -148,6 +158,8 @@ module.exports = {
   selectDropdownByNumber: (element, index, milliseconds) => {
     element.findElements(by.tagName('option')).then(options => {
       options[index].click();
+    }).catch(() => {
+      process.exit(1);
     });
     if (milliseconds) {
       browser.sleep(milliseconds);
@@ -166,8 +178,12 @@ module.exports = {
           if (text.indexOf(item) !== -1) {
             option.click();
           }
+        }).catch(() => {
+          process.exit(1);
         });
       });
+    }).catch(() => {
+      process.exit(1);
     });
     if (milliseconds) {
       browser.sleep(milliseconds);
@@ -179,6 +195,8 @@ module.exports = {
       if (options[0]) {
         options[0].click();
       }
+    }).catch(() => {
+      process.exit(1);
     });
     if (milliseconds) {
       browser.sleep(milliseconds);
@@ -195,6 +213,8 @@ module.exports = {
   takeScreenshot: filename => {
     browser.takeScreenshot().then(png => {
       writeScreenShot(png, filename);
+    }).catch(() => {
+      process.exit(1);
     });
   },
 

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -41,7 +41,7 @@ module.exports = {
    * expectedText : text that element should include
    */
   findElementByTextAndClick: (elements, expectedText) => {
-    browser
+    return browser
       .wait(
         EC.presenceOf(elements),
         12000,
@@ -49,7 +49,7 @@ module.exports = {
       )
       .then(() => {
         elements.each(element => {
-          element.getText().then(text => {
+          return element.getText().then(text => {
             if (
               text
                 .toLowerCase()
@@ -58,13 +58,8 @@ module.exports = {
             ) {
               element.click();
             }
-          }).catch(() => {
-            process.exit(1);
           });
         });
-      })
-      .catch(() => {
-        process.exit(1);
       });
   },
 
@@ -106,10 +101,8 @@ module.exports = {
       )
       .then(() => {
         elements.each(element => {
-          element.getText().then(text => {
+          return element.getText().then(text => {
             textFromElements.push(text.trim());
-          }).catch(() => {
-            process.exit(1);
           });
         });
         return textFromElements;
@@ -124,7 +117,7 @@ module.exports = {
   },
 
   logConsoleErrors: spec => {
-    browser
+    return browser
       .manage()
       .logs()
       .get('browser')
@@ -142,9 +135,6 @@ module.exports = {
             );
           }
         });
-      })
-      .catch(() => {
-        process.exit(1);
       });
   },
 
@@ -174,12 +164,10 @@ module.exports = {
   selectDropdownByText: (element, item, milliseconds) => {
     element.all(by.tagName('option')).then(options => {
       options.some(option => {
-        option.getText().then(text => {
+        return option.getText().then(text => {
           if (text.indexOf(item) !== -1) {
             option.click();
           }
-        }).catch(() => {
-          process.exit(1);
         });
       });
     }).catch(() => {

--- a/tests/page-objects/forms/z-score.po.js
+++ b/tests/page-objects/forms/z-score.po.js
@@ -134,11 +134,7 @@ const docs = [
   }];
 
 const clearAndFill = (el, value) => {
-  el.clear()
-    .then(() => el.sendKeys(value))
-    .catch(() => {
-      process.exit(1);
-    });
+  return el.clear().then(() => el.sendKeys(value));
 };
 
 const clickAndGetValue = el => {

--- a/tests/page-objects/forms/z-score.po.js
+++ b/tests/page-objects/forms/z-score.po.js
@@ -134,7 +134,11 @@ const docs = [
   }];
 
 const clearAndFill = (el, value) => {
-  el.clear().then(() => el.sendKeys(value));
+  el.clear()
+    .then(() => el.sendKeys(value))
+    .catch(() => {
+      process.exit(1);
+    });
 };
 
 const clickAndGetValue = el => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -197,12 +197,10 @@ const refreshToGetNewSettings = () => {
     .catch(() => {
       // sometimes there's a double update which causes the dialog to be redrawn
       // retry with the new dialog
-      dialog.isPresent().then(function(result) {
+      return dialog.isPresent().then(function(result) {
         if (result) {
           dialog.click();
         }
-      }).catch(() => {
-        process.exit(1);
       });
     })
     .then(() => {
@@ -551,16 +549,13 @@ module.exports = {
   revertDb: revertDb,
 
   resetBrowser: () => {
-    browser.driver
+    return browser.driver
       .navigate()
       .refresh()
       .then(() => {
         return browser.wait(() => {
           return element(by.css('#messages-tab')).isPresent();
         }, 10000);
-      })
-      .catch(() => {
-        process.exit(1);
       });
   },
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -201,6 +201,8 @@ const refreshToGetNewSettings = () => {
         if (result) {
           dialog.click();
         }
+      }).catch(() => {
+        process.exit(1);
       });
     })
     .then(() => {
@@ -556,6 +558,9 @@ module.exports = {
         return browser.wait(() => {
           return element(by.css('#messages-tab')).isPresent();
         }, 10000);
+      })
+      .catch(() => {
+        process.exit(1);
       });
   },
 

--- a/webapp/tests/karma/unit/services/changes.js
+++ b/webapp/tests/karma/unit/services/changes.js
@@ -63,11 +63,7 @@ describe('Changes service', function() {
       service = _Changes_;
       dispatch = ServicesActions($ngRedux.dispatch);
       getLastChangedDoc = () => Selectors.getLastChangedDoc($ngRedux.getState());
-      service()
-        .then(done)
-        .catch((err) => {
-          window.__karma__.error(err);
-        });
+      return service().then(done);
     });
   });
 

--- a/webapp/tests/karma/unit/services/changes.js
+++ b/webapp/tests/karma/unit/services/changes.js
@@ -63,7 +63,9 @@ describe('Changes service', function() {
       service = _Changes_;
       dispatch = ServicesActions($ngRedux.dispatch);
       getLastChangedDoc = () => Selectors.getLastChangedDoc($ngRedux.getState());
-      return service().then(done);
+      service()
+        .then(done)
+        .catch(err => done(err));
     });
   });
 

--- a/webapp/tests/karma/unit/services/changes.js
+++ b/webapp/tests/karma/unit/services/changes.js
@@ -63,7 +63,11 @@ describe('Changes service', function() {
       service = _Changes_;
       dispatch = ServicesActions($ngRedux.dispatch);
       getLastChangedDoc = () => Selectors.getLastChangedDoc($ngRedux.getState());
-      service().then(done);
+      service()
+        .then(done)
+        .catch((err) => {
+          window.__karma__.error(err);
+        });
     });
   });
 

--- a/webapp/tests/karma/unit/services/database-connection-monitor.js
+++ b/webapp/tests/karma/unit/services/database-connection-monitor.js
@@ -38,6 +38,8 @@ describe('DatabaseConnectionMonitor service', function() {
     const write = i => {
       db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
         write(i + 1); 
+      }).catch((err) => {
+        window.__karma__.error(err);
       });
     };
     write(0); 

--- a/webapp/tests/karma/unit/services/database-connection-monitor.js
+++ b/webapp/tests/karma/unit/services/database-connection-monitor.js
@@ -38,7 +38,9 @@ describe('DatabaseConnectionMonitor service', function() {
     const write = i => {
       db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
         write(i + 1); 
-      }).catch();
+      }).catch((err) => {
+        throw new Error(err);
+      });
     };
     write(0); 
     db.destroy(); 

--- a/webapp/tests/karma/unit/services/database-connection-monitor.js
+++ b/webapp/tests/karma/unit/services/database-connection-monitor.js
@@ -31,18 +31,14 @@ describe('DatabaseConnectionMonitor service', function() {
     rootScope.$emit = () => done();
     service.listenForDatabaseClosed();
     triggerPouchDbDOMException();
-    setTimeout(() => {
-      expect(rootScope.$emit.callCount).to.eq(1);
-      done();
-    }, 50);
   });
 
   const triggerPouchDbDOMException = () => { 
     let db = new window.PouchDB('test', { auto_compaction: true }); 
     const write = i => {
-      return db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
+      db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
         write(i + 1); 
-      });
+      }).catch();
     };
     write(0); 
     db.destroy(); 

--- a/webapp/tests/karma/unit/services/database-connection-monitor.js
+++ b/webapp/tests/karma/unit/services/database-connection-monitor.js
@@ -39,7 +39,7 @@ describe('DatabaseConnectionMonitor service', function() {
       db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
         write(i + 1); 
       }).catch((err) => {
-        throw new Error(err);
+        throw err;
       });
     };
     write(0); 

--- a/webapp/tests/karma/unit/services/database-connection-monitor.js
+++ b/webapp/tests/karma/unit/services/database-connection-monitor.js
@@ -31,15 +31,17 @@ describe('DatabaseConnectionMonitor service', function() {
     rootScope.$emit = () => done();
     service.listenForDatabaseClosed();
     triggerPouchDbDOMException();
+    setTimeout(() => {
+      expect(rootScope.$emit.callCount).to.eq(1);
+      done();
+    }, 50);
   });
 
   const triggerPouchDbDOMException = () => { 
     let db = new window.PouchDB('test', { auto_compaction: true }); 
     const write = i => {
-      db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
+      return db.put({ _id: i + 'a', bar: 'bar' }).then(() => {
         write(i + 1); 
-      }).catch((err) => {
-        window.__karma__.error(err);
       });
     };
     write(0); 

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -142,6 +142,8 @@ describe('DBSync service', () => {
           expect(from.callCount).to.equal(2);
           done();
         });
+      }).catch((err) => {
+        window.__karma__.error(err);
       });
     });
 
@@ -257,7 +259,11 @@ describe('DBSync service', () => {
             expect(from.callCount).to.equal(3);
             done();
           });
+        }).catch((err) => {
+          window.__karma__.error(err);
         });
+      }).catch((err) => {
+        window.__karma__.error(err);
       });
     });
 

--- a/webapp/tests/karma/unit/services/db-sync.js
+++ b/webapp/tests/karma/unit/services/db-sync.js
@@ -142,9 +142,7 @@ describe('DBSync service', () => {
           expect(from.callCount).to.equal(2);
           done();
         });
-      }).catch((err) => {
-        window.__karma__.error(err);
-      });
+      }).catch(err => done(err));
     });
 
     it('does not attempt sync while offline', () => {
@@ -259,12 +257,8 @@ describe('DBSync service', () => {
             expect(from.callCount).to.equal(3);
             done();
           });
-        }).catch((err) => {
-          window.__karma__.error(err);
-        });
-      }).catch((err) => {
-        window.__karma__.error(err);
-      });
+        }).catch(err => done(err));
+      }).catch(err => done(err));
     });
 
     it('does not sync to remote if user lacks "can_edit" permission', () => {

--- a/webapp/tests/karma/unit/services/edit-group.js
+++ b/webapp/tests/karma/unit/services/edit-group.js
@@ -47,6 +47,8 @@ describe('EditGroup service', function() {
     service('123', group).then(function(actual) {
       chai.expect(actual).to.deep.equal(doc);
       done();
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 

--- a/webapp/tests/karma/unit/services/edit-group.js
+++ b/webapp/tests/karma/unit/services/edit-group.js
@@ -47,9 +47,7 @@ describe('EditGroup service', function() {
     service('123', group).then(function(actual) {
       chai.expect(actual).to.deep.equal(doc);
       done();
-    }).catch((err) => {
-      window.__karma__.error(err);
-    });
+    }).catch(err => done(err));
   });
 
   it('returns save errors', function(done) {

--- a/webapp/tests/karma/unit/services/language.js
+++ b/webapp/tests/karma/unit/services/language.js
@@ -37,9 +37,7 @@ describe('Language service', function() {
       chai.expect(ipCookie.args[1][1]).to.equal('latin');
       chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
-    }).catch((err) => {
-      window.__karma__.error(err);
-    });
+    }).catch(err => done(err));
   });
 
   it('uses the language configured in settings', function(done) {
@@ -56,9 +54,7 @@ describe('Language service', function() {
       chai.expect(ipCookie.args[1][1]).to.equal('yiddish');
       chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
-    }).catch((err) => {
-      window.__karma__.error(err);
-    });
+    }).catch(err => done(err));
   });
 
   it('defaults', function(done) {
@@ -75,9 +71,7 @@ describe('Language service', function() {
       chai.expect(ipCookie.args[1][1]).to.equal('en');
       chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
-    }).catch((err) => {
-      window.__karma__.error(err);
-    });
+    }).catch(err => done(err));
   });
 
   it('uses cookie if set', function(done) {
@@ -88,9 +82,7 @@ describe('Language service', function() {
       chai.expect(ipCookie.callCount).to.equal(1);
       chai.expect(actual).to.equal('ca');
       done();
-    }).catch((err) => {
-      window.__karma__.error(err);
-    });
+    }).catch(err => done(err));
   });
 
 });

--- a/webapp/tests/karma/unit/services/language.js
+++ b/webapp/tests/karma/unit/services/language.js
@@ -37,6 +37,8 @@ describe('Language service', function() {
       chai.expect(ipCookie.args[1][1]).to.equal('latin');
       chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 
@@ -54,6 +56,8 @@ describe('Language service', function() {
       chai.expect(ipCookie.args[1][1]).to.equal('yiddish');
       chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 
@@ -71,6 +75,8 @@ describe('Language service', function() {
       chai.expect(ipCookie.args[1][1]).to.equal('en');
       chai.expect(ipCookie.args[1][2]).to.deep.equal({ expires: 365, path: '/' });
       done();
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 
@@ -82,6 +88,8 @@ describe('Language service', function() {
       chai.expect(ipCookie.callCount).to.equal(1);
       chai.expect(actual).to.equal('ca');
       done();
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 

--- a/webapp/tests/karma/unit/services/message-state.js
+++ b/webapp/tests/karma/unit/services/message-state.js
@@ -119,7 +119,7 @@ describe('MessageState service', function() {
       chai.expect(SetTaskState.getCall(1).args[0]).to.deep.equal({ group: 2, state: 'muted' });
       chai.expect(SetTaskState.getCall(1).args[1]).to.equal('scheduled');
     })
-      .then(done, done)
+      .then(() => done())
       .catch(err => done(err));
   });
 });

--- a/webapp/tests/karma/unit/services/message-state.js
+++ b/webapp/tests/karma/unit/services/message-state.js
@@ -73,6 +73,8 @@ describe('MessageState service', function() {
     get.returns(Promise.resolve(doc));
     service.set('123', 2, 'scheduled', 'muted').then(function() {
       done();
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 
@@ -118,6 +120,8 @@ describe('MessageState service', function() {
       chai.expect(SetTaskState.getCall(0).args[1]).to.equal('scheduled');
       chai.expect(SetTaskState.getCall(1).args[0]).to.deep.equal({ group: 2, state: 'muted' });
       chai.expect(SetTaskState.getCall(1).args[1]).to.equal('scheduled');
-    }).then(done, done);
+    }).then(done, done).catch((err) => {
+      window.__karma__.error(err);
+    });
   });
 });

--- a/webapp/tests/karma/unit/services/message-state.js
+++ b/webapp/tests/karma/unit/services/message-state.js
@@ -73,9 +73,7 @@ describe('MessageState service', function() {
     get.returns(Promise.resolve(doc));
     service.set('123', 2, 'scheduled', 'muted').then(function() {
       done();
-    }).catch((err) => {
-      window.__karma__.error(err);
-    });
+    }).catch(err => done(err));
   });
 
   it('set returns save errors', function(done) {
@@ -120,8 +118,8 @@ describe('MessageState service', function() {
       chai.expect(SetTaskState.getCall(0).args[1]).to.equal('scheduled');
       chai.expect(SetTaskState.getCall(1).args[0]).to.deep.equal({ group: 2, state: 'muted' });
       chai.expect(SetTaskState.getCall(1).args[1]).to.equal('scheduled');
-    }).then(done, done).catch((err) => {
-      window.__karma__.error(err);
-    });
+    })
+      .then(done, done)
+      .catch(err => done(err));
   });
 });

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -75,8 +75,7 @@ describe('Search service', function() {
         .then(function() {
           throw new Error('the second promise should be ignored');
         })
-        .catch((err) => {
-          window.__karma__.error(err);
+        .catch(() => {
         });
     });
 

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -69,16 +69,14 @@ describe('Search service', function() {
           setTimeout(done); // defer execution to give the second query time to execute
         })
         .catch((err) => {
-          window.__karma__.error(err);
+          done(err);
         });
       service('reports', {})
-        .then(function() {
-          throw new Error('the second promise should be ignored');
-        })
-        .catch(() => done());
+        .then(() => done(new Error('the second promise should be ignored')))
+        .catch(err => done(err));
     });
 
-    it('does not debounce if the same query is executed twice with the force option', function() {
+    it('does not debounce if the same query is executed twice with the force option', (done) => {
       const expected = [ { id: 'a' } ];
       GetDataRecords.returns(Promise.resolve(expected));
       let firstReturned = false;
@@ -87,17 +85,17 @@ describe('Search service', function() {
           firstReturned = true;
           chai.expect(actual).to.deep.equal(expected);
         })
-        .catch((err) => {
-          window.__karma__.error(err);
-        });
-      return service('reports', {}, { force: true })
+        .catch(err => done(err));
+      service('reports', {}, { force: true })
         .then(function(actual) {
           chai.expect(firstReturned).to.equal(true);
           chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
-        });
+          done();
+        })
+        .catch(err => done(err));
     });
 
-    it('does not debounce different queries - medic/medic/issues/4331)', function() {
+    it('does not debounce different queries - medic/medic/issues/4331)', (done) => {
       GetDataRecords
         .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))
         .onSecondCall().returns(Promise.resolve([ { id: 'b' } ]));
@@ -109,19 +107,19 @@ describe('Search service', function() {
           chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
           firstReturned = true;
         })
-        .catch((err) => {
-          window.__karma__.error(err);
-        });
+        .catch(err => done(err));
 
       filters.foo = 'test';
-      return service('reports', filters)
+      service('reports', filters)
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([ { id: 'b' } ]);
           chai.expect(firstReturned).to.equal(true);
-        });
+          done();
+        })
+        .catch(err => done(err));
     });
 
-    it('does not debounce different queries', function() {
+    it('does not debounce different queries', (done) => {
       GetDataRecords
         .onFirstCall().returns(Promise.resolve([ { id: 'a' } ]))
         .onSecondCall().returns(Promise.resolve([ { id: 'b' } ]));
@@ -134,11 +132,13 @@ describe('Search service', function() {
         .catch((err) => {
           window.__karma__.error(err);
         });
-      return service('reports', { freetext: 'second' })
+      service('reports', { freetext: 'second' })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([ { id: 'b' } ]);
           chai.expect(firstReturned).to.equal(true);
-        });
+          done();
+        })
+        .catch(err => done(err));
     });
 
     it('does not debounce subsequent queries', function() {

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -131,9 +131,7 @@ describe('Search service', function() {
           chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
           firstReturned = true;
         })
-        .catch((err) => {
-          window.__karma__.error(err);
-        });
+        .catch(err => done(err));
       service('reports', { freetext: 'second' })
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([ { id: 'b' } ]);

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -72,10 +72,10 @@ describe('Search service', function() {
           done(err);
         });
       service('reports', {})
-        .then(function() {
-          throw new Error('the second promise should be ignored');
+        .then(function(actual) {
+          chai.expect(actual).to.be.empty;
         })
-        .catch(() => done());
+        .catch((err) => done(err));
     });
 
     it('does not debounce if the same query is executed twice with the force option', (done) => {

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -72,8 +72,10 @@ describe('Search service', function() {
           done(err);
         });
       service('reports', {})
-        .then(() => done(new Error('the second promise should be ignored')))
-        .catch(err => done(err));
+        .then(function() {
+          throw new Error('the second promise should be ignored');
+        })
+        .catch(() => done());
     });
 
     it('does not debounce if the same query is executed twice with the force option', (done) => {

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -67,10 +67,16 @@ describe('Search service', function() {
         .then(function(actual) {
           chai.expect(actual).to.deep.equal(expected);
           setTimeout(done); // defer execution to give the second query time to execute
+        })
+        .catch((err) => {
+          window.__karma__.error(err);
         });
       service('reports', {})
         .then(function() {
           throw new Error('the second promise should be ignored');
+        })
+        .catch((err) => {
+          window.__karma__.error(err);
         });
     });
 
@@ -82,6 +88,9 @@ describe('Search service', function() {
         .then(function(actual) {
           firstReturned = true;
           chai.expect(actual).to.deep.equal(expected);
+        })
+        .catch((err) => {
+          window.__karma__.error(err);
         });
       return service('reports', {}, { force: true })
         .then(function(actual) {
@@ -101,6 +110,9 @@ describe('Search service', function() {
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
           firstReturned = true;
+        })
+        .catch((err) => {
+          window.__karma__.error(err);
         });
 
       filters.foo = 'test';
@@ -120,6 +132,9 @@ describe('Search service', function() {
         .then(function(actual) {
           chai.expect(actual).to.deep.equal([ { id: 'a' } ]);
           firstReturned = true;
+        })
+        .catch((err) => {
+          window.__karma__.error(err);
         });
       return service('reports', { freetext: 'second' })
         .then(function(actual) {

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -75,7 +75,7 @@ describe('Search service', function() {
         .then(function() {
           throw new Error('the second promise should be ignored');
         })
-        .catch(err => done(err));
+        .catch(() => done());
     });
 
     it('does not debounce if the same query is executed twice with the force option', function() {

--- a/webapp/tests/karma/unit/services/search.js
+++ b/webapp/tests/karma/unit/services/search.js
@@ -75,8 +75,7 @@ describe('Search service', function() {
         .then(function() {
           throw new Error('the second promise should be ignored');
         })
-        .catch(() => {
-        });
+        .catch(err => done(err));
     });
 
     it('does not debounce if the same query is executed twice with the force option', function() {

--- a/webapp/tests/karma/unit/services/send-message.js
+++ b/webapp/tests/karma/unit/services/send-message.js
@@ -111,15 +111,13 @@ describe('SendMessage service', () => {
 
     allDocs.returns(mockAllDocs(recipient));
 
-    service(recipient, 'hello').then(() => {
+    return service(recipient, 'hello').then(() => {
       chai.expect(post.callCount).to.equal(1);
       assertMessage(post.args[0][0].tasks[0], {
         from: '+5551',
         sent_by: 'jack',
         to: '+5552'
       });
-    }).catch((err) => {
-      window.__karma__.error(err);
     });
   });
 

--- a/webapp/tests/karma/unit/services/send-message.js
+++ b/webapp/tests/karma/unit/services/send-message.js
@@ -118,6 +118,8 @@ describe('SendMessage service', () => {
         sent_by: 'jack',
         to: '+5552'
       });
+    }).catch((err) => {
+      window.__karma__.error(err);
     });
   });
 

--- a/webapp/tests/karma/unit/services/simprints.js
+++ b/webapp/tests/karma/unit/services/simprints.js
@@ -49,6 +49,8 @@ describe('Simprints service', () => {
         chai.expect(simprints_reg.callCount).to.equal(1);
         chai.expect(simprints_ident.callCount).to.equal(0);
         chai.expect(actual).to.equal(expected);
+      }).catch((err) => {
+        window.__karma__.error(err);
       });
       const requestId = simprints_reg.args[0][0];
       service.registerResponse(requestId, { id: expected });
@@ -75,6 +77,8 @@ describe('Simprints service', () => {
         chai.expect(simprints_reg.callCount).to.equal(0);
         chai.expect(simprints_ident.callCount).to.equal(1);
         chai.expect(actual).to.deep.equal(expected);
+      }).catch((err) => {
+        window.__karma__.error(err);
       });
       const requestId = simprints_ident.args[0][0];
       service.identifyResponse(requestId, given);
@@ -99,6 +103,8 @@ describe('Simprints service', () => {
         chai.expect(simprints_reg.callCount).to.equal(0);
         chai.expect(simprints_ident.callCount).to.equal(1);
         chai.expect(actual).to.deep.equal(expected);
+      }).catch((err) => {
+        window.__karma__.error(err);
       });
       const requestId = simprints_ident.args[0][0];
       service.identifyResponse(requestId, given);

--- a/webapp/tests/karma/unit/services/simprints.js
+++ b/webapp/tests/karma/unit/services/simprints.js
@@ -50,7 +50,7 @@ describe('Simprints service', () => {
         chai.expect(simprints_ident.callCount).to.equal(0);
         chai.expect(actual).to.equal(expected);
       }).catch((err) => {
-        window.__karma__.error(err);
+        throw err;
       });
       const requestId = simprints_reg.args[0][0];
       service.registerResponse(requestId, { id: expected });

--- a/webapp/tests/karma/unit/services/simprints.js
+++ b/webapp/tests/karma/unit/services/simprints.js
@@ -77,8 +77,8 @@ describe('Simprints service', () => {
         chai.expect(simprints_reg.callCount).to.equal(0);
         chai.expect(simprints_ident.callCount).to.equal(1);
         chai.expect(actual).to.deep.equal(expected);
-      }).catch((err) => {
-        window.__karma__.error(err);
+      }).catch(err => {
+        throw err;
       });
       const requestId = simprints_ident.args[0][0];
       service.identifyResponse(requestId, given);
@@ -103,8 +103,8 @@ describe('Simprints service', () => {
         chai.expect(simprints_reg.callCount).to.equal(0);
         chai.expect(simprints_ident.callCount).to.equal(1);
         chai.expect(actual).to.deep.equal(expected);
-      }).catch((err) => {
-        window.__karma__.error(err);
+      }).catch(err => {
+        throw err;
       });
       const requestId = simprints_ident.args[0][0];
       service.identifyResponse(requestId, given);

--- a/webapp/tests/karma/unit/services/user-settings.js
+++ b/webapp/tests/karma/unit/services/user-settings.js
@@ -82,7 +82,7 @@ describe('UserSettings service', () => {
       });
   });
 
-  it('multiple concurrent calls result in single database lookup', () => {
+  it('multiple concurrent calls result in single database lookup', (done) => {
     userCtx.returns({ name: 'jack' });
     get.returns(Promise.resolve({ id: 'j' }));
     const isExpected = doc => {
@@ -94,12 +94,10 @@ describe('UserSettings service', () => {
     service();
     service()
       .then(isExpected)
-      .catch(() => {
-      });
+      .catch(err => done(err));
     firstPromise
       .then(isExpected)
-      .catch(() => {
-      });
+      .catch(err => done(err));
   });
 
   it('gets from remote db', () => {

--- a/webapp/tests/karma/unit/services/user-settings.js
+++ b/webapp/tests/karma/unit/services/user-settings.js
@@ -92,8 +92,16 @@ describe('UserSettings service', () => {
 
     const firstPromise = service();
     service();
-    service().then(isExpected);
-    firstPromise.then(isExpected);
+    service()
+      .then(isExpected)
+      .catch((err) => {
+        window.__karma__.error(err);
+      });
+    firstPromise
+      .then(isExpected)
+      .catch((err) => {
+        window.__karma__.error(err);
+      });
   });
 
   it('gets from remote db', () => {

--- a/webapp/tests/karma/unit/services/user-settings.js
+++ b/webapp/tests/karma/unit/services/user-settings.js
@@ -98,6 +98,7 @@ describe('UserSettings service', () => {
     firstPromise
       .then(isExpected)
       .catch(err => done(err));
+    done();
   });
 
   it('gets from remote db', () => {

--- a/webapp/tests/karma/unit/services/user-settings.js
+++ b/webapp/tests/karma/unit/services/user-settings.js
@@ -82,7 +82,7 @@ describe('UserSettings service', () => {
       });
   });
 
-  it('multiple concurrent calls result in single database lookup', (done) => {
+  it('multiple concurrent calls result in single database lookup', () => {
     userCtx.returns({ name: 'jack' });
     get.returns(Promise.resolve({ id: 'j' }));
     const isExpected = doc => {
@@ -92,13 +92,10 @@ describe('UserSettings service', () => {
 
     const firstPromise = service();
     service();
-    service()
+    return service()
       .then(isExpected)
-      .catch(err => done(err));
-    firstPromise
-      .then(isExpected)
-      .catch(err => done(err));
-    done();
+      .then(() => firstPromise)
+      .then(isExpected);
   });
 
   it('gets from remote db', () => {

--- a/webapp/tests/karma/unit/services/user-settings.js
+++ b/webapp/tests/karma/unit/services/user-settings.js
@@ -94,13 +94,11 @@ describe('UserSettings service', () => {
     service();
     service()
       .then(isExpected)
-      .catch((err) => {
-        window.__karma__.error(err);
+      .catch(() => {
       });
     firstPromise
       .then(isExpected)
-      .catch((err) => {
-        window.__karma__.error(err);
+      .catch(() => {
       });
   });
 

--- a/webapp/tests/mocha/unit/swRegister.spec.js
+++ b/webapp/tests/mocha/unit/swRegister.spec.js
@@ -26,13 +26,12 @@ describe('Service worker registration (swRegister.js)', () => {
     };
   });
 
-  it('resolves if already installed', done => {
+  it('resolves if already installed', () => {
     fakeRegisterFunc.resolves({});
     const callback = sinon.stub();
     return swRegister(callback).then(actual => {
       expect(actual).to.eq(undefined);
       expect(callback.called).to.eq(false);
-      done();
     });
   });
 

--- a/webapp/tests/mocha/unit/swRegister.spec.js
+++ b/webapp/tests/mocha/unit/swRegister.spec.js
@@ -33,6 +33,8 @@ describe('Service worker registration (swRegister.js)', () => {
       expect(actual).to.eq(undefined);
       expect(callback.called).to.eq(false);
       done();
+    }).catch(() => {
+      process.exit(1);
     });
   });
 
@@ -47,6 +49,8 @@ describe('Service worker registration (swRegister.js)', () => {
       expect(actual).to.be.an('object');
       expect(callback.callCount).to.eq(1);
       done();
+    }).catch(() => {
+      process.exit(1);
     });
     executeSwLifecycle(registration);
   });

--- a/webapp/tests/mocha/unit/swRegister.spec.js
+++ b/webapp/tests/mocha/unit/swRegister.spec.js
@@ -29,12 +29,10 @@ describe('Service worker registration (swRegister.js)', () => {
   it('resolves if already installed', done => {
     fakeRegisterFunc.resolves({});
     const callback = sinon.stub();
-    swRegister(callback).then(actual => {
+    return swRegister(callback).then(actual => {
       expect(actual).to.eq(undefined);
       expect(callback.called).to.eq(false);
       done();
-    }).catch(() => {
-      process.exit(1);
     });
   });
 

--- a/webapp/tests/mocha/unit/swRegister.spec.js
+++ b/webapp/tests/mocha/unit/swRegister.spec.js
@@ -46,8 +46,8 @@ describe('Service worker registration (swRegister.js)', () => {
       expect(actual).to.be.an('object');
       expect(callback.callCount).to.eq(1);
       done();
-    }).catch(() => {
-      process.exit(1);
+    }).catch(err => {
+      throw err;
     });
     executeSwLifecycle(registration);
   });


### PR DESCRIPTION
# Description

Adds an eslint rule to make sure promises in tests either have a catch or are returned and refactors tests that fail as a result.

medic/cht-core#6369

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
