### PR TITLE
3.9 CHT Docker Image Update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   medic-os:
     container_name: medic-os
-    image: medicmobile/medic-os:cht-3.7.0-rc.1
+    image: medicmobile/medic-os:cht-3.9.0-rc.1
     volumes:
       - medic-data:/srv
     ports:

--- a/release-notes/docs/3.9.0.md
+++ b/release-notes/docs/3.9.0.md
@@ -15,6 +15,15 @@ None.
 
 ## Upgrade notes
 
+### CHT Docker Image
+
+#### 3.9 CHT Docker Image released
+
+Prior to initiating an upgrade to 3.9, you will need to update the CHT Docker Image and a few packages inside the medic-os container.
+Please closely follow our [3.9 CHT upgrade documentation](https://github.com/medic/cht-infrastructure/blob/master/docs/3.9_CHT_Upgrade.md)
+
+This image provides a new horticulturalist package to [stage ddocs properly](https://github.com/medic/horticulturalist/pull/58)
+
 ### Breaking changes
 
 #### Outbound Push only sends each report once

--- a/release-notes/docs/3.9.0.md
+++ b/release-notes/docs/3.9.0.md
@@ -15,16 +15,14 @@ None.
 
 ## Upgrade notes
 
-### CHT Docker Image
+### Breaking changes
 
-#### 3.9 CHT Docker Image released
+#### Docker image update required
 
 Prior to initiating an upgrade to 3.9, you will need to update the CHT Docker Image and a few packages inside the medic-os container.
-Please closely follow our [3.9 CHT upgrade documentation](https://github.com/medic/cht-infrastructure/blob/master/docs/3.9_CHT_Upgrade.md)
+Please closely follow our [3.9 CHT Docker Image Upgrade Process](https://github.com/medic/cht-infrastructure/blob/master/docs/3.9_CHT_Upgrade.md)
 
-This image provides a new horticulturalist package to [stage ddocs properly](https://github.com/medic/horticulturalist/pull/58)
-
-### Breaking changes
+This image updates the horticulturalist package to [stage ddocs properly](https://github.com/medic/horticulturalist/pull/58).
 
 #### Outbound Push only sends each report once
 


### PR DESCRIPTION
# Description
We updated the CHT docker image to include the new horticulturalist that contains a fix to handle upgrading projects to 3.9

@garethbowen 
Not sure if I created the correct subcategories to place this information inside. Please let me know if it should reside elsewhere.
