### PR TITLE
Add support for logging all geolocation results

### DIFF
--- a/webapp/src/js/services/enketo.js
+++ b/webapp/src/js/services/enketo.js
@@ -576,20 +576,15 @@ angular.module('inboxServices').service('Enketo',
         .then(function(docs) {
           if (geoHandle) {
             return geoHandle()
-            // REVIEWER
-            //   I'm not sure about this wrt edits. As it is written:
-            //    A) Create with no geo: no geolocation with relevant error
-            //    B) Create with geo: relevant geolocation with no error
-            //    C) Edit A with geo: relevant geolocation with old error
-            //    D) Edit A with no geo: no geolocation with relevant error
-            //    E) Edit B with no geo: old geolocation with relevant error
-            //    F) Edit B with geo: new geolcation with blank error
-            //
-            //  Perhaps we should just always overwrite doc.geolocation with either the success or the failure?
-            //  This is not what master does right now though, master follows the above but doesn't store the error
-            // REVIEWER
-              .then(coords => docs.forEach(doc => doc.geolocation = coords))
-              .catch(error => docs.forEach(doc => doc.geolocation_error = error))
+              .catch(err => err)
+              .then(geoData => docs.forEach(doc => {
+                doc.geolocation_log = doc.geolocation_log || [];
+                doc.geolocation_log.push({
+                  timestamp: Date.now(),
+                  recording: geoData
+                });
+                doc.geolocation = geoData;
+              }))
               .then(() => {
                 return docs;
               });

--- a/webapp/tests/karma/unit/services/enketo.js
+++ b/webapp/tests/karma/unit/services/enketo.js
@@ -476,7 +476,6 @@ describe('Enketo service', () => {
       dbGetAttachment.resolves('<form/>');
       UserContact.resolves({ _id: '123', phone: '555' });
       UserSettings.resolves({ name: 'Jim' });
-
       return service.save('V', form).then(actual => {
         actual = actual[0];
 
@@ -493,6 +492,207 @@ describe('Enketo service', () => {
         expect(actual.content_type).to.equal('xml');
         expect(actual.contact._id).to.equal('123');
         expect(actual.from).to.equal('555');
+        expect(dbGetAttachment.callCount).to.equal(1);
+        expect(dbGetAttachment.args[0][0]).to.equal('abc');
+        expect(AddAttachment.callCount).to.equal(1);
+        expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
+        expect(AddAttachment.args[0][1]).to.equal('content');
+        expect(AddAttachment.args[0][2]).to.equal(content);
+        expect(AddAttachment.args[0][3]).to.equal('application/xml');
+      });
+    });
+
+    describe('Geolocation recording', () => {
+      it('saves geolocation data into a new report', () => {
+        form.validate.resolves(true);
+        const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+        form.getDataStr.returns(content);
+        dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
+        dbGetAttachment.resolves('<form/>');
+        UserContact.resolves({ _id: '123', phone: '555' });
+        UserSettings.resolves({ name: 'Jim' });
+        const geoData = {
+          latitude: 1,
+          longitude: 2,
+          altitude: 3,
+          accuracy: 4,
+          altitudeAccuracy: 5,
+          heading: 6,
+          speed: 7
+        };
+        return service.save('V', form, () => Promise.resolve(geoData)).then(actual => {
+          actual = actual[0];
+
+          expect(form.validate.callCount).to.equal(1);
+          expect(form.getDataStr.callCount).to.equal(1);
+          expect(dbBulkDocs.callCount).to.equal(1);
+          expect(UserContact.callCount).to.equal(1);
+          expect(actual._id).to.match(/(\w+-)\w+/);
+          expect(actual._rev).to.equal('1-abc');
+          expect(actual.fields.name).to.equal('Sally');
+          expect(actual.fields.lmp).to.equal('10');
+          expect(actual.form).to.equal('V');
+          expect(actual.type).to.equal('data_record');
+          expect(actual.content_type).to.equal('xml');
+          expect(actual.contact._id).to.equal('123');
+          expect(actual.from).to.equal('555');
+          expect(actual.geolocation).to.deep.equal(geoData);
+          expect(actual.geolocation_log.length).to.equal(1);
+          expect(actual.geolocation_log[0].timestamp).to.be.greaterThan(0);
+          expect(actual.geolocation_log[0].recording).to.deep.equal(geoData);
+          expect(dbGetAttachment.callCount).to.equal(1);
+          expect(dbGetAttachment.args[0][0]).to.equal('abc');
+          expect(AddAttachment.callCount).to.equal(1);
+          expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
+          expect(AddAttachment.args[0][1]).to.equal('content');
+          expect(AddAttachment.args[0][2]).to.equal(content);
+          expect(AddAttachment.args[0][3]).to.equal('application/xml');
+        });
+      });
+
+      it('saves a geolocation error into a new report', () => {
+        form.validate.resolves(true);
+        const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+        form.getDataStr.returns(content);
+        dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
+        dbGetAttachment.resolves('<form/>');
+        UserContact.resolves({ _id: '123', phone: '555' });
+        UserSettings.resolves({ name: 'Jim' });
+        const geoError = {
+          code: 42,
+          message: 'some bad geo'
+        };
+        return service.save('V', form, () => Promise.reject(geoError)).then(actual => {
+          actual = actual[0];
+
+          expect(form.validate.callCount).to.equal(1);
+          expect(form.getDataStr.callCount).to.equal(1);
+          expect(dbBulkDocs.callCount).to.equal(1);
+          expect(UserContact.callCount).to.equal(1);
+          expect(actual._id).to.match(/(\w+-)\w+/);
+          expect(actual._rev).to.equal('1-abc');
+          expect(actual.fields.name).to.equal('Sally');
+          expect(actual.fields.lmp).to.equal('10');
+          expect(actual.form).to.equal('V');
+          expect(actual.type).to.equal('data_record');
+          expect(actual.content_type).to.equal('xml');
+          expect(actual.contact._id).to.equal('123');
+          expect(actual.from).to.equal('555');
+          expect(actual.geolocation).to.deep.equal(geoError);
+          expect(actual.geolocation_log.length).to.equal(1);
+          expect(actual.geolocation_log[0].timestamp).to.be.greaterThan(0);
+          expect(actual.geolocation_log[0].recording).to.deep.equal(geoError);
+          expect(dbGetAttachment.callCount).to.equal(1);
+          expect(dbGetAttachment.args[0][0]).to.equal('abc');
+          expect(AddAttachment.callCount).to.equal(1);
+          expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
+          expect(AddAttachment.args[0][1]).to.equal('content');
+          expect(AddAttachment.args[0][2]).to.equal(content);
+          expect(AddAttachment.args[0][3]).to.equal('application/xml');
+        });
+      });
+
+      it('overwrites exising geolocation info on edit with new info and appends to the log', () => {
+        form.validate.resolves(true);
+        const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+        form.getDataStr.returns(content);
+        const originalGeoData = {
+          latitude: 1,
+          longitude: 2,
+          altitude: 3,
+          accuracy: 4,
+          altitudeAccuracy: 5,
+          heading: 6,
+          speed: 7
+        };
+        const originalGeoLogEntry = {
+          timestamp: 12345,
+          recording: originalGeoData
+        };
+        dbGet.resolves({
+          _id: '6',
+          _rev: '1-abc',
+          form: 'V',
+          fields: { name: 'Silly' },
+          content: '<doc><name>Silly</name></doc>',
+          content_type: 'xml',
+          type: 'data_record',
+          reported_date: 500,
+          geolocation: originalGeoData,
+          geolocation_log: [originalGeoLogEntry]
+        });
+        dbBulkDocs.resolves([ { ok: true, id: '6', rev: '2-abc' } ]);
+        dbGetAttachment.resolves('<form/>');
+        const geoData = {
+          latitude: 10,
+          longitude: 11,
+          altitude: 12,
+          accuracy: 13,
+          altitudeAccuracy: 14,
+          heading: 15,
+          speed: 16
+        };
+        return service.save('V', form, () => Promise.resolve(geoData), '6').then(actual => {
+          actual = actual[0];
+
+          expect(form.validate.callCount).to.equal(1);
+          expect(form.getDataStr.callCount).to.equal(1);
+          expect(dbGet.callCount).to.equal(1);
+          expect(dbGet.args[0][0]).to.equal('6');
+          expect(dbBulkDocs.callCount).to.equal(1);
+          expect(actual._id).to.equal('6');
+          expect(actual._rev).to.equal('2-abc');
+          expect(actual.fields.name).to.equal('Sally');
+          expect(actual.fields.lmp).to.equal('10');
+          expect(actual.form).to.equal('V');
+          expect(actual.type).to.equal('data_record');
+          expect(actual.reported_date).to.equal(500);
+          expect(actual.content_type).to.equal('xml');
+          expect(actual.geolocation).to.deep.equal(geoData);
+          expect(actual.geolocation_log.length).to.equal(2);
+          expect(actual.geolocation_log[0]).to.deep.equal(originalGeoLogEntry);
+          expect(actual.geolocation_log[1].timestamp).to.be.greaterThan(0);
+          expect(actual.geolocation_log[1].recording).to.deep.equal(geoData);
+          expect(AddAttachment.callCount).to.equal(1);
+          expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
+          expect(AddAttachment.args[0][1]).to.equal('content');
+          expect(AddAttachment.args[0][2]).to.equal(content);
+          expect(AddAttachment.args[0][3]).to.equal('application/xml');
+          expect(ServicesActions.setLastChangedDoc.callCount).to.equal(1);
+          expect(ServicesActions.setLastChangedDoc.args[0]).to.deep.equal([actual]);
+        });
+      });
+    });
+
+    it('creates report with erroring geolocation', () => {
+      form.validate.resolves(true);
+      const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+      form.getDataStr.returns(content);
+      dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
+      dbGetAttachment.resolves('<form/>');
+      UserContact.resolves({ _id: '123', phone: '555' });
+      UserSettings.resolves({ name: 'Jim' });
+      const geoError = {
+        code: 42,
+        message: 'geolocation failed for some reason'
+      };
+      return service.save('V', form, () => Promise.reject(geoError  )).then(actual => {
+        actual = actual[0];
+
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
+        expect(actual._id).to.match(/(\w+-)\w+/);
+        expect(actual._rev).to.equal('1-abc');
+        expect(actual.fields.name).to.equal('Sally');
+        expect(actual.fields.lmp).to.equal('10');
+        expect(actual.form).to.equal('V');
+        expect(actual.type).to.equal('data_record');
+        expect(actual.content_type).to.equal('xml');
+        expect(actual.contact._id).to.equal('123');
+        expect(actual.from).to.equal('555');
+        expect(actual.geolocation).to.deep.equal(geoError);
         expect(dbGetAttachment.callCount).to.equal(1);
         expect(dbGetAttachment.args[0][0]).to.equal('abc');
         expect(AddAttachment.callCount).to.equal(1);
@@ -679,7 +879,16 @@ describe('Enketo service', () => {
       ]);
       dbGetAttachment.resolves('<form/>');
       UserContact.resolves({ _id: '123', phone: '555' });
-      return service.save('V', form, () => Promise.resolve(true)).then(actual => {
+      const geoData = {
+        latitude: 1,
+        longitude: 2,
+        altitude: 3,
+        accuracy: 4,
+        altitudeAccuracy: 5,
+        heading: 6,
+        speed: 7
+      };
+      return service.save('V', form, () => Promise.resolve(geoData)).then(actual => {
         const endTime = Date.now() + 1;
 
         expect(form.validate.callCount).to.equal(1);
@@ -704,14 +913,14 @@ describe('Enketo service', () => {
         expect(actualReport.fields.doc1).to.equal(undefined);
         expect(actualReport.fields.doc2).to.equal(undefined);
 
-        expect(actualReport.geolocation).to.equal(true);
+        expect(actualReport.geolocation).to.deep.equal(geoData);
 
         const actualThing1 = actual[1];
         expect(actualThing1._id).to.match(/(\w+-)\w+/);
         expect(actualThing1.reported_date).to.be.above(startTime);
         expect(actualThing1.reported_date).to.be.below(endTime);
         expect(actualThing1.some_property_1).to.equal('some_value_1');
-        expect(actualThing1.geolocation).to.equal(true);
+        expect(actualThing1.geolocation).to.deep.equal(geoData);
 
         const actualThing2 = actual[2];
         expect(actualThing2._id).to.match(/(\w+-)\w+/);
@@ -719,7 +928,7 @@ describe('Enketo service', () => {
         expect(actualThing2.reported_date).to.be.below(endTime);
         expect(actualThing2.some_property_2).to.equal('some_value_2');
 
-        expect(actualThing2.geolocation).to.equal(true);
+        expect(actualThing2.geolocation).to.deep.equal(geoData);
 
         expect(_.uniq(_.map(actual, '_id')).length).to.equal(3);
       });


### PR DESCRIPTION
Creates a timestamped log that can be analysed later, keeping the
original location for backwards compatability. Potentially we'd want to
change the original location so that it never overwrites that location.