### PR TITLE
update couchdb credentials for running tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,8 +126,8 @@ module.exports = function(grunt) {
       },
       test: {
         options: {
-          user: couchConfig.username,
-          pass: couchConfig.password,
+          user: 'admin',
+          pass: 'pass',
         },
         files: {
           ['http://admin:pass@localhost:4984/medic-test']: 'build/ddocs/medic.json',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,10 +125,6 @@ module.exports = function(grunt) {
         }
       },
       test: {
-        options: {
-          user: 'admin',
-          pass: 'pass',
-        },
         files: {
           ['http://admin:pass@localhost:4984/medic-test']: 'build/ddocs/medic.json',
         },


### PR DESCRIPTION
# Description

Running unit tests locally fails if the credentials you have set up from couchdb do not match what is expected. This change just explicitly sets the expected username and password.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
