### PR TITLE
Adds a script that purges certain tasks locally in 3.8

### DIFF
--- a/admin/tests/unit/controllers/message-queue.js
+++ b/admin/tests/unit/controllers/message-queue.js
@@ -59,7 +59,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(MessageQueue.query.args[0]).to.deep.equal(['tab', 0, 25, undefined]);
         chai.expect(scope.basePath).to.equal('some path');
         done();
-      });
+      }, 50);
     });
 
     it('catches Settings errors', done => {
@@ -70,7 +70,7 @@ describe('MessageQueueCtrl controller', () => {
       setTimeout(() => {
         chai.expect(MessageQueue.query.callCount).to.equal(0);
         done();
-      });
+      }, 50);
     });
 
     it('catches loadTranslation errors', done => {
@@ -81,7 +81,7 @@ describe('MessageQueueCtrl controller', () => {
       setTimeout(() => {
         chai.expect(MessageQueue.query.callCount).to.equal(0);
         done();
-      });
+      }, 50);
     });
   });
 
@@ -97,7 +97,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(MessageQueue.query.args[0][3]).to.equal(undefined);
         chai.expect(scope.pagination.page).to.equal(1);
         done();
-      });
+      }, 50);
     });
 
     it('queries MessageQueue with descending param if set', done => {
@@ -111,7 +111,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(MessageQueue.query.args[0][3]).to.equal('descending');
         chai.expect(scope.pagination.page).to.equal(1);
         done();
-      });
+      }, 50);
     });
 
     it('loads selected page', done => {
@@ -126,7 +126,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 10 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
 
     it('normalizes page param (objects)', done => {
@@ -141,7 +141,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 1 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
 
     it('normalizes page param (arrays)', done => {
@@ -156,7 +156,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 1 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
 
     it('normalizes page param (strings)', done => {
@@ -171,7 +171,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 1 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
 
     it('normalizes page param (strings)', done => {
@@ -186,7 +186,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 22 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
 
     it('normalizes page param (negative numbers)', done => {
@@ -201,7 +201,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 1 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
 
     it('normalizes page param (floating point numbers)', done => {
@@ -216,7 +216,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(stateGo.callCount).to.equal(1);
         chai.expect(stateGo.args[0]).to.deep.equal(['.', { page: 4 }, { notify: false }]);
         done();
-      });
+      }, 50);
     });
   });
 
@@ -240,7 +240,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(scope.loading).to.equal(false);
         chai.expect(scope.displayLastUpdated).to.equal(true);
         done();
-      });
+      }, 50);
     });
 
     it('catches query errors', done => {
@@ -254,7 +254,7 @@ describe('MessageQueueCtrl controller', () => {
         chai.expect(scope.loading).to.equal(false);
         chai.expect(scope.displayLastUpdated).to.equal(true);
         done();
-      });
+      }, 50);
     });
 
     it('applies conditional styling params', done => {
@@ -283,7 +283,7 @@ describe('MessageQueueCtrl controller', () => {
           { state: 'random', stateHistory: { timestamp: 0 } }
         ]);
         done();
-      });
+      }, 50);
     });
 
     it('does not display last updated date for scheduled tab', done =>{
@@ -298,7 +298,7 @@ describe('MessageQueueCtrl controller', () => {
       setTimeout(() => {
         chai.expect(scope.displayLastUpdated).to.equal(false);
         done();
-      });
+      }, 50);
     });
   });
 
@@ -331,8 +331,8 @@ describe('MessageQueueCtrl controller', () => {
               chai.expect(MessageQueue.query.args[4][1]).to.equal(0);
               chai.expect(scope.pagination.page).to.equal(1);
               done();
-            });
-          });
+            }, 50);
+          }, 50);
         });
       });
     });
@@ -380,9 +380,9 @@ describe('MessageQueueCtrl controller', () => {
                 chai.expect(MessageQueue.query.args[3][1]).to.equal(275);
                 chai.expect(MessageQueue.query.args[4][1]).to.equal(0);
                 done();
-              });
-            });
-          });
+              }, 50);
+            }, 50);
+          }, 50);
         });
       });
     });

--- a/tests/patches/webdriver-manager-config.patch
+++ b/tests/patches/webdriver-manager-config.patch
@@ -13,7 +13,7 @@
     "webdriverVersions": {
       "selenium": "2.53.1",
       "chromedriver": "2.27",
-!     "maxChromedriver": "79",
+!     "maxChromedriver": "83",
       "geckodriver": "v0.13.0",
       "iedriver": "2.53.1",
       "androidsdk": "24.4.1",

--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -6,6 +6,7 @@
   const translator = require('./translator');
   const utils = require('./utils');
   const purger = require('./purger');
+  const taskPurger = require('./task-purger');
 
   const ONLINE_ROLE = 'mm-online';
 
@@ -230,6 +231,21 @@
             }
 
             return purger
+              .purge(localDb, userCtx)
+              .on('start', () => setUiStatus('PURGE_INIT'))
+              .on('progress', progress => setUiStatus('PURGE_INFO', { count: progress.purged }))
+              .catch(err => console.error('Error attempting to purge', err));
+          });
+      })
+      .then(() => {
+        return taskPurger
+          .shouldPurge(localDb)
+          .then(shouldPurge => {
+            if (!shouldPurge) {
+              return;
+            }
+
+            return taskPurger
               .purge(localDb, userCtx)
               .on('start', () => setUiStatus('PURGE_INIT'))
               .on('progress', progress => setUiStatus('PURGE_INFO', { count: progress.purged }))

--- a/webapp/src/js/bootstrapper/task-purger.js
+++ b/webapp/src/js/bootstrapper/task-purger.js
@@ -26,12 +26,13 @@ module.exports.purge = (localDb, userCtx) => {
     .then(() => localDb.get('settings'))
     .then(settings => {
       let promiseChain = Promise.resolve();
+      emit('start');
+
       settings.settings.purge_tasks.forEach(purgeSetting => {
         if (!purgeSetting.event_name) {
           return;
         }
 
-        emit('start');
         promiseChain = promiseChain.then(() => purgeTasks(localDb, userCtx, purgeSetting));
       });
 
@@ -49,7 +50,7 @@ module.exports.purge = (localDb, userCtx) => {
 
 const purgeTasks = (localDb, userCtx, { event_name, all_contacts }) => {
   if (!all_contacts) {
-    return getUserContact(localDb, userCtx)
+    return getUserContactId(localDb, userCtx)
       .then(contactId => purgeTasksForContact(localDb, event_name, contactId, userCtx));
   }
 
@@ -68,7 +69,7 @@ const getAllContactsIds = localDb => {
     .then(result => result.rows.map(row => row.id));
 };
 
-const getUserContact = (localDb, userCtx) => {
+const getUserContactId = (localDb, userCtx) => {
   return localDb
     .get(`org.couchdb.user:${userCtx.name}`)
     .then(userSettings => userSettings.contact_id);

--- a/webapp/src/js/bootstrapper/task-purger.js
+++ b/webapp/src/js/bootstrapper/task-purger.js
@@ -1,0 +1,107 @@
+let totalPurged;
+let emit;
+
+module.exports.shouldPurge = (localDb) => {
+  return localDb.get('settings')
+    .then(settings => {
+      if (!settings || !settings.settings || !settings.settings.purge_tasks || !settings.settings.purge_tasks.length) {
+        return  false;
+      }
+      return true;
+    })
+    .catch(() => false);
+};
+
+module.exports.purge = (localDb, userCtx) => {
+  totalPurged = 0;
+  const handlers = [];
+
+  emit = (name, event) => {
+    console.debug(`Emitting '${name}' event with:`, event);
+    (handlers[name] || []).forEach(callback => callback(event));
+  };
+
+  const promise = Promise
+    .resolve()
+    .then(() => localDb.get('settings'))
+    .then(settings => {
+      let promiseChain = Promise.resolve();
+      settings.settings.purge_tasks.forEach(purgeSetting => {
+        if (!purgeSetting.event_name) {
+          return;
+        }
+
+        emit('start');
+        promiseChain = promiseChain.then(() => purgeTasks(localDb, userCtx, purgeSetting));
+      });
+
+      return promiseChain;
+    });
+
+  promise.on = (type, callback) => {
+    handlers[type] = handlers[type] || [];
+    handlers[type].push(callback);
+    return promise;
+  };
+
+  return promise;
+};
+
+const purgeTasks = (localDb, userCtx, { event_name, all_contacts }) => {
+  if (!all_contacts) {
+    return getUserContact(localDb, userCtx)
+      .then(contactId => purgeTasksForContact(localDb, event_name, contactId, userCtx));
+  }
+
+  return getAllContactsIds(localDb).then(contactIds => {
+    let promise = Promise.resolve();
+    contactIds.forEach(contactId => {
+      promise = promise.then(() => purgeTasksForContact(localDb, event_name, contactId, userCtx));
+    });
+    return promise;
+  });
+};
+
+const getAllContactsIds = localDb => {
+  return localDb
+    .query('medic-client/contacts_by_type')
+    .then(result => result.rows.map(row => row.id));
+};
+
+const getUserContact = (localDb, userCtx) => {
+  return localDb
+    .get(`org.couchdb.user:${userCtx.name}`)
+    .then(userSettings => userSettings.contact_id);
+};
+
+const purgeTasksForContact = (localDb, eventName, contactId, userCtx) => {
+  const searchKey = `task~org.couchdb.user:${userCtx.name}~${contactId}~${eventName}`;
+  return localDb
+    .allDocs({ start_key: searchKey, end_key: searchKey + '\ufff0', limit: 100 })
+    .then(result => {
+      if (!result.rows || !result.rows.length) {
+        // we're done!
+        return;
+      }
+
+      const deleteStubs = result.rows
+        .filter(row => !row.error)
+        .map(row => ({ _id: row.id, _rev: row.value.rev, _deleted: true, purged: true }));
+
+      return localDb.bulkDocs(deleteStubs).then(results => {
+        let errors = '';
+        results.forEach(result => {
+          if (!result.ok) {
+            errors += result.id + ' with ' + result.message + '; ';
+          }
+        });
+        if (errors) {
+          throw new Error(`Not all documents purged successfully: ${errors}`);
+        }
+
+        totalPurged += deleteStubs.length;
+        emit('progress', { purged: totalPurged });
+        return purgeTasksForContact(localDb, eventName, contactId, userCtx);
+      });
+    });
+};

--- a/webapp/tests/karma/unit/directives/auth.js
+++ b/webapp/tests/karma/unit/directives/auth.js
@@ -31,7 +31,7 @@ describe('auth directive', () => {
       chai.expect(Auth.callCount).to.equal(1);
       chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
       done();
-    });
+    }, 50);
   });
 
   it('should be hidden when auth errors', done => {
@@ -43,7 +43,7 @@ describe('auth directive', () => {
       chai.expect(Auth.callCount).to.equal(1);
       chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff']);
       done();
-    });
+    }, 50);
   });
 
   it('splits comma separated permissions', done => {
@@ -55,7 +55,7 @@ describe('auth directive', () => {
       chai.expect(Auth.callCount).to.equal(1);
       chai.expect(Auth.args[0][0]).to.deep.equal(['can_do_stuff', '!can_not_do_stuff']);
       done();
-    });
+    }, 50);
   });
 
   describe('mmAuthOnline', () => {
@@ -69,7 +69,7 @@ describe('auth directive', () => {
         chai.expect(Auth.online.args[0]).to.deep.equal([true]);
         done();
       });
-    });
+    }, 50);
 
     it('should be hidden when auth errors', (done) => {
       Auth.online.rejects({ some: 'err' });
@@ -81,7 +81,7 @@ describe('auth directive', () => {
         chai.expect(Auth.online.args[0]).to.deep.equal([false]);
         done();
       });
-    });
+    }, 50);
 
     it('parses the attribute value', (done) => {
       Auth.online.resolves();
@@ -93,7 +93,7 @@ describe('auth directive', () => {
         chai.expect(Auth.online.args[0]).to.deep.equal([6]);
         done();
       });
-    });
+    }, 50);
   });
 
   describe('mmAuth + mmAuthOnline', () => {
@@ -110,7 +110,7 @@ describe('auth directive', () => {
         chai.expect(Auth.callCount).to.equal(1);
         chai.expect(Auth.args[0][0]).to.deep.equal(['permission_to_have']);
         done();
-      });
+      }, 50);
     });
 
     it('should be hidden when online succeeds and permissions err', (done) => {
@@ -126,7 +126,7 @@ describe('auth directive', () => {
         chai.expect(Auth.callCount).to.equal(1);
         chai.expect(Auth.args[0][0]).to.deep.equal(['permission_to_have']);
         done();
-      });
+      }, 50);
     });
 
     it('should be hidden when online fails and permissions succeed', (done) => {
@@ -142,7 +142,7 @@ describe('auth directive', () => {
         chai.expect(Auth.callCount).to.equal(1);
         chai.expect(Auth.args[0][0]).to.deep.equal(['permission_to_have']);
         done();
-      });
+      }, 50);
     });
 
     it('should be hidden when online fails and auth any succeeds', (done) => {
@@ -154,7 +154,7 @@ describe('auth directive', () => {
       setTimeout(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         done();
-      });
+      }, 50);
     });
 
     it('should be hidden when both fail', (done) => {
@@ -170,7 +170,7 @@ describe('auth directive', () => {
         chai.expect(Auth.callCount).to.equal(1);
         chai.expect(Auth.args[0][0]).to.deep.equal(['permission_to_have']);
         done();
-      });
+      }, 50);
     });
   });
 
@@ -184,7 +184,7 @@ describe('auth directive', () => {
         chai.expect(element2.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.any.callCount).to.equal(0);
         done();
-      });
+      }, 50);
     });
 
     it('should be shown with true parameter(s)', (done) => {
@@ -196,7 +196,7 @@ describe('auth directive', () => {
         chai.expect(element2.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.any.callCount).to.equal(0);
         done();
-      });
+      }, 50);
     });
 
     it('should be shown with at least one allowed permission', (done) => {
@@ -209,7 +209,7 @@ describe('auth directive', () => {
         chai.expect(Auth.any.callCount).to.equal(1);
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['perm1'], ['perm2']]);
         done();
-      });
+      }, 50);
     });
 
     it('should be hidden with no allowed permissions', (done) => {
@@ -234,7 +234,7 @@ describe('auth directive', () => {
         chai.expect(Auth.any.callCount).to.equal(1);
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['a', 'b'], ['c', 'd'], ['e', 'f'], ['g']]);
         done();
-      });
+      }, 50);
     });
 
     it('should work with expressions ', (done) => {
@@ -248,7 +248,7 @@ describe('auth directive', () => {
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['a', 'b'], ['f']]);
         done();
       });
-    });
+    }, 50);
   });
 
 });

--- a/webapp/tests/mocha/unit/bootstrapper.spec.js
+++ b/webapp/tests/mocha/unit/bootstrapper.spec.js
@@ -8,6 +8,7 @@ const sinon = require('sinon'),
 const rewire = require('rewire');
 const bootstrapper = rewire('../../../src/js/bootstrapper');
 const purger = require('../../../src/js/bootstrapper/purger');
+const taskPurger = require('../../../src/js/bootstrapper/task-purger');
 
 let originalDocument;
 let originalWindow;
@@ -20,6 +21,7 @@ let remoteClose;
 let localAllDocs;
 let localId;
 let purgeOn;
+let taskPurgeOn;
 
 describe('bootstrapper', () => {
 
@@ -75,6 +77,13 @@ describe('bootstrapper', () => {
       return promise;
     });
 
+    taskPurgeOn = sinon.stub();
+    taskPurgeOn.callsFake(() => {
+      const promise = Promise.resolve();
+      promise.on = taskPurgeOn;
+      return promise;
+    });
+
     $ = sinon.stub().returns({
       text: sinon.stub(),
       click: sinon.stub(),
@@ -122,6 +131,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);
@@ -148,6 +158,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);
@@ -163,6 +174,7 @@ describe('bootstrapper', () => {
     localGet.withArgs('settings').resolves({_id: 'settings', settings: {}});
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);
@@ -186,6 +198,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     const localReplicateResult = Promise.resolve();
     localReplicateResult.on = () => {};
@@ -251,6 +264,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);
@@ -348,6 +362,7 @@ describe('bootstrapper', () => {
     setUserCtxCookie({ name: 'jim' });
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
 
@@ -382,6 +397,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     const localReplicateResult = Promise.resolve();
     localReplicateResult.on = () => {};
@@ -436,6 +452,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     let purgeOn;
     purgeOn = sinon.stub().returns({ on: purgeOn, catch: sinon.stub() });
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
@@ -459,6 +476,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     let purgeOn;
     purgeOn = sinon.stub().returns({ on: purgeOn, catch: sinon.stub() });
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
@@ -496,6 +514,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(true);
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     const localReplicateResult = Promise.resolve();
     localReplicateResult.on = () => {};
@@ -546,6 +565,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
 
     bootstrapper(pouchDbOptions, err => {
@@ -566,6 +586,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
     purgeOn.onCall(1).rejects({ some: 'err' });
 
@@ -575,6 +596,45 @@ describe('bootstrapper', () => {
       assert.deepEqual(purger.setOptions.args[0], [pouchDbOptions]);
       assert.equal(purger.shouldPurge.callCount, 1);
       assert.equal(purger.purge.callCount, 1);
+      done();
+    });
+  });
+
+  it('should run task-purge after skipping initial replication when needed', done => {
+    setUserCtxCookie({ name: 'jim' });
+
+    localGet.withArgs('_design/medic-client').resolves({_id: '_design/medic-client'});
+    localGet.withArgs('settings').resolves({_id: 'settings', settings: {}});
+    localId.resolves('some-randomn-uuid');
+    sinon.stub(purger, 'setOptions');
+    sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'purge').returns({ on: taskPurgeOn });
+
+    bootstrapper(pouchDbOptions, err => {
+      assert.equal(null, err);
+      assert.equal(taskPurger.shouldPurge.callCount, 1);
+      assert.equal(taskPurger.purge.callCount, 1);
+      done();
+    });
+  });
+
+  it('should catch task-purge errors', done => {
+    setUserCtxCookie( { name: 'jim' });
+
+    localGet.withArgs('_design/medic-client').resolves({_id: '_design/medic-client'});
+    localGet.withArgs('settings').resolves({_id: 'settings', settings: {}});
+    localId.resolves('some-randomn-uuid');
+    sinon.stub(purger, 'setOptions');
+    sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'purge').returns({ on: taskPurgeOn });
+    taskPurgeOn.onCall(1).rejects({ some: 'err' });
+
+    bootstrapper(pouchDbOptions, err => {
+      assert.equal(null, err);
+      assert.equal(taskPurger.shouldPurge.callCount, 1);
+      assert.equal(taskPurger.purge.callCount, 1);
       done();
     });
   });

--- a/webapp/tests/mocha/unit/task-purger.spec.js
+++ b/webapp/tests/mocha/unit/task-purger.spec.js
@@ -1,0 +1,277 @@
+const taskPurgerSpec = require('../../../src/js/bootstrapper/task-purger');
+const sinon = require('sinon');
+const chai = require('chai');
+
+let localDb;
+let userCtx;
+
+describe('Purger', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  beforeEach(done => {
+
+    fetch = sinon.stub();
+    localDb = {
+      get: sinon.stub(),
+      allDocs: sinon.stub(),
+      bulkDocs: sinon.stub(),
+      query: sinon.stub(),
+    };
+    userCtx = { roles: [], name: 'userName' };
+    done();
+  });
+
+  describe('shouldPurge', () => {
+    it('should return false on local db errors', () => {
+      localDb.get.withArgs('settings').rejects({ some: 'error' });
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(false);
+        chai.expect(localDb.get.callCount).to.equal(1);
+        chai.expect(localDb.get.args).to.deep.equal([['settings']]);
+      });
+    });
+
+    it('should return false when settings doc is malformed', () => {
+      localDb.get.withArgs('settings').resolves({  });
+      return taskPurgerSpec.shouldPurge(localDb).then(result => {
+        chai.expect(result).to.equal(false);
+      });
+    });
+
+    it('should return false when purge is not configured', () => {
+      localDb.get.withArgs('settings').resolves({ settings: {} });
+
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(false);
+      });
+    });
+
+    it('should return false when no purges configured', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [] } });
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(false);
+      });
+    });
+
+    it('should return true when purges are configured', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'aaaa' }] } });
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(true);
+      });
+    });
+  });
+
+  describe('purge', () => {
+    it('should skip eventless configs', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ all_contacts: true }] } });
+
+      return taskPurgerSpec.purge(localDb, userCtx).then(() => {
+        chai.expect(localDb.allDocs.callCount).to.equal(0);
+        chai.expect(localDb.bulkDocs.callCount).to.equal(0);
+      });
+    });
+
+
+    describe('for single contact', () => {
+      it('should purge tasks for the contact associated with the user, in batches', () => {
+        localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'event' }] } });
+        localDb.get.withArgs('org.couchdb.user:userName').resolves({ contact_id: 'user_contact' });
+
+        const batch1 = [
+          { id: 'task~event~1', value: { rev: '1' } },
+          { id: 'task~event~2', value: { rev: '2' } },
+          { id: 'task~event~3', value: { rev: '3' } },
+          { id: 'task~event~4', value: { rev: '4' } },
+        ];
+        const batch2 = [
+          { id: 'task~event~5', value: { rev: '5' } },
+          { id: 'task~event~6', value: { rev: '6' } },
+          { id: 'task~event~7', value: { rev: '7' } },
+          { id: 'task~event~8', value: { rev: '8' } },
+        ];
+
+        localDb.allDocs
+          .onCall(0).resolves({ rows: batch1 })
+          .onCall(1).resolves({ rows: batch2 })
+          .onCall(2).resolves({ rows: [] });
+
+        localDb.bulkDocs.resolves([]);
+
+        return taskPurgerSpec.purge(localDb, userCtx).then(() => {
+          chai.expect(localDb.get.callCount).to.equal(2);
+          chai.expect(localDb.get.args).to.deep.equal([['settings'],['org.couchdb.user:userName']]);
+
+          chai.expect(localDb.allDocs.callCount).to.equal(3);
+          const args = {
+            start_key: 'task~org.couchdb.user:userName~user_contact~event',
+            end_key: 'task~org.couchdb.user:userName~user_contact~event\ufff0',
+            limit: 100,
+          };
+          chai.expect(localDb.allDocs.args[0]).to.deep.equal([args]);
+          chai.expect(localDb.allDocs.args[1]).to.deep.equal([args]);
+          chai.expect(localDb.allDocs.args[2]).to.deep.equal([args]);
+
+          chai.expect(localDb.bulkDocs.callCount).to.equal(2);
+          chai.expect(localDb.bulkDocs.args[0]).to.deep.equal([[
+            { _id: 'task~event~1', _rev: '1', _deleted: true, purged: true },
+            { _id: 'task~event~2', _rev: '2', _deleted: true, purged: true },
+            { _id: 'task~event~3', _rev: '3', _deleted: true, purged: true },
+            { _id: 'task~event~4', _rev: '4', _deleted: true, purged: true },
+          ]]);
+          chai.expect(localDb.bulkDocs.args[1]).to.deep.equal([[
+            { _id: 'task~event~5', _rev: '5', _deleted: true, purged: true },
+            { _id: 'task~event~6', _rev: '6', _deleted: true, purged: true },
+            { _id: 'task~event~7', _rev: '7', _deleted: true, purged: true },
+            { _id: 'task~event~8', _rev: '8', _deleted: true, purged: true },
+          ]]);
+        });
+      });
+    });
+
+    describe('for all contacts', () => {
+      it('should purge tasks for all contacts, in batches', () => {
+        localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'evt', all_contacts: true }] } });
+        localDb.query.withArgs('medic-client/contacts_by_type').resolves({ rows: [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }] });
+
+        const batch1 = [
+          { id: 'task~c1~event~1', value: { rev: '1' } },
+          { id: 'task~c1~event~2', value: { rev: '2' } },
+          { id: 'task~c1~event~3', value: { rev: '3' } },
+          { id: 'task~c1~event~4', value: { rev: '4' } },
+        ];
+        const batch2 = [
+          { id: 'task~c1~event~5', value: { rev: '5' } },
+          { id: 'task~c1~event~6', value: { rev: '6' } },
+          { id: 'task~c1~event~7', value: { rev: '7' } },
+          { id: 'task~c1~event~8', value: { rev: '8' } },
+        ];
+
+        localDb.allDocs.withArgs(sinon.match({ start_key: 'task~org.couchdb.user:userName~c1~evt'}))
+          .onCall(0).resolves({ rows: batch1 })
+          .onCall(1).resolves({ rows: batch2 })
+          .onCall(2).resolves({ rows: [] });
+
+        localDb.allDocs.withArgs(sinon.match({ start_key: 'task~org.couchdb.user:userName~c2~evt'}))
+          .resolves({ rows: [] });
+
+        const batch3 = [
+          { id: 'task~c3~event~9', value: { rev: '9' } },
+          { id: 'task~c3~event~10', value: { rev: '10' } },
+          { id: 'task~c3~event~11', value: { rev: '11' } },
+          { id: 'task~c3~event~12', value: { rev: '12' } },
+        ];
+        localDb.allDocs.withArgs(sinon.match({ start_key: 'task~org.couchdb.user:userName~c3~evt'}))
+          .onCall(0).resolves({ rows: batch3 })
+          .onCall(1).resolves({ rows: [] });
+
+        localDb.bulkDocs.resolves([]);
+
+        return taskPurgerSpec.purge(localDb, userCtx).then(() => {
+          chai.expect(localDb.get.callCount).to.equal(1);
+          chai.expect(localDb.get.args).to.deep.equal([['settings']]);
+          chai.expect(localDb.query.callCount).to.equal(1);
+          chai.expect(localDb.query.args[0]).to.deep.equal(['medic-client/contacts_by_type']);
+
+          console.log(localDb.allDocs.args);
+          chai.expect(localDb.allDocs.callCount).to.equal(6);
+
+          chai.expect(localDb.allDocs.args).to.deep.equal([
+            [{
+              start_key: 'task~org.couchdb.user:userName~c1~evt',
+              end_key: 'task~org.couchdb.user:userName~c1~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c1~evt',
+              end_key: 'task~org.couchdb.user:userName~c1~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c1~evt',
+              end_key: 'task~org.couchdb.user:userName~c1~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c2~evt',
+              end_key: 'task~org.couchdb.user:userName~c2~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c3~evt',
+              end_key: 'task~org.couchdb.user:userName~c3~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c3~evt',
+              end_key: 'task~org.couchdb.user:userName~c3~evt\ufff0',
+              limit: 100,
+            }],
+          ]);
+
+          chai.expect(localDb.bulkDocs.callCount).to.equal(3);
+          chai.expect(localDb.bulkDocs.args).to.deep.equal([
+            [[
+              { _id: 'task~c1~event~1', _rev: '1', _deleted: true, purged: true },
+              { _id: 'task~c1~event~2', _rev: '2', _deleted: true, purged: true },
+              { _id: 'task~c1~event~3', _rev: '3', _deleted: true, purged: true },
+              { _id: 'task~c1~event~4', _rev: '4', _deleted: true, purged: true },
+            ]],
+            [[
+              { _id: 'task~c1~event~5', _rev: '5', _deleted: true, purged: true },
+              { _id: 'task~c1~event~6', _rev: '6', _deleted: true, purged: true },
+              { _id: 'task~c1~event~7', _rev: '7', _deleted: true, purged: true },
+              { _id: 'task~c1~event~8', _rev: '8', _deleted: true, purged: true },
+            ]],
+            [[
+              { _id: 'task~c3~event~9', _rev: '9', _deleted: true, purged: true },
+              { _id: 'task~c3~event~10', _rev: '10', _deleted: true, purged: true },
+              { _id: 'task~c3~event~11', _rev: '11', _deleted: true, purged: true },
+              { _id: 'task~c3~event~12', _rev: '12', _deleted: true, purged: true },
+            ]],
+          ]);
+        });
+      });
+    });
+
+    it('should throw an error when purge save is not successful', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'event' }] } });
+      localDb.get.withArgs('org.couchdb.user:userName').resolves({ contact_id: 'user_contact' });
+
+      const batch1 = [
+        { id: 'task~event~1', value: { rev: '1' } },
+        { id: 'task~event~2', value: { rev: '2' } },
+        { id: 'task~event~3', value: { rev: '3' } },
+        { id: 'task~event~4', value: { rev: '4' } },
+      ];
+      localDb.allDocs.resolves({ rows: batch1 });
+      localDb.bulkDocs.resolves([{ error: true }]);
+
+      return taskPurgerSpec.purge(localDb, userCtx)
+        .then(() => chai.assert.fail('should have thrown'))
+        .catch(err => {
+          chai.expect(err.message.startsWith('Not all documents purged successfully')).to.equal(true);
+
+          chai.expect(localDb.get.callCount).to.equal(2);
+          chai.expect(localDb.get.args).to.deep.equal([['settings'],['org.couchdb.user:userName']]);
+
+          chai.expect(localDb.allDocs.callCount).to.equal(1);
+          const args = {
+            start_key: 'task~org.couchdb.user:userName~user_contact~event',
+            end_key: 'task~org.couchdb.user:userName~user_contact~event\ufff0',
+            limit: 100,
+          };
+          chai.expect(localDb.allDocs.args[0]).to.deep.equal([args]);
+
+          chai.expect(localDb.bulkDocs.callCount).to.equal(1);
+          chai.expect(localDb.bulkDocs.args[0]).to.deep.equal([[
+            { _id: 'task~event~1', _rev: '1', _deleted: true, purged: true },
+            { _id: 'task~event~2', _rev: '2', _deleted: true, purged: true },
+            { _id: 'task~event~3', _rev: '3', _deleted: true, purged: true },
+            { _id: 'task~event~4', _rev: '4', _deleted: true, purged: true },
+          ]]);
+        });
+    });
+  });
+});


### PR DESCRIPTION
# Description

# DO NOT MERGE!

When a structure like this exists at the root of your app_settings
```
"purge_tasks": [
    {
      "event_name": "vm"
    },
    {
      "event_name": "too_many_events",
      "all_contacts": true
    }
  ]
```

this script will try to purge the indicated tasks, like: 
For the 1st option `{ event_name: "vm" }`, it will try to purge all tasks that are about the user's contact document (the CHW contact) and that have an event name that starts with "vm". 
This is achieved by querying allDocs with keys like `task~org.couchdb.user:<username>~<user_contact_id>~vm`. 

For the 2nd option `{ event_name: "too_many_events", all_contacts: true }`, we will get a list of all contact ids from the device and try to purge all tasks about these contacts that have an event name that starts with "too_many_events".
This is achieved by querying allDocs with keys like `task~org.couchdb.user:<username>~<every_contact_id>~too_many_events`. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
