### PR TITLE
Purge specfic tasks 3.9.x

### DIFF
--- a/webapp/src/js/bootstrapper/index.js
+++ b/webapp/src/js/bootstrapper/index.js
@@ -6,6 +6,7 @@
   const translator = require('./translator');
   const utils = require('./utils');
   const purger = require('./purger');
+  const taskPurger = require('./task-purger');
 
   const ONLINE_ROLE = 'mm-online';
 
@@ -248,6 +249,21 @@
             }
 
             return purger
+              .purge(localDb, userCtx)
+              .on('start', () => setUiStatus('PURGE_INIT'))
+              .on('progress', progress => setUiStatus('PURGE_INFO', { count: progress.purged }))
+              .catch(err => console.error('Error attempting to purge', err));
+          });
+      })
+      .then(() => {
+        return taskPurger
+          .shouldPurge(localDb)
+          .then(shouldPurge => {
+            if (!shouldPurge) {
+              return;
+            }
+
+            return taskPurger
               .purge(localDb, userCtx)
               .on('start', () => setUiStatus('PURGE_INIT'))
               .on('progress', progress => setUiStatus('PURGE_INFO', { count: progress.purged }))

--- a/webapp/src/js/bootstrapper/task-purger.js
+++ b/webapp/src/js/bootstrapper/task-purger.js
@@ -1,0 +1,107 @@
+let totalPurged;
+let emit;
+
+module.exports.shouldPurge = (localDb) => {
+  return localDb.get('settings')
+    .then(settings => {
+      if (!settings || !settings.settings || !settings.settings.purge_tasks || !settings.settings.purge_tasks.length) {
+        return  false;
+      }
+      return true;
+    })
+    .catch(() => false);
+};
+
+module.exports.purge = (localDb, userCtx) => {
+  totalPurged = 0;
+  const handlers = [];
+
+  emit = (name, event) => {
+    console.debug(`Emitting '${name}' event with:`, event);
+    (handlers[name] || []).forEach(callback => callback(event));
+  };
+
+  const promise = Promise
+    .resolve()
+    .then(() => localDb.get('settings'))
+    .then(settings => {
+      let promiseChain = Promise.resolve();
+      settings.settings.purge_tasks.forEach(purgeSetting => {
+        if (!purgeSetting.event_name) {
+          return;
+        }
+
+        emit('start');
+        promiseChain = promiseChain.then(() => purgeTasks(localDb, userCtx, purgeSetting));
+      });
+
+      return promiseChain;
+    });
+
+  promise.on = (type, callback) => {
+    handlers[type] = handlers[type] || [];
+    handlers[type].push(callback);
+    return promise;
+  };
+
+  return promise;
+};
+
+const purgeTasks = (localDb, userCtx, { event_name, all_contacts }) => {
+  if (!all_contacts) {
+    return getUserContact(localDb, userCtx)
+      .then(contactId => purgeTasksForContact(localDb, event_name, contactId, userCtx));
+  }
+
+  return getAllContactsIds(localDb).then(contactIds => {
+    let promise = Promise.resolve();
+    contactIds.forEach(contactId => {
+      promise = promise.then(() => purgeTasksForContact(localDb, event_name, contactId, userCtx));
+    });
+    return promise;
+  });
+};
+
+const getAllContactsIds = localDb => {
+  return localDb
+    .query('medic-client/contacts_by_type')
+    .then(result => result.rows.map(row => row.id));
+};
+
+const getUserContact = (localDb, userCtx) => {
+  return localDb
+    .get(`org.couchdb.user:${userCtx.name}`)
+    .then(userSettings => userSettings.contact_id);
+};
+
+const purgeTasksForContact = (localDb, eventName, contactId, userCtx) => {
+  const searchKey = `task~org.couchdb.user:${userCtx.name}~${contactId}~${eventName}`;
+  return localDb
+    .allDocs({ start_key: searchKey, end_key: searchKey + '\ufff0', limit: 100 })
+    .then(result => {
+      if (!result.rows || !result.rows.length) {
+        // we're done!
+        return;
+      }
+
+      const deleteStubs = result.rows
+        .filter(row => !row.error)
+        .map(row => ({ _id: row.id, _rev: row.value.rev, _deleted: true, purged: true }));
+
+      return localDb.bulkDocs(deleteStubs).then(results => {
+        let errors = '';
+        results.forEach(result => {
+          if (!result.ok) {
+            errors += result.id + ' with ' + result.message + '; ';
+          }
+        });
+        if (errors) {
+          throw new Error(`Not all documents purged successfully: ${errors}`);
+        }
+
+        totalPurged += deleteStubs.length;
+        emit('progress', { purged: totalPurged });
+        return purgeTasksForContact(localDb, eventName, contactId, userCtx);
+      });
+    });
+};

--- a/webapp/tests/mocha/unit/bootstrapper.spec.js
+++ b/webapp/tests/mocha/unit/bootstrapper.spec.js
@@ -684,6 +684,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'shouldPurge').resolves(false);
     sinon.stub(taskPurger, 'shouldPurge').resolves(true);
     sinon.stub(taskPurger, 'purge').returns({ on: taskPurgeOn });
+    sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);
@@ -704,6 +705,7 @@ describe('bootstrapper', () => {
     sinon.stub(taskPurger, 'shouldPurge').resolves(true);
     sinon.stub(taskPurger, 'purge').returns({ on: taskPurgeOn });
     taskPurgeOn.onCall(1).rejects({ some: 'err' });
+    sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);

--- a/webapp/tests/mocha/unit/bootstrapper.spec.js
+++ b/webapp/tests/mocha/unit/bootstrapper.spec.js
@@ -8,6 +8,7 @@ const pouchDbOptions = {
 const rewire = require('rewire');
 const bootstrapper = rewire('../../../src/js/bootstrapper');
 const purger = require('../../../src/js/bootstrapper/purger');
+const taskPurger = require('../../../src/js/bootstrapper/task-purger');
 
 let originalDocument;
 let originalWindow;
@@ -20,6 +21,7 @@ let remoteClose;
 let localAllDocs;
 let localId;
 let purgeOn;
+let taskPurgeOn;
 let localMetaClose;
 
 let localMedicDb;
@@ -90,6 +92,13 @@ describe('bootstrapper', () => {
       return promise;
     });
 
+    taskPurgeOn = sinon.stub();
+    taskPurgeOn.callsFake(() => {
+      const promise = Promise.resolve();
+      promise.on = taskPurgeOn;
+      return promise;
+    });
+
     $ = sinon.stub().returns({
       text: sinon.stub(),
       click: sinon.stub(),
@@ -138,6 +147,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
       assert.equal(null, err);
@@ -165,6 +175,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
@@ -181,6 +192,7 @@ describe('bootstrapper', () => {
     localGet.withArgs('settings').resolves({_id: 'settings', settings: {}});
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
@@ -205,6 +217,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
 
     const localReplicateResult = Promise.resolve();
@@ -271,6 +284,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
 
     bootstrapper(pouchDbOptions, err => {
@@ -375,6 +389,7 @@ describe('bootstrapper', () => {
     setUserCtxCookie({ name: 'jim' });
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
     sinon.stub(purger, 'info').resolves('some-info');
     sinon.stub(purger, 'checkpoint').resolves();
@@ -411,6 +426,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'checkpoint').resolves();
     sinon.stub(purger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     const localReplicateResult = Promise.resolve();
     localReplicateResult.on = () => {};
@@ -466,6 +482,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     let purgeOn;
     purgeOn = sinon.stub().returns({ on: purgeOn, catch: sinon.stub() }); // eslint-disable-line prefer-const
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
@@ -490,6 +507,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     let purgeOn;
     purgeOn = sinon.stub().returns({ on: purgeOn, catch: sinon.stub() }); // eslint-disable-line prefer-const
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
@@ -528,6 +546,7 @@ describe('bootstrapper', () => {
     sinon.stub(purger, 'shouldPurge').resolves(true);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
 
     const localReplicateResult = Promise.resolve();
     localReplicateResult.on = () => {};
@@ -578,6 +597,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
 
@@ -599,6 +619,7 @@ describe('bootstrapper', () => {
     localId.resolves('some-randomn-uuid');
     sinon.stub(purger, 'setOptions');
     sinon.stub(purger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(false);
     sinon.stub(purger, 'purge').returns({ on: purgeOn });
     sinon.stub(purger, 'shouldPurgeMeta').resolves(false);
     purgeOn.onCall(1).rejects({ some: 'err' });
@@ -649,6 +670,45 @@ describe('bootstrapper', () => {
       assert.deepEqual(purger.shouldPurgeMeta.args[0], [localMetaDb]);
       assert.equal(purger.purgeMeta.callCount, 1);
       assert.deepEqual(purger.purgeMeta.args[0], [localMetaDb]);
+      done();
+    });
+  });
+
+  it('should run task-purge after skipping initial replication when needed', done => {
+    setUserCtxCookie({ name: 'jim' });
+
+    localGet.withArgs('_design/medic-client').resolves({_id: '_design/medic-client'});
+    localGet.withArgs('settings').resolves({_id: 'settings', settings: {}});
+    localId.resolves('some-randomn-uuid');
+    sinon.stub(purger, 'setOptions');
+    sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'purge').returns({ on: taskPurgeOn });
+
+    bootstrapper(pouchDbOptions, err => {
+      assert.equal(null, err);
+      assert.equal(taskPurger.shouldPurge.callCount, 1);
+      assert.equal(taskPurger.purge.callCount, 1);
+      done();
+    });
+  });
+
+  it('should catch task-purge errors', done => {
+    setUserCtxCookie( { name: 'jim' });
+
+    localGet.withArgs('_design/medic-client').resolves({_id: '_design/medic-client'});
+    localGet.withArgs('settings').resolves({_id: 'settings', settings: {}});
+    localId.resolves('some-randomn-uuid');
+    sinon.stub(purger, 'setOptions');
+    sinon.stub(purger, 'shouldPurge').resolves(false);
+    sinon.stub(taskPurger, 'shouldPurge').resolves(true);
+    sinon.stub(taskPurger, 'purge').returns({ on: taskPurgeOn });
+    taskPurgeOn.onCall(1).rejects({ some: 'err' });
+
+    bootstrapper(pouchDbOptions, err => {
+      assert.equal(null, err);
+      assert.equal(taskPurger.shouldPurge.callCount, 1);
+      assert.equal(taskPurger.purge.callCount, 1);
       done();
     });
   });

--- a/webapp/tests/mocha/unit/task-purger.spec.js
+++ b/webapp/tests/mocha/unit/task-purger.spec.js
@@ -1,0 +1,277 @@
+const taskPurgerSpec = require('../../../src/js/bootstrapper/task-purger');
+const sinon = require('sinon');
+const chai = require('chai');
+
+let localDb;
+let userCtx;
+
+describe('Purger', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  beforeEach(done => {
+
+    fetch = sinon.stub();
+    localDb = {
+      get: sinon.stub(),
+      allDocs: sinon.stub(),
+      bulkDocs: sinon.stub(),
+      query: sinon.stub(),
+    };
+    userCtx = { roles: [], name: 'userName' };
+    done();
+  });
+
+  describe('shouldPurge', () => {
+    it('should return false on local db errors', () => {
+      localDb.get.withArgs('settings').rejects({ some: 'error' });
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(false);
+        chai.expect(localDb.get.callCount).to.equal(1);
+        chai.expect(localDb.get.args).to.deep.equal([['settings']]);
+      });
+    });
+
+    it('should return false when settings doc is malformed', () => {
+      localDb.get.withArgs('settings').resolves({  });
+      return taskPurgerSpec.shouldPurge(localDb).then(result => {
+        chai.expect(result).to.equal(false);
+      });
+    });
+
+    it('should return false when purge is not configured', () => {
+      localDb.get.withArgs('settings').resolves({ settings: {} });
+
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(false);
+      });
+    });
+
+    it('should return false when no purges configured', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [] } });
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(false);
+      });
+    });
+
+    it('should return true when purges are configured', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'aaaa' }] } });
+      return taskPurgerSpec.shouldPurge(localDb, userCtx).then(result => {
+        chai.expect(result).to.equal(true);
+      });
+    });
+  });
+
+  describe('purge', () => {
+    it('should skip eventless configs', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ all_contacts: true }] } });
+
+      return taskPurgerSpec.purge(localDb, userCtx).then(() => {
+        chai.expect(localDb.allDocs.callCount).to.equal(0);
+        chai.expect(localDb.bulkDocs.callCount).to.equal(0);
+      });
+    });
+
+
+    describe('for single contact', () => {
+      it('should purge tasks for the contact associated with the user, in batches', () => {
+        localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'event' }] } });
+        localDb.get.withArgs('org.couchdb.user:userName').resolves({ contact_id: 'user_contact' });
+
+        const batch1 = [
+          { id: 'task~event~1', value: { rev: '1' } },
+          { id: 'task~event~2', value: { rev: '2' } },
+          { id: 'task~event~3', value: { rev: '3' } },
+          { id: 'task~event~4', value: { rev: '4' } },
+        ];
+        const batch2 = [
+          { id: 'task~event~5', value: { rev: '5' } },
+          { id: 'task~event~6', value: { rev: '6' } },
+          { id: 'task~event~7', value: { rev: '7' } },
+          { id: 'task~event~8', value: { rev: '8' } },
+        ];
+
+        localDb.allDocs
+          .onCall(0).resolves({ rows: batch1 })
+          .onCall(1).resolves({ rows: batch2 })
+          .onCall(2).resolves({ rows: [] });
+
+        localDb.bulkDocs.resolves([]);
+
+        return taskPurgerSpec.purge(localDb, userCtx).then(() => {
+          chai.expect(localDb.get.callCount).to.equal(2);
+          chai.expect(localDb.get.args).to.deep.equal([['settings'],['org.couchdb.user:userName']]);
+
+          chai.expect(localDb.allDocs.callCount).to.equal(3);
+          const args = {
+            start_key: 'task~org.couchdb.user:userName~user_contact~event',
+            end_key: 'task~org.couchdb.user:userName~user_contact~event\ufff0',
+            limit: 100,
+          };
+          chai.expect(localDb.allDocs.args[0]).to.deep.equal([args]);
+          chai.expect(localDb.allDocs.args[1]).to.deep.equal([args]);
+          chai.expect(localDb.allDocs.args[2]).to.deep.equal([args]);
+
+          chai.expect(localDb.bulkDocs.callCount).to.equal(2);
+          chai.expect(localDb.bulkDocs.args[0]).to.deep.equal([[
+            { _id: 'task~event~1', _rev: '1', _deleted: true, purged: true },
+            { _id: 'task~event~2', _rev: '2', _deleted: true, purged: true },
+            { _id: 'task~event~3', _rev: '3', _deleted: true, purged: true },
+            { _id: 'task~event~4', _rev: '4', _deleted: true, purged: true },
+          ]]);
+          chai.expect(localDb.bulkDocs.args[1]).to.deep.equal([[
+            { _id: 'task~event~5', _rev: '5', _deleted: true, purged: true },
+            { _id: 'task~event~6', _rev: '6', _deleted: true, purged: true },
+            { _id: 'task~event~7', _rev: '7', _deleted: true, purged: true },
+            { _id: 'task~event~8', _rev: '8', _deleted: true, purged: true },
+          ]]);
+        });
+      });
+    });
+
+    describe('for all contacts', () => {
+      it('should purge tasks for all contacts, in batches', () => {
+        localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'evt', all_contacts: true }] } });
+        localDb.query.withArgs('medic-client/contacts_by_type').resolves({ rows: [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }] });
+
+        const batch1 = [
+          { id: 'task~c1~event~1', value: { rev: '1' } },
+          { id: 'task~c1~event~2', value: { rev: '2' } },
+          { id: 'task~c1~event~3', value: { rev: '3' } },
+          { id: 'task~c1~event~4', value: { rev: '4' } },
+        ];
+        const batch2 = [
+          { id: 'task~c1~event~5', value: { rev: '5' } },
+          { id: 'task~c1~event~6', value: { rev: '6' } },
+          { id: 'task~c1~event~7', value: { rev: '7' } },
+          { id: 'task~c1~event~8', value: { rev: '8' } },
+        ];
+
+        localDb.allDocs.withArgs(sinon.match({ start_key: 'task~org.couchdb.user:userName~c1~evt'}))
+          .onCall(0).resolves({ rows: batch1 })
+          .onCall(1).resolves({ rows: batch2 })
+          .onCall(2).resolves({ rows: [] });
+
+        localDb.allDocs.withArgs(sinon.match({ start_key: 'task~org.couchdb.user:userName~c2~evt'}))
+          .resolves({ rows: [] });
+
+        const batch3 = [
+          { id: 'task~c3~event~9', value: { rev: '9' } },
+          { id: 'task~c3~event~10', value: { rev: '10' } },
+          { id: 'task~c3~event~11', value: { rev: '11' } },
+          { id: 'task~c3~event~12', value: { rev: '12' } },
+        ];
+        localDb.allDocs.withArgs(sinon.match({ start_key: 'task~org.couchdb.user:userName~c3~evt'}))
+          .onCall(0).resolves({ rows: batch3 })
+          .onCall(1).resolves({ rows: [] });
+
+        localDb.bulkDocs.resolves([]);
+
+        return taskPurgerSpec.purge(localDb, userCtx).then(() => {
+          chai.expect(localDb.get.callCount).to.equal(1);
+          chai.expect(localDb.get.args).to.deep.equal([['settings']]);
+          chai.expect(localDb.query.callCount).to.equal(1);
+          chai.expect(localDb.query.args[0]).to.deep.equal(['medic-client/contacts_by_type']);
+
+          console.log(localDb.allDocs.args);
+          chai.expect(localDb.allDocs.callCount).to.equal(6);
+
+          chai.expect(localDb.allDocs.args).to.deep.equal([
+            [{
+              start_key: 'task~org.couchdb.user:userName~c1~evt',
+              end_key: 'task~org.couchdb.user:userName~c1~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c1~evt',
+              end_key: 'task~org.couchdb.user:userName~c1~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c1~evt',
+              end_key: 'task~org.couchdb.user:userName~c1~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c2~evt',
+              end_key: 'task~org.couchdb.user:userName~c2~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c3~evt',
+              end_key: 'task~org.couchdb.user:userName~c3~evt\ufff0',
+              limit: 100,
+            }],
+            [{
+              start_key: 'task~org.couchdb.user:userName~c3~evt',
+              end_key: 'task~org.couchdb.user:userName~c3~evt\ufff0',
+              limit: 100,
+            }],
+          ]);
+
+          chai.expect(localDb.bulkDocs.callCount).to.equal(3);
+          chai.expect(localDb.bulkDocs.args).to.deep.equal([
+            [[
+              { _id: 'task~c1~event~1', _rev: '1', _deleted: true, purged: true },
+              { _id: 'task~c1~event~2', _rev: '2', _deleted: true, purged: true },
+              { _id: 'task~c1~event~3', _rev: '3', _deleted: true, purged: true },
+              { _id: 'task~c1~event~4', _rev: '4', _deleted: true, purged: true },
+            ]],
+            [[
+              { _id: 'task~c1~event~5', _rev: '5', _deleted: true, purged: true },
+              { _id: 'task~c1~event~6', _rev: '6', _deleted: true, purged: true },
+              { _id: 'task~c1~event~7', _rev: '7', _deleted: true, purged: true },
+              { _id: 'task~c1~event~8', _rev: '8', _deleted: true, purged: true },
+            ]],
+            [[
+              { _id: 'task~c3~event~9', _rev: '9', _deleted: true, purged: true },
+              { _id: 'task~c3~event~10', _rev: '10', _deleted: true, purged: true },
+              { _id: 'task~c3~event~11', _rev: '11', _deleted: true, purged: true },
+              { _id: 'task~c3~event~12', _rev: '12', _deleted: true, purged: true },
+            ]],
+          ]);
+        });
+      });
+    });
+
+    it('should throw an error when purge save is not successful', () => {
+      localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'event' }] } });
+      localDb.get.withArgs('org.couchdb.user:userName').resolves({ contact_id: 'user_contact' });
+
+      const batch1 = [
+        { id: 'task~event~1', value: { rev: '1' } },
+        { id: 'task~event~2', value: { rev: '2' } },
+        { id: 'task~event~3', value: { rev: '3' } },
+        { id: 'task~event~4', value: { rev: '4' } },
+      ];
+      localDb.allDocs.resolves({ rows: batch1 });
+      localDb.bulkDocs.resolves([{ error: true }]);
+
+      return taskPurgerSpec.purge(localDb, userCtx)
+        .then(() => chai.assert.fail('should have thrown'))
+        .catch(err => {
+          chai.expect(err.message.startsWith('Not all documents purged successfully')).to.equal(true);
+
+          chai.expect(localDb.get.callCount).to.equal(2);
+          chai.expect(localDb.get.args).to.deep.equal([['settings'],['org.couchdb.user:userName']]);
+
+          chai.expect(localDb.allDocs.callCount).to.equal(1);
+          const args = {
+            start_key: 'task~org.couchdb.user:userName~user_contact~event',
+            end_key: 'task~org.couchdb.user:userName~user_contact~event\ufff0',
+            limit: 100,
+          };
+          chai.expect(localDb.allDocs.args[0]).to.deep.equal([args]);
+
+          chai.expect(localDb.bulkDocs.callCount).to.equal(1);
+          chai.expect(localDb.bulkDocs.args[0]).to.deep.equal([[
+            { _id: 'task~event~1', _rev: '1', _deleted: true, purged: true },
+            { _id: 'task~event~2', _rev: '2', _deleted: true, purged: true },
+            { _id: 'task~event~3', _rev: '3', _deleted: true, purged: true },
+            { _id: 'task~event~4', _rev: '4', _deleted: true, purged: true },
+          ]]);
+        });
+    });
+  });
+});

--- a/webapp/tests/mocha/unit/task-purger.spec.js
+++ b/webapp/tests/mocha/unit/task-purger.spec.js
@@ -132,8 +132,10 @@ describe('Purger', () => {
 
     describe('for all contacts', () => {
       it('should purge tasks for all contacts, in batches', () => {
-        localDb.get.withArgs('settings').resolves({ settings: { purge_tasks: [{ event_name: 'evt', all_contacts: true }] } });
-        localDb.query.withArgs('medic-client/contacts_by_type').resolves({ rows: [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }] });
+        localDb.get.withArgs('settings')
+          .resolves({ settings: { purge_tasks: [{ event_name: 'evt', all_contacts: true }] } });
+        localDb.query.withArgs('medic-client/contacts_by_type')
+          .resolves({ rows: [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }] });
 
         const batch1 = [
           { id: 'task~c1~event~1', value: { rev: '1' } },


### PR DESCRIPTION
# Description

When a structure like this exists at the root of your app_settings
```
"purge_tasks": [
    {
      "event_name": "vm"
    },
    {
      "event_name": "too_many_events",
      "all_contacts": true
    }
  ]
```

this script will try to purge the indicated tasks, like: 
For the 1st option `{ event_name: "vm" }`, it will try to purge all tasks that are about the user's contact document (the CHW contact) and that have an event name that starts with "vm". 
This is achieved by querying allDocs with keys like `task~org.couchdb.user:<username>~<user_contact_id>~vm`. 

For the 2nd option `{ event_name: "too_many_events", all_contacts: true }`, we will get a list of all contact ids from the device and try to purge all tasks about these contacts that have an event name that starts with "too_many_events".
This is achieved by querying allDocs with keys like `task~org.couchdb.user:<username>~<every_contact_id>~too_many_events`. 
# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
