### PR TITLE
Single emissions recalculation thread

### DIFF
--- a/shared-libs/rules-engine/test/mocks.js
+++ b/shared-libs/rules-engine/test/mocks.js
@@ -72,7 +72,7 @@ rule GenerateEvents {
     return Object.assign({
       rules: chtSettingsDoc.tasks.rules,
       targets: chtSettingsDoc.tasks.targets.items,
-      taskScedules: chtSettingsDoc.tasks.schedules,
+      taskSchedules: chtSettingsDoc.tasks.schedules,
       enableTasks: true,
       enableTargets: true,
       user: userSettingsDoc,

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -1057,7 +1057,7 @@ describe('provider-wireup integration tests', () => {
       });
     });
 
-    it('should provide `on` property and only emit `running` when actions are disabled', async () => {
+    it('should provide `on` property and emit nothing when actions are disabled', async () => {
       sinon.stub(rulesEmitter, 'isLatestNoolsSchema').returns(true);
 
       const settings = { rules: noolsPartnerTemplate(''), enableTargets: false, enableTasks: false };
@@ -1091,16 +1091,16 @@ describe('provider-wireup integration tests', () => {
 
       // none queued, all running
       chai.expect(listeners[0].queued.callCount).to.equal(0);
-      chai.expect(listeners[0].running.callCount).to.equal(1);
+      chai.expect(listeners[0].running.callCount).to.equal(0);
 
       chai.expect(listeners[1].queued.callCount).to.equal(0);
-      chai.expect(listeners[1].running.callCount).to.equal(1);
+      chai.expect(listeners[1].running.callCount).to.equal(0);
 
       chai.expect(listeners[2].queued.callCount).to.equal(0);
-      chai.expect(listeners[2].running.callCount).to.equal(1);
+      chai.expect(listeners[2].running.callCount).to.equal(0);
 
       chai.expect(listeners[3].queued.callCount).to.equal(0);
-      chai.expect(listeners[3].running.callCount).to.equal(1);
+      chai.expect(listeners[3].running.callCount).to.equal(0);
     });
   });
 });

--- a/webapp/src/js/services/debounce.js
+++ b/webapp/src/js/services/debounce.js
@@ -9,6 +9,7 @@ angular.module('inboxServices').factory('Debounce',
       let context;
       let timeoutDelayed;
       let executed = false;
+      let cancelled = false;
 
       if (typeof func !== 'function') {
         throw new Error('First argument must be a function');
@@ -68,10 +69,13 @@ angular.module('inboxServices').factory('Debounce',
         $timeout.cancel(timeoutDelayed);
         timeout = null;
         timeoutDelayed = null;
+        cancelled = true;
       };
 
       debounced.executed = () => executed;
+      debounced.cancelled = () => cancelled;
 
+      
       return debounced;
     };
   }

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -10,7 +10,6 @@ const ENSURE_FRESHNESS_SECS = 120;
 
 angular.module('inboxServices').factory('RulesEngine', function(
   $parse,
-  $q,
   $translate,
   Auth,
   CalendarInterval,
@@ -33,12 +32,6 @@ angular.module('inboxServices').factory('RulesEngine', function(
   let ensureTargetFreshness;
   let ensureTaskFreshnessTelemetryData;
   let ensureTargetFreshnessTelemetryData;
-
-  let recalculationQueue = $q.resolve();
-  const enqueue = callback => {
-    recalculationQueue = recalculationQueue.then(() => callback());
-    return recalculationQueue;
-  };
 
   const initialize = () => (
     Promise.all([Auth.has('can_view_tasks'), Auth.has('can_view_analytics')])
@@ -226,10 +219,8 @@ angular.module('inboxServices').factory('RulesEngine', function(
         .then(() => {
           Telemetry.record('rules-engine:tasks:dirty-contacts', RulesEngineCore.getDirtyContacts().length);
           cancelDebounce(ensureTaskFreshness, ensureTaskFreshnessTelemetryData);
-          return enqueue(() => {
-            telemetryData.start();
-            return RulesEngineCore.fetchTasksFor();
-          });
+          telemetryData.start();
+          return RulesEngineCore.fetchTasksFor();
         })
         .then(telemetryData.passThrough)
         .then(translateTaskDocs);
@@ -240,11 +231,8 @@ angular.module('inboxServices').factory('RulesEngine', function(
       return initialized
         .then(() => {
           Telemetry.record('rules-engine:tasks:dirty-contacts', RulesEngineCore.getDirtyContacts().length);
-
-          return enqueue(() => {
-            telemetryData.start();
-            return RulesEngineCore.fetchTasksFor(contactIds);
-          });
+          telemetryData.start();
+          return RulesEngineCore.fetchTasksFor(contactIds);
         })
         .then(telemetryData.passThrough)
         .then(translateTaskDocs);
@@ -257,10 +245,8 @@ angular.module('inboxServices').factory('RulesEngine', function(
           Telemetry.record('rules-engine:targets:dirty-contacts', RulesEngineCore.getDirtyContacts().length);
           cancelDebounce(ensureTargetFreshness, ensureTargetFreshnessTelemetryData);
           const relevantInterval = CalendarInterval.getCurrent(uhcMonthStartDate);
-          return enqueue(() => {
-            telemetryData.start();
-            return RulesEngineCore.fetchTargets(relevantInterval);
-          });
+          telemetryData.start();
+          return RulesEngineCore.fetchTargets(relevantInterval);
         })
         .then(telemetryData.passThrough);
     },

--- a/webapp/src/js/services/rules-engine.js
+++ b/webapp/src/js/services/rules-engine.js
@@ -88,6 +88,7 @@ angular.module('inboxServices').factory('RulesEngine', function(
     };
 
     const record = () => {
+      data.start = data.start || Date.now();
       data.end = Date.now();
       Telemetry.record(data.entry, data.end - data.start);
     };

--- a/webapp/tests/karma/unit/services/debounce.js
+++ b/webapp/tests/karma/unit/services/debounce.js
@@ -112,18 +112,22 @@ describe('Debounce Service', () => {
     it('should not callback if canceled', () => {
       const debounced = service(callback, 50);
       debounced();
+      chai.expect(debounced.cancelled()).to.equal(false);
       $timeout.flush(25);
       debounced.cancel();
       $timeout.flush(50);
+      chai.expect(debounced.cancelled()).to.equal(true);
       chai.expect(callback.callCount).to.equal(0);
     });
 
     it('should not callback if canceled, using maxDelay', () => {
       const debounced = service(callback, 50, 100);
       debounced();
+      chai.expect(debounced.cancelled()).to.equal(false);
       $timeout.flush(25);
       debounced.cancel();
       $timeout.flush(100);
+      chai.expect(debounced.cancelled()).to.equal(true);
       chai.expect(callback.callCount).to.equal(0);
 
     });

--- a/webapp/tests/karma/unit/services/rules-engine.js
+++ b/webapp/tests/karma/unit/services/rules-engine.js
@@ -16,6 +16,12 @@ describe(`RulesEngine service`, () => {
   let UserSettings;
   let UHCSettings;
   let Telemetry;
+  let fetchTasksFor;
+  let fetchTasksForRecursive;
+  let fetchTasksResult;
+  let fetchTargets;
+  let fetchTargetsRecursive;
+  let fetchTargetsResult;
 
   const settingsDoc = {
     _id: 'settings',
@@ -74,11 +80,37 @@ describe(`RulesEngine service`, () => {
     UHCSettings = { getMonthStartDate: sinon.stub().returns(1) };
     Telemetry = { record: sinon.stub() };
 
+    fetchTasksResult = Promise.resolve;
+    fetchTasksFor = sinon.stub();
+    fetchTasksForRecursive = sinon.stub();
+    fetchTasksFor.events = {};
+    fetchTasksForRecursive.callsFake((event, fn) => {
+      fetchTasksFor.events[event] = fetchTasksFor.events[event] || [];
+      fetchTasksFor.events[event].push(fn);
+      const promise = fetchTasksResult();
+      promise.on = fetchTasksForRecursive;
+      return promise;
+    });
+    fetchTasksFor.returns({ on: fetchTasksForRecursive });
+
+    fetchTargetsResult = Promise.resolve;
+    fetchTargets = sinon.stub();
+    fetchTargets.events = {};
+    fetchTargetsRecursive = sinon.stub();
+    fetchTargetsRecursive.callsFake((event, fn) => {
+      fetchTargets.events[event] = fetchTargets.events[event] || [];
+      fetchTargets.events[event].push(fn);
+      const promise = fetchTargetsResult();
+      promise.on = fetchTargetsRecursive;
+      return promise;
+    });
+    fetchTargets.returns({ on: fetchTargetsRecursive });
+
     RulesEngineCore = {
       initialize: sinon.stub().resolves(true),
       isEnabled: sinon.stub().returns(true),
-      fetchTasksFor: sinon.stub().resolves([]),
-      fetchTargets: sinon.stub().resolves([]),
+      fetchTasksFor: fetchTasksFor,
+      fetchTargets: fetchTargets,
       updateEmissionsFor: sinon.stub().resolves(),
       rulesConfigChange: sinon.stub().returns(true),
       getDirtyContacts: sinon.stub().returns([]),
@@ -259,7 +291,7 @@ describe(`RulesEngine service`, () => {
     });
 
     it('fetchTaskDocsForAllContacts', async () => {
-      RulesEngineCore.fetchTasksFor.resolves([deepCopy(sampleTaskDoc)]);
+      fetchTasksResult = sinon.stub().resolves([deepCopy(sampleTaskDoc)]);
       RulesEngineCore.getDirtyContacts.returns(['a', 'b', 'c']);
       const actual = await getService().fetchTaskDocsForAllContacts();
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
@@ -280,7 +312,7 @@ describe(`RulesEngine service`, () => {
 
     it('fetchTaskDocsFor', async () => {
       const contactIds = ['a', 'b', 'c'];
-      RulesEngineCore.fetchTasksFor.resolves([deepCopy(sampleTaskDoc)]);
+      fetchTasksResult = sinon.stub().resolves([deepCopy(sampleTaskDoc)]);
       RulesEngineCore.getDirtyContacts.returns(['a', 'b']);
       const actual = await getService().fetchTaskDocsFor(contactIds);
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
@@ -299,6 +331,7 @@ describe(`RulesEngine service`, () => {
     });
 
     it('correct range is passed when getting targets', async () => {
+      fetchTargetsResult = sinon.stub().resolves([]);
       const actual = await getService().fetchTargets();
       expect(actual).to.deep.eq([]);
 
@@ -323,6 +356,8 @@ describe(`RulesEngine service`, () => {
     });
 
     it('ensure freshness of tasks only', async () => {
+      fetchTargetsResult = sinon.stub().resolves([]);
+
       const service = getService();
       await service.isEnabled();
 
@@ -340,6 +375,8 @@ describe(`RulesEngine service`, () => {
     });
 
     it('cancel all ensure freshness threads', async () => {
+      fetchTargetsResult = sinon.stub().resolves([]);
+      fetchTasksResult = sinon.stub().resolves([]);
       const service = getService();
       await service.isEnabled();
 
@@ -357,6 +394,68 @@ describe(`RulesEngine service`, () => {
       expect(Telemetry.record.args[4]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 0]);
       expect(Telemetry.record.args[5][0]).to.equal('rules-engine:ensureTaskFreshness:cancel');
       expect(Telemetry.record.args[6][0]).to.equal('rules-engine:tasks:all-contacts');
+    });
+
+    it('should record correct telemetry data with emitted events', async () => {
+      const realSetTimeout = setTimeout;
+      const nextTick = () => new Promise(resolve => realSetTimeout(() => resolve()));
+      const clock = sinon.useFakeTimers(1000);
+      let fetchTargetResultPromise;
+      const fetchTasksResultPromise = [];
+      fetchTargetsResult = sinon.stub().callsFake(() => new Promise(resolve => fetchTargetResultPromise = resolve));
+      fetchTasksResult = sinon.stub().callsFake(() => new Promise(resolve => fetchTasksResultPromise.push(resolve)));
+
+      const service = getService();
+      await service.isEnabled();
+
+      service.fetchTargets();
+      service.fetchTaskDocsForAllContacts();
+      service.fetchTaskDocsFor(['a']);
+      await Promise.resolve();
+      chai.expect(fetchTargets.events).to.have.keys(['queued', 'running']);
+      chai.expect(fetchTasksFor.events).to.have.keys(['queued', 'running']);
+
+      chai.expect(Telemetry.record.callCount).to.equal(6);
+      chai.expect(Telemetry.record.args.map(arg => arg[0])).to.deep.equal([
+        'rules-engine:initialize',
+        'rules-engine:targets:dirty-contacts',
+        'rules-engine:ensureTargetFreshness:cancel',
+        'rules-engine:tasks:dirty-contacts',
+        'rules-engine:ensureTaskFreshness:cancel',
+        'rules-engine:tasks:dirty-contacts',
+      ]);
+
+      fetchTargets.events.queued[0]();
+      fetchTasksFor.events.queued[0]();
+      fetchTasksFor.events.queued[1]();
+
+      chai.expect(Telemetry.record.callCount).to.equal(6);
+      fetchTargets.events.running[0]();
+      chai.expect(Telemetry.record.callCount).to.equal(7);
+      chai.expect(Telemetry.record.args[6]).to.deep.equal(['rules-engine:targets:queued', 0]);
+      await Promise.resolve();
+      clock.tick(5000);
+      fetchTargetResultPromise([]);
+      await nextTick();
+      chai.expect(Telemetry.record.callCount).to.equal(8);
+      chai.expect(Telemetry.record.args[7]).to.deep.equal(['rules-engine:targets', 5000]);
+      fetchTasksFor.events.running[0]();
+      chai.expect(Telemetry.record.callCount).to.equal(9);
+      chai.expect(Telemetry.record.args[8]).to.deep.equal(['rules-engine:tasks:all-contacts:queued', 5000]);
+      clock.tick(10000);
+      fetchTasksResultPromise[1]([]);
+      await nextTick();
+      chai.expect(Telemetry.record.callCount).to.equal(10);
+      chai.expect(Telemetry.record.args[9]).to.deep.equal(['rules-engine:tasks:all-contacts', 10000]);
+      fetchTasksFor.events.running[1]();
+      chai.expect(Telemetry.record.callCount).to.equal(11);
+      chai.expect(Telemetry.record.args[10]).to.deep.equal(['rules-engine:tasks:some-contacts:queued', 15000]);
+      clock.tick(550);
+      fetchTasksResultPromise[3]([]);
+      await nextTick();
+      chai.expect(Telemetry.record.callCount).to.equal(12);
+      chai.expect(Telemetry.record.args[11]).to.deep.equal(['rules-engine:tasks:some-contacts', 550]);
+      clock.restore();
     });
 
     describe('monitorExternalChanges', () => {

--- a/webapp/tests/karma/unit/services/rules-engine.js
+++ b/webapp/tests/karma/unit/services/rules-engine.js
@@ -312,14 +312,17 @@ describe(`RulesEngine service`, () => {
       await service.isEnabled();
       $timeout.flush(500 * 1000);
 
-      await service.isEnabled(); // to resolve promises
+      await Q.resolve();
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
+      await Q.resolve();
       expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
 
-      expect(Telemetry.record.callCount).to.equal(3);
+      expect(Telemetry.record.callCount).to.equal(4);
       expect(Telemetry.record.args[0][0]).to.equal('rules-engine:initialize');
       expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 20]);
       expect(Telemetry.record.args[2]).to.deep.equal(['rules-engine:targets:dirty-contacts', 20]);
+      // fetchTasksFor resolving triggered this
+      expect(Telemetry.record.args[3][0]).to.equal('rules-engine:tasks:all-contacts');
     });
 
     it('ensure freshness of tasks only', async () => {
@@ -329,14 +332,19 @@ describe(`RulesEngine service`, () => {
       await service.fetchTargets();
       $timeout.flush(500 * 1000);
 
-      await service.isEnabled(); // to resolve promises
+      await Q.resolve();
       expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
+      await Q.resolve();
       expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
-      expect(Telemetry.record.callCount).to.equal(5);
+
+      expect(Telemetry.record.callCount).to.equal(6);
+      expect(Telemetry.record.args[0][0]).to.equal('rules-engine:initialize');
       expect(Telemetry.record.args[1]).to.deep.equal(['rules-engine:targets:dirty-contacts', 0]);
       expect(Telemetry.record.args[2][0]).to.equal('rules-engine:ensureTargetFreshness:cancel');
       expect(Telemetry.record.args[3][0]).to.equal('rules-engine:targets');
       expect(Telemetry.record.args[4]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 0]);
+      // fetchTasksFor resolving triggered this
+      expect(Telemetry.record.args[5][0]).to.equal('rules-engine:tasks:all-contacts');
     });
 
     it('cancel all ensure freshness threads', async () => {
@@ -357,6 +365,65 @@ describe(`RulesEngine service`, () => {
       expect(Telemetry.record.args[4]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 0]);
       expect(Telemetry.record.args[5][0]).to.equal('rules-engine:ensureTaskFreshness:cancel');
       expect(Telemetry.record.args[6][0]).to.equal('rules-engine:tasks:all-contacts');
+    });
+
+    it('should never start more than one recalculation thread', async () => {
+      const service = getService();
+      await service.isEnabled();
+      const promises = [];
+      const registerResolve = () => new Promise(resolve => {
+        promises.push(resolve);
+      });
+
+      RulesEngineCore.fetchTargets.callsFake(registerResolve);
+      RulesEngineCore.fetchTasksFor.callsFake(registerResolve);
+
+      service.fetchTargets();
+      service.fetchTaskDocsForAllContacts();
+      service.fetchTaskDocsForAllContacts();
+      service.fetchTaskDocsForAllContacts();
+      service.fetchTargets();
+      service.fetchTargets();
+
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(0);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(0);
+      await Q.resolve();
+
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(0);
+
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(0);
+
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(0);
+
+      promises.pop()(); // call 1st resolve
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(1);
+
+      promises.pop()(); // call 2nd resolve
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(2);
+
+      promises.pop()(); // call 3rd resolve
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(1);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(3);
+
+      promises.pop()(); // call 4th resolve
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(2);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(3);
+
+      promises.pop()(); // call 5th resolve
+      await Q.resolve();
+      expect(RulesEngineCore.fetchTargets.callCount).to.eq(3);
+      expect(RulesEngineCore.fetchTasksFor.callCount).to.eq(3);
     });
 
     describe('monitorExternalChanges', () => {


### PR DESCRIPTION
# Description

Updates `rules-engine` shared lib to only allow a single `refreshRulesEmissions` call to be executed in parallel. All calls to `fetchTasksFor` and `fetchTargets` are queued and are execute sequentially. 
To support accurate Telemetry readings, calls to `fetchTargets` and `fetchTasksFor` return promisemitters, which resolve when the tasks are done and emit two events: `queued` when placed in the queue and `running` when execution started.
The webapp `RulesEngine` service listens to these events and logs a new Telemetry record, `queued`, that registers the time the request spent in a queue (from `queued` event to `running` event), along with the already existent "execution" record, that only registers execution time (from the `running` event to promise resolution). 

medic/cht-core#6562

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
