### PR TITLE
Fixes replication warning not being displayed when editing a user

### DIFF
--- a/admin/src/js/controllers/edit-user.js
+++ b/admin/src/js/controllers/edit-user.js
@@ -99,7 +99,7 @@ angular
         });
     };
 
-    determineEditUserModel()
+    this.setupPromise = determineEditUserModel()
       .then(model => {
         $scope.editUserModel = model;
       })

--- a/admin/src/js/controllers/edit-user.js
+++ b/admin/src/js/controllers/edit-user.js
@@ -381,6 +381,40 @@ angular
 
     const isEmailValid = email => email.match(/.+@.+/);
 
+    const updateUser = () => {
+      return changedUpdates($scope.editUserModel)
+        .then(updates => {
+          if (!haveUpdates(updates)) {
+            return;
+          }
+
+          if ($scope.editUserModel.id) {
+            return UpdateUser($scope.editUserModel.username, updates);
+          }
+
+          return CreateUser(updates);
+        })
+        .then(() => {
+          $scope.setFinished();
+          // TODO: change this from a broadcast to a changes watcher
+          //       https://github.com/medic/medic/issues/4094
+          $rootScope.$broadcast(
+            'UsersUpdated',
+            $scope.editUserModel.id
+          );
+          $uibModalInstance.close();
+        })
+        .catch(err => {
+          if (err && err.data && err.data.error && err.data.error.translationKey) {
+            $translate(err.data.error.translationKey, err.data.error.translationParams).then(function(value) {
+              $scope.setError(err, value);
+            });
+          } else {
+            $scope.setError(err, 'Error updating user');
+          }
+        });
+    };
+
     // #edit-user-profile is the admin view, which has additional fields.
     $scope.editUser = () => {
       $scope.setProcessing();
@@ -411,38 +445,8 @@ angular
             $scope.setError();
             return;
           }
-          return validateReplicationLimit()
-            .then(() => changedUpdates($scope.editUserModel))
-            .then(updates => {
-              if (!haveUpdates(updates)) {
-                return;
-              }
 
-              if ($scope.editUserModel.id) {
-                return UpdateUser($scope.editUserModel.username, updates);
-              }
-
-              return CreateUser(updates);
-            })
-            .then(() => {
-              $scope.setFinished();
-              // TODO: change this from a broadcast to a changes watcher
-              //       https://github.com/medic/medic/issues/4094
-              $rootScope.$broadcast(
-                'UsersUpdated',
-                $scope.editUserModel.id
-              );
-              $uibModalInstance.close();
-            })
-            .catch(err => {
-              if (err && err.data && err.data.error && err.data.error.translationKey) {
-                $translate(err.data.error.translationKey, err.data.error.translationParams).then(function(value) {
-                  $scope.setError(err, value);
-                });
-              } else {
-                $scope.setError(err, 'Error updating user');
-              }
-            });
+          return validateReplicationLimit().then(() => updateUser());
         })
         .catch(err => {
           if (err.key) {

--- a/admin/tests/unit/controllers/edit-user.js
+++ b/admin/tests/unit/controllers/edit-user.js
@@ -106,17 +106,17 @@ describe('EditUserCtrl controller', () => {
       };
       mockEditCurrentUser = user => {
         UserSettings.resolves(user);
-        createController();
+        return createController();
       };
 
       mockEditAUser = user => {
         // Don't mock UserSettings, we're not fetching current user.
-        createController(user);
+        return createController(user);
       };
 
       mockCreateNewUser = () => {
         // Don't mock UserSettings, we're not fetching current user.
-        createController({});
+        return createController({});
       };
     });
   });
@@ -143,288 +143,217 @@ describe('EditUserCtrl controller', () => {
     });
   };
   const mockContactGet = facilityId => {
-    dbGet.returns(Promise.resolve({ parent: { _id: facilityId } }));
+    dbGet.resolves({ parent: { _id: facilityId } });
   };
 
   describe('initialisation', () => {
-    it('edits the given user', done => {
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
-          chai.expect(scope.enabledLocales.length).to.equal(2);
-          chai.expect(scope.enabledLocales[0].code).to.equal('en');
-          chai.expect(scope.enabledLocales[1].code).to.equal('fr');
-          chai.expect(translationsDbQuery.callCount).to.equal(1);
-          chai
-            .expect(translationsDbQuery.args[0][0])
-            .to.equal('medic-client/doc_by_type');
-          chai
-            .expect(translationsDbQuery.args[0][1].key[0])
-            .to.equal('translations');
-          chai.expect(translationsDbQuery.args[0][1].key[1]).to.equal(true);
-          chai.expect(scope.editUserModel).to.deep.equal({
-            id: userToEdit._id,
-            username: userToEdit.name,
-            fullname: userToEdit.fullname,
-            email: userToEdit.email,
-            phone: userToEdit.phone,
-            facilitySelect: userToEdit.facility_id,
-            place: userToEdit.facility_id,
-            role: userToEdit.roles[0],
-            language: { code: userToEdit.language },
-            contactSelect: userToEdit.contact_id,
-            contact: userToEdit.contact_id,
-            tokenLoginEnabled: undefined,
-          });
-          done();
+    it('edits the given user', () => {
+      return mockEditAUser(userToEdit).setupPromise.then(() => {
+        chai.expect(scope.enabledLocales.length).to.equal(2);
+        chai.expect(scope.enabledLocales[0].code).to.equal('en');
+        chai.expect(scope.enabledLocales[1].code).to.equal('fr');
+        chai.expect(translationsDbQuery.callCount).to.equal(1);
+        chai
+          .expect(translationsDbQuery.args[0][0])
+          .to.equal('medic-client/doc_by_type');
+        chai
+          .expect(translationsDbQuery.args[0][1].key[0])
+          .to.equal('translations');
+        chai.expect(translationsDbQuery.args[0][1].key[1]).to.equal(true);
+        chai.expect(scope.editUserModel).to.deep.equal({
+          id: userToEdit._id,
+          username: userToEdit.name,
+          fullname: userToEdit.fullname,
+          email: userToEdit.email,
+          phone: userToEdit.phone,
+          facilitySelect: userToEdit.facility_id,
+          place: userToEdit.facility_id,
+          role: userToEdit.roles[0],
+          language: { code: userToEdit.language },
+          contactSelect: userToEdit.contact_id,
+          contact: userToEdit.contact_id,
+          tokenLoginEnabled: undefined,
         });
-      } catch(err) {
-        done(err);
-      }
+      });
     });
   });
 
   describe('$scope.editUser', () => {
-    it('username must be present', done => {
-      mockEditAUser(userToEdit);
-      Translate.fieldIsRequired.withArgs('User Name').returns(Promise.resolve('User Name field must be filled'));
-      try {
-        setTimeout(() => {
+    it('username must be present', () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
+          Translate.fieldIsRequired.withArgs('User Name').returns(Promise.resolve('User Name field must be filled'));
           scope.editUserModel.id = null;
           scope.editUserModel.username = '';
 
           scope.editUserModel.password = '1QrAs$$3%%kkkk445234234234';
           scope.editUserModel.passwordConfirm = scope.editUserModel.password;
-          scope.editUser();
-          setTimeout(() => {
-            chai.expect(scope.errors.username).to.equal('User Name field must be filled');
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.username).to.equal('User Name field must be filled');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('password must be filled when creating new user', done => {
-      mockCreateNewUser();
-      try {
-        setTimeout(() => {
+    it('password must be filled when creating new user', () => {
+      return mockCreateNewUser().setupPromise
+        .then(() => {
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
           Translate.fieldIsRequired.withArgs('Password').returns(Promise.resolve('Password field is a required field'));
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai
-                .expect(scope.errors.password)
-                .to.equal('Password field is a required field');
-              done();
-            });
-          });
+
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.password).to.equal('Password field is a required field');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it(`password doesn't need to be filled when editing user`, done => {
-      mockEditAUser(userToEdit);
-      translate.returns(Promise.resolve('something'));
-      Translate.fieldIsRequired = key => Promise.resolve(key);
-      try {
-        setTimeout(() => {
+    it(`password doesn't need to be filled when editing user`, () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
+          translate.resolves('something');
+          Translate.fieldIsRequired = key => Promise.resolve(key);
           chai.expect(scope.editUserModel).not.to.have.property('password');
-          scope.editUser();
-          setTimeout(() => {
-            chai.expect(scope.errors).not.to.have.property('password');
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors).not.to.have.property('password');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('error if password and confirm do not match when creating new user', done => {
-      mockEditCurrentUser();
-      try {
-        setTimeout(() => {
+    it('error if password and confirm do not match when creating new user', () => {
+      return mockEditCurrentUser()
+        .setupPromise
+        .then(() => {
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
-          translate.withArgs('Passwords must match').returns(
-            Promise.resolve('wrong')
-          );
-          setTimeout(() => {
-            const password = '1QrAs$$3%%kkkk445234234234';
-            scope.editUserModel.password = password;
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(scope.errors.password).to.equal('wrong');
-              done();
-            });
-          });
+          translate.withArgs('Passwords must match').resolves('wrong');
+          const password = '1QrAs$$3%%kkkk445234234234';
+          scope.editUserModel.password = password;
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.password).to.equal('wrong');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should not change password when none is supplied', done => {
+    it('should not change password when none is supplied', () => {
       // given
-      mockEditAUser(userToEdit);
       mockContact(userToEdit.contact_id);
       mockFacility(userToEdit.facility_id);
       mockContactGet(userToEdit.contact_id);
-      try {
-        setTimeout(() => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.currentPassword = 'blah';
           scope.editUserModel.password = '';
           scope.editUserModel.passwordConfirm = '';
 
-          // when
-          scope.editUser();
-
-          // then
-          setTimeout(() => {
-            chai.expect(UpdateUser.called).to.equal(false);
-
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.called).to.equal(false);
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('must have associated place if user type is offline user', done => {
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+    it('must have associated place if user type is offline user', () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.role = 'district-manager';
           mockFacility(null);
           mockContact(userToEdit.contact_id);
-          Translate.fieldIsRequired.withArgs('Facility').returns(Promise.resolve('Facility field is a required field'));
+          Translate.fieldIsRequired.withArgs('Facility').resolves('Facility field is a required field');
 
-          // when
-          scope.editUser();
-
-          // expect
-          setTimeout(() => {
-            chai.expect(scope.errors.place).to.equal('Facility field is a required field');
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.place).to.equal('Facility field is a required field');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('must have associated contact if user type is offline user', done => {
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+    it('must have associated contact if user type is offline user', () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.role = 'district-manager';
           mockFacility(userToEdit.facility_id);
           mockContact(null);
           Translate.fieldIsRequired.withArgs('associated.contact')
             .returns(Promise.resolve('An associated contact is required'));
 
-          // when
-          scope.editUser();
-
-          // expect
-          setTimeout(() => {
-            chai.expect(scope.errors.contact).to.equal('An associated contact is required');
-            done();
-          });
+          return  scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.contact).to.equal('An associated contact is required');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('must have associated place and contact if user type is offline user', done => {
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+    it('must have associated place and contact if user type is offline user', () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.role = 'district-manager';
           mockFacility(null);
           mockContact(null);
           Translate.fieldIsRequired.withArgs('associated.contact')
             .returns(Promise.resolve('An associated contact is required'));
-          Translate.fieldIsRequired.withArgs('Facility').returns(Promise.resolve('Facility field is required'));
+          Translate.fieldIsRequired.withArgs('Facility').resolves('Facility field is required');
 
-          // when
-          scope.editUser();
-
-          // expect
-          setTimeout(() => {
-            chai.expect(scope.errors.place).to.equal('Facility field is required');
-            chai.expect(scope.errors.contact).to.equal('An associated contact is required');
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.place).to.equal('Facility field is required');
+          chai.expect(scope.errors.contact).to.equal('An associated contact is required');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it(`doesn't need associated place and contact if user type is not restricted user`, done => {
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+    it(`doesn't need associated place and contact if user type is not restricted user`, () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.role = 'some-other-type';
           mockFacility(null);
           mockContact(null);
 
-          // when
-          scope.editUser();
-
-          // expect
+          return scope.editUser();
+        })
+        .then(() => {
           chai.expect(scope.errors).not.to.have.property('facility_id');
           chai.expect(scope.errors).not.to.have.property('contact_id');
-          done();
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('associated place must be parent of contact', done => {
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+    it('associated place must be parent of contact', () => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.type = 'district-manager';
           mockContact(userToEdit.contact_id);
           mockFacility(userToEdit.facility_id);
           mockContactGet('some-other-id');
-          translate.withArgs('configuration.user.place.contact').returns(
-            Promise.resolve('outside')
-          );
+          translate.withArgs('configuration.user.place.contact').resolves('outside');
 
-          // when
-          scope.editUser();
-
-          // expect
-          setTimeout(() => {
-            chai.expect(scope.errors.contact).to.equal('outside');
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.contact).to.equal('outside');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('user is updated', done => {
-      mockEditAUser(userToEdit);
+    it('user is updated', () => {
+
       mockContact(userToEdit.contact_id);
       mockFacility(userToEdit.facility_id);
       mockContactGet(userToEdit.contact_id);
       http.get.withArgs('/api/v1/users-info').resolves({ data: { total_docs: 1000, warn: false, limit: 10000 }});
-      try {
-        setTimeout(() => {
+
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.fullname = 'fullname';
           scope.editUserModel.email = 'email@email.com';
           scope.editUserModel.phone = 'phone';
@@ -435,71 +364,59 @@ describe('EditUserCtrl controller', () => {
           scope.editUserModel.passwordConfirm = 'medic.1234';
           scope.editUserModel.role = 'supervisor';
 
-          scope.editUser();
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.called).to.equal(true);
+          const updateUserArgs = UpdateUser.getCall(0).args;
 
-          setTimeout(() => {
-            chai.expect(UpdateUser.called).to.equal(true);
-            const updateUserArgs = UpdateUser.getCall(0).args;
+          chai.expect(updateUserArgs[0]).to.equal('user.name');
 
-            chai.expect(updateUserArgs[0]).to.equal('user.name');
-
-            const updates = updateUserArgs[1];
-            chai.expect(updates.fullname).to.equal(scope.editUserModel.fullname);
-            chai.expect(updates.email).to.equal(scope.editUserModel.email);
-            chai.expect(updates.phone).to.equal(scope.editUserModel.phone);
-            chai.expect(updates.place).to.equal(scope.editUserModel.facility_id);
-            chai.expect(updates.contact).to.equal(scope.editUserModel.contact_id);
-            chai.expect(updates.language).to.equal(scope.editUserModel.language.code);
-            chai.expect(updates.roles[0]).to.equal(scope.editUserModel.role);
-            chai.expect(updates.password).to.deep.equal(scope.editUserModel.password);
-            chai.expect(http.get.callCount).to.equal(1);
-            chai.expect(http.get.args[0]).to.deep.equal([
-              '/api/v1/users-info',
-              { params: {
-                role: 'supervisor',
-                facility_id: scope.editUserModel.place,
-                contact_id: scope.editUserModel.contact
-              }}
-            ]);
-            done();
-          });
+          const updates = updateUserArgs[1];
+          chai.expect(updates.fullname).to.equal(scope.editUserModel.fullname);
+          chai.expect(updates.email).to.equal(scope.editUserModel.email);
+          chai.expect(updates.phone).to.equal(scope.editUserModel.phone);
+          chai.expect(updates.place).to.equal(scope.editUserModel.facility_id);
+          chai.expect(updates.contact).to.equal(scope.editUserModel.contact_id);
+          chai.expect(updates.language).to.equal(scope.editUserModel.language.code);
+          chai.expect(updates.roles[0]).to.equal(scope.editUserModel.role);
+          chai.expect(updates.password).to.deep.equal(scope.editUserModel.password);
+          chai.expect(http.get.callCount).to.equal(1);
+          chai.expect(http.get.args[0]).to.deep.equal([
+            '/api/v1/users-info',
+            { params: {
+              role: 'supervisor',
+              facility_id: scope.editUserModel.place,
+              contact_id: scope.editUserModel.contact
+            }}
+          ]);
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('associated contact must have place when creating a new user', done => {
-      mockCreateNewUser();
-      try {
-        setTimeout(() => {
+    it('associated contact must have place when creating a new user', () => {
+      return mockCreateNewUser()
+        .setupPromise
+        .then(() => {
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
           mockContact('xyz');
 
-          Translate.fieldIsRequired.withArgs('Facility').returns(Promise.resolve('Facility field is a required field'));
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai
-                .expect(scope.errors.place)
-                .to.equal('Facility field is a required field');
-              done();
-            });
-          });
+          Translate.fieldIsRequired.withArgs('Facility').resolves('Facility field is a required field');
+
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.place).to.equal('Facility field is a required field');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should not query users-info when user role is not offline', done => {
-      mockEditAUser(userToEdit);
+    it('should not query users-info when user role is not offline', () => {
       mockContact(userToEdit.contact_id);
       mockFacility(userToEdit.facility_id);
       mockContactGet(userToEdit.contact_id);
-      try {
-        setTimeout(() => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.fullname = 'fullname';
           scope.editUserModel.email = 'email@email.com';
           scope.editUserModel.phone = 'phone';
@@ -510,38 +427,80 @@ describe('EditUserCtrl controller', () => {
           scope.editUserModel.passwordConfirm = 'medic.1234';
           scope.editUserModel.role = 'national-manager';
 
-          scope.editUser();
-
-          setTimeout(() => {
-            chai.expect(UpdateUser.called).to.equal(true);
-            chai.expect(http.get.callCount).to.equal(0);
-            chai.expect(UpdateUser.args[0]).to.deep.equal([
-              'user.name',
-              {
-                fullname: 'fullname',
-                email: 'email@email.com',
-                phone: 'phone',
-                roles: ['national-manager'],
-                language: 'language-code',
-                password: 'medic.1234'
-              }
-            ]);
-            done();
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.called).to.equal(true);
+          chai.expect(http.get.callCount).to.equal(0);
+          chai.expect(UpdateUser.args[0]).to.deep.equal([
+            'user.name',
+            {
+              fullname: 'fullname',
+              email: 'email@email.com',
+              phone: 'phone',
+              roles: ['national-manager'],
+              language: 'language-code',
+              password: 'medic.1234'
+            }
+          ]);
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should not save user if offline and is warned by users-info', done => {
-      mockEditAUser(userToEdit);
+    it('should not save user if offline and is warned by users-info', () => {
       mockContact('new_contact_id');
       mockFacility('new_facility_id');
-      mockContactGet(userToEdit.contact_id);
+      mockContactGet('new_facility_id');
       http.get.withArgs('/api/v1/users-info').resolves({ data: { warn: true, total_docs: 10200, limit: 10000 } });
-      try {
-        setTimeout(() => {
+
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
+          scope.editUserModel.fullname = 'fullname';
+          scope.editUserModel.email = 'email@email.com';
+          scope.editUserModel.phone = 'phone';
+          scope.editUserModel.facilitySelect = 'new_facility';
+          scope.editUserModel.contactSelect = 'new_contact';
+          scope.editUserModel.language.code = 'language-code';
+          scope.editUserModel.password = 'medic.1234';
+          scope.editUserModel.passwordConfirm = 'medic.1234';
+          scope.editUserModel.role = 'supervisor';
+          translate.resolves('translation result');
+
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.callCount).to.equal(0);
+          chai.expect(http.get.callCount).to.equal(1);
+          chai.expect(http.get.args[0]).to.deep.equal([
+            '/api/v1/users-info',
+            { params: { role: 'supervisor', facility_id: 'new_facility_id', contact_id: 'new_contact_id' }}
+          ]);
+          chai.expect(scope.setError.callCount).to.equal(1);
+          chai.expect(scope.setError.args[0]).to.deep.equal([
+            {
+              key: 'configuration.user.replication.limit.exceeded',
+              params: {
+                total_docs: 10200,
+                limit: 10000,
+              },
+              severity: 'warning',
+            },
+            'translation result',
+            'warning'
+          ]);
+        });
+    });
+
+    it('should save user if offline and warned when user clicks on submit the 2nd time', () => {
+      mockContact('new_contact_id');
+      mockFacility('new_facility_id');
+      mockContactGet('new_facility_id');
+      http.get.withArgs('/api/v1/users-info').resolves({ data: { warn: true, total_docs: 10200, limit: 10000 } });
+      translate.resolves('translation');
+
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.fullname = 'fullname';
           scope.editUserModel.email = 'email@email.com';
           scope.editUserModel.phone = 'phone';
@@ -552,76 +511,38 @@ describe('EditUserCtrl controller', () => {
           scope.editUserModel.passwordConfirm = 'medic.1234';
           scope.editUserModel.role = 'supervisor';
 
-          scope.editUser();
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.callCount).to.equal(0);
+          chai.expect(http.get.callCount).to.equal(1);
+          chai.expect(http.get.args[0]).to.deep.equal([
+            '/api/v1/users-info',
+            { params: { role: 'supervisor', facility_id: 'new_facility_id', contact_id: 'new_contact_id' }}
+          ]);
 
-          setTimeout(() => {
-            chai.expect(UpdateUser.callCount).to.equal(0);
-            chai.expect(http.get.callCount).to.equal(1);
-            chai.expect(http.get.args[0]).to.deep.equal([
-              '/api/v1/users-info',
-              { params: { role: 'supervisor', facility_id: 'new_facility_id', contact_id: 'new_contact_id' }}
-            ]);
-            done();
-          });
+          chai.expect(translate.callCount).to.equal(1);
+          chai.expect(translate.args[0][0]).to.equal('configuration.user.replication.limit.exceeded');
+
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.callCount).to.equal(1);
+          chai.expect(http.get.callCount).to.equal(1);
+
+          const updateUserArgs = UpdateUser.args[0];
+          chai.expect(updateUserArgs[0]).to.equal('user.name');
+          const updates = updateUserArgs[1];
+          chai.expect(updates.fullname).to.equal(scope.editUserModel.fullname);
+          chai.expect(updates.email).to.equal(scope.editUserModel.email);
+          chai.expect(updates.phone).to.equal(scope.editUserModel.phone);
+          chai.expect(updates.language).to.equal(scope.editUserModel.language.code);
+          chai.expect(updates.roles[0]).to.equal(scope.editUserModel.role);
+          chai.expect(updates.password).to.deep.equal(scope.editUserModel.password);
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should save user if offline and warned when user clicks on submit the 2nd time', done => {
-      mockEditAUser(userToEdit);
-      mockContact('new_contact_id');
-      mockFacility('new_facility_id');
-      mockContactGet(userToEdit.contact_id);
-      http.get.withArgs('/api/v1/users-info').resolves({ data: { warn: true, total_docs: 10200, limit: 10000 } });
-      try {
-        setTimeout(() => {
-          scope.editUserModel.fullname = 'fullname';
-          scope.editUserModel.email = 'email@email.com';
-          scope.editUserModel.phone = 'phone';
-          scope.editUserModel.facilitySelect = 'new_facility';
-          scope.editUserModel.contactSelect = 'new_contact';
-          scope.editUserModel.language.code = 'language-code';
-          scope.editUserModel.password = 'medic.1234';
-          scope.editUserModel.passwordConfirm = 'medic.1234';
-          scope.editUserModel.role = 'supervisor';
-
-          scope.editUser();
-
-          setTimeout(() => {
-            chai.expect(UpdateUser.callCount).to.equal(0);
-            chai.expect(http.get.callCount).to.equal(1);
-            chai.expect(http.get.args[0]).to.deep.equal([
-              '/api/v1/users-info',
-              { params: { role: 'supervisor', facility_id: 'new_facility_id', contact_id: 'new_contact_id' }}
-            ]);
-
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(UpdateUser.callCount).to.equal(1);
-              chai.expect(http.get.callCount).to.equal(1);
-
-              const updateUserArgs = UpdateUser.args[0];
-              chai.expect(updateUserArgs[0]).to.equal('user.name');
-              const updates = updateUserArgs[1];
-              chai.expect(updates.fullname).to.equal(scope.editUserModel.fullname);
-              chai.expect(updates.email).to.equal(scope.editUserModel.email);
-              chai.expect(updates.phone).to.equal(scope.editUserModel.phone);
-              chai.expect(updates.language).to.equal(scope.editUserModel.language.code);
-              chai.expect(updates.roles[0]).to.equal(scope.editUserModel.role);
-              chai.expect(updates.password).to.deep.equal(scope.editUserModel.password);
-
-              done();
-            });
-          });
-        });
-      } catch(err) {
-        done(err);
-      }
-    });
-
-    it('should require phone when token_login is enabled for new user', done => {
+    it('should require phone when token_login is enabled for new user', () => {
       Settings = sinon.stub().resolves({
         roles: {
           'district-manager': { name: 'xyz', offline: true }, 'data-entry': { name: 'abc' },
@@ -634,29 +555,23 @@ describe('EditUserCtrl controller', () => {
         }
       });
 
-      mockCreateNewUser();
-      try {
-        setTimeout(() => {
+      return mockCreateNewUser()
+        .setupPromise
+        .then(() => {
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
           scope.editUserModel.token_login = true;
 
           translate.withArgs('configuration.enable.token.login.phone').resolves('phone required');
 
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(scope.errors.phone).to.equal('phone required');
-              done();
-            });
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.phone).to.equal('phone required');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should require phone when token_login is enabled for existent user', (done) => {
+    it('should require phone when token_login is enabled for existent user', () => {
       Settings = sinon.stub().resolves({
         roles: {
           'district-manager': { name: 'xyz', offline: true }, 'data-entry': { name: 'abc' },
@@ -669,9 +584,9 @@ describe('EditUserCtrl controller', () => {
         }
       });
 
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
           scope.editUserModel.token_login = true;
@@ -679,20 +594,14 @@ describe('EditUserCtrl controller', () => {
 
           translate.withArgs('configuration.enable.token.login.phone').resolves('phone required');
 
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(scope.errors.phone).to.equal('phone required');
-              done();
-            });
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.phone).to.equal('phone required');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should require valid phone when token_login is enabled', (done) => {
+    it('should require valid phone when token_login is enabled', () => {
       Settings = sinon.stub().resolves({
         roles: {
           'district-manager': { name: 'xyz', offline: true }, 'data-entry': { name: 'abc' },
@@ -705,9 +614,9 @@ describe('EditUserCtrl controller', () => {
         }
       });
 
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
           scope.editUserModel.token_login = true;
@@ -715,20 +624,14 @@ describe('EditUserCtrl controller', () => {
 
           translate.withArgs('configuration.enable.token.login.phone').resolves('phone required');
 
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(scope.errors.phone).to.equal('phone required');
-              done();
-            });
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(scope.errors.phone).to.equal('phone required');
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should not require password when token_login is enabled for new users', (done) => {
+    it('should not require password when token_login is enabled for new users', () => {
       Settings = sinon.stub().resolves({
         roles: {
           'district-manager': { name: 'xyz', offline: true }, 'data-entry': { name: 'abc' },
@@ -741,35 +644,29 @@ describe('EditUserCtrl controller', () => {
         }
       });
 
-      mockCreateNewUser();
-      http.get.withArgs('/api/v1/users-info').resolves({ data: { warn: false, total_docs: 100, limit: 10000 } });
-      try {
-        setTimeout(() => {
+      return mockCreateNewUser()
+        .setupPromise
+        .then(() => {
+          http.get.withArgs('/api/v1/users-info').resolves({ data: { warn: false, total_docs: 100, limit: 10000 } });
           scope.editUserModel.username = 'newuser';
           scope.editUserModel.role = 'data-entry';
           scope.editUserModel.token_login = true;
           scope.editUserModel.phone = '+40755696969';
 
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(CreateUser.callCount).to.equal(1);
-              chai.expect(CreateUser.args[0][0]).to.deep.include({
-                username: 'newuser',
-                phone: '+40755696969',
-                roles: ['data-entry'],
-                token_login: true,
-              });
-              done();
-            }, 10);
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(CreateUser.callCount).to.equal(1);
+          chai.expect(CreateUser.args[0][0]).to.deep.include({
+            username: 'newuser',
+            phone: '+40755696969',
+            roles: ['data-entry'],
+            token_login: true,
           });
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should not overwrite token_login when editing and making no changes', (done) => {
+    it('should not overwrite token_login when editing and making no changes', () => {
       Settings = sinon.stub().resolves({
         roles: {
           'district-manager': { name: 'xyz', offline: true }, 'data-entry': { name: 'abc' },
@@ -785,30 +682,24 @@ describe('EditUserCtrl controller', () => {
       Translate.fieldIsRequired.resolves('Facility field is a required field');
 
       userToEdit.token_login = true;
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.phone = '+40755696969';
           scope.editUserModel.role = 'data-entry';
 
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(UpdateUser.callCount).to.equal(1);
-              chai.expect(UpdateUser.args[0][1]).to.deep.include({
-                phone: '+40755696969',
-                roles: ['data-entry']
-              });
-              done();
-            }, 10);
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.callCount).to.equal(1);
+          chai.expect(UpdateUser.args[0][1]).to.deep.include({
+            phone: '+40755696969',
+            roles: ['data-entry']
           });
         });
-      } catch(err) {
-        done(err);
-      }
     });
 
-    it('should require password when disabling token_login', (done) => {
+    it('should require password when disabling token_login', () => {
       Settings = sinon.stub().resolves({
         roles: {
           'district-manager': { name: 'xyz', offline: true }, 'data-entry': { name: 'abc' },
@@ -824,26 +715,19 @@ describe('EditUserCtrl controller', () => {
       Translate.fieldIsRequired.withArgs('Password').resolves('password required');
 
       userToEdit.token_login = true;
-      mockEditAUser(userToEdit);
-      try {
-        setTimeout(() => {
+      return mockEditAUser(userToEdit)
+        .setupPromise
+        .then(() => {
           scope.editUserModel.token_login = false;
           scope.editUserModel.phone = '';
           scope.editUserModel.role = 'data-entry';
 
-
-          setTimeout(() => {
-            scope.editUser();
-            setTimeout(() => {
-              chai.expect(UpdateUser.callCount).to.equal(0);
-              chai.expect(scope.errors.password).to.equal('password required');
-              done();
-            }, 10);
-          });
+          return scope.editUser();
+        })
+        .then(() => {
+          chai.expect(UpdateUser.callCount).to.equal(0);
+          chai.expect(scope.errors.password).to.equal('password required');
         });
-      } catch(err) {
-        done(err);
-      }
     });
   });
 });


### PR DESCRIPTION
# Description

Fixes issue where the replication warning rejection was caught by the wrong catch block and not ending up displayed to the user. 
Also converts all edit-user unit tests to use promises instead of timeouts. 

medic/cht-core#6578

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
