### PR TITLE
Only search for submitter on "demand" and use binary search.

### DIFF
--- a/api/tests/mocha/services/authorization.spec.js
+++ b/api/tests/mocha/services/authorization.spec.js
@@ -314,7 +314,7 @@ describe('Authorization service', () => {
           { id: 'r4_tombstone', key: 'subject', value: {} },
         ]});
 
-      tombstoneUtils.isTombstoneId.callsFake(id => id.indexOf('tombstone'));
+      tombstoneUtils.isTombstoneId.callsFake(id => id.endsWith('tombstone'));
       tombstoneUtils.extractStub.callsFake(id => ({ id: id.replace('_tombstone', '') }));
 
       return service


### PR DESCRIPTION
# Description

Authorization `isSensitive` now can accept a function to determine if the user is allowed to see the submitter.
When getting allowed doc ids, sort subjects array to leverage much quicker binary search. 
Also uses binary search when searching for undone-deletions in the ids list. 

medic/cht-core#6577

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
