### PR TITLE
Attempt to de-flake some unit/e2e tests

### DIFF
--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -71,6 +71,7 @@ describe('bulk-docs handler', () => {
   beforeAll(() => {
     return utils
       .saveDoc(parentPlace)
+      .then(() => sUtils.waitForSentinel())
       .then(() => utils.createUsers(users));
   });
 

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -254,11 +254,6 @@ describe('Purging on login', () => {
     loginPage.login(restrictedUserName, restrictedPass);
     commonElements.calm();
     commonElements.goToReports();
-    browser.wait(
-      () => element(by.css('#reports-list li:first-child')).isPresent(),
-      10000,
-      'There should be at least one report in the LHS'
-    );
     reports.expectReportsToExist([goodFormId]);
     reports.expectReportsToNotExist([badFormId]);
     let purgeDate;

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -256,6 +256,7 @@ describe('Purging on login', () => {
     commonElements.goToReports();
     reports.expectReportsToExist([goodFormId]);
     reports.expectReportsToNotExist([badFormId]);
+
     let purgeDate;
 
     return getPurgeLog()

--- a/tests/e2e/login/purge.spec.js
+++ b/tests/e2e/login/purge.spec.js
@@ -197,7 +197,10 @@ describe('Purging on login', () => {
     return reports.filter(r => r.form === 'a-bad-form-type').map(r => r._id);
   };
 
+  let originalTimeout;
   beforeAll(done => {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
     let seq;
     return utils
       .saveDocs(initialReports.concat(initialDocs))
@@ -215,6 +218,7 @@ describe('Purging on login', () => {
   });
 
   afterAll(done => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     commonElements.goToLoginPage();
     loginPage.login(auth.username, auth.password);
     return Promise.all([

--- a/tests/page-objects/forms/generic-form.po.js
+++ b/tests/page-objects/forms/generic-form.po.js
@@ -16,13 +16,11 @@ module.exports = {
 
   invalidateReport: () => {
     const reportInvalidBtn = element(by.css('[ng-include*="verify-invalid"]'));
-    const reportInvalidIcon = element(by.css('.detail>.status>.error'));
-    const reportInvalidMessage = element(
-      by.css('.verify-error>span:last-of-type')
-    );
     helper.waitUntilReady(reportInvalidBtn);
     reportInvalidBtn.click();
+    const reportInvalidIcon = element(by.css('.detail>.status>.error'));
     helper.waitUntilReady(reportInvalidIcon);
+    const reportInvalidMessage = element(by.css('.verify-error>span:last-of-type'));
     expect(reportInvalidMessage.getText()).toEqual('Has errors');
   },
 
@@ -74,13 +72,11 @@ module.exports = {
 
   validateReport: () => {
     const reportValidBtn = element(by.css('[ng-include*="verify-valid"]'));
-    const reportValidIcon = element(by.css('.detail>.status>.verified'));
-    const reportValidMessage = element(
-      by.css('.verify-valid>span:last-of-type')
-    );
     helper.waitElementToBeClickable(reportValidBtn);
     reportValidBtn.click();
+    const reportValidIcon = element(by.css('.detail>.status>.verified'));
     helper.waitUntilReady(reportValidIcon);
+    const reportValidMessage = element(by.css('.verify-valid>span:last-of-type'));
     expect(reportValidMessage.getText()).toEqual('Correct');
   },
 

--- a/tests/page-objects/reports/reports.po.js
+++ b/tests/page-objects/reports/reports.po.js
@@ -6,6 +6,11 @@ const reportBodyDetails = '#reports-content .report-body .details';
 
 module.exports = {
   expectReportsToExist: uuids => {
+    browser.wait(
+      () => element(by.css('#reports-list li:first-child')).isPresent(),
+      10000,
+      'There should be at least one report in the LHS'
+    );
     uuids.forEach(uuid => {
       expect(browser.isElementPresent(by.css(`#reports-list li[data-record-id="${uuid}"]`))).toBeTruthy();
     });

--- a/webapp/tests/karma/karma-unit.conf.js
+++ b/webapp/tests/karma/karma-unit.conf.js
@@ -49,5 +49,4 @@ module.exports = function(config) {
       'tests/karma/unit/**/*.js'
     ]
   });
-
 };

--- a/webapp/tests/karma/unit/directives/auth.js
+++ b/webapp/tests/karma/unit/directives/auth.js
@@ -24,130 +24,123 @@ describe('auth directive', () => {
     });
   });
 
-  it('should be shown when auth does not error', done => {
+  const nextTick = () => new Promise(resolve => setTimeout(resolve));
+
+  it('should be shown when auth does not error',  () => {
     Auth.has.resolves(true);
     const element = compile('<a mm-auth="can_do_stuff">')(scope);
     scope.$digest();
-    setTimeout(() => {
+    return nextTick().then(() => {
       chai.expect(element.hasClass('hidden')).to.equal(false);
       chai.expect(Auth.has.callCount).to.equal(1);
       chai.expect(Auth.has.args[0][0]).to.deep.equal(['can_do_stuff']);
-      done();
-    }, 10);
+    });
   });
 
-  it('should be hidden when auth fails', done => {
+  it('should be hidden when auth fails', () => {
     Auth.has.resolves(false);
     const element = compile('<a mm-auth="can_do_stuff">')(scope);
     scope.$digest();
-    setTimeout(() => {
+    return nextTick().then(() => {
       chai.expect(element.hasClass('hidden')).to.equal(true);
       chai.expect(Auth.has.callCount).to.equal(1);
       chai.expect(Auth.has.args[0][0]).to.deep.equal(['can_do_stuff']);
-      done();
-    }, 10);
+    });
   });
 
-  it('splits comma separated permissions', done => {
+  it('splits comma separated permissions', () => {
     Auth.has.resolves(true);
     const element = compile('<a mm-auth="can_do_stuff,!can_not_do_stuff">')(scope);
     scope.$digest();
-    setTimeout(() => {
+    return nextTick().then(() => {
       chai.expect(element.hasClass('hidden')).to.equal(false);
       chai.expect(Auth.has.callCount).to.equal(1);
       chai.expect(Auth.has.args[0][0]).to.deep.equal(['can_do_stuff', '!can_not_do_stuff']);
-      done();
-    }, 10);
+    });
   });
 
   describe('mmAuthOnline', () => {
-    it('should be shown when auth does not error', (done) => {
+    it('should be shown when auth does not error', () => {
       Auth.online.returns(true);
       const element = compile('<a mm-auth mm-auth-online="true">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([true]);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be hidden when auth errors', (done) => {
+    it('should be hidden when auth errors', () => {
       Auth.online.returns(false);
       const element = compile('<a mm-auth mm-auth-online="false">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([false]);
-        done();
-      }, 10);
+      });
     });
 
-    it('parses the attribute value', (done) => {
+    it('parses the attribute value', () => {
       Auth.online.returns(true);
       const element = compile('<a mm-auth mm-auth-online="1 + 2 + 3">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([6]);
-        done();
-      }, 10);
+      });
     });
   });
 
   describe('mmAuth + mmAuthOnline', () => {
-    it('should be shown when both do not err', (done) => {
+    it('should be shown when both do not err', () => {
       Auth.has.resolves(true);
       Auth.online.returns(true);
 
       const element = compile('<a mm-auth="permission_to_have" mm-auth-online="true">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([true]);
         chai.expect(Auth.has.callCount).to.equal(1);
         chai.expect(Auth.has.args[0][0]).to.deep.equal(['permission_to_have']);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be hidden when online succeeds and permissions err', (done) => {
+    it('should be hidden when online succeeds and permissions err', () => {
       Auth.has.resolves(false);
       Auth.online.returns(true);
 
       const element = compile('<a mm-auth="permission_to_have" mm-auth-online="false">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([false]);
         chai.expect(Auth.has.callCount).to.equal(1);
         chai.expect(Auth.has.args[0][0]).to.deep.equal(['permission_to_have']);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be hidden when online fails and permissions succeed', (done) => {
+    it('should be hidden when online fails and permissions succeed', () => {
       Auth.has.resolves(true);
       Auth.online.returns(false);
 
       const element = compile('<a mm-auth="permission_to_have" mm-auth-online="true">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([true]);
         chai.expect(Auth.has.callCount).to.equal(1);
         chai.expect(Auth.has.args[0][0]).to.deep.equal(['permission_to_have']);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be hidden when online fails and auth any succeeds', (done) => {
+    it('should be hidden when online fails and auth any succeeds', () => {
       Auth.any.resolves(true);
       Auth.online.returns(false);
 
@@ -155,105 +148,97 @@ describe('auth directive', () => {
         '<a mm-auth mm-auth-any="[\'permission_to_have\', \'another_permission\']" mm-auth-online="true">'
       )(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be hidden when both fail', (done) => {
+    it('should be hidden when both fail', () => {
       Auth.has.resolves(false);
       Auth.online.returns(false);
 
       const element = compile('<a mm-auth="permission_to_have" mm-auth-online="false">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.online.callCount).to.equal(1);
         chai.expect(Auth.online.args[0]).to.deep.equal([false]);
         chai.expect(Auth.has.callCount).to.equal(1);
         chai.expect(Auth.has.args[0][0]).to.deep.equal(['permission_to_have']);
-        done();
-      }, 10);
+      });
     });
   });
 
   describe('- any', () => {
-    it('should be hidden with false parameter(s)', (done) => {
+    it('should be hidden with false parameter(s)', () => {
       const element = compile('<a mm-auth mm-auth-any="false">')(scope);
       const element2 = compile('<a mm-auth mm-auth-any="[false, false, false]">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(element2.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.any.callCount).to.equal(0);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be shown with true parameter(s)', (done) => {
+    it('should be shown with true parameter(s)', () => {
       const element = compile('<a mm-auth mm-auth-any="true">')(scope);
       const element2 = compile('<a mm-auth mm-auth-any="[false, false, true, false, true]">')(scope);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
         chai.expect(element2.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.any.callCount).to.equal(0);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be shown with at least one allowed permission', (done) => {
+    it('should be shown with at least one allowed permission', () => {
       const element = compile('<a mm-auth mm-auth-any="[\'perm1\', \'perm2\']">')(scope);
       Auth.any.resolves(true);
 
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.any.callCount).to.equal(1);
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['perm1'], ['perm2']]);
-        done();
-      }, 10);
+      });
     });
 
-    it('should be hidden with no allowed permissions', (done) => {
+    it('should be hidden with no allowed permissions', () => {
       const element = compile('<a mm-auth mm-auth-any="[\'perm1\', \'perm2\']">')(scope);
       Auth.any.resolves(false);
       scope.$digest();
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.any.callCount).to.equal(1);
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['perm1'], ['perm2']]);
-        done();
-      }, 10);
+      });
     });
 
-    it('should work with stacked permissions', (done) => {
+    it('should work with stacked permissions', () => {
       const template = '<a mm-auth mm-auth-any="[[\'a\', \'b\'], [[\'c\', \'d\']], [[[\'e\', \'f\']]], \'g\']">';
       const element = compile(template)(scope);
       Auth.any.withArgs([['a', 'b'], ['c', 'd'], ['e', 'f'], ['g']]).resolves(true);
       scope.$digest();
 
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(false);
         chai.expect(Auth.any.callCount).to.equal(1);
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['a', 'b'], ['c', 'd'], ['e', 'f'], ['g']]);
-        done();
-      }, 10);
+      });
     });
 
-    it('should work with expressions ', (done) => {
+    it('should work with expressions ', () => {
       const template = '<a mm-auth mm-auth-any="[true && [\'a\', \'b\'], false && [\'c\', \'d\'], \'f\']">';
       const element = compile(template)(scope);
       Auth.any.withArgs([['a', 'b'], ['f']]).resolves(false);
       scope.$digest();
 
-      setTimeout(() => {
+      return nextTick().then(() => {
         chai.expect(element.hasClass('hidden')).to.equal(true);
         chai.expect(Auth.any.callCount).to.equal(1);
         chai.expect(Auth.any.args[0][0]).to.deep.equal([['a', 'b'], ['f']]);
-        done();
-      }, 10);
+      });
     });
   });
 

--- a/webapp/tests/karma/unit/directives/auth.js
+++ b/webapp/tests/karma/unit/directives/auth.js
@@ -24,7 +24,7 @@ describe('auth directive', () => {
     });
   });
 
-  const nextTick = () => new Promise(resolve => setTimeout(resolve));
+  const nextTick = () => new Promise(resolve => setTimeout(resolve, 20));
 
   it('should be shown when auth does not error',  () => {
     Auth.has.resolves(true);


### PR DESCRIPTION
# Description

Tries to fix:
- Auth directive unit tests
- Offline user purge e2e test (that didn't wait for reports to load before asserting and sometimes timed out)
- Bulk docs e2e test that was timing out waiting for sentinel to process past docs
- the add new family form e2e test that was accessing stale elements because of "referencing" them while before asserting / accessing them

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
