### PR TITLE
Fix due_tasks to match due date the same as the messages_by_state view

### DIFF
--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -14,14 +14,25 @@ const BATCH_SIZE = 1000;
 // @return     {<object>}  {validTasks, invalidTasks}, where a validTask is {task doc} and invalid
 //                         tasks are {task row}
 //
-const queuedTasks = () => {
-  return db.sentinel.allDocs({
-    startkey: 'task:outbound:',
-    endkey: 'task:outbound:\ufff0',
-    include_docs: true,
-    limit: BATCH_SIZE,
-  })
+const queuedTasks = startKey => {
+  return db.sentinel
+    .allDocs({
+      startkey: startKey || 'task:outbound:',
+      endkey: 'task:outbound:\ufff0',
+      include_docs: true,
+      limit: BATCH_SIZE,
+    })
     .then(taskResults => {
+      if (!taskResults.rows.length || (taskResults.rows.length === 1 && taskResults.rows[0].key === startKey)) {
+        return;
+      }
+
+      const lastDocId = taskResults.rows[taskResults.rows.length - 1].key;
+      if (taskResults.rows[0].key === startKey) {
+        // prevent last document from previous batch from being processed twice
+        taskResults.rows.shift();
+      }
+
       const outboundTaskDocs = taskResults.rows.map(r => r.doc);
       const associatedDocIds = outboundTaskDocs.map(q => q.doc_id);
 
@@ -55,11 +66,11 @@ const queuedTasks = () => {
                 t.doc = hydratedDocs[idx];
               });
 
-              return { validTasks, invalidTasks };
+              return { validTasks, invalidTasks, lastDocId };
             });
-        } else {
-          return { validTasks, invalidTasks };
         }
+
+        return { validTasks, invalidTasks, lastDocId };
       });
     });
 };
@@ -152,6 +163,9 @@ const removeInvalidTasks = invalidTasks => {
 // @return     {<array>}  { task, doc, info }
 //
 const attachInfoDocs = tasks => {
+  if (!tasks.length) {
+    return [];
+  }
   return db.sentinel.allDocs({
     keys: tasks.map(({doc}) => `${doc._id}-info`),
     include_docs: true
@@ -162,27 +176,23 @@ const attachInfoDocs = tasks => {
   });
 };
 
-// Coordinates the attempted pushing of documents that need it
-const execute = () => {
-  const configuredPushes = configService.get(CONFIGURED_PUSHES) || {};
-  if (!Object.keys(configuredPushes).length) {
-    return Promise.resolve();
-  }
-
-  return queuedTasks()
-    .then(({validTasks, invalidTasks}) => {
+const batch = (configuredPushes, startKey) => {
+  let nextKey;
+  return queuedTasks(startKey)
+    .then(({ validTasks = [], invalidTasks = [], lastDocId } = {}) => {
+      nextKey = lastDocId;
       if (invalidTasks.length) {
         return removeInvalidTasks(invalidTasks).then(() => validTasks);
-      } else {
-        return validTasks;
       }
+
+      return validTasks;
     })
     .then(validTasks => attachInfoDocs(validTasks))
     .then(validTasks => {
       const pushes = validTasks.reduce((acc, {task, doc, info}) => {
         const pushesForDoc =
-          getConfigurationsToPush(configuredPushes, task)
-            .map(([key, config]) => ({task, doc, info, config, key}));
+                getConfigurationsToPush(configuredPushes, task)
+                  .map(([key, config]) => ({task, doc, info, config, key}));
 
         return acc.concat(pushesForDoc);
       }, []);
@@ -197,7 +207,18 @@ const execute = () => {
         (p, {task, doc, info, config, key}) => p.then(() => singlePush(task, doc, info, config, key)),
         Promise.resolve()
       );
-    });
+    })
+    .then(() => nextKey && batch(configuredPushes, nextKey));
+};
+
+// Coordinates the attempted pushing of documents that need it
+const execute = () => {
+  const configuredPushes = configService.get(CONFIGURED_PUSHES) || {};
+  if (!Object.keys(configuredPushes).length) {
+    return Promise.resolve();
+  }
+
+  return batch(configuredPushes);
 };
 
 module.exports = {

--- a/sentinel/tests/unit/schedule/outbound.js
+++ b/sentinel/tests/unit/schedule/outbound.js
@@ -37,12 +37,14 @@ describe('outbound schedule', () => {
 
       dbSentinelAllDocs.resolves({
         rows: [{
+          key: task._id,
           doc: task
         }]
       });
 
       dbMedicAllDocs.resolves({
         rows: [{
+          key: doc._id,
           doc: doc
         }]
       });
@@ -51,10 +53,17 @@ describe('outbound schedule', () => {
 
       return outbound.__get__('queuedTasks')()
         .then(results => {
+          assert.deepEqual(dbSentinelAllDocs.args[0][0], {
+            endkey: 'task:outbound:\ufff0',
+            include_docs: true,
+            limit: 1000,
+            startkey: 'task:outbound:',
+          });
           assert.equal(lineage.callCount, 1);
           assert.deepEqual(results, {
             validTasks: [{ task: task, doc: doc }],
-            invalidTasks: []
+            invalidTasks: [],
+            lastDocId: task._id,
           });
         });
     });
@@ -75,7 +84,8 @@ describe('outbound schedule', () => {
 
       dbSentinelAllDocs.resolves({
         rows: [{
-          doc: task
+          key: task._id,
+          doc: task,
         }]
       });
 
@@ -88,7 +98,8 @@ describe('outbound schedule', () => {
           assert.equal(lineage.callCount, 0);
           assert.deepEqual(results, {
             validTasks: [],
-            invalidTasks: [{task: task, row: error}]
+            invalidTasks: [{task: task, row: error}],
+            lastDocId: task._id,
           });
         });
     });
@@ -112,6 +123,7 @@ describe('outbound schedule', () => {
 
       dbSentinelAllDocs.resolves({
         rows: [{
+          key: task._id,
           doc: task
         }]
       });
@@ -125,7 +137,8 @@ describe('outbound schedule', () => {
           assert.equal(lineage.callCount, 0);
           assert.deepEqual(results, {
             validTasks: [],
-            invalidTasks: [{task: task, row: error}]
+            invalidTasks: [{task: task, row: error}],
+            lastDocId: task._id,
           });
         });
     });
@@ -146,6 +159,7 @@ describe('outbound schedule', () => {
 
       dbSentinelAllDocs.resolves({
         rows: [{
+          key: task._id,
           doc: task
         }]
       });
@@ -158,6 +172,102 @@ describe('outbound schedule', () => {
         .catch(err => err)
         .then(err => {
           assert.match(err.message, /Unexpected error retrieving a document/);
+        });
+    });
+
+    it('should nothing when the single doc to process should be skipped', () => {
+      const task = {
+        _id: 'task:outbound:some_doc_id',
+        doc_id: 'some_doc_id',
+        queue: ['some', 'task']
+      };
+      const dbSentinelAllDocs = sinon.stub(db.sentinel, 'allDocs');
+      dbSentinelAllDocs.resolves({
+        rows: [{
+          key: task._id,
+          doc: task
+        }]
+      });
+
+      return outbound
+        .__get__('queuedTasks')('task:outbound:some_doc_id')
+        .then(results => {
+          assert.deepEqual(dbSentinelAllDocs.args[0][0], {
+            endkey: 'task:outbound:\ufff0',
+            include_docs: true,
+            limit: 1000,
+            startkey: 'task:outbound:some_doc_id',
+          });
+          assert.equal(lineage.callCount, 0);
+          assert.deepEqual(results, undefined);
+        });
+    });
+
+    it('should nothing when no results returned', () => {
+      const dbSentinelAllDocs = sinon.stub(db.sentinel, 'allDocs');
+      dbSentinelAllDocs.resolves({ rows: [] });
+
+      return outbound
+        .__get__('queuedTasks')('task:outbound:otherDocId')
+        .then(results => {
+          assert.deepEqual(dbSentinelAllDocs.args[0][0], {
+            endkey: 'task:outbound:\ufff0',
+            include_docs: true,
+            limit: 1000,
+            startkey: 'task:outbound:otherDocId',
+          });
+          assert.equal(lineage.callCount, 0);
+          assert.deepEqual(results, undefined);
+        });
+    });
+
+    it('should skip first doc from being processed', () => {
+      const task1 = {
+        _id: 'task:outbound:some_doc_id',
+        doc_id: 'some_doc_id',
+        queue: ['some', 'task']
+      };
+      const task2 = {
+        _id: 'task:outbound:some_doc_id_2',
+        doc_id: 'some_doc_id_2',
+        queue: ['some', 'task']
+      };
+      const doc2 = { _id: 'some_doc_id_2', date: '2' };
+      const dbSentinelAllDocs = sinon.stub(db.sentinel, 'allDocs');
+      dbSentinelAllDocs.resolves({
+        rows: [
+          { key: task1._id, doc: task1 },
+          { key: task2._id, doc: task2 },
+        ]
+      });
+
+      const dbMedicAllDocs = sinon.stub(db.medic, 'allDocs');
+      dbMedicAllDocs.resolves({
+        rows: [{ doc: doc2 }],
+      });
+      lineage.callsFake(doc => Promise.resolve(doc));
+
+      return outbound
+        .__get__('queuedTasks')(task1._id)
+        .then(results => {
+          assert.deepEqual(dbSentinelAllDocs.args[0][0], {
+            endkey: 'task:outbound:\ufff0',
+            include_docs: true,
+            limit: 1000,
+            startkey: 'task:outbound:some_doc_id',
+          });
+          assert.deepEqual(dbMedicAllDocs.callCount, 1);
+          assert.deepEqual(dbMedicAllDocs.args[0], [{
+            include_docs: true,
+            keys: [doc2._id]
+          }]);
+          assert.equal(lineage.callCount, 1);
+          assert.deepEqual(lineage.args[0][0], [doc2] );
+          assert.deepEqual(results, {
+            validTasks: [{ doc: doc2, task: task2 }],
+            invalidTasks: [],
+            lastDocId: task2._id,
+          });
         });
     });
   });
@@ -491,25 +601,146 @@ describe('outbound schedule', () => {
       };
 
       configGet.returns(config);
-      queuedTasks.resolves({
+      queuedTasks.onCall(0).resolves({
         validTasks: [{ task: task1, doc: doc1 }, { task: task2, doc: doc2 }],
-        invalidTasks: [{task: task3, row: error3}]
+        invalidTasks: [{ task: task3, row: error3 }],
+        lastDocId: task3._id,
       });
+      queuedTasks.onCall(1).resolves();
 
       removeInvalidTasks.resolves();
 
-      attachInfoDocs.resolves([{ task: task1, doc: doc1, info: doc1Info }, { task: task2, doc: doc2, info: doc2Info }]);
+      attachInfoDocs
+        .onCall(0).resolves([{ task: task1, doc: doc1, info: doc1Info }, { task: task2, doc: doc2, info: doc2Info }])
+        .onCall(1).resolves([]);
 
       singlePush.resolves();
 
       return outbound.execute().then(() => {
+        assert.equal(queuedTasks.callCount, 2);
+        assert.deepEqual(queuedTasks.args, [[undefined], [task3._id]]);
         assert.equal(configGet.callCount, 1);
         assert.equal(removeInvalidTasks.callCount, 1);
+        assert.equal(attachInfoDocs.callCount, 2);
+        assert.deepEqual(attachInfoDocs.args[0], [[{ task: task1, doc: doc1 }, { task: task2, doc: doc2 }]]);
+        assert.deepEqual(attachInfoDocs.args[1], [[]]);
         assert.equal(singlePush.callCount, 2);
 
         assert.deepEqual(removeInvalidTasks.args[0][0], [{task: task3, row: error3}]);
         assert.deepEqual(singlePush.args[0], [task1, doc1, doc1Info, {some: 'config'}, 'test-push-1']);
         assert.deepEqual(singlePush.args[1], [task2, doc2, doc2Info, {other: 'config'}, 'test-push-2']);
+      });
+    });
+
+    it('should keep querying until no more results', () => {
+      const config = {
+        'test-push-1': {
+          some: 'config'
+        },
+        'test-push-2': {
+          other: 'config'
+        }
+      };
+
+      const task1 = {
+        _id: 'task:outbound:test-doc-1',
+        doc_id: 'test-doc-1',
+        queue: ['test-push-1'],
+      };
+      const task2 = {
+        _id: 'task:outbound:test-doc-2',
+        doc_id: 'test-doc-2',
+        queue: ['test-push-2'],
+      };
+      const task3 = {
+        _id: 'task:outbound:test-doc-3',
+        doc_id: 'test-doc-3',
+        queue: ['test-push-2'],
+      };
+
+      const task4 = {
+        _id: 'task:outbound:test-doc-4',
+        doc_id: 'test-doc-4',
+        queue: ['test-push-1'],
+      };
+      const task5 = {
+        _id: 'task:outbound:test-doc-5',
+        doc_id: 'test-doc-5',
+        queue: ['test-push-2'],
+      };
+      const task6 = {
+        _id: 'task:outbound:test-doc-6',
+        doc_id: 'test-doc-6',
+        queue: ['test-push-1'],
+      };
+
+      const doc1 = {
+        _id: 'test-doc-1', some: 'data-1',
+      };
+      const doc2 = {
+        _id: 'test-doc-2', some: 'data-2',
+      };
+      const error3 = {
+        key: 'test-doc-3',
+        error: 'not_found',
+      };
+
+      const error4 = {
+        key: 'test-doc-4',
+        error: 'not_found',
+      };
+      const doc5 = {
+        _id: 'test-doc-5', some: 'data-5',
+      };
+      const doc6 = {
+        _id: 'test-doc-6', some: 'data-6',
+      };
+
+      const doc1Info = { _id: 'test-doc-1-info' };
+      const doc2Info = { _id: 'test-doc-2-info' };
+
+      const doc5Info = { _id: 'test-doc-5-info' };
+      const doc6Info = { _id: 'test-doc-6-info' };
+
+      configGet.returns(config);
+      queuedTasks.onCall(0).resolves({
+        validTasks: [{ task: task1, doc: doc1 }, { task: task2, doc: doc2 }],
+        invalidTasks: [{ task: task3, row: error3 }],
+        lastDocId: task3._id,
+      });
+      queuedTasks.onCall(1).resolves({
+        validTasks: [{ task: task5, doc: doc5 }, { task: task6, doc: doc6 }],
+        invalidTasks: [{ task: task4, row: error4 }],
+        lastDocId: task6._id,
+      });
+      queuedTasks.onCall(2).resolves();
+
+      removeInvalidTasks.resolves();
+
+      attachInfoDocs
+        .onCall(0).resolves([{ task: task1, doc: doc1, info: doc1Info }, { task: task2, doc: doc2, info: doc2Info }])
+        .onCall(1).resolves([{ task: task5, doc: doc5, info: doc5Info }, { task: task6, doc: doc6, info: doc6Info }])
+        .onCall(2).resolves([]);
+
+      singlePush.resolves();
+
+      return outbound.execute().then(() => {
+        assert.equal(queuedTasks.callCount, 3);
+        assert.deepEqual(queuedTasks.args, [[undefined], [task3._id], [task6._id]]);
+        assert.equal(configGet.callCount, 1);
+        assert.equal(removeInvalidTasks.callCount, 2);
+        assert.equal(attachInfoDocs.callCount, 3);
+        assert.deepEqual(attachInfoDocs.args[0], [[{ task: task1, doc: doc1 }, { task: task2, doc: doc2 }]]);
+        assert.deepEqual(attachInfoDocs.args[1], [[{ task: task5, doc: doc5 }, { task: task6, doc: doc6 }]]);
+        assert.deepEqual(attachInfoDocs.args[2], [[]]);
+        assert.equal(singlePush.callCount, 4);
+
+        assert.deepEqual(removeInvalidTasks.args[0][0], [{task: task3, row: error3}]);
+        assert.deepEqual(removeInvalidTasks.args[1][0], [{task: task4, row: error4}]);
+        assert.deepEqual(singlePush.args[0], [task1, doc1, doc1Info, {some: 'config'}, 'test-push-1']);
+        assert.deepEqual(singlePush.args[1], [task2, doc2, doc2Info, {other: 'config'}, 'test-push-2']);
+        assert.deepEqual(singlePush.args[2], [task5, doc5, doc5Info, {other: 'config'}, 'test-push-2']);
+        assert.deepEqual(singlePush.args[3], [task6, doc6, doc6Info, {some: 'config'}, 'test-push-1']);
       });
     });
   });

--- a/shared-libs/transitions/package-lock.json
+++ b/shared-libs/transitions/package-lock.json
@@ -64,6 +64,17 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "ajv": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+      "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -104,6 +115,19 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -115,11 +139,34 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "bikram-sambat": {
       "version": "1.6.0",
@@ -174,6 +221,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.2.0",
@@ -295,11 +347,32 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "debug": {
       "version": "3.2.6",
@@ -334,11 +407,25 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -393,6 +480,26 @@
       "resolved": "https://registry.npmjs.org/eurodigit/-/eurodigit-3.1.3.tgz",
       "integrity": "sha512-/bS2/yTT1/sa5tiT3sjxQ6dobYwGDkWRCeoWYUSUFcLYomEPWlgVfnCE3Iv4eJDJE9upHhtNycxD9XQbR+zicg=="
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
     "fclone": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
@@ -426,6 +533,21 @@
         "is-buffer": "~2.0.3"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -449,6 +571,14 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.3",
@@ -489,6 +619,20 @@
       "resolved": "https://registry.npmjs.org/gsm/-/gsm-0.1.4.tgz",
       "integrity": "sha1-+CdiTYokdi+lC8Sb/KgsIAbR6wo="
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -515,6 +659,16 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -604,6 +758,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -616,6 +775,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
@@ -624,6 +788,37 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "jsverify": {
@@ -687,6 +882,19 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
       }
     },
     "minimatch": {
@@ -791,6 +999,11 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -890,11 +1103,31 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "rc4": {
       "version": "0.1.5",
@@ -911,6 +1144,58 @@
         "picomatch": "^2.0.4"
       }
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "requires": {
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+        }
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -922,6 +1207,16 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.7.1",
@@ -978,6 +1273,27 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "2.1.1",
@@ -1064,11 +1380,33 @@
         "is-number": "^7.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "trampa": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trampa/-/trampa-1.0.1.tgz",
       "integrity": "sha512-93WeyHNuRggPEsfCe+yHxCgM2s6H3Q8Wmlt6b6ObJL8qc7eZlRaFjQxwTrB+zbvGtlDRnAkMoYYo3+2uH/fEwA==",
       "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-detect": {
       "version": "4.0.8",
@@ -1081,6 +1419,29 @@
       "resolved": "https://registry.npmjs.org/typify-parser/-/typify-parser-1.1.0.tgz",
       "integrity": "sha1-rHO/pfJTQ0aOLQ8zRsYRe8A9PJk=",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/shared-libs/transitions/package.json
+++ b/shared-libs/transitions/package.json
@@ -31,6 +31,8 @@
     "lodash": "^4.17.15",
     "moment": "^2.26.0",
     "mustache": "^4.0.1",
-    "object-path": "^0.11.4"
+    "object-path": "^0.11.4",
+    "request": "^2.88.2",
+    "request-promise-native": "^1.0.9"
   }
 }

--- a/shared-libs/transitions/src/db.js
+++ b/shared-libs/transitions/src/db.js
@@ -10,6 +10,8 @@ if (UNIT_TEST_ENV) {
     process.exit(1);
   };
 
+  module.exports.couchUrl = stubMe('couchUrl');
+
   module.exports.medic = {
     allDocs: stubMe('allDocs'),
     bulkDocs: stubMe('bulkDocs'),

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -38,6 +38,10 @@ const getTemplateContext = (doc) => {
 };
 
 const updateScheduledTasks = (doc, context, dueDates) => {
+  if (!doc) {
+    return;
+  }
+
   let updatedTasks = false;
   // set task to pending for gateway to pick up
   doc.scheduled_tasks.forEach(task => {

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -5,6 +5,7 @@ const utils = require('../lib/utils');
 const date = require('../date');
 const config = require('../config');
 const db = require('../db');
+const rpn = require('request-promise-native');
 const lineage = require('@medic/lineage')(Promise, db.medic);
 const messageUtils = require('@medic/message-utils');
 
@@ -40,7 +41,13 @@ const updateScheduledTasks = (doc, context, dueDates) => {
   let updatedTasks = false;
   // set task to pending for gateway to pick up
   doc.scheduled_tasks.forEach(task => {
-    if (dueDates.includes(task.due)) {
+    // use the same due calculation as the `messages_by_state` view
+    let due = task.due || task.timestamp || doc.reported_date;
+    if (typeof due !== 'string') {
+      due = moment(due).toISOString();
+    }
+
+    if (dueDates.includes(due)) {
       if (!task.messages) {
         const content = {
           translationKey: task.message_key,
@@ -74,48 +81,79 @@ const updateScheduledTasks = (doc, context, dueDates) => {
   return updatedTasks;
 };
 
+const getBatch = (query, startKey, startKeyDocId) => {
+  const queryString = Object.assign({}, query);
+  if (startKeyDocId) {
+    queryString.startkey_docid = startKeyDocId;
+    queryString.startkey = JSON.stringify(startKey);
+  }
+
+  const options = {
+    baseUrl: db.couchUrl,
+    uri: '/_design/medic/_view/messages_by_state',
+    qs: queryString,
+    json: true
+  };
+
+  let nextKey;
+  let nextKeyDocId;
+
+  return rpn
+    .get(options)
+    .then(result => {
+      if (!result.rows || !result.rows.length || (result.rows.length === 1 && result.rows[0].id === startKeyDocId)) {
+        return;
+      }
+
+      ({ key: nextKey, id: nextKeyDocId } = result.rows[result.rows.length - 1]);
+      if (result.rows[0].id === startKeyDocId) {
+        // prevent last document from previous batch from being processed twice
+        result.rows.shift();
+      }
+
+      const objs = {};
+      result.rows.forEach(row => {
+        if (!objs[row.id]) {
+          row.dueDates = [];
+          objs[row.id] = row;
+        }
+        objs[row.id].dueDates.push(moment(row.key[1]).toISOString());
+      });
+
+      let promiseChain = Promise.resolve();
+      Object.values(objs).forEach(obj => {
+        promiseChain = promiseChain
+          .then(() => lineage.hydrateDocs([obj.doc]))
+          .then(([doc]) => {
+            return getTemplateContext(doc).then(context => {
+              const hasUpdatedTasks = updateScheduledTasks(doc, context, obj.dueDates);
+              if (!hasUpdatedTasks) {
+                return;
+              }
+
+              lineage.minify(doc);
+              return db.medic.put(doc);
+            });
+          });
+      });
+
+      return promiseChain;
+    })
+    .then(() => nextKeyDocId && getBatch(query, nextKey, nextKeyDocId));
+};
+
 module.exports = {
   execute: () => {
     const now = moment(date.getDate());
     const overdue = now.clone().subtract(7, 'days');
     const opts = {
       include_docs: true,
-      endkey: [ 'scheduled', now.valueOf() ],
-      startkey: [ 'scheduled', overdue.valueOf() ],
+      endkey: JSON.stringify([ 'scheduled', now.valueOf() ]),
+      startkey: JSON.stringify([ 'scheduled', overdue.valueOf() ]),
       limit: BATCH_SIZE,
     };
 
-    return db.medic
-      .query('medic/messages_by_state', opts)
-      .then(result => {
-        const objs = {};
-        result.rows.forEach(row => {
-          if (!objs[row.id]) {
-            row.dueDates = [];
-            objs[row.id] = row;
-          }
-          objs[row.id].dueDates.push(moment(row.key[1]).toISOString());
-        });
-
-        let promiseChain = Promise.resolve();
-        Object.values(objs).forEach(obj => {
-          promiseChain = promiseChain
-            .then(() => lineage.hydrateDocs([obj.doc]))
-            .then(([doc]) => {
-              return getTemplateContext(doc).then(context => {
-                const hasUpdatedTasks = updateScheduledTasks(doc, context, obj.dueDates);
-                if (!hasUpdatedTasks) {
-                  return;
-                }
-
-                lineage.minify(doc);
-                return db.medic.put(doc);
-              });
-            });
-        });
-
-        return promiseChain;
-      });
+    return getBatch(opts);
   },
   _lineage: lineage,
 };


### PR DESCRIPTION
# Description

Also changes batching mechanism for `due_tasks` and `outbound` now that Sentinel tasks are run in parallel and don't block each other. 
This fixes a potential bug where the queue of 1000 entries may be saturated with "errored" docs which will be processed over and over: for example a `scheduled_task` with a missing message translation or an outbound task that always fails to be sent. 

medic/cht-core#6582

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
