### PR TITLE
Refresh the userCtx expiry when getting session

### DIFF
--- a/api/src/services/cookie.js
+++ b/api/src/services/cookie.js
@@ -1,3 +1,14 @@
+const production = process.env.NODE_ENV === 'production';
+const ONE_YEAR = 31536000000;
+const SESSION_COOKIE_RE = /AuthSession=([^;]*);/;
+
+const getCookieOptions = () => {
+  return {
+    sameSite: 'lax', // prevents the browser from sending this cookie along with some cross-site requests
+    secure: production, // only transmit when requesting via https unless in development mode
+  };
+};
+
 module.exports = {
   get: (req, name) => {
     const cookies = req.headers && req.headers.cookie;
@@ -7,5 +18,21 @@ module.exports = {
     const prefix = name + '=';
     const cookie = cookies.split(';').find(cookie => cookie.trim().startsWith(prefix));
     return cookie && cookie.trim().substring(prefix.length);
+  },
+  setUserCtx: (res, content) => {
+    const options = getCookieOptions();
+    options.maxAge = ONE_YEAR;
+    res.cookie('userCtx', content, options);
+  },
+  setSession: (res, cookie) => {
+    const sessionId = SESSION_COOKIE_RE.exec(cookie)[1];
+    const options = getCookieOptions();
+    options.httpOnly = true; // don't allow javascript access to stop xss
+    res.cookie('AuthSession', sessionId, options);
+  },
+  setLocale: (res, locale) => {
+    const options = getCookieOptions();
+    options.maxAge = ONE_YEAR;
+    res.cookie('locale', locale, options);
   }
 };


### PR DESCRIPTION
This keeps pushing the userCtx expiry date a year ahead so it's
unlikely to ever expire in normal usage conditions. If this cookie
expires then the user is redirected to the login page despite
having a valid CouchDB session and AuthSession cookie.

medic/cht-core#6583

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
