### PR TITLE
Updates release issue templates to exclude archived channel reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -44,7 +44,7 @@ Once all issues have passed acceptance testing and have been merged into `master
 - [ ] Upgrade the `demo-cht.dev` instance to this version.
 - [ ] Follow the instructions for [releasing other products](https://docs.communityhealthtoolkit.org/core/guides/releasing/) that have been updated in this project (eg: medic-conf, medic-gateway, medic-android).
 - [ ] Add the release to the [Supported versions](https://docs.communityhealthtoolkit.org/core/overview/supported-software/) and update the EOL date and status of previous releases.
-- [ ] Announce the release in #products and #cht-contributors using this template:
+- [ ] Announce the release in #products using this template:
 ```
 @channel *We're excited to announce the release of {{version}}*
 

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -29,7 +29,7 @@ Once all issues have passed acceptance testing and have been merged into `master
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
 - [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Add the release to the [Supported versions](https://docs.communityhealthtoolkit.org/core/overview/supported-software/) and update the EOL date and status of previous releases.
-- [ ] Announce the release in #products and #cht-contributors using this template:
+- [ ] Announce the release in #products using this template:
 ```
 @channel *Announcing the release of {{version}}*
 

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -28,11 +28,11 @@ Once all issues have passed acceptance testing and have been merged into `master
 - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another beta.
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
 - [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
-- [ ] Add the release to the [Supported versions](https://docs.communityhealthtoolkit.org/core/overview/supported-software/) and update the EOL date and status of previous releases.
 - [ ] Announce the release in #products using this template:
 ```
 @channel *Announcing the release of {{version}}*
 
 This release fixes {{number of bugs}}. Read the release notes for full details: {{url}}
 ```
+- [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/), under the "Product - Releases" category. You can use the previous message and omit `@channel`.
 - [ ] Mark this issue "done" and close the project.


### PR DESCRIPTION
# Description

The slack #cht-contributors channel has been archived in June 2020. 
Removes patch release supported software step. 
Adds patch release forum post step. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
