### PR TITLE
Fix regex that causes usernames with `-` chars to skip meta replication

### DIFF
--- a/sentinel/src/schedule/replications.js
+++ b/sentinel/src/schedule/replications.js
@@ -121,7 +121,7 @@ module.exports = {
     return Promise.resolve();
   },
   runReplication: () => {
-    const SRC_DB_REGEX = new RegExp(`${db.medicDbName}-user-[^\\-]+-meta`);
+    const SRC_DB_REGEX = new RegExp(`${db.medicDbName}-user-[a-z0-9_-]+-meta`);
     const TO_DB_NAME = `${db.medicDbName}-users-meta`;
     return db.allDbs().then(dbs => {
       const srcDbs = dbs.filter(db => SRC_DB_REGEX.exec(db));

--- a/sentinel/src/schedule/replications.js
+++ b/sentinel/src/schedule/replications.js
@@ -121,7 +121,7 @@ module.exports = {
     return Promise.resolve();
   },
   runReplication: () => {
-    const SRC_DB_REGEX = new RegExp(`${db.medicDbName}-user-[a-z0-9_-]+-meta`);
+    const SRC_DB_REGEX = new RegExp(`${db.medicDbName}-user-.+-meta`);
     const TO_DB_NAME = `${db.medicDbName}-users-meta`;
     return db.allDbs().then(dbs => {
       const srcDbs = dbs.filter(db => SRC_DB_REGEX.exec(db));

--- a/sentinel/tests/unit/schedule/replications.js
+++ b/sentinel/tests/unit/schedule/replications.js
@@ -38,10 +38,20 @@ describe('replications', () => {
     const replicateDbs = sinon.stub(replications, 'replicateDbs');
     replicateDbs.returns(Promise.resolve());
     sinon.stub(db, 'allDbs')
-      .resolves(['medic-b', 'medic-s', `${db.medicDbName}-user-x-meta`, `${db.medicDbName}-user-y-meta`]);
+      .resolves([
+        'medic-b',
+        'medic-s',
+        `${db.medicDbName}-user-x-meta`,
+        `${db.medicDbName}-user-y-meta`,
+        `${db.medicDbName}-user-xx-yy-meta`
+      ]);
     return replications.execute().then(() => {
       assert.equal(replicateDbs.callCount, 1);
-      assert.deepEqual(replicateDbs.args[0][0], [`${db.medicDbName}-user-x-meta`, `${db.medicDbName}-user-y-meta`]);
+      assert.deepEqual(replicateDbs.args[0][0], [
+        `${db.medicDbName}-user-x-meta`,
+        `${db.medicDbName}-user-y-meta`,
+        `${db.medicDbName}-user-xx-yy-meta`
+      ]);
       assert.equal(replicateDbs.args[0][1], `${db.medicDbName}-users-meta`);
     });
   });


### PR DESCRIPTION
# Description

Ticket: https://github.com/medic/cht-core/issues/6591

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
