### PR TITLE
Updates getReportsBySubject to return array without duplicates.

### DIFF
--- a/shared-libs/transitions/src/lib/utils.js
+++ b/shared-libs/transitions/src/lib/utils.js
@@ -186,7 +186,7 @@ module.exports = {
     }
 
     return db.medic.query('medic-client/reports_by_subject', viewOptions).then(result => {
-      const reports = result.rows.map(row => row.doc);
+      const reports = _.uniqBy(result.rows.map(row => row.doc), '_id');
       if (!options.registrations) {
         return reports;
       }

--- a/shared-libs/transitions/test/unit/lib/utils.js
+++ b/shared-libs/transitions/test/unit/lib/utils.js
@@ -181,6 +181,26 @@ describe('utils util', () => {
         ]);
       });
     });
+
+    it('should return unique docs', () => {
+      sinon.stub(config, 'getAll').returns({ config: 'all' });
+      const docs = [
+        { _id: 'a', fields: { patient_id: 'a', patient_uuid: 'uuid' } },
+        { _id: 'b', fields: { patient_id: 'b', patient_uuid: 'uuidb' } },
+        { _id: 'a', fields: { patient_id: 'a', patient_uuid: 'uuid' } },
+        { _id: 'b', fields: { patient_id: 'b', patient_uuid: 'uuidb' } },
+        { _id: 'c', fields: { patient_id: 'c', patient_uuid: 'uuidc' } },
+      ];
+      db.medic.query.resolves({ rows: docs.map(doc => ({ doc })) });
+
+      return utils.getReportsBySubject({ id: 'a'}).then((actual) => {
+        actual.should.deep.equal([
+          { _id: 'a', fields: { patient_id: 'a', patient_uuid: 'uuid' } },
+          { _id: 'b', fields: { patient_id: 'b', patient_uuid: 'uuidb' } },
+          { _id: 'c', fields: { patient_id: 'c', patient_uuid: 'uuidc' } },
+        ]);
+      });
+    });
   });
 
   describe('setTasksStates', () => {

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -1796,6 +1796,7 @@ describe('registration', () => {
       form: 'FORM',
       from: '+444999',
       fields: {
+        patient_uuid: 'person',
         patient_id: 'patient',
       },
       some_date_field: moment().subtract(3, 'week').valueOf(),
@@ -1812,6 +1813,7 @@ describe('registration', () => {
       form: 'FORM',
       from: '+444999',
       fields: {
+        patient_uuid: 'person',
         patient_id: 'patient',
       },
       some_date_field: moment().subtract(2, 'week').valueOf(),


### PR DESCRIPTION
# Description

Because `medic-client/reports_by_subject` emits multiple times per document, ensure we're returning a unique array when attempting to clear schedules.

medic/cht-core#6624

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
