### PR TITLE
6605-fix-e2e-login

### DIFF
--- a/tests/e2e/login/token-login.spec.js
+++ b/tests/e2e/login/token-login.spec.js
@@ -72,6 +72,7 @@ describe('token login', () => {
   it('should redirect the user to the app if already logged in', () => {
     commonElements.goToLoginPage();
     loginPage.login(auth.username, auth.password);
+    browser.waitForAngular();
     browser.driver.get(getUrl('this is a random string'));
     waitForLoaderToDisappear();
     browser.waitForAngular();

--- a/tests/e2e/login/token-login.spec.js
+++ b/tests/e2e/login/token-login.spec.js
@@ -56,12 +56,9 @@ describe('token login', () => {
 
   afterEach(() => utils.deleteUsers([user]).then(() => utils.revertDb([], [])));
 
-  beforeAll(() => {
+  afterAll(() => {
     commonElements.goToLoginPage();
     loginPage.login(auth.username, auth.password);
-  });
-
-  afterAll(() => {
     return utils.revertDb();
   });
 
@@ -74,8 +71,9 @@ describe('token login', () => {
   };
 
   it('should redirect the user to the app if already logged in', () => {
+    commonElements.goToLoginPage();
+    loginPage.login(auth.username, auth.password);
     browser.driver.get(getUrl('this is a random string'));
-    waitForLoaderToDisappear();
     browser.waitForAngular();
     helper.waitUntilReady(element(by.id('message-list')));
   });

--- a/tests/e2e/login/token-login.spec.js
+++ b/tests/e2e/login/token-login.spec.js
@@ -53,11 +53,15 @@ describe('token login', () => {
     };
     browser.manage().deleteAllCookies();
   });
+
   afterEach(() => utils.deleteUsers([user]).then(() => utils.revertDb([], [])));
 
-  afterAll(() => {
+  beforeAll(() => {
     commonElements.goToLoginPage();
     loginPage.login(auth.username, auth.password);
+  });
+
+  afterAll(() => {
     return utils.revertDb();
   });
 
@@ -70,10 +74,7 @@ describe('token login', () => {
   };
 
   it('should redirect the user to the app if already logged in', () => {
-    commonElements.goToLoginPage();
-    loginPage.login(auth.username, auth.password);
     browser.driver.get(getUrl('this is a random string'));
-    browser.waitForAngular();
     waitForLoaderToDisappear();
     browser.waitForAngular();
     helper.waitUntilReady(element(by.id('message-list')));

--- a/tests/e2e/login/token-login.spec.js
+++ b/tests/e2e/login/token-login.spec.js
@@ -72,8 +72,8 @@ describe('token login', () => {
   it('should redirect the user to the app if already logged in', () => {
     commonElements.goToLoginPage();
     loginPage.login(auth.username, auth.password);
-    browser.waitForAngular();
     browser.driver.get(getUrl('this is a random string'));
+    browser.waitForAngular();
     waitForLoaderToDisappear();
     browser.waitForAngular();
     helper.waitUntilReady(element(by.id('message-list')));

--- a/tests/page-objects/reports/reports.po.js
+++ b/tests/page-objects/reports/reports.po.js
@@ -11,6 +11,7 @@ module.exports = {
       10000,
       'There should be at least one report in the LHS'
     );
+    browser.waitForAngular();
     uuids.forEach(uuid => {
       expect(browser.isElementPresent(by.css(`#reports-list li[data-record-id="${uuid}"]`))).toBeTruthy();
     });

--- a/tests/page-objects/reports/reports.po.js
+++ b/tests/page-objects/reports/reports.po.js
@@ -6,14 +6,10 @@ const reportBodyDetails = '#reports-content .report-body .details';
 
 module.exports = {
   expectReportsToExist: uuids => {
-    browser.wait(
-      () => element(by.css('#reports-list li:first-child')).isPresent(),
-      10000,
-      'There should be at least one report in the LHS'
-    );
-    browser.waitForAngular();
     uuids.forEach(uuid => {
-      expect(browser.isElementPresent(by.css(`#reports-list li[data-record-id="${uuid}"]`))).toBeTruthy();
+      browser.wait(() => element(by.css(`#reports-list li[data-record-id="${uuid}"]`)).isPresent(),
+        10000,
+        `Report ${uuid} not found`);
     });
   },
   expectReportsToNotExist: uuids => {


### PR DESCRIPTION
# Description

This PR will increase reliability in e2e tests:
1. Remove loading spinner check on page redirection, since redirection happens first.
2. Check reports IDs when angular/browser is ready.

medic/cht-core#6605

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
