### PR TITLE
Add Grunt tasks to run just unit tests from API or Sentinel

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -799,6 +799,16 @@ module.exports = function(grunt) {
           timeout: 10000,
         },
       },
+      api: {
+        src: [
+          'api/tests/mocha/**/*.js'
+        ],
+      },
+      sentinel: {
+        src: [
+          'sentinel/tests/**/*.js'
+        ],
+      }
     },
     ngtemplates: {
       inboxApp: {
@@ -1046,6 +1056,16 @@ module.exports = function(grunt) {
     'env:unit-test',
     'exec:shared-lib-unit',
     'mochaTest:unit',
+  ]);
+
+  grunt.registerTask('unit-api', 'API unit tests', [
+    'env:unit-test',
+    'mochaTest:api',
+  ]);
+
+  grunt.registerTask('unit-sentinel', 'Sentinel unit tests', [
+    'env:unit-test',
+    'mochaTest:sentinel',
   ]);
 
   // CI tasks


### PR DESCRIPTION
# Description

Ticket: medic/cht-core#6632

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
