### PR TITLE
add test for the version of openrosa-xpath-evaluator

### DIFF
--- a/tests/e2e/concatenate-xpath-strings.spec.js
+++ b/tests/e2e/concatenate-xpath-strings.spec.js
@@ -18,6 +18,8 @@ const userContactDoc = {
   },
 };
 
+// If this test starts failing then we need to document in the release notes that we've removed the deprecated 
+// feature allowing for concatenation of strings
 describe('Concatenate xpath strings', () => {
   beforeAll(done => {
     Promise.resolve()
@@ -47,12 +49,13 @@ describe('Concatenate xpath strings', () => {
       )
     ).click();
     helper.waitElementToPresent(
-      element(by.css('#first-name'))
+      element(by.css('#concat'))
     );
-    element(by.css('#first-name')).sendKeys('Bruce');
-    helper.waitElementToPresent(
-      element(by.css('#full-name'))
-    );
-    expect(element(by.css('#full-name'))).toEqual('Bruce Wayne');
+    let name = element(by.name('/concatenate-strings/inputs/full_name')).getAttribute('value');
+    expect(name).toEqual('John Doe');
+    element(by.name('/concatenate-strings/inputs/first_name')).sendKeys('Bruce');
+    element(by.name('/concatenate-strings/inputs/full_name')).click();
+    name = element(by.name('/concatenate-strings/inputs/full_name')).getAttribute('value');
+    expect(name).toEqual('Bruce Wayne');
   });
 });

--- a/tests/e2e/concatenate-xpath-strings.spec.js
+++ b/tests/e2e/concatenate-xpath-strings.spec.js
@@ -1,0 +1,66 @@
+const helper = require('../helper');
+const photoUpload = require('../page-objects/forms/photo-upload.po');
+const common = require('../page-objects/common/common.po');
+const utils = require('../utils');
+const constants = require('../constants');
+const path = require('path');
+
+const userContactDoc = {
+  _id: constants.USER_CONTACT_ID,
+  name: 'Jack' + 'Sparrow',
+  date_of_birth: '',
+  phone: '+64274444444',
+  alternate_phone: '',
+  notes: '',
+  type: 'person',
+  reported_date: 1478469976421,
+  parent: {
+    _id: 'some_parent',
+  },
+};
+
+describe('Concatenate xpath strings', () => {
+  beforeAll(done => {
+    Promise.resolve()
+      .then(() => photoUpload.configureForm(userContactDoc, done))
+      .catch(done.fail);
+  });
+
+  afterEach(done => {
+    utils.resetBrowser();
+    done();
+  });
+
+  afterAll(utils.afterEach);
+
+  it('concatenates strings', () => {
+    common.goToReports();
+
+    // select form
+    const addButton = element(
+      by.css('.action-container .general-actions:not(.ng-hide) .fa-plus')
+    );
+    helper.waitElementToPresent(addButton);
+    helper.clickElement(addButton);
+    element(
+      by.css(
+        '.action-container .general-actions .dropup.open .dropdown-menu li:first-child a'
+      )
+    ).click();
+    helper.waitElementToPresent(
+      element(by.css('#photo-upload input[type=file]'))
+    );
+    element(by.css('#photo-upload input[type=file]')).sendKeys(
+      path.join(__dirname, '../../../webapp/src/img/simprints.png')
+    );
+    helper.waitElementToPresent(
+      element(by.css('#photo-upload .file-picker .file-preview img'))
+    );
+    //submit
+    photoUpload.submit();
+    helper.waitElementToPresent(element(by.css('div.details')));
+    expect(element(by.css('div.details')).isPresent()).toBeTruthy();
+    helper.waitElementToPresent(element(by.css('.report-image')));
+    expect(element(by.css('.report-image')).isPresent()).toBeTruthy();
+  });
+});

--- a/tests/e2e/concatenate-xpath-strings.spec.js
+++ b/tests/e2e/concatenate-xpath-strings.spec.js
@@ -1,13 +1,12 @@
 const helper = require('../helper');
-const photoUpload = require('../page-objects/forms/photo-upload.po');
+const concatenateStrings = require('../page-objects/forms/concatenate-strings.po');
 const common = require('../page-objects/common/common.po');
 const utils = require('../utils');
 const constants = require('../constants');
-const path = require('path');
 
 const userContactDoc = {
   _id: constants.USER_CONTACT_ID,
-  name: 'Jack' + 'Sparrow',
+  name: 'Jack',
   date_of_birth: '',
   phone: '+64274444444',
   alternate_phone: '',
@@ -22,7 +21,7 @@ const userContactDoc = {
 describe('Concatenate xpath strings', () => {
   beforeAll(done => {
     Promise.resolve()
-      .then(() => photoUpload.configureForm(userContactDoc, done))
+      .then(() => concatenateStrings.configureForm(userContactDoc, done))
       .catch(done.fail);
   });
 
@@ -48,19 +47,12 @@ describe('Concatenate xpath strings', () => {
       )
     ).click();
     helper.waitElementToPresent(
-      element(by.css('#photo-upload input[type=file]'))
+      element(by.css('#concat #first-name'))
     );
-    element(by.css('#photo-upload input[type=file]')).sendKeys(
-      path.join(__dirname, '../../../webapp/src/img/simprints.png')
-    );
+    element(by.css('#concat #first-name')).sendKeys('Bruce');
     helper.waitElementToPresent(
-      element(by.css('#photo-upload .file-picker .file-preview img'))
+      element(by.css('#concat #full-name'))
     );
-    //submit
-    photoUpload.submit();
-    helper.waitElementToPresent(element(by.css('div.details')));
-    expect(element(by.css('div.details')).isPresent()).toBeTruthy();
-    helper.waitElementToPresent(element(by.css('.report-image')));
-    expect(element(by.css('.report-image')).isPresent()).toBeTruthy();
+    expect(element(by.css('#concat #full-name'))).toEqual('Bruce Wayne');
   });
 });

--- a/tests/e2e/concatenate-xpath-strings.spec.js
+++ b/tests/e2e/concatenate-xpath-strings.spec.js
@@ -47,12 +47,12 @@ describe('Concatenate xpath strings', () => {
       )
     ).click();
     helper.waitElementToPresent(
-      element(by.css('#concat #first-name'))
+      element(by.css('#first-name'))
     );
-    element(by.css('#concat #first-name')).sendKeys('Bruce');
+    element(by.css('#first-name')).sendKeys('Bruce');
     helper.waitElementToPresent(
-      element(by.css('#concat #full-name'))
+      element(by.css('#full-name'))
     );
-    expect(element(by.css('#concat #full-name'))).toEqual('Bruce Wayne');
+    expect(element(by.css('#full-name'))).toEqual('Bruce Wayne');
   });
 });

--- a/tests/page-objects/forms/concatenate-strings.po.js
+++ b/tests/page-objects/forms/concatenate-strings.po.js
@@ -1,0 +1,65 @@
+const utils = require('../../utils');
+const helper = require('../../helper');
+
+const xml = `<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+	<h:head>
+		<h:title>photo-upload</h:title>
+
+		<model>
+			<instance>
+        <concatenate-strings id="concat">
+          <inputs>
+            <first_name id="first-name"/>
+            <full_name id="full-name"/>
+          </inputs>
+        </concatenate-strings>
+			</instance>
+
+      <bind nodeset="/concatenate-strings/first_name" type="string"/>
+      <bind calculate="if( /concatenate-strings/first_name  = 'Bruce', 'Bruce ' + 'Wayne', 'John' + 'Doe')"
+        nodeset="/concatenate-strings/full_name" type="string"/>
+		</model>
+	</h:head>
+
+	<h:body>
+    <input ref="concatenate-strings/first_name">
+      <label>First Name</label>
+    </input>
+    <input appearance="hidden" ref="/concatenate-strings/full_name">
+      <label>Full Name</label>
+    </input>
+	</h:body>
+</h:html>
+`;
+
+const docs = [
+  {
+    _id: 'form:concatenate-strings',
+    internalId: 'concatenate-strings',
+    title: 'Concatenate Strings',
+    type: 'form',
+    _attachments: {
+      xml: {
+        content_type: 'application/octet-stream',
+        data: Buffer.from(xml).toString('base64')
+      }
+    }
+  }];
+
+module.exports = {
+  configureForm: (userContactDoc, done) => {
+    utils.seedTestData(done, userContactDoc, docs);
+  },
+
+  submit: () => {
+    const submitButton = element(by.css('[ng-click="onSubmit()"]'));
+    helper.waitElementToBeClickable(submitButton);
+    submitButton.click();
+    helper.waitElementToBeVisible(element(by.css('div#reports-content')));
+  },
+
+  reset: () => {
+    element(by.css('.icon.icon-refresh')).click();
+  }
+};

--- a/tests/page-objects/forms/concatenate-strings.po.js
+++ b/tests/page-objects/forms/concatenate-strings.po.js
@@ -7,26 +7,29 @@ const xml = `<?xml version="1.0"?>
 		<h:title>photo-upload</h:title>
 
 		<model>
-			<instance>
-        <concatenate-strings id="concat">
-          <inputs>
-            <first_name id="first-name"/>
-            <full_name id="full-name"/>
-          </inputs>
-        </concatenate-strings>
-			</instance>
+    <instance>
+    <concatenate-strings id="concat">
+      <inputs>
+        <first_name/>
+        <full_name/>
+      </inputs>
+      <meta>
+        <instanceID/>
+      </meta>
+    </concatenate-strings>
+  </instance>
 
-      <bind nodeset="/concatenate-strings/first_name" type="string"/>
-      <bind calculate="if( /concatenate-strings/first_name  = 'Bruce', 'Bruce ' + 'Wayne', 'John' + 'Doe')"
-        nodeset="/concatenate-strings/full_name" type="string"/>
+  <bind nodeset="/concatenate-strings/inputs/first_name" type="string"/>
+  <bind calculate="if( /concatenate-strings/inputs/first_name  = 'Bruce', 'Bruce ' + 'Wayne', 'John ' + 'Doe')"
+    nodeset="/concatenate-strings/inputs/full_name" type="string"/>
 		</model>
 	</h:head>
 
 	<h:body>
-    <input ref="concatenate-strings/first_name">
+    <input ref="/concatenate-strings/inputs/first_name">
       <label>First Name</label>
     </input>
-    <input appearance="hidden" ref="/concatenate-strings/full_name">
+    <input ref="/concatenate-strings/inputs/full_name">
       <label>Full Name</label>
     </input>
 	</h:body>

--- a/webapp/tests/mocha/unit/packages.spec.js
+++ b/webapp/tests/mocha/unit/packages.spec.js
@@ -1,0 +1,9 @@
+const package = require('../../../package.json');
+const { expect } = require('chai');
+
+describe.only('test openrosa-xpath-evaluator version', () => {
+  console.log('running only this test');
+  it('matches ^1.5.1', () => {
+    expect(package.dependencies['openrosa-xpath-evaluator']).to.equal('^1.5.1');
+  });
+});

--- a/webapp/tests/mocha/unit/packages.spec.js
+++ b/webapp/tests/mocha/unit/packages.spec.js
@@ -1,9 +1,0 @@
-const package = require('../../../package.json');
-const { expect } = require('chai');
-
-describe.only('test openrosa-xpath-evaluator version', () => {
-  console.log('running only this test');
-  it('matches ^1.5.1', () => {
-    expect(package.dependencies['openrosa-xpath-evaluator']).to.equal('^1.5.1');
-  });
-});


### PR DESCRIPTION
# Description

Add a test which runs against the version of `openrosa-xpath-evaluator`

medic/cht-core#6490

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
