### PR TITLE
4750 update selectors

### DIFF
--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -90,10 +90,10 @@ export class AppComponent {
     private translateFromService:TranslateFromService,
   ) {
     combineLatest(
-      store.pipe(select(Selectors.getReplicationStatus)),
-      store.pipe(select(Selectors.getAndroidAppVersion)),
-      store.pipe(select(Selectors.getCurrentTab)),
-      store.pipe(select(Selectors.getMinimalTabs)),
+      store.select(Selectors.getReplicationStatus),
+      store.select(Selectors.getAndroidAppVersion),
+      store.select(Selectors.getCurrentTab),
+      store.select(Selectors.getMinimalTabs),
     )
       .subscribe(([
         replicationStatus,

--- a/webapp/src/ts/components/filters/facility-filter/facility-filter.component.ts
+++ b/webapp/src/ts/components/filters/facility-filter/facility-filter.component.ts
@@ -39,7 +39,7 @@ export class FacilityFilterComponent implements OnDestroy, OnInit, AbstractFilte
 
   ngOnInit() {
     const subscription = combineLatest(
-      this.store.pipe(select(Selectors.getIsAdmin)),
+      this.store.select(Selectors.getIsAdmin),
     ).subscribe(([
       isAdmin,
     ]) => {

--- a/webapp/src/ts/components/filters/form-type-filter/form-type-filter.component.ts
+++ b/webapp/src/ts/components/filters/form-type-filter/form-type-filter.component.ts
@@ -32,7 +32,7 @@ export class FormTypeFilterComponent implements OnDestroy, OnInit, AbstractFilte
 
   ngOnInit() {
     const subscription = combineLatest(
-      this.store.pipe(select(Selectors.getForms)),
+      this.store.select(Selectors.getForms),
     ).subscribe(([
       forms,
     ]) => {

--- a/webapp/src/ts/components/filters/freetext-filter/freetext-filter.component.ts
+++ b/webapp/src/ts/components/filters/freetext-filter/freetext-filter.component.ts
@@ -42,7 +42,7 @@ export class FreetextFilterComponent implements OnDestroy, OnInit, AbstractFilte
 
   ngOnInit() {
     const subscription = combineLatest(
-      this.store.pipe(select(Selectors.getCurrentTab)),
+      this.store.select(Selectors.getCurrentTab),
     ).subscribe(([
       currentTab,
     ]) => {

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -1,24 +1,27 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { Store, select } from '@ngrx/store';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest, Subscription } from 'rxjs';
 
-import { Selectors } from '../../selectors';
-import {SettingsService} from '../../services/settings.service';
-import {HeaderTabsService} from '../../services/header-tabs.service';
-import {AuthService} from '../../services/auth.service';
-import {GlobalActions} from "../../actions/global";
-import {ModalService} from "../../modals/mm-modal/mm-modal";
-import {LogoutConfirmComponent} from "../../modals/logout/logout-confirm.component";
-import { FeedbackComponent } from '../../modals/feedback/feedback.component';
-import { combineLatest } from 'rxjs';
-import { DBSyncService } from '../../services/db-sync.service';
-import { GuidedSetupComponent } from '../../modals/guided-setup/guided-setup.component';
+import { Selectors } from '@mm-selectors/index';
+import { SettingsService } from '@mm-services/settings.service';
+import { HeaderTabsService } from '@mm-services/header-tabs.service';
+import { AuthService } from '@mm-services/auth.service';
+import { GlobalActions } from '@mm-actions/global';
+import { ModalService } from '@mm-modals/mm-modal/mm-modal';
+import { LogoutConfirmComponent } from '@mm-modals/logout/logout-confirm.component';
+import { FeedbackComponent } from '@mm-modals/feedback/feedback.component';
+
+import { DBSyncService } from '@mm-services/db-sync.service';
+import { GuidedSetupComponent } from '@mm-modals/guided-setup/guided-setup.component';
 
 
 @Component({
   selector: 'mm-header',
   templateUrl: './header.component.html'
 })
-export class HeaderComponent implements OnInit {
+export class HeaderComponent implements OnInit, OnDestroy {
+  private subscription: Subscription = new Subscription();
+
   @Input() adminUrl;
   @Input() canLogOut;
   @Input() tours;
@@ -39,9 +42,13 @@ export class HeaderComponent implements OnInit {
     private modalService: ModalService,
     private dbSyncService: DBSyncService,
   ) {
-    combineLatest(
-      store.select(Selectors.getReplicationStatus),
-      store.select(Selectors.getCurrentTab),
+    this.globalActions = new GlobalActions(store);
+  }
+
+  ngOnInit(): void {
+    const subscription = combineLatest(
+      this.store.select(Selectors.getReplicationStatus),
+      this.store.select(Selectors.getCurrentTab),
     ).subscribe(([
       replicationStatus,
       currentTab
@@ -49,11 +56,8 @@ export class HeaderComponent implements OnInit {
       this.replicationStatus = replicationStatus;
       this.currentTab = currentTab;
     });
+    this.subscription.add(subscription);
 
-    this.globalActions = new GlobalActions(store);
-  }
-
-  ngOnInit(): void {
     this.settingsService.get().then(settings => {
       const tabs = this.headerTabsService.get(settings);
       return Promise.all(tabs.map(tab => this.authService.has(tab.permissions))).then(results => {
@@ -61,6 +65,10 @@ export class HeaderComponent implements OnInit {
         this.globalActions.setMinimalTabs(this.permittedTabs.length > 3);
       });
     });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
   }
 
   openGuidedSetup() {

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -40,8 +40,8 @@ export class HeaderComponent implements OnInit {
     private dbSyncService: DBSyncService,
   ) {
     combineLatest(
-      store.pipe(select(Selectors.getReplicationStatus)),
-      store.pipe(select(Selectors.getCurrentTab)),
+      store.select(Selectors.getReplicationStatus),
+      store.select(Selectors.getCurrentTab),
     ).subscribe(([
       replicationStatus,
       currentTab

--- a/webapp/src/ts/components/snackbar/snackbar.component.ts
+++ b/webapp/src/ts/components/snackbar/snackbar.component.ts
@@ -27,19 +27,20 @@ export class SnackbarComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.store.select(Selectors.getSnackbarContent).subscribe(content => {
+    const reduxSubscription = this.store.select(Selectors.getSnackbarContent).subscribe(content => {
       if (!content) {
         return;
       }
 
       if (this.timer) {
         this.hide();
-        setTimeout(() => this.show(content), this.ANIMATION_DURATION)
+        setTimeout(() => this.show(content), this.ANIMATION_DURATION);
         return;
       }
 
       this.show(content);
     });
+    this.subscription.add(reduxSubscription);
     this.hide();
   }
 

--- a/webapp/src/ts/components/snackbar/snackbar.component.ts
+++ b/webapp/src/ts/components/snackbar/snackbar.component.ts
@@ -1,13 +1,18 @@
 import { Component, OnInit } from '@angular/core';
-import { select, Store } from '@ngrx/store';
-import { Selectors } from '../../selectors';
-import { GlobalActions } from '../../actions/global';
+import { Store } from '@ngrx/store';
+import { Subscription } from 'rxjs';
+
+import { Selectors } from '@mm-selectors/index'
+import { GlobalActions } from '@mm-actions/global';
+
 
 @Component({
   selector: 'snackbar',
   templateUrl: './snackbar.component.html'
 })
 export class SnackbarComponent implements OnInit {
+  private subscription: Subscription = new Subscription();
+
   private readonly SHOW_DURATION = 5000;
   private readonly ANIMATION_DURATION = 250;
 
@@ -19,7 +24,10 @@ export class SnackbarComponent implements OnInit {
 
   constructor(private store: Store) {
     this.globalActions = new GlobalActions(store);
-    store.pipe(select(Selectors.getSnackbarContent)).subscribe(content => {
+  }
+
+  ngOnInit() {
+    this.store.select(Selectors.getSnackbarContent).subscribe(content => {
       if (!content) {
         return;
       }
@@ -32,9 +40,6 @@ export class SnackbarComponent implements OnInit {
 
       this.show(content);
     });
-  }
-
-  ngOnInit() {
     this.hide();
   }
 

--- a/webapp/src/ts/modals/guided-setup/guided-setup.component.ts
+++ b/webapp/src/ts/modals/guided-setup/guided-setup.component.ts
@@ -1,10 +1,8 @@
 import { Component, AfterViewInit, AfterViewChecked } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
-import { Store } from '@ngrx/store';
 import { validate as validatePhoneNumber, normalize as normalizePhoneNumber } from '@medic/phone-number';
 
 import { MmModalAbstract } from '../mm-modal/mm-modal';
-import { GlobalActions } from '../../actions/global';
 import { UpdateSettingsService } from '../../services/update-settings.service';
 import { LanguagesService } from '../../services/languages.service';
 import { SettingsService } from '../../services/settings.service';
@@ -15,7 +13,6 @@ import { COUNTRY_LIST } from '../../providers/countries.provider';
   templateUrl: './guided-setup.component.html'
 })
 export class GuidedSetupComponent extends MmModalAbstract implements AfterViewInit, AfterViewChecked {
-  private globalactions;
   model:{ countryCode?, gatewayNumber? } = {};
   error:{ message? } = {};
   enabledLocales;
@@ -25,13 +22,11 @@ export class GuidedSetupComponent extends MmModalAbstract implements AfterViewIn
 
   constructor(
     public bsModalRef: BsModalRef,
-    private store: Store,
     private updateSettingsService: UpdateSettingsService,
-    private langugesService: LanguagesService,
+    private languagesService: LanguagesService,
     private settingsService: SettingsService,
   ) {
     super();
-    this.globalactions = new GlobalActions(store);
   }
 
   private updateNumbers() {
@@ -70,7 +65,7 @@ export class GuidedSetupComponent extends MmModalAbstract implements AfterViewIn
 
   ngAfterViewInit() {
     this.bsModalRef.setClass('modal-lg');
-    this.langugesService.get().then(languages => {
+    this.languagesService.get().then(languages => {
       this.enabledLocales = languages;
       this.countryList = COUNTRY_LIST;
       $('#guided-setup').on('click', '.horizontal-options a', this.selectOption);
@@ -99,8 +94,6 @@ export class GuidedSetupComponent extends MmModalAbstract implements AfterViewIn
     }
   }
 
-
-
   private validatePhoneNumber() {
     const countryCode = this.model.countryCode;
     const gatewayNumber = this.model.gatewayNumber;
@@ -128,12 +121,12 @@ export class GuidedSetupComponent extends MmModalAbstract implements AfterViewIn
 
     val = $('#guided-setup [name=gateway-number]').val();
     if (val) {
-      // normalise value        
-      const info = { 
+      // normalise value
+      const info = {
         default_country_code: this.model.countryCode,
         phone_validation: 'none'
       };
-      
+
       settings.gateway_number = normalizePhoneNumber(info, val);
     }
     val = $('#guided-setup [name=default-country-code]').val();

--- a/webapp/src/ts/modules/about/about.component.ts
+++ b/webapp/src/ts/modules/about/about.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Store,  } from '@ngrx/store';
+import { Store } from '@ngrx/store';
 import { combineLatest, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 

--- a/webapp/src/ts/modules/about/about.component.ts
+++ b/webapp/src/ts/modules/about/about.component.ts
@@ -1,17 +1,19 @@
-import {Component, OnDestroy, OnInit} from '@angular/core';
-import { Store, select } from '@ngrx/store';
-import {combineLatest} from 'rxjs';
-import {TranslateService} from '@ngx-translate/core';
-import {DbService} from '../../services/db.service';
-import {ResourceIconsService} from '../../services/resource-icons.service';
-import {Selectors} from "../../selectors";
-import {SessionService} from "../../services/session.service";
-import {VersionService} from "../../services/version.service";
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Store,  } from '@ngrx/store';
+import { combineLatest, Subscription } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+
+import { DbService } from '@mm-services/db.service';
+import { ResourceIconsService } from '@mm-services/resource-icons.service';
+import { Selectors } from '@mm-selectors/index';
+import { SessionService } from "@mm-services/session.service";
+import { VersionService } from '@mm-services/version.service';
 
 @Component({
   templateUrl: './about.component.html'
 })
 export class AboutComponent implements OnInit, OnDestroy {
+  private subscription: Subscription = new Subscription();
   private dataUsageUpdate;
 
   userCtx;
@@ -33,16 +35,18 @@ export class AboutComponent implements OnInit, OnDestroy {
     private versionService: VersionService,
     private translateService: TranslateService,
   ) {
-    combineLatest(
-      this.store.pipe(select(Selectors.getReplicationStatus)),
-      this.store.pipe(select(Selectors.getAndroidAppVersion)),
+  }
+
+  ngOnInit() {
+    const reduxSubscription = combineLatest(
+      this.store.select(Selectors.getReplicationStatus),
+      this.store.select(Selectors.getAndroidAppVersion),
     ).subscribe(([ replicationStatus, androidAppVersion ]) => {
       this.replicationStatus = replicationStatus;
       this.androidAppVersion = androidAppVersion;
     });
-  }
+    this.subscription.add(reduxSubscription);
 
-  ngOnInit() {
     this.userCtx = this.sessionService.userCtx();
     this.resourceIconsService.getDocResources('partners').then(partners => {
       this.partners = partners;
@@ -83,6 +87,7 @@ export class AboutComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     clearInterval(this.dataUsageUpdate);
+    this.subscription.unsubscribe();
   }
 
   private updateAndroidDataUsage() {

--- a/webapp/src/ts/modules/messages/messages.component.ts
+++ b/webapp/src/ts/modules/messages/messages.component.ts
@@ -28,11 +28,16 @@ export class MessagesComponent implements OnInit, OnDestroy {
     private changesService: ChangesService,
     private messageContactService: MessageContactService
   ) {
+    this.globalActions = new GlobalActions(store);
+    this.messagesActions = new MessagesActions(store);
+  }
+
+  ngOnInit(): void {
     const subscription = combineLatest(
-      this.store.pipe(select(Selectors.getConversations)),
-      this.store.pipe(select(Selectors.getSelectedConversation)),
-      this.store.pipe(select(Selectors.getLoadingContent)),
-      this.store.pipe(select(Selectors.getMessagesError)),
+      this.store.select(Selectors.getConversations),
+      this.store.select(Selectors.getSelectedConversation),
+      this.store.select(Selectors.getLoadingContent),
+      this.store.select(Selectors.getMessagesError),
     ).subscribe(([
       conversations,
       selectedConversation,
@@ -46,11 +51,6 @@ export class MessagesComponent implements OnInit, OnDestroy {
     });
     this.subscriptions.add(subscription);
 
-    this.globalActions = new GlobalActions(store);
-    this.messagesActions = new MessagesActions(store);
-  }
-
-  ngOnInit(): void {
     this.updateConversations();
     this.watchForChanges();
   }

--- a/webapp/src/ts/modules/reports/reports-content.component.ts
+++ b/webapp/src/ts/modules/reports/reports-content.component.ts
@@ -27,10 +27,15 @@ export class ReportsContentComponent implements OnInit {
     private changesService:ChangesService,
     private store:Store,
   ) {
-    const subscription = combineLatest(
-      this.store.pipe(select(Selectors.getSelectedReports)),
-      this.store.pipe(select(Selectors.getForms)),
-      this.store.pipe(select(Selectors.getLoadingContent)),
+    this.globalActions = new GlobalActions(store);
+    this.reportsActions = new ReportsActions(store);
+  }
+
+  ngOnInit() {
+    const reduxSubscription = combineLatest(
+      this.store.select(Selectors.getSelectedReports),
+      this.store.select(Selectors.getForms),
+      this.store.select(Selectors.getLoadingContent),
     ).subscribe(([
       selectedReports,
       forms,
@@ -40,14 +45,9 @@ export class ReportsContentComponent implements OnInit {
       this.loadingContent = loadingContent;
       this.forms = forms;
     });
-    this.subscription.add(subscription);
+    this.subscription.add(reduxSubscription);
 
-    this.globalActions = new GlobalActions(store);
-    this.reportsActions = new ReportsActions(store);
-  }
-
-  ngOnInit() {
-    const subscription = this.changesService.subscribe({
+    const changesSubscription = this.changesService.subscribe({
       key: 'reports-content',
       filter: (change) => {
         return this.selectedReports &&
@@ -80,7 +80,7 @@ export class ReportsContentComponent implements OnInit {
         }
       }
     });
-    this.subscription.add(subscription);
+    this.subscription.add(changesSubscription);
   }
 
   trackByFn(index, item) {

--- a/webapp/src/ts/modules/reports/reports-content.component.ts
+++ b/webapp/src/ts/modules/reports/reports-content.component.ts
@@ -1,11 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { ChangesService } from '../../services/changes.service';
-import { combineLatest, Subscription } from 'rxjs';
-import {Selectors} from '../../selectors';
-import {GlobalActions} from '../../actions/global';
-import {ReportsActions} from '../../actions/reports';
-import { select, Store } from '@ngrx/store';
 import * as _ from 'lodash-es';
+import { Store } from '@ngrx/store';
+import { combineLatest, Subscription } from 'rxjs';
+
+import { Selectors } from '@mm-selectors/index';
+import { GlobalActions } from '@mm-actions/global';
+import { ReportsActions } from '@mm-actions/reports';
+import { ChangesService } from '@mm-services/changes.service';
+
 
 @Component({
   templateUrl: './reports-content.component.html'

--- a/webapp/src/ts/modules/reports/reports.component.html
+++ b/webapp/src/ts/modules/reports/reports.component.html
@@ -1,6 +1,6 @@
 <div class="filters">
   <div class="inner">
-    <reports-filters (search)="search()" [disabled]="selectMode && selectedReports.length"></reports-filters>
+    <reports-filters (search)="search()" [disabled]="selectMode && selectedReports?.length"></reports-filters>
     <!--<mm-navigation></mm-navigation>-->
   </div>
 </div>
@@ -10,8 +10,8 @@
 
     <div id="reports-list" class="col-sm-4 inbox-items left-pane">
       <div class="selection-count" *ngIf="selectMode">
-        <span *ngIf="selectedReports.length === 1" translate>select.mode.count.singular</span>
-        <span *ngIf="selectedReports.length !== 1" translate [translateParams]="{ number: selectedReports.length || 0 }">select.mode.count.plural</span>
+        <span *ngIf="selectedReports?.length === 1" translate>select.mode.count.singular</span>
+        <span *ngIf="selectedReports?.length !== 1" translate [translateParams]="{ number: selectedReports?.length || 0 }">select.mode.count.plural</span>
       </div>
       <ul [hidden]="loading && !appending">
         <mm-content-row

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -52,14 +52,19 @@ export class ReportsComponent implements OnInit, OnDestroy {
     private searchService:SearchService,
     private translateService:TranslateService,
   ) {
-    const subscription = combineLatest(
-      this.store.pipe(select(Selectors.getReportsList)),
+    this.globalActions = new GlobalActions(store);
+    this.reportsActions = new ReportsActions(store);
+    this.servicesActions = new ServicesActions(store);
+  }
 
-      this.store.pipe(select(Selectors.getSelectedReports)),
-      this.store.pipe(select(Selectors.listContains)),
-      this.store.pipe(select(Selectors.getForms)),
-      this.store.pipe(select(Selectors.getFilters)),
-      this.store.pipe(select(Selectors.getShowContent))
+  ngOnInit() {
+    const reduxSubscription = combineLatest(
+      this.store.select(Selectors.getReportsList),
+      this.store.select(Selectors.getSelectedReports),
+      this.store.select(Selectors.listContains),
+      this.store.select(Selectors.getForms),
+      this.store.select(Selectors.getFilters),
+      this.store.select(Selectors.getShowContent)
     ).subscribe(([
       reportsList,
       selectedReports,
@@ -75,15 +80,9 @@ export class ReportsComponent implements OnInit, OnDestroy {
       this.filters = filters;
       this.showContent = showContent;
     });
-    this.subscription.add(subscription);
+    this.subscription.add(reduxSubscription);
 
-    this.globalActions = new GlobalActions(store);
-    this.reportsActions = new ReportsActions(store);
-    this.servicesActions = new ServicesActions(store);
-  }
-
-  ngOnInit() {
-    const subscription = this.changesService.subscribe({
+    const dbSubscription = this.changesService.subscribe({
       key: 'reports-list',
       callback: (change) => {
         if (change.deleted) {
@@ -98,7 +97,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
         return change.doc && change.doc.form || this.listContains(change.id);
       },
     });
-    this.subscription.add(subscription);
+    this.subscription.add(dbSubscription);
     this.reportsActions.setSelectedReports([]);
     this.appending = false;
     this.error = false;
@@ -152,7 +151,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
       this.error = false;
       this.errorSyntax = false;
       this.loading = true;
-      if (this.selectedReports.length && isMobile()) {
+      if (this.selectedReports?.length && isMobile()) {
         // ctrl.unsetSelected(); todo
       }
 

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -1,3 +1,5 @@
+import { createSelector } from '@ngrx/store';
+
 const getGlobalState = (state) => state.global || {};
 const getServicesState = (state) => state.services || {};
 const getReportsState = (state) => state.reports || {};
@@ -5,31 +7,33 @@ const getMessagesState = (state) => state.messages || {};
 
 export const Selectors = {
   // global
-  getReplicationStatus: (state) => getGlobalState(state).replicationStatus,
-  getAndroidAppVersion: (state) => getGlobalState(state).androidAppVersion,
-  getCurrentTab: (state) => getGlobalState(state).currentTab,
-  getSnackbarContent: (state) => getGlobalState(state).snackbarContent,
-  getLoadingContent: state => getGlobalState(state).loadingContent,
-  getMinimalTabs: state => getGlobalState(state).minimalTabs,
-  getShowContent: state => getGlobalState(state).showContent,
-  getSelectMode: state => getGlobalState(state).selectMode,
-  getShowActionBar: state => getGlobalState(state).showActionBar,
-  getForms: state => getGlobalState(state).forms,
-  getFilters: state => getGlobalState(state).filters,
-  getIsAdmin: state => getGlobalState(state).isAdmin,
+  getReplicationStatus: createSelector(getGlobalState, (globalState) => globalState.replicationStatus),
+  getAndroidAppVersion:  createSelector(getGlobalState, (globalState) => globalState.androidAppVersion),
+  getCurrentTab: createSelector(getGlobalState, (globalState) => globalState.currentTab),
+  getSnackbarContent: createSelector(getGlobalState, (globalState) => globalState.snackbarContent),
+  getLoadingContent: createSelector(getGlobalState, (globalState) => globalState.loadingContent),
+  getMinimalTabs: createSelector(getGlobalState, (globalState) => globalState.minimalTabs),
+  getShowContent: createSelector(getGlobalState, (globalState) => globalState.showContent),
+  getSelectMode: createSelector(getGlobalState, (globalState) => globalState.selectMode),
+  getShowActionBar: createSelector(getGlobalState, (globalState) => globalState.showActionBar),
+  getForms: createSelector(getGlobalState, (globalState) => globalState.forms),
+  getFilters: createSelector(getGlobalState, (globalState) => globalState.filters),
+  getIsAdmin: createSelector(getGlobalState, (globalState) => globalState.isAdmin),
 
   // services
-  getLastChangedDoc: (state) => getServicesState(state).lastChangedDoc,
+  getLastChangedDoc: createSelector(getServicesState, (servicesState) => servicesState.lastChangedDoc),
 
   // reports
-  getReportsList: (state) => getReportsState(state).reports,
-  listContains: (state) => (id) => getReportsState(state).reportsById.has(id),
-  getSelectedReports: (state) => getReportsState(state).selected,
+  getReportsList: createSelector(getReportsState, (reportsState) => reportsState.reports),
+  listContains: createSelector(getReportsState, (reportsState, props) => {
+    return reportsState.reportsById.has(props.id);
+  }),
+  getSelectedReports: createSelector(getReportsState, (reportsState) => reportsState.selected),
 
   // messages
-  getMessagesError: state => getMessagesState(state).error,
-  getSelectedConversation: state => getMessagesState(state).selected,
-  getConversations: state => getMessagesState(state).conversations,
+  getMessagesError: createSelector(getMessagesState, (messagesState) => messagesState.error),
+  getSelectedConversation: createSelector(getMessagesState, (messagesState) => messagesState.selected),
+  getConversations: createSelector(getMessagesState, (messagesState) => messagesState.conversations),
 };
 /*
 

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -25,8 +25,8 @@ export const Selectors = {
 
   // reports
   getReportsList: createSelector(getReportsState, (reportsState) => reportsState.reports),
-  listContains: createSelector(getReportsState, (reportsState, props) => {
-    return reportsState.reportsById.has(props.id);
+  listContains: createSelector(getReportsState, (reportsState) => {
+    return (id) => reportsState.reportsById.has(id);
   }),
   getSelectedReports: createSelector(getReportsState, (reportsState) => reportsState.selected),
 

--- a/webapp/src/ts/services/changes.service.ts
+++ b/webapp/src/ts/services/changes.service.ts
@@ -53,7 +53,7 @@ export class ChangesService {
     private session: SessionService,
     private store: Store
   ) {
-    this.store.pipe(select(Selectors.getLastChangedDoc)).subscribe(obj => this.lastChangedDoc = obj);
+    this.store.select(Selectors.getLastChangedDoc).subscribe(obj => this.lastChangedDoc = obj);
     this.servicesActions = new ServicesActions(store);
 
     this.init();

--- a/webapp/tests/karma/ts/modules/messages/messages.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/messages/messages.component.spec.ts
@@ -34,22 +34,24 @@ describe('Messages Component', () => {
       { selector: 'getMessagesError', value: false },
     ];
 
-    TestBed.configureTestingModule({
-      imports: [
-        TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
-        RouterTestingModule
-      ],
-      declarations: [
-        MessagesComponent,
-        RelativeDatePipe
-      ],
-      providers: [
-        provideMockStore({ selectors: mockedSelectors }),
-        { provide: ChangesService, useValue: changesServiceMock },
-        { provide: MessageContactService, useValue: messageContactServiceMock },
-        { provide: SettingsService, useValue: {} } // Needed because of ngx-translate provider's constructor.
-      ]
-    }).compileComponents()
+    TestBed
+      .configureTestingModule({
+        imports: [
+          TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
+          RouterTestingModule
+        ],
+        declarations: [
+          MessagesComponent,
+          RelativeDatePipe
+        ],
+        providers: [
+          provideMockStore({ selectors: mockedSelectors }),
+          { provide: ChangesService, useValue: changesServiceMock },
+          { provide: MessageContactService, useValue: messageContactServiceMock },
+          { provide: SettingsService, useValue: {} } // Needed because of ngx-translate provider's constructor.
+        ]
+      })
+      .compileComponents()
       .then(() => {
         fixture = TestBed.createComponent(MessagesComponent);
         component = fixture.componentInstance;
@@ -77,7 +79,7 @@ describe('Messages Component', () => {
 
     expect(spyUpdateConversations.callCount).to.equal(1);
     expect(changesService.subscribe.callCount).to.equal(1);
-    expect(spySubscriptionsAdd.callCount).to.equal(1);
+    expect(spySubscriptionsAdd.callCount).to.equal(2);
   });
 
   it('listTrackBy() should return unique identifier', () => {


### PR DESCRIPTION
# Description

Updates all selectors to be created with "createSelector". 
Moves all redux subscriptions in components from constructors to ngOnInit. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
