### PR TITLE
update delete non-admin users to work, compatible with http/s #6663

### DIFF
--- a/scripts/remove_non_admin_users.js
+++ b/scripts/remove_non_admin_users.js
@@ -12,7 +12,7 @@ const _ = require('underscore');
 
 let instance_url;
 let httpHandler;
-let instance_url_obj
+let instance_url_obj;
 
 if (process.env.COUCH_URL) {
   instance_url_obj = url.parse(process.env.COUCH_URL);

--- a/scripts/remove_non_admin_users.js
+++ b/scripts/remove_non_admin_users.js
@@ -1,6 +1,12 @@
+/**
+ * This script will delete every user but two: the "admin" user and the "_design/_auth" user.
+ * You have been warned!
+ *
+ * Last updated 7 Oct 2020 against 3.10
+ */
+
 const https = require('https');
 const http = require('http');
-const url = require('url');
 const _ = require('underscore');
 
 let instance_url;
@@ -38,7 +44,7 @@ httpHandler.get(all_users_url, (res) => {
       const user_id = medic_user.id;
 
       if(user_id === 'org.couchdb.user:admin' || user_id === '_design/_auth'){
-        console.log('Skipping admin or _design/_auth');
+        console.log('Skipping', user_id);
       } else {
         const del_url = users_db + '/' + user_id + '?rev=' + rev_value;
         const options = url.parse(del_url);

--- a/scripts/remove_non_admin_users.js
+++ b/scripts/remove_non_admin_users.js
@@ -1,11 +1,20 @@
 const https = require('https');
+const http = require('http');
 const url = require('url');
 const _ = require('underscore');
 
 let instance_url;
+let httpHandler;
+let instance_url_obj
 
 if (process.env.COUCH_URL) {
-  instance_url = url.parse(process.env.COUCH_URL);
+  instance_url_obj = url.parse(process.env.COUCH_URL);
+  instance_url = instance_url_obj.protocol + '//' + instance_url_obj.auth + '@' + instance_url_obj.host;
+  if(instance_url_obj.protocol === 'https'){
+    httpHandler = https;
+  } else {
+    httpHandler = http;
+  }
 } else {
   console.log('Please set COUCH_URL as an enviromental variable. E.g. https://admin:secret@project.medicmobile.org');
 }
@@ -13,7 +22,7 @@ if (process.env.COUCH_URL) {
 const users_db = instance_url + '/_users';
 const all_users_url = users_db + '/_all_docs';
 
-https.get(all_users_url, (res) => {
+httpHandler.get(all_users_url, (res) => {
   let medic_users_res = '';
 
   res.on('data', (d) => {
@@ -29,26 +38,24 @@ https.get(all_users_url, (res) => {
       const user_id = medic_user.id;
 
       if(user_id === 'org.couchdb.user:admin' || user_id === '_design/_auth'){
-        console.log('Skipping...');
+        console.log('Skipping admin or _design/_auth');
       } else {
-        console.log(user_id);
-        console.log('Deleting...');
         const del_url = users_db + '/' + user_id + '?rev=' + rev_value;
         const options = url.parse(del_url);
 
         const del_options = _.extend(options, {method: 'DELETE'});
 
-        const del_req = https.request(del_options, function (resp) {
+        const del_req = httpHandler.request(del_options, function (resp) {
           resp.setEncoding('utf-8');
 
           resp.on('data', function (resp) {
-            console.log(resp);
+            console.log('Response from Deleting', user_id, resp);
           });
         });
 
         del_req.on('error', function (e) {
           if (e) {
-            console.log(e.message);
+            console.log('Error from Deleting', user_id,e.message);
           }
         });
         del_req.end();

--- a/scripts/remove_non_admin_users.js
+++ b/scripts/remove_non_admin_users.js
@@ -7,6 +7,7 @@
 
 const https = require('https');
 const http = require('http');
+const url = require('url');
 const _ = require('underscore');
 
 let instance_url;


### PR DESCRIPTION
# Description

The `remove_non_admin_users.js` script didn't seem to work as it was using an object from `url.parse()` as a string.  Further, it only worked with https, thus was hard to test against local dev instances.  This PR fixes both of these problems.

medic/cht-core#6663

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
