### PR TITLE
4750 - Angular migration of Language* services

### DIFF
--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -5,26 +5,26 @@ import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { setTheme as setBootstrapTheme} from 'ngx-bootstrap/utils';
 import { combineLatest } from 'rxjs';
-
-import { DBSyncService } from './services/db-sync.service'
+import { DBSyncService } from '@mm-services/db-sync.service'
 import { Selectors } from './selectors';
 import { GlobalActions } from './actions/global';
-import { TranslationLoaderService } from './services/translation-loader.service';
-import {SessionService} from './services/session.service';
-import {AuthService} from './services/auth.service';
-import {ResourceIconsService} from './services/resource-icons.service';
-import {ChangesService} from './services/changes.service';
-import {UpdateServiceWorkerService} from './services/update-service-worker.service';
-import {LocationService} from './services/location.service';
+import { TranslationLoaderService } from '@mm-services/translation-loader.service';
+import {SessionService} from '@mm-services/session.service';
+import {AuthService} from '@mm-services/auth.service';
+import {ResourceIconsService} from '@mm-services/resource-icons.service';
+import {ChangesService} from '@mm-services/changes.service';
+import {UpdateServiceWorkerService} from '@mm-services/update-service-worker.service';
+import {LocationService} from '@mm-services/location.service';
 import {ModalService} from './modals/mm-modal/mm-modal';
 import {ReloadingComponent} from './modals/reloading/reloading.component';
-import { FeedbackService } from './services/feedback.service';
+import { FeedbackService } from '@mm-services/feedback.service';
 import { environment } from './environments/environment';
-import { FormatDateService } from './services/format-date.service';
-import { XmlFormsService } from './services/xml-forms.service';
-import { JsonFormsService } from './services/json-forms.service';
-import { TranslateFromService } from './services/translate-from.service';
+import { FormatDateService } from '@mm-services/format-date.service';
+import { XmlFormsService } from '@mm-services/xml-forms.service';
+import { JsonFormsService } from '@mm-services/json-forms.service';
+import { TranslateFromService } from '@mm-services/translate-from.service';
 import { CountMessageService } from '@mm-services/count-message.service';
+import {LanguageService, SetLanguageService} from '@mm-services/language.service';
 
 const SYNC_STATUS = {
   inProgress: {
@@ -76,6 +76,8 @@ export class AppComponent {
     private store: Store,
     private translateService: TranslateService,
     private translationLoaderService: TranslationLoaderService,
+    private languageService: LanguageService,
+    private setLanguageService: SetLanguageService,
     private sessionService: SessionService,
     private authService: AuthService,
     private resourceIconsService: ResourceIconsService,
@@ -95,6 +97,7 @@ export class AppComponent {
     this.globalActions = new GlobalActions(store);
 
     moment.locale(['en']);
+
     this.formatDateService.init();
 
     this.adminUrl = this.locationService.adminPath;
@@ -102,18 +105,22 @@ export class AppComponent {
     setBootstrapTheme('bs3');
   }
 
+  private loadTranslations() {
+    this.translationsLoaded = this.languageService
+      .get()
+      .then((language) => {
+        this.setLanguageService.set(language, false);
+      })
+      .catch(err => {
+        console.error('Error loading language', err);
+      });
+  }
+
   private setupRouter() {
     this.router.events.subscribe((event:RouterEvent) => {
       if (event instanceof ActivationEnd) {
         return this.globalActions.setCurrentTab(event.snapshot.data.tab);
       }
-    });
-  }
-
-  private loadTranslations() {
-    this.translationsLoaded = this.translationLoaderService.getLocale().then(locale => {
-      this.translateService.setDefaultLang(locale);
-      return this.translateService.use(locale).toPromise();
     });
   }
 

--- a/webapp/src/ts/modals/edit-user/edit-user-settings.component.ts
+++ b/webapp/src/ts/modals/edit-user/edit-user-settings.component.ts
@@ -1,9 +1,10 @@
-import {Component, Input} from "@angular/core";
-import {EditUserAbstract} from "./edit-user.component";
-import {BsModalRef} from "ngx-bootstrap/modal";
-import {UserSettingsService} from "@mm-services/user-settings.service";
-import {UpdateUserService} from "@mm-services/update-user.service";
-import {LanguagesService} from "@mm-services/languages.service";
+import {Component, Input} from '@angular/core';
+import {EditUserAbstract} from './edit-user.component';
+import {BsModalRef} from 'ngx-bootstrap/modal';
+import {UserSettingsService} from '@mm-services/user-settings.service';
+import {UpdateUserService} from '@mm-services/update-user.service';
+import {LanguagesService} from '@mm-services/languages.service';
+import {SetLanguageService} from '@mm-services/language.service';
 
 @Component({
   selector: 'update-password',
@@ -30,6 +31,7 @@ export class EditUserSettingsComponent extends EditUserAbstract {
     userSettingsService: UserSettingsService,
     private updateUserService: UpdateUserService,
     private languagesService: LanguagesService,
+    private setLanguageService: SetLanguageService,
   ) {
     super(bsModalRef, userSettingsService);
   }
@@ -55,9 +57,7 @@ export class EditUserSettingsComponent extends EditUserAbstract {
         })
         .then(() => {
           if (updates.language) {
-            // editing current user, so update language
-            // TODO once SetLanguage migrated refactor the commented code below
-            //SetLanguage(updates.language);
+            this.setLanguageService.set(updates.language);
           }
           this.setFinished();
           this.cancel();

--- a/webapp/src/ts/services/language.service.ts
+++ b/webapp/src/ts/services/language.service.ts
@@ -16,6 +16,10 @@ export class SetLanguageCookieService {
   ) {
   }
 
+  /**
+   * Set the language for the current session.
+   * @param value the language code, eg. 'en', 'es' ...
+   */
   set(value) {
     this.cookieService.set(localeCookieKey, value, 365, '/');
     return value;
@@ -33,13 +37,13 @@ export class SetLanguageService {
   }
 
   private setDatepickerLanguage(language) {
-    // TODO
-    /*const availableCalendarLanguages = Object.keys($.fn.datepicker.dates);
-    const calendarLanguage = availableCalendarLanguages.indexOf(language) >= 0 ? language : 'en';
-    $.fn.datepicker.defaults.language = calendarLanguage;*/
-  };
+    //TODO Uncomment the code below once fn.datepicker is migrated to Angular 10
+    //const availableCalendarLanguages = Object.keys((<any>$.fn).datepicker.dates);
+    //const calendarLanguage = availableCalendarLanguages.indexOf(language) >= 0 ? language : 'en';
+    //(<any>$.fn).datepicker.defaults.language = calendarLanguage;
+  }
 
-  set(code, setLanguageCookie) {
+  set(code, setLanguageCookie?) {
     moment.locale([ code, 'en' ]);
     this.setDatepickerLanguage(code);
     this.translateService.use(code);
@@ -90,4 +94,3 @@ export class LanguageService {
       .then(locale => this.setLanguageCookieService.set(locale));
   }
 }
-

--- a/webapp/src/ts/services/languages.service.ts
+++ b/webapp/src/ts/services/languages.service.ts
@@ -10,7 +10,7 @@ export class LanguagesService {
     private dbService:DbService,
   ){}
 
-  get() {
+  get(): Promise<Object> {
     return this.dbService.get()
       .query('medic-client/doc_by_type', { key: [ 'translations', true ] })
       .then((result) => {

--- a/webapp/tests/karma/ts/modals/edit-user/edit-user-settings.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/edit-user/edit-user-settings.component.spec.ts
@@ -10,6 +10,7 @@ import { UpdateUserService } from '@mm-services/update-user.service';
 import { EditUserSettingsComponent } from '@mm-modals/edit-user/edit-user-settings.component';
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { LanguagesService } from '@mm-services/languages.service';
+import {SetLanguageService} from '@mm-services/language.service';
 import { MmModal } from '@mm-modals/mm-modal/mm-modal';
 
 describe('EditUserSettingsComponent', () => {
@@ -18,7 +19,10 @@ describe('EditUserSettingsComponent', () => {
   let fixture: ComponentFixture<EditUserSettingsComponent>;
   let userSettingsService: any = {};
   let updateUserService: any = {};
-  let languagesService: any = {}
+  let languagesService: any = {};
+  let setLanguageService: any = {
+    set(code, setLanguageCookie) { }
+  };
 
   beforeEach(async(() => {
     updateUserService.update = sinon.stub().resolves();
@@ -53,6 +57,7 @@ describe('EditUserSettingsComponent', () => {
         {provide: UpdateUserService, useValue: updateUserService},
         {provide: UserSettingsService, useValue: userSettingsService},
         {provide: LanguagesService, useValue: languagesService},
+        {provide: SetLanguageService, useValue: setLanguageService},
         {provide: BsModalRef, useValue: new BsModalRef()},
       ]
     })

--- a/webapp/tests/karma/ts/modals/edit-user/update-password.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/edit-user/update-password.component.spec.ts
@@ -10,7 +10,6 @@ import { UpdatePasswordComponent } from '@mm-modals/edit-user/update-password.co
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { LanguagesService } from '@mm-services/languages.service';
 import { UpdateUserService } from '@mm-services/update-user.service';
-
 import { MmModal } from '@mm-modals/mm-modal/mm-modal';
 
 describe('UpdatePasswordComponent', () => {


### PR DESCRIPTION
# Description

medic/cht-core#4750

Migration of the services `SetLanguageCookie`, `SetLanguage` and `Language` from [js/services/language.js](https://github.com/medic/cht-core/blob/2c1db1618bdafc5ec14c3a27aa4a37249fcc1b4a/webapp/src/js/services/language.js).

# Notes

- The changes cause that when the user goes to _"User settings" > "Edit user profile"_ and change its language setting the UI changes the current language to the one selected. Also causes that when the user logs in or refresh the page, the user language is used instead of the default one.
- There is a block commented with a TODO [here](https://github.com/medic/cht-core/blob/bdb4ec74fe0a9bac700897f7a538ce94aa7cbdb6/webapp/src/ts/services/language.service.ts#L40-L47) that uses a component `$.datepicker` that looks not migrated yet. Once migrated these lines should be un-commented and revised to ensure they don't need further changes, but I'm not sure what is the purpose of the code and whether is not old code not used anymore.
- Also applied some minor corrections like the usage of `'` for literals instead of `"` and changed the usage  of relative imports of services with the prefix `@mm-services/`, but just in the files edited in the PR with the purpose to make the language* services to work again.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
