### PR TITLE
Configure node debugger for development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -458,11 +458,11 @@ module.exports = function(grunt) {
       },
       'api-dev': {
         cmd:
-          'TZ=UTC ./node_modules/.bin/nodemon --ignore "api/src/extracted-resources/**" --watch api --watch "shared-libs/**/src/**" api/server.js -- --allow-cors',
+          'TZ=UTC ./node_modules/.bin/nodemon --inspect=0.0.0.0:9229 --ignore "api/src/extracted-resources/**" --watch api --watch "shared-libs/**/src/**" api/server.js -- --allow-cors',
       },
       'sentinel-dev': {
         cmd:
-          'TZ=UTC ./node_modules/.bin/nodemon --watch sentinel --watch "shared-libs/**/src/**" sentinel/server.js',
+          'TZ=UTC ./node_modules/.bin/nodemon --inspect=0.0.0.0:9228 --watch sentinel --watch "shared-libs/**/src/**" sentinel/server.js',
       },
       'blank-link-check': {
         cmd: `echo "Checking for dangerous _blank links..." &&


### PR DESCRIPTION
Adding the --inspect option opens a port that can be used by an editor/IDE to allow for interactive debugging.

The switch is described here: https://nodejs.org/en/docs/guides/debugging-getting-started/#enable-inspector

VS Code instructions to attach: https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_attach-to-node-process-action

Jetbrains IDE instructions to attach: https://www.jetbrains.com/help/ruby/running-and-debugging-node-js.html#4c71e
