### PR TITLE
Adds translations compiler to support pluralization

### DIFF
--- a/webapp/src/ts/app.module.ts
+++ b/webapp/src/ts/app.module.ts
@@ -8,7 +8,7 @@ import { StoreModule } from '@ngrx/store';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { storeLogger } from 'ngrx-store-logger';
 import { CookieService } from 'ngx-cookie-service';
-import { TranslateModule, TranslateLoader, MissingTranslationHandler, MissingTranslationHandlerParams } from '@ngx-translate/core';
+import { TranslateModule, TranslateLoader, MissingTranslationHandler, MissingTranslationHandlerParams, TranslateCompiler } from '@ngx-translate/core';
 import { ModalModule, BsModalRef } from 'ngx-bootstrap/modal';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { AccordionModule } from 'ngx-bootstrap/accordion';
@@ -34,6 +34,7 @@ import { ReportsEffects } from '@mm-effects/reports.effects';
 import { ParseProvider } from '@mm-providers/parse.provider';
 import { IntegrationApiService } from '@mm-services/integration-api.service';
 import { reducers } from "./reducers";
+import { TranslateMessageFormatCompilerProvider } from '@mm-providers/translate-message-format-compiler.provider';
 
 const logger = reducer => {
   // default, no options
@@ -71,6 +72,10 @@ export class MissingTranslationHandlerLog implements MissingTranslationHandler {
       missingTranslationHandler: {
         provide: MissingTranslationHandler,
         useClass: MissingTranslationHandlerLog
+      },
+      compiler: {
+        provide: TranslateCompiler,
+        useClass: TranslateMessageFormatCompilerProvider,
       },
     }),
     ModalModule.forRoot(),

--- a/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
+++ b/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
@@ -1,0 +1,41 @@
+import { TranslateCompiler } from '@ngx-translate/core';
+import * as MessageFormat from 'messageformat';
+
+const defaultConfig = {
+  biDiSupport: false,
+  formatters: undefined,
+  locales: undefined,
+  strictNumberSign: false,
+  disablePluralKeyChecks: false,
+};
+
+export class TranslateMessageFormatCompilerProvider extends TranslateCompiler {
+  private messageFormat;
+
+  constructor() {
+    super();
+    this.messageFormat = new MessageFormat(defaultConfig.locales);
+  }
+
+  compile(value, lang) {
+    // use default interpolation for these values
+    // message-format doesn't support the double curly braces notation
+    if (value.includes('{{')) {
+      return value;
+    }
+
+    try {
+      return this.messageFormat.compile(value, lang);
+    } catch (err) {
+      console.error('messageformat compile error', err);
+      return value;
+    }
+  }
+
+  compileTranslations(translations, lang) {
+    Object.keys(translations).map(key => {
+      translations[key] = this.compile(translations[key], lang)
+    });
+    return translations;
+  }
+}

--- a/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
+++ b/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
@@ -20,7 +20,7 @@ export class TranslateMessageFormatCompilerProvider extends TranslateCompiler {
   compile(value, lang) {
     // use default interpolation for these values
     // message-format doesn't support the double curly braces notation
-    if (value.includes('{{')) {
+    if (value.includes('{{') || !value.includes('{')) {
       return value;
     }
 

--- a/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
+++ b/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
@@ -1,27 +1,21 @@
 import { TranslateCompiler } from '@ngx-translate/core';
 import * as MessageFormat from 'messageformat';
 
-const defaultConfig = {
-  biDiSupport: false,
-  formatters: undefined,
-  locales: undefined,
-  strictNumberSign: false,
-  disablePluralKeyChecks: false,
-};
-
 export class TranslateMessageFormatCompilerProvider extends TranslateCompiler {
   private messageFormat;
+  private readonly doubleOrNoneCurlyBraces = new RegExp(/\{{|^[^{]+$/);
 
   constructor() {
     super();
-    this.messageFormat = new MessageFormat(defaultConfig.locales);
+    this.messageFormat = new MessageFormat([]);
   }
 
   compile(value, lang) {
-    // use default interpolation for these values
-    // message-format doesn't support the double curly braces notation
-    // TODO find a better way to determine if the value should be compiled via messgeformat
-    if (value.includes('{{') || !value.includes('{')) {
+    // message-format uses single curly braces for defining parameters( like `His name is {NAME}` )
+    // passing a string that contains open double curly braces to message-format produces an error
+    // if the message has either double curly braces or no curly braces at all, bypass message-format entirely
+    const hasDoubleOrNoCurlyBraces = this.doubleOrNoneCurlyBraces.test(value);
+    if (hasDoubleOrNoCurlyBraces) {
       return value;
     }
 

--- a/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
+++ b/webapp/src/ts/providers/translate-message-format-compiler.provider.ts
@@ -20,6 +20,7 @@ export class TranslateMessageFormatCompilerProvider extends TranslateCompiler {
   compile(value, lang) {
     // use default interpolation for these values
     // message-format doesn't support the double curly braces notation
+    // TODO find a better way to determine if the value should be compiled via messgeformat
     if (value.includes('{{') || !value.includes('{')) {
       return value;
     }

--- a/webapp/tests/karma/ts/providers/translate-message-formate-compiler.provider.spec.ts
+++ b/webapp/tests/karma/ts/providers/translate-message-formate-compiler.provider.spec.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import * as MessageFormat from 'messageformat';
 
 import { TranslateMessageFormatCompilerProvider } from '@mm-providers/translate-message-format-compiler.provider';
-import { exitCodeFromResult } from '@angular/compiler-cli';
 
 let service;
 
@@ -16,7 +15,6 @@ describe('Translate MessageFormat compiler provider', () => {
     it('should initialize local messageFormat', () => {
       service = new TranslateMessageFormatCompilerProvider();
       const compiled = service.compile('the {value}', 'fr');
-      console.log(compiled);
       expect(compiled).to.be.a('function');
       expect(compiled({ value: 'thing' })).to.equal('the thing');
     });

--- a/webapp/tests/karma/ts/providers/translate-message-formate-compiler.provider.spec.ts
+++ b/webapp/tests/karma/ts/providers/translate-message-formate-compiler.provider.spec.ts
@@ -1,0 +1,84 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import * as MessageFormat from 'messageformat';
+
+import { TranslateMessageFormatCompilerProvider } from '@mm-providers/translate-message-format-compiler.provider';
+import { exitCodeFromResult } from '@angular/compiler-cli';
+
+let service;
+
+describe('Translate MessageFormat compiler provider', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('compile', () => {
+    it('should initialize local messageFormat', () => {
+      service = new TranslateMessageFormatCompilerProvider();
+      const compiled = service.compile('the {value}', 'fr');
+      console.log(compiled);
+      expect(compiled).to.be.a('function');
+      expect(compiled({ value: 'thing' })).to.equal('the thing');
+    });
+
+    it('should not pass double open curly braces or no curly braces strings to message format', () => {
+      const mfCompile = sinon.stub(MessageFormat.prototype, 'compile');
+      service = new TranslateMessageFormatCompilerProvider();
+      expect(service.compile('the {{value}}')).to.equal('the {{value}}');
+      expect(mfCompile.callCount).to.equal(0);
+      expect(service.compile('the value')).to.equal('the value');
+      expect(mfCompile.callCount).to.equal(0);
+      expect(service.compile('{{a value')).to.equal('{{a value');
+      expect(mfCompile.callCount).to.equal(0);
+      expect(service.compile('{{some}} other {value}')).to.equal('{{some}} other {value}');
+      expect(mfCompile.callCount).to.equal(0);
+    });
+
+    it('should pass single open curly braces strings to message format', () => {
+      const mfCompile = sinon.stub(MessageFormat.prototype, 'compile');
+      mfCompile.callsFake((string) => () => `${string} compiled`);
+      service = new TranslateMessageFormatCompilerProvider();
+
+      expect(service.compile('a {thing}', 'en')()).to.equal('a {thing} compiled');
+      expect(mfCompile.callCount).to.equal(1);
+      expect(mfCompile.args[0]).to.deep.equal(['a {thing}', 'en']);
+      expect(service.compile('a {thing} or {other}', 'fr')()).to.equal('a {thing} or {other} compiled');
+      expect(mfCompile.callCount).to.equal(2);
+      expect(mfCompile.args[1]).to.deep.equal(['a {thing} or {other}', 'fr']);
+    });
+
+    it('should catch message format throwing errors', () => {
+      const mfCompile = sinon.stub(MessageFormat.prototype, 'compile').throws({ some: 'error' });
+      service = new TranslateMessageFormatCompilerProvider();
+      expect(service.compile('a {thing}')).to.equal('a {thing}');
+      expect(mfCompile.callCount).to.equal(1);
+    });
+  });
+
+  describe('compile translations', () => {
+    it('should compile every value', () => {
+      const translations = {
+        'a': 'a translation',
+        'b': 'b translation',
+        'c': 'c translation',
+        'd': 'd translation',
+      };
+      service = new TranslateMessageFormatCompilerProvider();
+      sinon.stub(service, 'compile').callsFake((translation) => `${translation} compiled`);
+      const result = service.compileTranslations(translations, 'the_lang');
+      expect(result).to.deep.equal({
+        'a': 'a translation compiled',
+        'b': 'b translation compiled',
+        'c': 'c translation compiled',
+        'd': 'd translation compiled',
+      });
+      expect(service.compile.callCount).to.equal(4);
+      expect(service.compile.args).to.deep.equal([
+        ['a translation', 'the_lang'],
+        ['b translation', 'the_lang'],
+        ['c translation', 'the_lang'],
+        ['d translation', 'the_lang'],
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# Description

We used to rely on messageformat to provide pluralization. The AngularJS translator allowed you to control how you could interpolate a translation, but ngx-translate does not. 
It does, however, allow you to overwrite the default compiler and use that as the middle man between it and messageformat. 

I found a library that passed **all** translations through messageformat (https://www.npmjs.com/package/ngx-translate-messageformat-compiler) which is bad for use, because of all the caveats. for example, messageformat encloses params in single curly braces, versus double curly braces that we use. 

So I quickly created our own compiler that does a really stupid filter (only passes translations to messageformat if they use single curly braces!) and mostly rushed it to unblock @njogz with display last visited dates in contacts lists. I did add a TODO to investigate whether there are better options. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
