### PR TITLE
Adds a timeout in Geolocation service to forcefully resolve its promise

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -14,7 +14,7 @@ if (UNIT_TEST_ENV) {
     'users',
     'medicUsersMeta',
     'sentinel',
-    'logs'
+    'medicLogs'
   ];
   const DB_FUNCTIONS_TO_STUB = [
     'allDocs',

--- a/api/tests/mocha/migrations/restrict-access-to-audit-db.spec.js
+++ b/api/tests/mocha/migrations/restrict-access-to-audit-db.spec.js
@@ -19,7 +19,11 @@ describe('restrict-access-to-audit-db', () => {
   });
 
   it('should request with the right parameters', () => {
-    const putStub = sinon.stub(request, 'put').resolves(Promise.resolve());
+    const putStub = sinon.stub(request, 'put').resolves();
+    sinon.stub(environment, 'protocol').value('http:');
+    sinon.stub(environment, 'host').value('host');
+    sinon.stub(environment, 'port').value('port');
+    sinon.stub(environment, 'db').returns('database');
     const url = `${environment.protocol}//${environment.host}:${environment.port}/${environment.db}-audit/_security`;
     const auth = {
       user: environment.username,

--- a/api/tests/mocha/migrations/restrict-access-to-sentinel-db.spec.js
+++ b/api/tests/mocha/migrations/restrict-access-to-sentinel-db.spec.js
@@ -19,7 +19,11 @@ describe('restrict-access-to-sentinel-db migration', () => {
   });
 
   it('should request with the right parameters', () => {
-    const putStub = sinon.stub(request, 'put').resolves(Promise.resolve());
+    const putStub = sinon.stub(request, 'put').resolves();
+    sinon.stub(environment, 'protocol').value('http:');
+    sinon.stub(environment, 'host').value('host');
+    sinon.stub(environment, 'port').value('port');
+    sinon.stub(environment, 'db').returns('database');
     const url = `${environment.protocol}//${environment.host}:${environment.port}/${environment.db}-sentinel/_security`;
     const auth = {
       user: environment.username,

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -233,6 +233,7 @@ describe('Monitoring service', () => {
     // empty rows is how couchdb responds to reducing with no rows - this should return 0
     sinon.stub(db.sentinel, 'query').resolves({ rows: [] });
     sinon.stub(db.medicUsersMeta, 'query').resolves({ rows: [] });
+    sinon.stub(db.medicLogs, 'query').resolves({ rows: [] });
     return service.json().then(actual => {
       chai.expect(actual.outbound_push).to.deep.equal({ backlog: 0 });
       chai.expect(actual.feedback).to.deep.equal({ count: 0 });

--- a/shared-libs/outbound/test/outbound.spec.js
+++ b/shared-libs/outbound/test/outbound.spec.js
@@ -551,7 +551,7 @@ describe('outbound shared library', () => {
 
     it('doesnt mess up numbers or dates', () => {
       assert.equal(
-        outbound.__get__('orderedStringify')({blah: new Date(2020, 1, 1)}),
+        outbound.__get__('orderedStringify')({blah: new Date(Date.UTC(2020, 1, 1))}),
         '{"blah":"2020-02-01T00:00:00.000Z"}');
     });
   });

--- a/webapp/src/js/services/geolocation.js
+++ b/webapp/src/js/services/geolocation.js
@@ -2,6 +2,7 @@ angular.module('inboxServices').service('Geolocation',
   function(
     $log,
     $q,
+    $timeout,
     $window,
     Telemetry
   ) {
@@ -18,6 +19,7 @@ angular.module('inboxServices').service('Geolocation',
     let geo;
     let geoError;
     let watcher;
+    let timeout;
 
     const getAndroidPermission = () => {
       try {
@@ -82,12 +84,19 @@ angular.module('inboxServices').service('Geolocation',
         };
       } else {
         watcher = $window.navigator.geolocation.watchPosition(success, failure, GEO_OPTIONS);
+        timeout = $timeout(() => {
+          geoError = {
+            code: -1,
+            message: 'Geolocation timeout exceeded',
+          };
+        }, GEO_OPTIONS.timeout + 1);
       }
     };
 
     const stopWatching = () => {
       $log.debug('Cancelling geolocation');
       watcher && $window.navigator.geolocation && $window.navigator.geolocation.clearWatch(watcher);
+      timeout && clearTimeout(timeout);
     };
 
     return {

--- a/webapp/src/js/services/geolocation.js
+++ b/webapp/src/js/services/geolocation.js
@@ -89,6 +89,7 @@ angular.module('inboxServices').service('Geolocation',
             code: -1,
             message: 'Geolocation timeout exceeded',
           };
+          finalise();
         }, GEO_OPTIONS.timeout + 1);
       }
     };

--- a/webapp/src/js/services/geolocation.js
+++ b/webapp/src/js/services/geolocation.js
@@ -34,6 +34,7 @@ angular.module('inboxServices').service('Geolocation',
     };
 
     const finalise = () => {
+      $timeout.cancel(timeout);
       $log.debug('Finalising geolocation');
       $window.navigator.geolocation && $window.navigator.geolocation.clearWatch(watcher);
 
@@ -85,11 +86,10 @@ angular.module('inboxServices').service('Geolocation',
       } else {
         watcher = $window.navigator.geolocation.watchPosition(success, failure, GEO_OPTIONS);
         timeout = $timeout(() => {
-          geoError = {
+          failure({
             code: -1,
             message: 'Geolocation timeout exceeded',
-          };
-          finalise();
+          });
         }, GEO_OPTIONS.timeout + 1);
       }
     };
@@ -97,7 +97,7 @@ angular.module('inboxServices').service('Geolocation',
     const stopWatching = () => {
       $log.debug('Cancelling geolocation');
       watcher && $window.navigator.geolocation && $window.navigator.geolocation.clearWatch(watcher);
-      timeout && clearTimeout(timeout);
+      $timeout.cancel(timeout);
     };
 
     return {


### PR DESCRIPTION
# Description

So now, when the 30s geolocation allowance expire, the geolocation promise will resolve with an error code. 
Also fixes a few brittle unit tests that were failing locally. 

medic/cht-core#6711

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
