### PR TITLE
protractor no longer requires directories when running e2e locally

### DIFF
--- a/tests/conf.js
+++ b/tests/conf.js
@@ -17,7 +17,7 @@ const baseConfig = {
   },
   seleniumAddress: 'http://localhost:4444/wd/hub',
   suites: {
-    web:'e2e/**/*',
+    web:'e2e/**/*.js',
     mobile:'mobile/**/*.js',
     performance: 'performance/**/*.js'
   },


### PR DESCRIPTION
# Description

Currently if you do nothing to the conf and try to run e2e tests it will fail. Protractor is trying to load directories as modules with the path expansion defined. This fixes for now. I see we have a second config that has just 2 conditionals that are for travis only. Really should work out how to get that back into 1 file. 

medic/cht-core#[number]

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
