### PR TITLE
Bumps main.js bundlesize from 700 to 750kb.

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "bundlesize": [
     {
       "path": "./build/ddocs/medic/_attachments/main.js",
-      "maxSize": "700 kB"
+      "maxSize": "750 kB"
     },
     {
       "path": "./build/ddocs/medic/_attachments/polyfills-es5.js",


### PR DESCRIPTION
# Description

We're already exceeding it with a few kb in some branches.
I'm not sure what tipped us over so suddenly, I've created an issue to investigate the bundle when the migration is complete: https://github.com/medic/angular10-migration/issues/39

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
