### PR TITLE
fix 404 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you are a developer looking to contribute to the Core Framework itself, you s
 
 If you wish to evaluate the Core Framework, _or_ you are a developer looking to create or modify applications built with the Core Framework, you can instead follow the [easy deployment](./INSTALL.md) instructions, which will get the latest stable release running locally via Docker.
 
-You will need to also familiarise yourself with [medic-conf](https://github.com/medic/medic-conf), a tool to manage and configure your apps built using the Core Framework. A brief guide for modifying the config is available [alongside the config](./config/default/GUIDE.md). A more detailed guide is available in [cht-docs](https://docs.communityhealthtoolkit.org/design/apps/).
+You will need to also familiarise yourself with [medic-conf](https://github.com/medic/medic-conf), a tool to manage and configure your apps built using the Core Framework. A brief guide for modifying the config is available [alongside the config](./config/default/GUIDE.md). A more detailed guide is available in [cht-docs](https://docs.communityhealthtoolkit.org/apps/).
 
 ### Supported Browsers
 


### PR DESCRIPTION
# Description

Fixes a 404 error (detailed guide is available in cht-docs...). The link leads to https://docs.communityhealthtoolkit.org/design/apps/, which doesn't exist.

<!--
# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
-->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
