### PR TITLE
Support places centric workflows in SMS

### DIFF
--- a/admin/src/js/services/message-queue.js
+++ b/admin/src/js/services/message-queue.js
@@ -32,12 +32,14 @@ angular.module('services').factory('MessageQueue',
     'use strict';
     'ngInject';
 
-    const findSummary = (summaries, message) => {
+    const findSummary = function(summaries, message) {
       if (!message.sms || !message.sms.to) {
         return;
       }
 
-      const summary = summaries.rows.find((summary) => summary.value && summary.value.phone === message.sms.to);
+      const summary = summaries.rows.find(function(summary) {
+        return summary.value && summary.value.phone === message.sms.to;
+      });
 
       return summary && summary.value;
     };
@@ -58,21 +60,30 @@ angular.module('services').factory('MessageQueue',
         .map((row) => row.doc);
     };
 
-    const findContactById = (hydratedContacts, contactId) => {
-      const contact = hydratedContacts.find((hydratedContact) => hydratedContact.id === contactId);
+    const findContactById = function(hydratedContacts, contactId) {
+      const contact = hydratedContacts.find(function(hydratedContact) {
+        return hydratedContact.id === contactId;
+      });
+
       return contact && contact.doc;
     };
 
-    const getValidRegistrations = (registrations, settings) => {
-      return registrations.rows.filter((row) => MessageQueueUtils.registrations.isValidRegistration(row.doc, settings));
+    const getValidRegistrations = function(registrations, settings) {
+      return registrations.rows.filter(function(row) {
+        return MessageQueueUtils.registrations.isValidRegistration(row.doc, settings);
+      });
     };
 
-    const compactUnique = (array) => {
-      return array.filter((item, idx, self) => item && self.indexOf(item) === idx);
+    const compactUnique = function(array) {
+      return array.filter(function(item, idx, self) {
+        return item && self.indexOf(item) === idx;
+      });
     };
 
-    const getRecipients = (messages) => {
-      const phoneNumbers = compactUnique(messages.map((row) => row.sms && row.sms.to));
+    const getRecipients = function(messages) {
+      const phoneNumbers = compactUnique(messages.map(function(row) {
+        return row.sms && row.sms.to;
+      }));
 
       if (!phoneNumbers.length) {
         return messages;
@@ -80,12 +91,15 @@ angular.module('services').factory('MessageQueue',
 
       return DB({ remote: true })
         .query('medic-client/contacts_by_phone', { keys: phoneNumbers })
-        .then((contactsByPhone) => {
-          const ids = contactsByPhone.rows.map((row) => row.id);
+        .then(function(contactsByPhone) {
+          const ids = contactsByPhone.rows.map(function(row) {
+            return row.id;
+          });
+
           return DB({ remote: true }).query('medic/doc_summaries_by_id', { keys: ids });
         })
-        .then((summaries) => {
-          messages.forEach((message) => {
+        .then(function(summaries) {
+          messages.forEach(function(message) {
             message.recipient = findSummary(summaries, message);
           });
 
@@ -128,9 +142,9 @@ angular.module('services').factory('MessageQueue',
         });
     };
 
-    const hydrateContacts = (messages) => {
+    const hydrateContacts = function(messages) {
       let contactIds = [];
-      messages.forEach((message) => {
+      messages.forEach(function(message) {
         if (!message.sms) {
           contactIds.push(
             message.context.patient_uuid,
@@ -146,8 +160,8 @@ angular.module('services').factory('MessageQueue',
 
       return MessageQueueUtils.lineage
         .fetchLineageByIds(contactIds)
-        .then((docList) => {
-          const hydratedDocs = docList.map((docs) => {
+        .then(function(docList) {
+          const hydratedDocs = docList.map(function(docs) {
             const doc = docs.shift();
             return {
               id: doc._id,
@@ -165,10 +179,12 @@ angular.module('services').factory('MessageQueue',
         });
     };
 
-    const generateScheduledMessages = (messages, settings) => {
-      const translate = (key, locale) => $translate.instant(key, null, 'no-interpolation', locale, null);
+    const generateScheduledMessages = function(messages, settings) {
+      const translate = function(key, locale) {
+        return $translate.instant(key, null, 'no-interpolation', locale, null);
+      };
 
-      messages.forEach((message) => {
+      messages.forEach(function(message) {
         if (message.sms) {
           return;
         }
@@ -191,7 +207,7 @@ angular.module('services').factory('MessageQueue',
       return messages;
     };
 
-    const getTaskDisplayName = (task) => {
+    const getTaskDisplayName = function(task) {
       if (task.translation_key) {
         return $translate.instant(task.translation_key, { group: task.group });
       }
@@ -199,8 +215,8 @@ angular.module('services').factory('MessageQueue',
       return task.type && task.type + (task.group ? ':' + task.group : '' ) || false;
     };
 
-    const formatMessages = (messages) => {
-      return messages.map((message) => {
+    const formatMessages = function(messages) {
+      return messages.map(function(message) {
         return {
           record: {
             id: message.doc._id,
@@ -218,7 +234,7 @@ angular.module('services').factory('MessageQueue',
       });
     };
 
-    const getParams = (tab, skip, limit, descending) => {
+    const getParams = function(tab, skip, limit, descending) {
       const list = {
         limit: limit || 25,
         skip: skip || 0,
@@ -271,23 +287,23 @@ angular.module('services').factory('MessageQueue',
     };
 
     return {
-      loadTranslations: () => {
+      loadTranslations: function() {
         return Languages()
-          .then((languages) => {
-            return languages && $q.all(languages.map((language) => {
+          .then(function(languages) {
+            return languages && $q.all(languages.map(function(language) {
               return language &&
                      language.code &&
                      language.code !== 'en' &&
                      $translate('admin.message.queue', {}, null, 'admin.message.queue', language.code);
             }));
           })
-          .catch((err) => {
+          .catch(function(err) {
             $log.error('Error fetching languages', err);
             throw(err);
           });
       },
 
-      query: (tab, skip, limit, descending) => {
+      query: function(tab, skip, limit, descending) {
         const params = getParams(tab, skip, limit, descending);
         return $q
           .all([

--- a/admin/tests/unit/services/message-queue.js
+++ b/admin/tests/unit/services/message-queue.js
@@ -72,9 +72,7 @@ describe('MessageQueue service', function() {
 
       return service
         .loadTranslations()
-        .then(() => {
-          chai.expect(0).to.equal('Should have thrown');
-        })
+        .then(() => chai.assert.fail('Should have thrown'))
         .catch(err => {
           chai.expect(err).to.deep.equal({ some: 'err' });
         });
@@ -440,7 +438,7 @@ describe('MessageQueue service', function() {
       });
     });
 
-    it('should query for unique patient ids and contacts', () => {
+    it('should query for unique patient ids, place ids and contacts', () => {
       const messages = [{
         doc: { _id: 'report_id1', reported_date: 100, patient_id: '1111' },
         value: {
@@ -456,28 +454,28 @@ describe('MessageQueue service', function() {
           due: 300
         }
       }, {
-        doc: { _id: 'report_id2', reported_date: 200, fields: { patient_id: '2222' } },
+        doc: { _id: 'report_id3', reported_date: 200, fields: { patient_id: '2222' } },
         value: {
           scheduled_sms: { translation_key: 'sms3', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
       }, {
-        doc: { _id: 'report_id3', reported_date: 200, patient_id: '1111' },
+        doc: { _id: 'report_id4', reported_date: 200, patient_id: '1111' },
         value: {
           scheduled_sms: { translation_key: 'sms4', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
       }, {
-        doc: { _id: 'report_id3', reported_date: 200, patient_id: '2222' },
+        doc: { _id: 'report_id5', reported_date: 200, patient_id: '2222' },
         value: {
           scheduled_sms: { translation_key: 'sms5', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
       }, {
-        doc: { _id: 'report_id4', reported_date: 200, patient_uuid: 'patient1' },
+        doc: { _id: 'report_id6', reported_date: 200, patient_uuid: 'patient1' },
         value: {
           scheduled_sms: { translation_key: 'sms6', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
@@ -485,7 +483,7 @@ describe('MessageQueue service', function() {
         }
       }, {
         doc: {
-          _id: 'report_id4', reported_date: 200,
+          _id: 'report_id7', reported_date: 200,
           fields: { patient_uuid: 'patient1' }, contact: { _id: 'patient2' }
         },
         value: {
@@ -494,20 +492,62 @@ describe('MessageQueue service', function() {
           due: 300
         }
       }, {
-        doc: { _id: 'report_id4', reported_date: 200, contact: { _id: 'patient1' } },
+        doc: { _id: 'report_id8', reported_date: 200, contact: { _id: 'patient1' } },
         value: {
           scheduled_sms: { translation_key: 'sms8', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
       }, {
-        doc: { _id: 'report_id4', reported_date: 200, contact: { _id: 'patient3' }, patient_id: '3333' },
+        doc: { _id: 'report_id9', reported_date: 200, contact: { _id: 'patient3' }, patient_id: '3333' },
         value: {
           scheduled_sms: { translation_key: 'sms9', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
-      }];
+      }, {
+        doc: { _id: 'report_id10', reported_date: 100, patient_id: '3333', place_id: 'place1111' },
+        value: {
+          scheduled_sms: { translation_key: 'sms10', recipient: 'recipient' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: { _id: 'report_id11', reported_date: 100, fields: { patient_id: '2222', place_id: 'place2222' } },
+        value: {
+          scheduled_sms: { translation_key: 'sms11', recipient: 'recipient' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: { _id: 'report_id12', reported_date: 100, fields: { patient_id: '3333', place_id: 'place1111' } },
+        value: {
+          scheduled_sms: { translation_key: 'sms12', recipient: 'recipient' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: { _id: 'report_id12', reported_date: 100, fields: { place_id: 'place3333' } },
+        value: {
+          scheduled_sms: { translation_key: 'sms13', recipient: 'recipient' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: { _id: 'report_id12', reported_date: 100, place_id: 'place3333' },
+        value: {
+          scheduled_sms: { translation_key: 'sms13', recipient: 'recipient' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: { _id: 'report_id13', reported_date: 100, place_id: 'place4444' },
+        value: {
+          scheduled_sms: { translation_key: 'sms14', recipient: 'recipient' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      },];
 
       translate.instant.callsFake(t => t);
 
@@ -519,16 +559,24 @@ describe('MessageQueue service', function() {
 
       query
         .withArgs('medic-client/contacts_by_reference')
-        .resolves({ rows: [
-          { key: '1111', value: 'patient1' },
-          { key: '2222', value: 'patient2' }
-        ] });
+        .resolves({
+          rows: [
+            { key: '1111', value: 'patient1' },
+            { key: '2222', value: 'patient2' },
+            { key: 'place1111', value: 'place1' },
+            { key: 'place2222', value: 'place2' },
+            { key: 'place3333', value: 'place3' },
+          ],
+        });
 
       query.withArgs('medic-client/registered_patients').resolves({ rows: [] });
 
       utils.lineage.fetchLineageByIds.resolves([
         [{ _id: 'patient1', patient_id: '1111', name: 'patient one' }],
-        [{ _id: 'patient2', patient_id: '2222', name: 'patient two' }]
+        [{ _id: 'patient2', patient_id: '2222', name: 'patient two' }],
+        [{ _id: 'place1', place_id: 'place1111', name: 'place one' }],
+        [{ _id: 'place2', place_id: 'place2222', name: 'place two' }],
+        [{ _id: 'place3', place_id: 'place3333', name: 'place three' }],
       ]);
       utils.lineage.fillParentsInDocs.callsFake(doc => doc);
 
@@ -550,15 +598,26 @@ describe('MessageQueue service', function() {
         chai.expect(query.callCount).to.equal(6);
         chai.expect(query.args[2]).to.deep.equal([
           'medic-client/contacts_by_reference',
-          { keys: [['shortcode', '1111'], ['shortcode', '2222'], ['shortcode', '3333']] }
+          {
+            keys: [
+              ['shortcode', '1111'], ['shortcode', '2222'], ['shortcode', '3333'],
+              ['shortcode', 'place1111'], ['shortcode', 'place2222'], ['shortcode', 'place3333'],
+              ['shortcode', 'place4444'],
+            ],
+          },
         ]);
         chai.expect(query.args[3]).to.deep.equal([
           'medic-client/registered_patients',
-          { keys: ['1111', '2222', '3333'], include_docs: true }
+          {
+            keys: ['1111', '2222', '3333', 'place1111', 'place2222', 'place3333', 'place4444'],
+            include_docs: true
+          }
         ]);
 
         chai.expect(utils.lineage.fetchLineageByIds.callCount).to.equal(1);
-        chai.expect(utils.lineage.fetchLineageByIds.args[0]).to.deep.equal([[ 'patient1', 'patient2', 'patient3' ]]);
+        chai.expect(utils.lineage.fetchLineageByIds.args[0]).to.deep.equal([
+          [ 'patient1', 'patient2', 'patient3', 'place1', 'place2', 'place3' ],
+        ]);
 
         chai.expect(query.args[4]).to.deep.equal([
           'medic-client/contacts_by_phone',
@@ -603,6 +662,39 @@ describe('MessageQueue service', function() {
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
+      }, {
+        doc: {
+          _id: 'report_id4',
+          reported_date: 200,
+          place_id: 'place1111'
+        },
+        value: {
+          scheduled_sms: { translation_key: 'sms4', recipient: 'recipient3' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: {
+          _id: 'report_id5',
+          reported_date: 200,
+          fields: { patient_id: '2222', place_id: 'place2222' }
+        },
+        value: {
+          scheduled_sms: { translation_key: 'sms4', recipient: 'recipient3' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
+      }, {
+        doc: {
+          _id: 'report_id5',
+          reported_date: 200,
+          fields: { place_id: 'place2222' }
+        },
+        value: {
+          scheduled_sms: { translation_key: 'sms4', recipient: 'recipient3' },
+          task: { translation_key: 'task3', state: 'pending' },
+          due: 300
+        }
       }];
 
       translate.instant.callsFake(t => t);
@@ -615,11 +707,15 @@ describe('MessageQueue service', function() {
 
       query
         .withArgs('medic-client/contacts_by_reference')
-        .resolves({ rows: [
-          { key: ['shortcode', '1111'], id: 'patient1' },
-          { key: ['shortcode', '2222'], id: 'patient2' },
-          { key: ['shortcode', '3333'], id: 'patient3' }
-        ] });
+        .resolves({
+          rows: [
+            { key: ['shortcode', '1111'], id: 'patient1' },
+            { key: ['shortcode', '2222'], id: 'patient2' },
+            { key: ['shortcode', '3333'], id: 'patient3' },
+            { key: ['shortcode', 'place1111'], id: 'place1' },
+            { key: ['shortcode', 'place2222'], id: 'place2' },
+          ]
+        });
 
       query.withArgs('medic-client/registered_patients').resolves({ rows: [
         { key: '1111', doc: { type: 'valid', patient_id: '1111' } },
@@ -630,6 +726,10 @@ describe('MessageQueue service', function() {
         { key: '2222', doc: { type: 'invalid', patient_id: '2222' } },
         { key: '3333', doc: { type: 'invalid', patient_id: '3333' } },
         { key: '3333', doc: { type: 'invalid', patient_id: '3333' } },
+        { key: 'place1111', doc: { type: 'invalid', place_id: 'place1111' } },
+        { key: 'place1111', doc: { type: 'valid', place_id: 'place1111' } },
+        { key: 'place2222', doc: { type: 'invalid', place_id: 'place2222' } },
+        { key: 'place2222', doc: { type: 'invalid', place_id: 'place2222' } },
       ]});
 
       utils.lineage.fetchLineageByIds.resolves([
@@ -638,6 +738,8 @@ describe('MessageQueue service', function() {
         [{ _id: 'patient3', patient_id: '3333', name: 'patient three' }],
         [{ _id: 'contact1', patient_id: 'c1', name: 'contact one' }],
         [{ _id: 'contact2', patient_id: 'c2', name: 'contact two' }],
+        [{ _id: 'place1', place_id: 'place1111', name: 'place one' }],
+        [{ _id: 'place2', place_id: 'place2222', name: 'place two' }],
       ]);
       utils.lineage.fillParentsInDocs.callsFake(doc => doc);
 
@@ -730,6 +832,27 @@ describe('MessageQueue service', function() {
             patient: { _id: 'patient3', patient_id: '3333', name: 'patient three' },
             patient_uuid: 'patient3',
             registrations: []
+          }
+        ]);
+
+        chai.expect(utils.messages.generate.args[3].slice(2)).to.deep.equal([
+          {
+            _id: 'report_id4',
+            reported_date: 200,
+            place_id: 'place1111',
+            contact: undefined
+          },
+          {
+            translationKey: 'sms4',
+            message: undefined
+          },
+          'recipient3',
+          {
+            place_id: 'place1111',
+            place: { _id: 'place1', place_id: 'place1111', name: 'place one' },
+            place_uuid: 'place1',
+            registrations: [],
+            placeRegistrations: [],
           }
         ]);
 

--- a/admin/tests/unit/services/message-queue.js
+++ b/admin/tests/unit/services/message-queue.js
@@ -527,21 +527,21 @@ describe('MessageQueue service', function() {
           due: 300
         }
       }, {
-        doc: { _id: 'report_id12', reported_date: 100, fields: { place_id: 'place3333' } },
+        doc: { _id: 'report_id13', reported_date: 100, fields: { place_id: 'place3333' } },
         value: {
           scheduled_sms: { translation_key: 'sms13', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
       }, {
-        doc: { _id: 'report_id12', reported_date: 100, place_id: 'place3333' },
+        doc: { _id: 'report_id14', reported_date: 100, place_id: 'place3333' },
         value: {
           scheduled_sms: { translation_key: 'sms13', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
           due: 300
         }
       }, {
-        doc: { _id: 'report_id13', reported_date: 100, place_id: 'place4444' },
+        doc: { _id: 'report_id15', reported_date: 100, place_id: 'place4444' },
         value: {
           scheduled_sms: { translation_key: 'sms14', recipient: 'recipient' },
           task: { translation_key: 'task3', state: 'pending' },
@@ -561,11 +561,11 @@ describe('MessageQueue service', function() {
         .withArgs('medic-client/contacts_by_reference')
         .resolves({
           rows: [
-            { key: '1111', value: 'patient1' },
-            { key: '2222', value: 'patient2' },
-            { key: 'place1111', value: 'place1' },
-            { key: 'place2222', value: 'place2' },
-            { key: 'place3333', value: 'place3' },
+            { key: ['shortcode', '1111'], id: 'patient1' },
+            { key: ['shortcode', '2222'], id: 'patient2' },
+            { key: ['shortcode', 'place1111'], id: 'place1' },
+            { key: ['shortcode', 'place2222'], id: 'place2' },
+            { key: ['shortcode', 'place3333'], id: 'place3' },
           ],
         });
 
@@ -593,8 +593,7 @@ describe('MessageQueue service', function() {
         .resolves({ rows: [{ key: 'recipient_id', value: { phone: 'recipient' }}]});
 
       return service.query('tab').then(result => {
-        chai.expect(result.messages.length).to.equal(9);
-
+        chai.expect(result.messages.length).to.equal(15);
         chai.expect(query.callCount).to.equal(6);
         chai.expect(query.args[2]).to.deep.equal([
           'medic-client/contacts_by_reference',
@@ -686,7 +685,7 @@ describe('MessageQueue service', function() {
         }
       }, {
         doc: {
-          _id: 'report_id5',
+          _id: 'report_id6',
           reported_date: 200,
           fields: { place_id: 'place2222' }
         },
@@ -728,7 +727,8 @@ describe('MessageQueue service', function() {
         { key: '3333', doc: { type: 'invalid', patient_id: '3333' } },
         { key: 'place1111', doc: { type: 'invalid', place_id: 'place1111' } },
         { key: 'place1111', doc: { type: 'valid', place_id: 'place1111' } },
-        { key: 'place2222', doc: { type: 'invalid', place_id: 'place2222' } },
+        { key: 'place2222', doc: { type: 'valid', place_id: 'place2222' } },
+        { key: 'place2222', doc: { type: 'valid', place_id: 'place2222' } },
         { key: 'place2222', doc: { type: 'invalid', place_id: 'place2222' } },
       ]});
 
@@ -768,8 +768,8 @@ describe('MessageQueue service', function() {
         ]});
 
       return service.query('tab').then((result) => {
-        chai.expect(utils.registrations.isValidRegistration.callCount).to.equal(8);
-        chai.expect(utils.messages.generate.callCount).to.equal(3);
+        chai.expect(utils.registrations.isValidRegistration.callCount).to.equal(13);
+        chai.expect(utils.messages.generate.callCount).to.equal(6);
 
         chai.expect(utils.messages.generate.args[0].slice(2)).to.deep.equal([
           {
@@ -791,7 +791,11 @@ describe('MessageQueue service', function() {
               { type: 'valid', patient_id: '1111' },
               { type: 'valid', patient_id: '1111' },
               { type: 'valid', patient_id: '1111' }
-            ]
+            ],
+            place_id: undefined,
+            place_uuid: undefined,
+            placeRegistrations: [],
+            place: undefined,
           }
         ]);
 
@@ -811,7 +815,11 @@ describe('MessageQueue service', function() {
             patient_id: '2222',
             patient: { _id: 'patient2', patient_id: '2222', name: 'patient two' },
             patient_uuid: 'patient2',
-            registrations: [{ type: 'valid', patient_id: '2222' }]
+            registrations: [{ type: 'valid', patient_id: '2222' }],
+            place_id: undefined,
+            place_uuid: undefined,
+            placeRegistrations: [],
+            place: undefined,
           }
         ]);
 
@@ -831,7 +839,11 @@ describe('MessageQueue service', function() {
             patient_id: '3333',
             patient: { _id: 'patient3', patient_id: '3333', name: 'patient three' },
             patient_uuid: 'patient3',
-            registrations: []
+            registrations: [],
+            place_id: undefined,
+            place_uuid: undefined,
+            placeRegistrations: [],
+            place: undefined,
           }
         ]);
 
@@ -848,11 +860,72 @@ describe('MessageQueue service', function() {
           },
           'recipient3',
           {
+            patient_id: undefined,
+            patient_uuid: undefined,
+            patient: undefined,
             place_id: 'place1111',
             place: { _id: 'place1', place_id: 'place1111', name: 'place one' },
             place_uuid: 'place1',
             registrations: [],
-            placeRegistrations: [],
+            placeRegistrations: [
+              { type: 'valid', place_id: 'place1111' },
+            ],
+          }
+        ]);
+
+        chai.expect(utils.messages.generate.args[4].slice(2)).to.deep.equal([
+          {
+            _id: 'report_id5',
+            reported_date: 200,
+            fields: { patient_id: '2222', place_id: 'place2222' },
+            contact: undefined,
+          },
+          {
+            translationKey: 'sms4',
+            message: undefined
+          },
+          'recipient3',
+          {
+            patient_id: '2222',
+            patient_uuid: 'patient2',
+            patient: { _id: 'patient2', patient_id: '2222', name: 'patient two' },
+            place_id: 'place2222',
+            place: { _id: 'place2', place_id: 'place2222', name: 'place two' },
+            place_uuid: 'place2',
+            registrations: [
+              { type: 'valid', patient_id: '2222' },
+            ],
+            placeRegistrations: [
+              { type: 'valid', place_id: 'place2222' },
+              { type: 'valid', place_id: 'place2222' },
+            ],
+          }
+        ]);
+
+        chai.expect(utils.messages.generate.args[5].slice(2)).to.deep.equal([
+          {
+            _id: 'report_id6',
+            reported_date: 200,
+            fields: { place_id: 'place2222' },
+            contact: undefined,
+          },
+          {
+            translationKey: 'sms4',
+            message: undefined
+          },
+          'recipient3',
+          {
+            patient_id: undefined,
+            patient_uuid: undefined,
+            patient: undefined,
+            place_id: 'place2222',
+            place: { _id: 'place2', place_id: 'place2222', name: 'place two' },
+            place_uuid: 'place2',
+            registrations: [],
+            placeRegistrations: [
+              { type: 'valid', place_id: 'place2222' },
+              { type: 'valid', place_id: 'place2222' },
+            ],
           }
         ]);
 
@@ -894,7 +967,40 @@ describe('MessageQueue service', function() {
             due: 300,
             link: false,
             error: false
-          }
+          },
+          {
+            record: { id: 'report_id4', reportedDate: 200 },
+            recipient: 'recipient 3',
+            task: 'task3',
+            state: 'pending',
+            stateHistory: undefined,
+            content: 'sms4',
+            due: 300,
+            link: false,
+            error: false
+          },
+          {
+            record: { id: 'report_id5', reportedDate: 200 },
+            recipient: 'recipient 3',
+            task: 'task3',
+            state: 'pending',
+            stateHistory: undefined,
+            content: 'sms4',
+            due: 300,
+            link: false,
+            error: false
+          },
+          {
+            record: { id: 'report_id6', reportedDate: 200 },
+            recipient: 'recipient 3',
+            task: 'task3',
+            state: 'pending',
+            stateHistory: undefined,
+            content: 'sms4',
+            due: 300,
+            link: false,
+            error: false
+          },
         ]);
       });
     });

--- a/ddocs/medic-db/medic-client/views/registered_patients/map.js
+++ b/ddocs/medic-db/medic-client/views/registered_patients/map.js
@@ -1,15 +1,22 @@
-// NB: This returns *registrations* for patients. If patients are created by
+// NB: This returns *registrations* for contacts. If contacts are created by
 //     means other then sending in a registration report (eg created in the UI)
 //     they will not show up in this view.
 //
 //     For a view with all patients by their shortcode, use:
-//        medic/patient_by_patient_shortcode_id
+//        medic/docs_by_shortcode
 function(doc) {
   var patientId = doc.patient_id || (doc.fields && doc.fields.patient_id);
-  if (doc.form &&
-      doc.type === 'data_record' &&
-      (!doc.errors || doc.errors.length === 0) &&
-      patientId) {
+  var placeId = doc.place_id || (doc.fields && doc.fields.place_id);
+
+  if (!doc.form || doc.type !== 'data_record' || (doc.errors && doc.errors.length)) {
+    return;
+  }
+
+  if (patientId) {
     emit(String(patientId));
+  }
+
+  if (placeId) {
+    emit(String(placeId));
   }
 }

--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -764,6 +764,7 @@ messages.d.validation.delivery_code = {{\#delivery_code}}The delivery code was n
 messages.errors.invalid = Invalid message\:
 messages.errors.message.empty = Missing translation
 messages.errors.patient.missing = Patient not found
+messages.errors.place.missing = Place not found
 messages.f.report_accepted = Thank you for flagging {{patient_name}} ({{patient_id}}). If this is an emergency, please refer her to the clinic immediately.
 messages.f.report_accepted_parent = {{patient_name}} ({{patient_id}}) was flagged by {{contact.name}} ({{contact.phone}}) for further attention.
 messages.generic.no_provided_patient_id = External ID number support is configured, but is not found on document in the configured location.

--- a/ddocs/medic/views/doc_summaries_by_id/map.js
+++ b/ddocs/medic/views/doc_summaries_by_id/map.js
@@ -33,7 +33,9 @@ function(doc) {
     var subject = {};
     var reference = doc.patient_id ||
                     (doc.fields && doc.fields.patient_id) ||
-                    doc.place_id;
+                    doc.place_id ||
+                    (doc.fields && doc.fields.place_id);
+
     var patientName = doc.fields && doc.fields.patient_name;
     if (patientName) {
       subject.name = patientName;
@@ -42,9 +44,6 @@ function(doc) {
     if (reference) {
       subject.value = reference;
       subject.type = 'reference';
-    } else if (doc.fields && doc.fields.place_id) {
-      subject.value = doc.fields.place_id;
-      subject.type = 'id';
     } else if (patientName) {
       subject.value = patientName;
       subject.type = 'name';

--- a/shared-libs/lineage/src/hydration.js
+++ b/shared-libs/lineage/src/hydration.js
@@ -141,8 +141,8 @@ module.exports = function(Promise, DB) {
 
   /*
    * @returns {Object} subjectMaps
-   * @returns {Map} subjectMaps.patientUuids - map with (k, v) pairs of recordUuid and patientUuid
-   * @returns {Map} subjectMaps.placeUuids - map with (k, v) pairs of recordUuid and placeUuid
+   * @returns {Map} subjectMaps.patientUuids - map with [k, v] pairs of [recordUuid, patientUuid]
+   * @returns {Map} subjectMaps.placeUuids - map with [k, v] pairs of [recordUuid, placeUuid]
    */
   const fetchSubjectsUuids = (records) => {
     const shortcodes = [];
@@ -210,7 +210,7 @@ module.exports = function(Promise, DB) {
   };
 
   /*
-  * @returns {Map} map with (k,v) pairs of (shortcode, uuid)
+  * @returns {Map} map with [k, v] pairs of [shortcode, uuid]
   */
   const contactUuidByShortcode = function(shortcodes) {
     const keys = shortcodes
@@ -224,9 +224,7 @@ module.exports = function(Promise, DB) {
           return matchingRow && matchingRow.id;
         };
 
-        const shortcodeToUuidMap = new Map();
-        shortcodes.forEach(shortcode => shortcodeToUuidMap.set(shortcode, findIdWithKey(shortcode) || shortcode));
-        return shortcodeToUuidMap;
+        return new Map(shortcodes.map(shortcode => ([ shortcode, findIdWithKey(shortcode) || shortcode, ])));
       });
   };
 
@@ -384,8 +382,8 @@ module.exports = function(Promise, DB) {
     const hydratedDocs = deepCopy(docs); // a copy of the original docs which we will incrementally hydrate and return
     const knownDocs = [...hydratedDocs]; // an array of all documents which we have fetched
 
-    let patientUuids; // a map of (k, v) pairs with (hydratedDocUuid, patientUuid)
-    let placeUuids; // a map of (k, v) pairs with (hydratedDocUuid, placeUuid)
+    let patientUuids; // a map of [k, v] pairs with [hydratedDocUuid, patientUuid]
+    let placeUuids; // a map of [k, v] pairs with [hydratedDocUuid, placeUuid]
     let subjectDocs;
 
     return fetchSubjectsUuids(hydratedDocs)

--- a/shared-libs/lineage/src/hydration.js
+++ b/shared-libs/lineage/src/hydration.js
@@ -376,7 +376,7 @@ module.exports = function(Promise, DB) {
       .then(() => fetchPlaceUuids(hydratedDocs))
       .then(uuids => {
         placeUuids = uuids;
-        return fetchDocs(placeUuids)
+        return fetchDocs(placeUuids);
       })
       .then(function(places) {
         placeDocs = places;

--- a/shared-libs/lineage/src/hydration.js
+++ b/shared-libs/lineage/src/hydration.js
@@ -384,8 +384,8 @@ module.exports = function(Promise, DB) {
     const hydratedDocs = deepCopy(docs); // a copy of the original docs which we will incrementally hydrate and return
     const knownDocs = [...hydratedDocs]; // an array of all documents which we have fetched
 
-    let patientUuids; // a map of (v,k) pairs with (hydratedDocUuid, patientUuid)
-    let placeUuids; // a map of (v,k) pairs with (hydratedDocUuid, placeUuid)
+    let patientUuids; // a map of (k, v) pairs with (hydratedDocUuid, patientUuid)
+    let placeUuids; // a map of (k, v) pairs with (hydratedDocUuid, placeUuid)
     let subjectDocs;
 
     return fetchSubjectsUuids(hydratedDocs)

--- a/shared-libs/lineage/src/utils.js
+++ b/shared-libs/lineage/src/utils.js
@@ -17,7 +17,15 @@ const validLinkedDocs = doc => {
   return isContact(doc) && _.isObject(doc.linked_docs) && !_.isArray(doc.linked_docs);
 };
 
+const isReport = (doc) => doc.type === 'data_record';
+const getPatientId = (doc) => (doc.fields && (doc.fields.patient_id || doc.fields.patient_uuid)) || doc.patient_id;
+const getPlaceId = (doc) => (doc.fields && doc.fields.place_id) || doc.place_id;
+
+
 module.exports = {
   getId,
   validLinkedDocs,
+  isReport,
+  getPatientId,
+  getPlaceId,
 };

--- a/shared-libs/lineage/test/integration.js
+++ b/shared-libs/lineage/test/integration.js
@@ -251,6 +251,25 @@ const report_with_place = {
     place_id: '54321'
   }
 };
+
+const report_with_place_uuid = {
+  _id: 'report_with_place_uuid',
+  type: 'data_record',
+  form: 'A',
+  contact: {
+    _id: report_contact._id,
+    parent: {
+      _id: report_parent._id,
+      parent: {
+        _id: report_grandparent._id
+      }
+    }
+  },
+  fields: {
+    place_id: report_place._id,
+  }
+};
+
 const report_with_place_and_patient = {
   _id: 'report_with_place_and_patient',
   type: 'data_record',
@@ -491,6 +510,7 @@ const fixtures = [
   report_place,
   report,
   report_with_place,
+  report_with_place_uuid,
   report_with_place_and_patient,
   report2,
   report3,
@@ -725,6 +745,43 @@ describe('Lineage', function() {
 
     it('attaches the full lineage for reports with place_id', function() {
       return lineage.fetchHydratedDoc(report_with_place._id).then(actual => {
+        expect(actual.patient).to.equal(undefined);
+        assert.checkDeepProperties(actual, {
+          form: 'A',
+          place: {
+            name: report_place.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                name: report_parentContact.name,
+                phone: report_parentContact.phone,
+              }
+            }
+          },
+          contact: {
+            name: report_contact.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                phone: '+123',
+                name: report_parentContact.name,
+              },
+              parent: {
+                name: report_grandparent.name,
+                contact: {
+                  phone: '+456',
+                  name: report_grandparentContact.name,
+                }
+              }
+            }
+          },
+          parent: undefined
+        });
+      });
+    });
+
+    it('attaches the full lineage for reports with place_id containing a uuid', () => {
+      return lineage.fetchHydratedDoc(report_with_place_uuid._id).then(actual => {
         expect(actual.patient).to.equal(undefined);
         assert.checkDeepProperties(actual, {
           form: 'A',

--- a/shared-libs/lineage/test/integration.js
+++ b/shared-libs/lineage/test/integration.js
@@ -204,6 +204,19 @@ const report_patient = {
   },
   reported_date: '5'
 };
+const report_place = {
+  _id: 'report_place',
+  place_id: '54321',
+  type: 'clinic',
+  name: 'place_name',
+  parent: {
+    _id: report_parent._id,
+    parent: {
+      _id: report_grandparent._id
+    }
+  },
+  reported_date: '5'
+};
 const report = {
   _id: 'report',
   type: 'data_record',
@@ -219,6 +232,41 @@ const report = {
   },
   fields: {
     patient_id: '12345'
+  }
+};
+const report_with_place = {
+  _id: 'report_with_place',
+  type: 'data_record',
+  form: 'A',
+  contact: {
+    _id: report_contact._id,
+    parent: {
+      _id: report_parent._id,
+      parent: {
+        _id: report_grandparent._id
+      }
+    }
+  },
+  fields: {
+    place_id: '54321'
+  }
+};
+const report_with_place_and_patient = {
+  _id: 'report_with_place_and_patient',
+  type: 'data_record',
+  form: 'A',
+  contact: {
+    _id: report_contact._id,
+    parent: {
+      _id: report_parent._id,
+      parent: {
+        _id: report_grandparent._id
+      }
+    }
+  },
+  fields: {
+    place_id: '54321',
+    patient_id: '12345',
   }
 };
 const report2 = {
@@ -271,6 +319,23 @@ const report4 = {
   },
   fields: {
     patient_id: 'something'
+  }
+};
+const report5 = {
+  _id: 'report5',
+  type: 'data_record',
+  form: 'A',
+  contact: {
+    _id: report_contact._id,
+    parent: {
+      _id: report_parent._id,
+      parent: {
+        _id: report_grandparent._id
+      }
+    }
+  },
+  fields: {
+    place_id: 'something'
   }
 };
 const stub_contacts = {
@@ -423,10 +488,14 @@ const fixtures = [
   report_grandparentContact,
   report_contact,
   report_patient,
+  report_place,
   report,
+  report_with_place,
+  report_with_place_and_patient,
   report2,
   report3,
   report4,
+  report5,
   stub_contacts,
   stub_parents,
   sms_doc,
@@ -557,8 +626,9 @@ describe('Lineage', function() {
       });
     });
 
-    it('attaches the full lineage for reports', function() {
+    it('attaches the full lineage for reports with patient_id', function() {
       return lineage.fetchHydratedDoc(report._id).then(actual => {
+        expect(actual.place).to.equal(undefined);
         assert.checkDeepProperties(actual, {
           form: 'A',
           patient: {
@@ -595,6 +665,7 @@ describe('Lineage', function() {
 
     it('attaches patient lineage when using patient_uuid field', () => {
       return lineage.fetchHydratedDoc(report2._id).then(actual => {
+        expect(actual.place).to.equal(undefined);
         assert.checkDeepProperties(actual, {
           form: 'A',
           patient: {
@@ -624,6 +695,7 @@ describe('Lineage', function() {
 
     it('attaches patient lineage when using patient_id field that contains a uuid', () => {
       return lineage.fetchHydratedDoc(report3._id).then(actual => {
+        expect(actual.place).to.equal(undefined);
         assert.checkDeepProperties(actual, {
           form: 'A',
           patient: {
@@ -651,8 +723,113 @@ describe('Lineage', function() {
       });
     });
 
+    it('attaches the full lineage for reports with place_id', function() {
+      return lineage.fetchHydratedDoc(report_with_place._id).then(actual => {
+        expect(actual.patient).to.equal(undefined);
+        assert.checkDeepProperties(actual, {
+          form: 'A',
+          place: {
+            name: report_place.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                name: report_parentContact.name,
+                phone: report_parentContact.phone,
+              }
+            }
+          },
+          contact: {
+            name: report_contact.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                phone: '+123',
+                name: report_parentContact.name,
+              },
+              parent: {
+                name: report_grandparent.name,
+                contact: {
+                  phone: '+456',
+                  name: report_grandparentContact.name,
+                }
+              }
+            }
+          },
+          parent: undefined
+        });
+      });
+    });
+
+    it('attaches the full lineage for reports with place_id and patient_id', function() {
+      return lineage.fetchHydratedDoc(report_with_place_and_patient._id).then(actual => {
+        assert.checkDeepProperties(actual, {
+          form: 'A',
+          place: {
+            name: report_place.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                name: report_parentContact.name,
+                phone: report_parentContact.phone,
+              }
+            }
+          },
+          patient: {
+            name: report_patient.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                name: report_parentContact.name,
+              }
+            }
+          },
+          contact: {
+            name: report_contact.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                phone: '+123',
+                name: report_parentContact.name,
+              },
+              parent: {
+                name: report_grandparent.name,
+                contact: {
+                  phone: '+456',
+                  name: report_grandparentContact.name,
+                }
+              }
+            }
+          },
+          parent: undefined
+        });
+      });
+    });
+
     it('should work when patient is not found', () => {
       return lineage.fetchHydratedDoc(report4._id).then(actual => {
+        expect(actual.patient).to.equal(undefined);
+        expect(actual.place).to.equal(undefined);
+        assert.checkDeepProperties(actual, {
+          form: 'A',
+          contact: {
+            name: report_contact.name,
+            parent: {
+              name: report_parent.name,
+              contact: { phone: '+123' },
+              parent: {
+                name: report_grandparent.name,
+                contact: { phone: '+456' }
+              }
+            }
+          },
+          parent: undefined
+        });
+      });
+    });
+
+    it('should work when place is not found', () => {
+      return lineage.fetchHydratedDoc(report5._id).then(actual => {
+        expect(actual.place).to.equal(undefined);
         expect(actual.patient).to.equal(undefined);
         assert.checkDeepProperties(actual, {
           form: 'A',
@@ -771,11 +948,76 @@ describe('Lineage', function() {
 
   describe('hydrateDocs', function() {
     it('binds contacts and parents', function() {
-      const docs = [ report, place ];
+      const docs = [ report, place, report_with_place, report_with_place_and_patient ];
 
       return lineage.hydrateDocs(docs)
-        .then(([ hydratedReport, hydratedPlace ]) => {
+        .then(([ hydratedReport, hydratedPlace, hydratedReportWithPlace, hydratedReportWithPlaceAndPatient ]) => {
           assert.checkDeepProperties(hydratedReport, {
+            contact: {
+              name: report_contact.name,
+              parent: {
+                name: report_parent.name,
+                contact: { name: report_parentContact.name },
+                parent: {
+                  name: report_grandparent.name,
+                  contact: { name: report_grandparentContact.name }
+                }
+              }
+            },
+            parent: undefined,
+            place: undefined,
+            patient: {
+              _id: report_patient._id,
+              name: report_patient.name,
+              parent: {
+                _id: report_parent._id,
+                name: report_parent.name,
+                contact: {
+                  _id: report_parentContact._id,
+                  name: report_parentContact.name,
+                }
+              }
+            },
+          });
+          assert.checkDeepProperties(hydratedPlace, {
+            contact: { name: place_contact.name },
+            parent: {
+              name: place_parent.name,
+              contact: { name: place_parentContact.name },
+              parent: {
+                name: place_grandparent.name,
+                contact: { name: place_grandparentContact.name }
+              }
+            }
+          });
+          assert.checkDeepProperties(hydratedReportWithPlace, {
+            contact: {
+              name: report_contact.name,
+              parent: {
+                name: report_parent.name,
+                contact: { name: report_parentContact.name },
+                parent: {
+                  name: report_grandparent.name,
+                  contact: { name: report_grandparentContact.name }
+                }
+              }
+            },
+            parent: undefined,
+            patient: undefined,
+            place: {
+              _id: report_place._id,
+              name: report_place.name,
+              parent: {
+                _id: report_parent._id,
+                name: report_parent.name,
+                contact: {
+                  _id: report_parentContact._id,
+                  name: report_parentContact.name,
+                }
+              }
+            },
+          });
+          assert.checkDeepProperties(hydratedReportWithPlaceAndPatient, {
             contact: {
               name: report_contact.name,
               parent: {
@@ -799,28 +1041,29 @@ describe('Lineage', function() {
                   name: report_parentContact.name,
                 }
               }
-            }
-          });
-          assert.checkDeepProperties(hydratedPlace, {
-            contact: { name: place_contact.name },
-            parent: {
-              name: place_parent.name,
-              contact: { name: place_parentContact.name },
+            },
+            place: {
+              _id: report_place._id,
+              name: report_place.name,
               parent: {
-                name: place_grandparent.name,
-                contact: { name: place_grandparentContact.name }
+                _id: report_parent._id,
+                name: report_parent.name,
+                contact: {
+                  _id: report_parentContact._id,
+                  name: report_parentContact.name,
+                }
               }
-            }
+            },
           });
         });
     });
 
     it('ignores db-fetch errors', function() {
-      const docs = [ report, place ];
+      const docs = [ report, place, report_with_place ];
 
       return deleteDocs([place_parent._id, report_parentContact._id])
         .then(() => lineage.hydrateDocs(docs))
-        .then(([ hydratedReport, hydratedPlace ]) => {
+        .then(([ hydratedReport, hydratedPlace, hydratedReportWithPlace ]) => {
           assert.checkDeepProperties(hydratedReport, {
             contact: {
               name: report_contact.name,
@@ -849,18 +1092,37 @@ describe('Lineage', function() {
               }
             }
           });
+          assert.checkDeepProperties(hydratedReportWithPlace, {
+            contact: {
+              name: report_contact.name,
+              parent: {
+                name: report_parent.name,
+                contact: {
+                  _id: report_parentContact._id,
+                  name: undefined
+                },
+                parent: {
+                  name: report_grandparent.name,
+                  contact: { name: report_grandparentContact.name }
+                }
+              }
+            },
+            parent: undefined
+          });
         });
     });
 
     it('minifying the result returns the starting documents', function() {
-      const docs = [ cloneDeep(report), cloneDeep(place) ];
+      const docs = [ cloneDeep(report), cloneDeep(place), cloneDeep(report_with_place) ];
 
       return lineage.hydrateDocs(docs)
-        .then(([ hydratedReport, hydratedPlace ]) => {
+        .then(([ hydratedReport, hydratedPlace, hydratedReportWithPlace ]) => {
           lineage.minify(hydratedReport);
           lineage.minify(hydratedPlace);
+          lineage.minify(hydratedReportWithPlace);
           expect(hydratedReport).excluding('_rev').to.deep.equal(report);
           expect(hydratedPlace).excluding('_rev').to.deep.equal(place);
+          expect(hydratedReportWithPlace).excluding('_rev').to.deep.equal(report_with_place);
         });
     });
 
@@ -1241,8 +1503,9 @@ describe('Lineage', function() {
     });
 
     it('should work with multiple docs', () => {
-      return lineage.fetchHydratedDocs([report_patient._id, 'not_found', place._id, report._id]).then(result => {
-        expect(result.length).to.equal(3);
+      const docIds = [report_patient._id, 'not_found', place._id, report._id, report_with_place._id];
+      return lineage.fetchHydratedDocs(docIds).then(result => {
+        expect(result.length).to.equal(4);
         assert.checkDeepProperties(result[0], {
           _id: 'report_patient',
           patient_id: '12345',
@@ -1299,6 +1562,40 @@ describe('Lineage', function() {
           },
           patient: {
             name: report_patient.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                name: report_parentContact.name,
+              },
+              parent: {
+                name: report_grandparent.name,
+                contact: {
+                  name: report_grandparentContact.name
+                }
+              }
+            }
+          }
+        });
+
+        assert.checkDeepProperties(result[3], {
+          _id: 'report_with_place',
+          contact: {
+            name: report_contact.name,
+            parent: {
+              name: report_parent.name,
+              contact: {
+                name: report_parentContact.name,
+              },
+              parent: {
+                name: report_grandparent.name,
+                contact: {
+                  name: report_grandparentContact.name,
+                }
+              }
+            }
+          },
+          place: {
+            name: report_place.name,
             parent: {
               name: report_parent.name,
               contact: {

--- a/shared-libs/lineage/test/integration.js
+++ b/shared-libs/lineage/test/integration.js
@@ -646,7 +646,7 @@ describe('Lineage', function() {
       });
     });
 
-    it('attaches the full lineage for reports with patient_id', function() {
+    it('attaches the full lineage for reports with patient_id', () => {
       return lineage.fetchHydratedDoc(report._id).then(actual => {
         expect(actual.place).to.equal(undefined);
         assert.checkDeepProperties(actual, {
@@ -743,7 +743,7 @@ describe('Lineage', function() {
       });
     });
 
-    it('attaches the full lineage for reports with place_id', function() {
+    it('attaches the full lineage for reports with place_id', () => {
       return lineage.fetchHydratedDoc(report_with_place._id).then(actual => {
         expect(actual.patient).to.equal(undefined);
         assert.checkDeepProperties(actual, {
@@ -817,7 +817,7 @@ describe('Lineage', function() {
       });
     });
 
-    it('attaches the full lineage for reports with place_id and patient_id', function() {
+    it('attaches the full lineage for reports with place_id and patient_id', () => {
       return lineage.fetchHydratedDoc(report_with_place_and_patient._id).then(actual => {
         assert.checkDeepProperties(actual, {
           form: 'A',

--- a/shared-libs/message-utils/src/index.js
+++ b/shared-libs/message-utils/src/index.js
@@ -214,6 +214,10 @@ const extendedTemplateContext = function(doc, extras) {
     _.defaults(templateContext, extractTemplateContext(extras.registrations[0]));
   }
 
+  if (extras.placeRegistrations && extras.placeRegistrations.length) {
+    _.defaults(templateContext, extractTemplateContext(extras.placeRegistrations[0]));
+  }
+
   return templateContext;
 };
 
@@ -268,8 +272,8 @@ const truncateMessage = function(parts, max) {
  *        property on the doc.
  * @param {Object} [extraContext={}] An object with additional values to
  *        provide as a context for templating. Properties: `patient` (object),
- *        `registrations` (array), and `templateContext` (object) for any
- *        unstructured context additions.
+ *        `registrations` (array), `place` (object), `placeRegistrations` (array),
+ *        and `templateContext` (object) for any unstructured context additions.
  * @returns {Object} The generated message object.
  */
 exports.generate = function(config, translate, doc, content, recipient, extraContext) {
@@ -306,6 +310,14 @@ exports.generate = function(config, translate, doc, content, recipient, extraCon
                          extraContext.registrations.length;
   if (isMissingPatient) {
     result.error = 'messages.errors.patient.missing';
+  }
+
+  const isMissingPlace = extraContext &&
+                         !extraContext.place &&
+                         extraContext.placeRegistrations &&
+                         extraContext.placeRegistrations.length;
+  if (isMissingPlace) {
+    result.error = 'messages.errors.place.missing';
   }
 
   return [ result ];

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -390,14 +390,19 @@ describe('messageUtils', () => {
       const doc = { name: 'alice', fields: { name: 'bob' } };
       const patient = { name: 'charles' };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient, registrations });
+      const place = { name: 'charles area' };
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place, placeRegistrations });
       actual.name.should.equal('charles');
     });
 
     it('should pick place data second', () => {
       const doc = { name: 'alice', fields: { name: 'bob' } };
       const place = { name: 'charles' };
-      const actual = utils._extendedTemplateContext(doc, { place });
+      const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+      const actual = utils._extendedTemplateContext(doc, { place, registrations, placeRegistrations });
       actual.name.should.equal('charles');
     });
 
@@ -406,7 +411,8 @@ describe('messageUtils', () => {
       const patient = { };
       const place = { };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place });
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place, placeRegistrations });
       actual.name.should.equal('bob');
     });
 
@@ -415,25 +421,48 @@ describe('messageUtils', () => {
       const patient = { };
       const place = { };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place });
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place, placeRegistrations });
       actual.name.should.equal('alice');
     });
 
-    it('picks registration[0].fields properties fifth', () => {
+    it('picks registrations[0].fields properties fifth', () => {
       const doc = { };
       const patient = { };
       const place = { };
       const registrations = [{ name: 'doug', fields: { name: 'elisa' } }];
-      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place });
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place, placeRegistrations });
       actual.name.should.equal('elisa');
     });
 
-    it('picks registration[0].fields properties sixth', () => {
+    it('picks registrations[0] properties sixth', () => {
       const doc = { };
       const patient = { };
       const registrations = [{ name: 'doug' }];
-      const actual = utils._extendedTemplateContext(doc, { patient, registrations });
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, placeRegistrations });
       actual.name.should.equal('doug');
+    });
+
+    it('picks placeRegistrations[0].fields properties seventh', () => {
+      const doc = { };
+      const patient = { };
+      const place = { };
+      const registrations = [];
+      const placeRegistrations = [{ name: 'mary', fields: { name: 'zeewa' } }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place, placeRegistrations });
+      actual.name.should.equal('zeewa');
+    });
+
+    it('picks placeRegistrations[0] properties eighth', () => {
+      const doc = { };
+      const patient = { };
+      const place = { };
+      const registrations = [];
+      const placeRegistrations = [{ name: 'mary' }];
+      const actual = utils._extendedTemplateContext(doc, { patient, registrations, place, placeRegistrations });
+      actual.name.should.equal('mary');
     });
 
     it('should allow registrations without a patient', () => {
@@ -696,6 +725,48 @@ describe('messageUtils', () => {
         const content = { message: 'sms' };
         const recipient = '1234';
         const context = { patient: { name: 'a' } };
+
+        const messages = utils.generate(config, translate, doc, content, recipient, context);
+        expect(messages[0].message).to.equal('sms');
+        expect(messages[0].to).to.equal('1234');
+        expect(messages[0].error).to.equal(undefined);
+      });
+
+      it('should add an error when placeRegistrations are provided without a place', () => {
+        const config = {};
+        const translate = null;
+        const doc = {};
+        const content = { message: 'sms' };
+        const recipient = '1234';
+        const context = { placeRegistrations: [{ _id: 'a' }] };
+
+        const messages = utils.generate(config, translate, doc, content, recipient, context);
+        expect(messages[0].message).to.equal('sms');
+        expect(messages[0].to).to.equal('1234');
+        expect(messages[0].error).to.equal('messages.errors.place.missing');
+      });
+
+      it('should not add an error when no patient, no place and no registrations are provided', () => {
+        const config = {};
+        const translate = null;
+        const doc = {};
+        const content = { message: 'sms' };
+        const recipient = '1234';
+        const context = { registrations: false };
+
+        const messages = utils.generate(config, translate, doc, content, recipient, context);
+        expect(messages[0].message).to.equal('sms');
+        expect(messages[0].to).to.equal('1234');
+        expect(messages[0].error).to.equal(undefined);
+      });
+
+      it('should not add an error when place is provided', () => {
+        const config = {};
+        const translate = null;
+        const doc = {};
+        const content = { message: 'sms' };
+        const recipient = '1234';
+        const context = { place: { name: 'a' } };
 
         const messages = utils.generate(config, translate, doc, content, recipient, context);
         expect(messages[0].message).to.equal('sms');

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -11,12 +11,12 @@
  */
 const _ = require('lodash');
 const crypto = require('crypto');
-//const objectPath = require('object-path');
-//const urlJoin = require('url-join');
+const objectPath = require('object-path');
+const urlJoin = require('url-join');
 const request = require('request-promise-native');
 const vm = require('vm');
 
-//const secureSettings = require('@medic/settings');
+const secureSettings = require('@medic/settings');
 
 const OUTBOUND_REQ_TIMEOUT = 10 * 1000;
 

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -11,12 +11,12 @@
  */
 const _ = require('lodash');
 const crypto = require('crypto');
-const objectPath = require('object-path');
-const urlJoin = require('url-join');
+//const objectPath = require('object-path');
+//const urlJoin = require('url-join');
 const request = require('request-promise-native');
 const vm = require('vm');
 
-const secureSettings = require('@medic/settings');
+//const secureSettings = require('@medic/settings');
 
 const OUTBOUND_REQ_TIMEOUT = 10 * 1000;
 

--- a/shared-libs/transitions/package-lock.json
+++ b/shared-libs/transitions/package-lock.json
@@ -19,6 +19,9 @@
     "@medic/outbound": {
       "version": "file:../outbound"
     },
+    "@medic/settings": {
+      "version": "file:../settings"
+    },
     "@medic/phone-number": {
       "version": "file:../phone-number"
     },
@@ -1427,6 +1430,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "uuid": {
       "version": "3.4.0",

--- a/shared-libs/transitions/package.json
+++ b/shared-libs/transitions/package.json
@@ -21,6 +21,7 @@
     "@medic/message-utils": "file:../message-utils",
     "@medic/outbound": "file:../outbound",
     "@medic/phone-number": "file:../phone-number",
+    "@medic/settings": "file:../settings",
     "@medic/registration-utils": "file:../registration-utils",
     "@medic/task-utils": "file:../task-utils",
     "async": "^3.2.0",
@@ -33,6 +34,7 @@
     "mustache": "^4.0.1",
     "object-path": "^0.11.4",
     "request": "^2.88.2",
-    "request-promise-native": "^1.0.9"
+    "request-promise-native": "^1.0.9",
+    "url-join": "^4.0.1"
   }
 }

--- a/shared-libs/transitions/src/lib/schedules.js
+++ b/shared-libs/transitions/src/lib/schedules.js
@@ -70,8 +70,9 @@ module.exports = {
   },
 
   //Take doc and schedule config and setup schedule tasks.
-  assignSchedule: function(doc, schedule, patientRegistrations, patient, placeRegistrations, place) {
+  assignSchedule: (doc, schedule, context={}) => {
     const self = module.exports;
+    const { place, patient, patientRegistrations, placeRegistrations } = context;
     const now = moment(date.getDate());
     const muted = isMuted(patient, place);
     const allowedState = muted ? 'muted' : 'scheduled';

--- a/shared-libs/transitions/src/lib/schedules.js
+++ b/shared-libs/transitions/src/lib/schedules.js
@@ -10,14 +10,23 @@ const messages = require('../lib/messages');
 const messageUtils = require('@medic/message-utils');
 const mutingUtils = require('../lib/muting_utils');
 
-const isMuted = (patient, place) => {
-  if (patient) {
-    return patient.muted || mutingUtils.isMutedInLineage(patient);
-  }
+const isMuted = (contact) => contact.muted || mutingUtils.isMutedInLineage(contact);
 
-  if (place) {
-    return place.muted || mutingUtils.isMutedInLineage(place);
+/**
+ * @param {Object} patient - the report's patient subject
+ * @param {Object} place - the report's place subject
+ * @returns {boolean}
+ * if both patient and place exist, prioritise the patient's muted state over the place's muted state.
+ * If neither exist, the schedule should not be muted.
+ */
+const shouldMuteSchedule = (patient, place) => {
+  if (patient) {
+    return isMuted(patient);
   }
+  if (place) {
+    return isMuted(place);
+  }
+  return false;
 };
 
 module.exports = {
@@ -74,7 +83,7 @@ module.exports = {
     const self = module.exports;
     const { place, patient, patientRegistrations, placeRegistrations } = context;
     const now = moment(date.getDate());
-    const muted = isMuted(patient, place);
+    const muted = shouldMuteSchedule(patient, place);
     const allowedState = muted ? 'muted' : 'scheduled';
     const skipGroups = [];
 

--- a/shared-libs/transitions/src/lib/schedules.js
+++ b/shared-libs/transitions/src/lib/schedules.js
@@ -68,9 +68,8 @@ module.exports = {
     });
     return ret;
   },
-  /*
-     * Take doc and schedule config and setup schedule tasks.
-     */
+
+  //Take doc and schedule config and setup schedule tasks.
   assignSchedule: function(doc, schedule, patientRegistrations, patient, placeRegistrations, place) {
     const self = module.exports;
     const now = moment(date.getDate());
@@ -92,8 +91,7 @@ module.exports = {
       return false;
     }
 
-    // if start_form property is null, we skip schedule creation, but mark
-    // transtition as complete.
+    // if start_form property is null, we skip schedule creation, but mark transition as complete.
     if (docStart === null) {
       return true;
     }

--- a/shared-libs/transitions/src/lib/schedules.js
+++ b/shared-libs/transitions/src/lib/schedules.js
@@ -18,7 +18,7 @@ const isMuted = (patient, place) => {
   if (place) {
     return place.muted || mutingUtils.isMutedInLineage(place);
   }
-}
+};
 
 module.exports = {
   // return [hour, minute, timezone]

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -32,8 +32,8 @@ const getTemplateContext = (doc) => {
 
   return Promise
     .all([
-      utils.getRegistrations({ id: patientShortcodeId }),
-      utils.getRegistrations({ id: placeShortcodeId }),
+      patientShortcodeId && utils.getRegistrations({ id: patientShortcodeId }),
+      placeShortcodeId && utils.getRegistrations({ id: placeShortcodeId }),
       getContactByShortcode(patientShortcodeId),
       getContactByShortcode(placeShortcodeId),
     ])

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -11,18 +11,6 @@ const messageUtils = require('@medic/message-utils');
 
 const BATCH_SIZE = 1000;
 
-const getContactByShortcode = (shortcode) => {
-  return utils
-    .getContactUuid(shortcode)
-    .then(uuid => {
-      if (!uuid) {
-        return;
-      }
-
-      return lineage.fetchHydratedDoc(uuid);
-    });
-};
-
 const getTemplateContext = (doc) => {
   const patientShortcodeId = doc.fields && doc.fields.patient_id;
   const placeShortcodeId = doc.fields && doc.fields.place_id;
@@ -34,14 +22,13 @@ const getTemplateContext = (doc) => {
     .all([
       patientShortcodeId && utils.getRegistrations({ id: patientShortcodeId }),
       placeShortcodeId && utils.getRegistrations({ id: placeShortcodeId }),
-      getContactByShortcode(patientShortcodeId),
-      getContactByShortcode(placeShortcodeId),
     ])
-    .then(([ patientRegistrations, placeRegistrations, patient, place ]) => ({
+    .then(([ patientRegistrations, placeRegistrations]) => ({
       registrations: patientRegistrations,
       placeRegistrations,
-      patient,
-      place,
+      // the doc is already hydrated
+      patient: doc.patient,
+      place: doc.place,
     }));
 };
 

--- a/shared-libs/transitions/src/transitions/accept_case_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_case_reports.js
@@ -1,6 +1,5 @@
 const config = require('../config');
 const messages = require('../lib/messages');
-const validation = require('../lib/validation');
 const utils = require('../lib/utils');
 const transitionUtils = require('./utils');
 const acceptPatientReports = require('./accept_patient_reports');
@@ -9,15 +8,6 @@ const NAME = 'accept_case_reports';
 const getConfig = form => {
   const fullConfig = config.get('accept_case_reports') || [];
   return fullConfig.find(config => config.form === form);
-};
-
-const validate = (config, doc) => {
-  const validations = config.validations && config.validations.list;
-  return new Promise(resolve => {
-    validation.validate(doc, validations, errors => {
-      resolve(errors);
-    });
-  });
 };
 
 // NB: this is very similar to a function in the registration transition, except
@@ -57,14 +47,7 @@ const getCaseRegistrations = doc => {
 };
 
 const silenceRegistrations = (doc, config, registrations) => {
-  return new Promise((resolve, reject) => {
-    acceptPatientReports.silenceRegistrations(
-      config,
-      doc,
-      registrations,
-      (err, result) => err ? reject(err) : resolve(result)
-    );
-  });
+  return acceptPatientReports.silenceRegistrations(config, doc, registrations);
 };
 
 const updatePlaceUuid = (doc, registrations) => {
@@ -99,7 +82,7 @@ module.exports = {
       return Promise.resolve();
     }
 
-    return validate(config, doc).then(errors => {
+    return transitionUtils.validate(config, doc).then(errors => {
       if (errors && errors.length > 0) {
         messages.addErrors(config, doc, errors);
         return true;

--- a/shared-libs/transitions/src/transitions/accept_case_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_case_reports.js
@@ -41,7 +41,8 @@ const addMessagesToDoc = (doc, config, registrations) => {
     if (messageRelevant(msg, doc)) {
       messages.addMessage(doc, msg, msg.recipient, {
         patient: doc.patient,
-        registrations
+        registrations,
+        place: doc.place,
       });
     }
   });

--- a/shared-libs/transitions/src/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_patient_reports.js
@@ -152,7 +152,7 @@ const findValidRegistration = (doc, config, registrations) => {
         // If the visit falls within the silence_for range of a reminder that
         // has been cleared, we move to the next registration because we assume
         // that this visit is not responding to the reminder. This happens only when
-        // we are transtioning from one group to another one. Note that existing
+        // we are transitioning from one group to another one. Note that existing
         // functionality will set the cleared_by on the reminders of the task group
         if (silenceStart < visitReportedDate &&
             task.state === 'cleared' &&
@@ -161,7 +161,7 @@ const findValidRegistration = (doc, config, registrations) => {
           break;
         }
 
-        // We loop through until we find a task that has been "deliverd" or "sent" and
+        // We loop through until we find a task that has been "delivered" or "sent" and
         // that is older than the visit reported date
         if (moment(task.due) < visitReportedDate &&
               ['delivered', 'sent'].includes(task.state)) {

--- a/shared-libs/transitions/src/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_patient_reports.js
@@ -243,11 +243,11 @@ const getRegistrations = (contact) => {
     return [];
   }
   const subjectIds = utils.getSubjectIds(contact);
-  if (!subjectIds || !subjectIds.length) {
-    return [];
+  if (subjectIds && subjectIds.length) {
+    return utils.getReportsBySubject({ ids: subjectIds, registrations: true });
   }
 
-  return utils.getReportsBySubject({ ids: subjectIds, registrations: true });
+  return [];
 };
 
 const handleReport = (doc, config, callback) => {

--- a/shared-libs/transitions/src/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/src/transitions/accept_patient_reports.js
@@ -238,11 +238,23 @@ const addMessagesToDoc = (doc, config, registrations, placeRegistrations) => {
   });
 };
 
+const getRegistrations = (contact) => {
+  if (!contact) {
+    return [];
+  }
+  const subjectIds = utils.getSubjectIds(contact);
+  if (!subjectIds || !subjectIds.length) {
+    return [];
+  }
+
+  return utils.getReportsBySubject({ ids: subjectIds, registrations: true });
+};
+
 const handleReport = (doc, config, callback) => {
   return Promise
     .all([
-      utils.getReportsBySubject({ ids: utils.getSubjectIds(doc.patient), registrations: true }),
-      utils.getReportsBySubject({ ids: utils.getSubjectIds(doc.place), registrations: true }),
+      getRegistrations(doc.patient),
+      getRegistrations(doc.place),
     ])
     .then(([patientRegistrations, placeRegistrations]) => {
       const allRegistrations = [...patientRegistrations, ...placeRegistrations];

--- a/shared-libs/transitions/src/transitions/muting.js
+++ b/shared-libs/transitions/src/transitions/muting.js
@@ -3,7 +3,6 @@ const config = require('../config');
 const transitionUtils = require('./utils');
 const utils = require('../lib/utils');
 const messages = require('../lib/messages');
-const validation = require('../lib/validation');
 const mutingUtils = require('../lib/muting_utils');
 
 const TRANSITION_NAME = 'muting';
@@ -72,19 +71,14 @@ module.exports = {
 
   filter: (doc, info = {}) => isRelevantReport(doc, info) || isRelevantContact(doc, info),
 
-  validate: function(doc) {
+  validate: (doc) => {
     const config = getConfig();
-    const validations = config.validations && config.validations.list;
-
-    return new Promise(resolve => {
-      validation.validate(doc, validations, (errors) => {
-        if (errors && errors.length) {
-          messages.addErrors(config, doc, errors, { patient: doc.patient });
-          return resolve(false);
-        }
-
-        resolve(true);
-      });
+    return transitionUtils.validate(config, doc).then(errors => {
+      if (errors && errors.length) {
+        messages.addErrors(config, doc, errors, { patient: doc.patient });
+        return false;
+      }
+      return true;
     });
   },
 

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -559,6 +559,20 @@ const addPlace = (options) => {
     });
 };
 
+// todo: should I just validate one subject or both?
+const hasValidSubject = (doc, patientId, placeId) => {
+  // already hydrated
+  if (patientId && !doc.patient && !contactTypesUtils.isPerson(config.getAll(), doc.patient)) {
+    return false;
+  }
+
+  if (placeId && !doc.place && !contactTypesUtils.isPlace(config.getAll(), doc.place)) {
+    return false;
+  }
+
+  return true;
+};
+
 module.exports = {
   name: NAME,
   init: () => {
@@ -671,15 +685,12 @@ module.exports = {
 
         // We're attaching this registration to an existing contact, let's
         // make sure it's valid
-        // todo should we explicitly require all subjects exist?
-        return utils.getContactUuid(patientId || placeId).then(subjectUuid => {
-          if (!subjectUuid) {
-            transitionUtils.addRegistrationNotFoundError(doc, registrationConfig);
-            return true;
-          }
+        if (!hasValidSubject(doc, patientId, placeId)) {
+          transitionUtils.addRegistrationNotFoundError(doc, registrationConfig);
+          return true;
+        }
 
-          return fireConfiguredTriggers(registrationConfig, doc);
-        });
+        return fireConfiguredTriggers(registrationConfig, doc);
       });
   },
 };

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -24,13 +24,6 @@ const findFirstDefinedValue = (doc, fields) => {
   return definedField && doc.fields[definedField];
 };
 
-const getRegistrations = (subjectId) => {
-  if (!subjectId) {
-    return Promise.resolve([]);
-  }
-  return utils.getRegistrations({ id: subjectId });
-};
-
 const getPatientNameField = (params) => getNameField(params, 'patient');
 const getPlaceNameField = (params) => getNameField(params, 'place');
 
@@ -302,7 +295,10 @@ const addMessages = (config, doc) => {
   }
 
   return Promise
-    .all([getRegistrations(patientId), getRegistrations(placeId)])
+    .all([
+      utils.getRegistrations({ id: patientId }),
+      utils.getRegistrations({ id: placeId }),
+    ])
     .then(([ patientRegistrations, placeRegistrations ]) => {
       const context = {
         patient: doc.patient,
@@ -327,7 +323,10 @@ const assignSchedule = (options) => {
   const placeId = options.doc.fields && options.doc.fields.place_id;
 
   return Promise
-    .all([ getRegistrations(patientId), getRegistrations(placeId) ])
+    .all([
+      utils.getRegistrations({ id: patientId }),
+      utils.getRegistrations({ id: placeId }),
+    ])
     .then(([ patientRegistrations, placeRegistrations ]) => {
       options.params.forEach(scheduleName => {
         const schedule = schedules.getScheduleConfig(scheduleName);

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -331,14 +331,13 @@ const assignSchedule = (options) => {
     .then(([ patientRegistrations, placeRegistrations ]) => {
       options.params.forEach(scheduleName => {
         const schedule = schedules.getScheduleConfig(scheduleName);
-        schedules.assignSchedule(
-          options.doc,
-          schedule,
+        const context = {
           patientRegistrations,
-          options.doc.patient,
+          patient: options.doc.patient,
           placeRegistrations,
-          options.doc.place
-        );
+          place: options.doc.place
+        };
+        schedules.assignSchedule(options.doc, schedule, context);
       });
     });
 };

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -227,7 +227,10 @@ const triggers = {
       silence_for: null,
     };
 
-    const subjectIds = utils.getSubjectIds(options.doc.patient);
+    const subjectIds = [
+      ...utils.getSubjectIds(options.doc.patient),
+      ...utils.getSubjectIds(options.doc.place),
+    ];
     const caseId = options.doc.case_id ||
       (options.doc.fields && options.doc.fields.case_id);
     if (caseId) {
@@ -334,7 +337,7 @@ const assignSchedule = (options) => {
           patientRegistrations,
           options.doc.patient,
           placeRegistrations,
-          options.doc.place,
+          options.doc.place
         );
       });
     });

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -559,14 +559,13 @@ const addPlace = (options) => {
     });
 };
 
-// todo: should I just validate one subject or both?
 const hasValidSubject = (doc, patientId, placeId) => {
-  // already hydrated
-  if (patientId && !doc.patient && !contactTypesUtils.isPerson(config.getAll(), doc.patient)) {
+  // doc is already hydrated.
+  if (patientId && (!doc.patient || (doc.patient && !contactTypesUtils.isPerson(config.getAll(), doc.patient)))) {
     return false;
   }
 
-  if (placeId && !doc.place && !contactTypesUtils.isPlace(config.getAll(), doc.place)) {
+  if (placeId && (!doc.place || (doc.place && !contactTypesUtils.isPlace(config.getAll(), doc.place)))) {
     return false;
   }
 

--- a/shared-libs/transitions/src/transitions/utils.js
+++ b/shared-libs/transitions/src/transitions/utils.js
@@ -2,6 +2,7 @@ const db = require('../db');
 const messages = require('../lib/messages');
 const utils = require('../lib/utils');
 const idGenerator = require('../lib/ids').generator(db);
+const validation = require('../lib/validation');
 
 const findFirstMatchingMessage = (config, eventType) => {
   if (!config.messages || !config.messages.length) {
@@ -67,7 +68,7 @@ module.exports = {
     return !!(doc.transitions && doc.transitions[transition]);
   },
 
-  getDeprecationMessage(name, deprecatedIn, extraInfo) {
+  getDeprecationMessage: (name, deprecatedIn, extraInfo) => {
     if (!name) {
       return;
     }
@@ -83,5 +84,10 @@ module.exports = {
     }
 
     return message;
-  }
+  },
+
+  validate: (config, doc) => {
+    const validations = config && config.validations && config.validations.list;
+    return new Promise(resolve => validation.validate(doc, validations, resolve));
+  },
 };

--- a/shared-libs/transitions/test/integration/schedules.js
+++ b/shared-libs/transitions/test/integration/schedules.js
@@ -262,7 +262,7 @@ describe('functional schedules', () => {
       from: contact.phone,
       contact: contact,
       fields: { patient_id: '98765' },
-      patient: { parent: { contact: { phone: '+5551596' } } }
+      patient: { parent: { contact: { phone: '+5551596' } }, type: 'person' }
     };
 
     return transition.onMatch({ doc: doc }).then(complete => {

--- a/shared-libs/transitions/test/integration/schedules.js
+++ b/shared-libs/transitions/test/integration/schedules.js
@@ -5,6 +5,7 @@ const utils = require('../../src/lib/utils');
 const transition = require('../../src/transitions/registration');
 const schedules = require('../../src/lib/schedules');
 const config = require('../../src/config');
+const contactTypeUtils = require('@medic/contact-types-utils');
 
 const contact = {
   phone: '+1234',
@@ -328,7 +329,8 @@ describe('functional schedules', () => {
       foo: 'baz',
       fields: { patient_id: '123' },
       patient: {
-        _id: 'uuid'
+        _id: 'uuid',
+        type: 'person',
       }
     };
 
@@ -455,7 +457,7 @@ describe('functional schedules', () => {
       }]
     });
 
-    const patient = { muted: true, parent: { contact: { phone: '+5551596' } } };
+    const patient = { muted: true, parent: { contact: { phone: '+5551596' } }, type: 'person' };
     const doc = {
       reported_date: moment().toISOString(),
       form: 'PATR',
@@ -512,7 +514,7 @@ describe('functional schedules', () => {
       }]
     });
 
-    const patient = { muted: false, parent: { contact: { phone: '+5551596' } } };
+    const patient = { muted: false, parent: { contact: { phone: '+5551596' } }, type: 'person' };
     const doc = {
       reported_date: moment().toISOString(),
       form: 'PATR',
@@ -569,7 +571,7 @@ describe('functional schedules', () => {
       }]
     });
 
-    const place = { muted: true, parent: { contact: { phone: '+5551596' } } };
+    const place = { muted: true, parent: { contact: { phone: '+5551596' } }, type: 'clinic' };
     const doc = {
       reported_date: moment().toISOString(),
       form: 'PATR',
@@ -578,7 +580,7 @@ describe('functional schedules', () => {
       fields: { place_id: '98765' },
       place: place,
     };
-    sinon.stub(utils, 'getContactUuid').resolves('uuid');
+    sinon.stub(contactTypeUtils, 'isPlace').returns(true);
 
     return transition
       .onMatch({ doc: doc })
@@ -627,7 +629,7 @@ describe('functional schedules', () => {
       }]
     });
 
-    const place = { muted: false, parent: { contact: { phone: '+5551596' } } };
+    const place = { muted: false, parent: { contact: { phone: '+5551596' } }, type: 'clinic' };
     const doc = {
       reported_date: moment().toISOString(),
       form: 'PATR',
@@ -636,7 +638,7 @@ describe('functional schedules', () => {
       fields: { place_id: '98765' },
       place: place,
     };
-    sinon.stub(utils, 'getContactUuid').resolves('uuid');
+    sinon.stub(contactTypeUtils, 'isPlace').returns(true);
 
     return transition
       .onMatch({ doc: doc })

--- a/shared-libs/transitions/test/integration/schedules.js
+++ b/shared-libs/transitions/test/integration/schedules.js
@@ -263,9 +263,8 @@ describe('functional schedules', () => {
       from: contact.phone,
       contact: contact,
       fields: { patient_id: '98765' },
-      patient: { parent: { contact: { phone: '+5551596' } }, contact_type: 'a_person', type: 'contact' },
+      patient: { parent: { contact: { phone: '+5551596' } }, type: 'person' },
     };
-    sinon.stub(config, 'getAll').returns({ contact_types: [{ id: 'a_person', person: true }, { id: 'place' }] });
 
     return transition.onMatch({ doc: doc }).then(complete => {
       assert.equal(complete, true);

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -212,7 +212,7 @@ describe('due tasks', () => {
       .stub(utils, 'translate')
       .returns('Please visit {{patient_name}} asap');
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getContactUuid = sinon.stub(utils, 'getContactUuid')
+    sinon.stub(utils, 'getContactUuid')
       .withArgs('123').resolves(patientUuid)
       .withArgs(undefined).resolves(undefined);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -212,7 +212,9 @@ describe('due tasks', () => {
       .stub(utils, 'translate')
       .returns('Please visit {{patient_name}} asap');
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
+    const getContactUuid = sinon.stub(utils, 'getContactUuid')
+      .withArgs('123').resolves(patientUuid)
+      .withArgs(undefined).resolves(undefined);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
@@ -293,8 +295,9 @@ describe('due tasks', () => {
       assert.equal(translate.callCount, 1);
       assert.equal(translate.args[0][0], 'visit-1');
       assert.equal(getRegistrations.callCount, 1);
-      assert.equal(getContactUuid.callCount, 1);
-      assert.equal(getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.callCount, 2);
+      assert.equal(utils.getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.args[1][0], undefined);
       assert.equal(fetchHydratedDoc.callCount, 1);
       assert.equal(fetchHydratedDoc.args[0][0], patientUuid);
       assert.equal(setTaskState.callCount, 1);
@@ -317,7 +320,9 @@ describe('due tasks', () => {
     const expectedPhone = '5556918';
     const expectedMessage = 'old message';
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
+    sinon.stub(utils, 'getContactUuid')
+      .withArgs('123').resolves(patientUuid)
+      .withArgs(undefined).resolves(undefined);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.stub(utils, 'setTaskState');
 
@@ -393,8 +398,9 @@ describe('due tasks', () => {
       assert.equal(view.callCount, 1);
       assert.equal(saveDoc.callCount, 1);
       assert.equal(getRegistrations.callCount, 1);
-      assert.equal(getContactUuid.callCount, 1);
-      assert.equal(getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.callCount, 2);
+      assert.equal(utils.getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.args[1][0], undefined);
       assert.equal(fetchHydratedDoc.callCount, 1);
       assert.equal(fetchHydratedDoc.args[0][0], patientUuid);
       assert.equal(setTaskState.callCount, 1);
@@ -480,8 +486,9 @@ describe('due tasks', () => {
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
       assert.equal(utils.getRegistrations.callCount, 1);
-      assert.equal(utils.getContactUuid.callCount, 1);
+      assert.equal(utils.getContactUuid.callCount, 2);
       assert.equal(utils.getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.args[1][0], undefined);
       assert.equal(schedule._lineage.fetchHydratedDoc.callCount, 0);
       assert.equal(utils.setTaskState.callCount, 0);
     });
@@ -568,8 +575,9 @@ describe('due tasks', () => {
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
       assert.equal(utils.getRegistrations.callCount, 1);
-      assert.equal(utils.getContactUuid.callCount, 1);
+      assert.equal(utils.getContactUuid.callCount, 2);
       assert.equal(utils.getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.args[1][0], undefined);
       assert.equal(schedule._lineage.fetchHydratedDoc.callCount, 0);
       assert.equal(utils.setTaskState.callCount, 1);
       assert.deepEqual(utils.setTaskState.args[0], [
@@ -605,7 +613,9 @@ describe('due tasks', () => {
     const expectedPhone = '5556918';
     const translate = sinon.stub(utils, 'translate').returns('Please visit {{patient_name}} asap');
     const getRegistrations = sinon.stub(utils, 'getRegistrations').resolves([]);
-    const getContactUuid = sinon.stub(utils, 'getContactUuid').resolves(patientUuid);
+    sinon.stub(utils, 'getContactUuid')
+      .withArgs('123').resolves(patientUuid)
+      .withArgs(undefined).resolves(undefined);
     const fetchHydratedDoc = sinon.stub(schedule._lineage, 'fetchHydratedDoc').resolves({ name: 'jim' });
     const setTaskState = sinon.spy(utils, 'setTaskState');
 
@@ -710,8 +720,9 @@ describe('due tasks', () => {
       assert.equal(translate.args[0][0], 'visit-1');
       assert.equal(translate.args[1][0], 'visit-1');
       assert.equal(getRegistrations.callCount, 1);
-      assert.equal(getContactUuid.callCount, 1);
-      assert.equal(getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.callCount, 2);
+      assert.equal(utils.getContactUuid.args[0][0], '123');
+      assert.equal(utils.getContactUuid.args[1][0], undefined);
       assert.equal(fetchHydratedDoc.callCount, 1);
       assert.equal(fetchHydratedDoc.args[0][0], patientUuid);
       assert.equal(setTaskState.callCount, 2);

--- a/shared-libs/transitions/test/unit/generate_patient_id_on_people.js
+++ b/shared-libs/transitions/test/unit/generate_patient_id_on_people.js
@@ -36,7 +36,7 @@ describe('generate_patient_id_on_people transition', () => {
 
   it('adds patient_id to people', () => {
     sinon.stub(transitionUtils, 'getUniqueId').resolves('something');
-    transition.onMatch({});
+    transition.onMatch({ doc: {} });
     assert.equal(transitionUtils.getUniqueId.callCount, 1);
   });
 

--- a/shared-libs/transitions/test/unit/patient_registration.js
+++ b/shared-libs/transitions/test/unit/patient_registration.js
@@ -505,7 +505,8 @@ describe('patient registration', () => {
         assert.equal(changed, true);
         assert.equal(doc.errors.length, 1);
         assert.equal(doc.errors[0].code, 'no_provided_patient_id');
-        assert.equal(utils.getRegistrations.callCount, 0);
+        assert.equal(utils.getRegistrations.callCount, 2);
+        assert.deepEqual(utils.getRegistrations.args, [[{ id: undefined }], [{ id: undefined }]]);
         assert.equal(utils.getContactUuid.callCount, 1);
         assert.equal(transitionUtils.getUniqueId.callCount, 0);
 
@@ -560,7 +561,8 @@ describe('patient registration', () => {
         assert.equal(changed, true);
         assert.equal(doc.errors.length, 1);
         assert.equal(doc.errors[0].code, 'provided_patient_id_not_unique');
-        assert.equal(utils.getRegistrations.callCount, 0);
+        assert.equal(utils.getRegistrations.callCount, 2);
+        assert.deepEqual(utils.getRegistrations.args, [[{ id: undefined }], [{ id: undefined }]]);
         assert.equal(utils.getContactUuid.callCount, 1);
         assert.equal(transitionUtils.getUniqueId.callCount, 0);
 
@@ -617,7 +619,8 @@ describe('patient registration', () => {
       return transition.onMatch({ doc }).then(changed => {
         assert.equal(changed, true);
         assert.equal(doc.errors, undefined);
-        assert.equal(utils.getRegistrations.callCount, 0);
+        assert.equal(utils.getRegistrations.callCount, 2);
+        assert.deepEqual(utils.getRegistrations.args, [[{ id: undefined }], [{ id: undefined }]]);
         assert.equal(utils.getContactUuid.callCount, 1);
         assert.equal(transitionUtils.getUniqueId.callCount, 0);
 

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -254,9 +254,11 @@ describe('pregnancy registration', () => {
     return transition.onMatch({ doc: doc }).then(function(changed) {
       assert.equal(changed, true);
       assert.equal(doc.lmp_date, null);
-      assert.deepEqual(doc.patient_id, 12345);
+      assert.equal(doc.patient_id, 12345);
       assert.equal(doc.tasks, undefined);
       assert.equal(db.medic.post.callCount, 1);
+      assert.equal(utils.getContactUuid.callCount, 1);
+      assert.deepEqual(utils.getContactUuid.args[0], [12345]);
       assert.deepEqual(db.medic.post.args[0], [{
         created_by: 'contact',
         name: 'abc',

--- a/shared-libs/transitions/test/unit/pregnancy_registration.js
+++ b/shared-libs/transitions/test/unit/pregnancy_registration.js
@@ -5,6 +5,8 @@ const moment = require('moment');
 const transitionUtils = require('../../src/transitions/utils');
 const utils = require('../../src/lib/utils');
 const config = require('../../src/config');
+const contactTypeUtils = require('@medic/contact-types-utils');
+const db = require('../../src/db');
 
 const transition = rewire('../../src/transitions/registration');
 
@@ -209,7 +211,6 @@ describe('pregnancy registration', () => {
 
   it('pregnancies on existing patients succeeds with a valid patient id', () => {
     sinon.stub(utils, 'getRegistrations').resolves([]);
-    sinon.stub(utils, 'getContactUuid').resolves('uuid');
 
     const doc = {
       form: 'ep',
@@ -217,6 +218,11 @@ describe('pregnancy registration', () => {
       fields: {
         patient_id: '12345',
         lmp: 5
+      },
+      patient: {
+        _id: 'uuid',
+        patient_id: '12345',
+        type: 'person'
       }
     };
 
@@ -228,24 +234,38 @@ describe('pregnancy registration', () => {
 
 
   it('zero lmp value only registers patient', () => {
-    sinon.stub(utils, 'getContactUuid').resolves('uuid');
-
+    sinon.stub(utils, 'getContactUuid').resolves(undefined);
     sinon.stub(transitionUtils, 'getUniqueId').resolves(12345);
+    sinon.stub(contactTypeUtils, 'isParentOf').returns(true);
+    sinon.stub(db.medic, 'post').resolves();
 
     const doc = {
+      _id: 'doc_id',
       form: 'p',
       type: 'data_record',
+      contact: { _id: 'contact', parent: { _id: 'parent' } },
       fields: {
         patient_name: 'abc',
         lmp: 0
-      }
+      },
+      reported_date: 12345678956
     };
 
     return transition.onMatch({ doc: doc }).then(function(changed) {
       assert.equal(changed, true);
       assert.equal(doc.lmp_date, null);
-      assert(doc.patient_id);
+      assert.deepEqual(doc.patient_id, 12345);
       assert.equal(doc.tasks, undefined);
+      assert.equal(db.medic.post.callCount, 1);
+      assert.deepEqual(db.medic.post.args[0], [{
+        created_by: 'contact',
+        name: 'abc',
+        parent: { _id: 'parent' },
+        patient_id: 12345,
+        type: 'person',
+        source_id: 'doc_id',
+        reported_date: 12345678956,
+      }]);
     });
   });
 

--- a/shared-libs/transitions/test/unit/transitions/accept_case_reports.js
+++ b/shared-libs/transitions/test/unit/transitions/accept_case_reports.js
@@ -47,7 +47,7 @@ describe('accept_case_reports', () => {
   });
 
   describe('onMatch', () => {
-    it('callback empty if form not included', () => {
+    it('return nothing if form not included', () => {
       sinon.stub(config, 'get').returns([{ form: 'x' }, { form: 'z' }]);
       const change = {
         doc: {

--- a/shared-libs/transitions/test/unit/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/test/unit/transitions/accept_patient_reports.js
@@ -187,7 +187,7 @@ describe('accept_patient_reports', () => {
       };
       transition._handleReport(doc, config, () => {
         utils.getReportsBySubject.callCount.should.equal(1);
-        utils.getReportsBySubject.args[0].should.deep.equal([{ ids: ['the_place', '698'], registrations: true }])
+        utils.getReportsBySubject.args[0].should.deep.equal([{ ids: ['the_place', '698'], registrations: true }]);
 
         doc.tasks[0].messages[0].message.should.equal(
           'Thank you, woot. The visit for Seneca (698)(reg beta) has been recorded.'
@@ -225,8 +225,8 @@ describe('accept_patient_reports', () => {
       };
       transition._handleReport(doc, config, () => {
         utils.getReportsBySubject.callCount.should.equal(2);
-        utils.getReportsBySubject.args[0].should.deep.equal([{ ids: ['patient', '559'], registrations: true }])
-        utils.getReportsBySubject.args[1].should.deep.equal([{ ids: ['the_place', '698'], registrations: true }])
+        utils.getReportsBySubject.args[0].should.deep.equal([{ ids: ['patient', '559'], registrations: true }]);
+        utils.getReportsBySubject.args[1].should.deep.equal([{ ids: ['the_place', '698'], registrations: true }]);
 
         doc.tasks[0].messages[0].message.should.equal(
           'Archibald (559 alpha) Seneca (698 beta)'

--- a/shared-libs/transitions/test/unit/transitions/accept_patient_reports.js
+++ b/shared-libs/transitions/test/unit/transitions/accept_patient_reports.js
@@ -159,7 +159,7 @@ describe('accept_patient_reports', () => {
 
     it('adding silence_type to handleReport calls _silenceReminders', done => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(3);
-      const doc = { _id: 'a', fields: { patient_id: 'x' } };
+      const doc = { _id: 'a', fields: { patient_id: 'x' }, patient: { patient_id: 'x' } };
       const config = { silence_type: 'x', messages: [] };
       const registrations = [
         { _id: 'a' }, // should not be silenced as it's the doc being processed
@@ -180,7 +180,7 @@ describe('accept_patient_reports', () => {
 
     it('adds registration_id property', done => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
-      const doc = { _id: 'z', fields: { patient_id: 'x' } };
+      const doc = { _id: 'z', fields: { patient_id: 'x' }, patient: { patient_id: 'x' } };
       const config = { silence_type: 'x', messages: [] };
       const registrations = [
         { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' },
@@ -195,7 +195,7 @@ describe('accept_patient_reports', () => {
 
     it('if there are multiple registrations uses the latest one', done => {
       sinon.stub(transition, '_silenceReminders').callsArgWith(3, null, true);
-      const doc = { _id: 'z', fields: { patient_id: 'x' } };
+      const doc = { _id: 'z', fields: { patient_id: 'x' }, patient: { patient_id: 'x' } };
       const config = { silence_type: 'x', messages: [] };
       const registrations = [
         { _id: 'a', reported_date: '2017-02-05T09:23:07.853Z' },
@@ -360,6 +360,7 @@ describe('accept_patient_reports', () => {
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
         reported_date: '2018-09-28T19:45:00.000Z',
       };
       const config = { silence_type: 'x', silence_for: '8 days', messages: [] };
@@ -422,11 +423,13 @@ describe('accept_patient_reports', () => {
       const doc1 = {
         _id: 'z',
         fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
         reported_date: '2018-09-28T20:45:00.000Z',
       };
       const doc2 = {
         _id: 'z',
         fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
         reported_date: '2018-09-28T21:45:00.000Z',
       };
       const config = { silence_type: 'x', silence_for: '8 days', messages: [] };
@@ -498,6 +501,7 @@ describe('accept_patient_reports', () => {
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
         reported_date: '2018-09-28T20:45:00.000Z',
       };
       const config = { silence_type: 'x', silence_for: '8 days', messages: [] };
@@ -560,6 +564,7 @@ describe('accept_patient_reports', () => {
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
         reported_date: '2018-12-15T18:45:00.000Z',
       };
       const config = { silence_type: 'x', silence_for: '8 days', messages: [] };
@@ -632,6 +637,7 @@ describe('accept_patient_reports', () => {
       const doc = {
         _id: 'z',
         fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
         reported_date: '2019-01-20T18:45:00.000Z',
       };
       const config = { silence_type: 'x', silence_for: '8 days', messages: [] };
@@ -700,10 +706,16 @@ describe('accept_patient_reports', () => {
     });
 
     it('should catch utils.getReportsBySubject errors', done => {
+      const doc = {
+        _id: 'z',
+        fields: { patient_id: 'x' },
+        patient: { patient_id: 'x' },
+        reported_date: '2019-01-20T18:45:00.000Z',
+      };
       sinon.stub(utils, 'getReportsBySubject').rejects({ some: 'error' });
       sinon.stub(utils, 'getSubjectIds').returns(['a', 'b']);
 
-      transition._handleReport({}, {}, (err, complete) => {
+      transition._handleReport(doc, {}, (err, complete) => {
         (!!complete).should.equal(false);
         err.should.deep.equal({ some: 'error' });
         utils.getReportsBySubject.callCount.should.equal(1);

--- a/shared-libs/transitions/test/unit/transitions/generate_shortcode_on_contacts.js
+++ b/shared-libs/transitions/test/unit/transitions/generate_shortcode_on_contacts.js
@@ -15,7 +15,7 @@ describe('generate_shortcode_on_contacts transition', () => {
 
   it('adds patient_id to people', () => {
     sinon.stub(transitionUtils, 'getUniqueId').resolves('something');
-    transition.onMatch({});
+    transition.onMatch({ doc: {} });
     assert.equal(transitionUtils.getUniqueId.callCount, 1);
   });
 

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -2496,7 +2496,7 @@ describe('registration', () => {
         .returns(['uuid', 'patient_id'])
         .withArgs(undefined).returns([]);
       const doc = { patient: { _id: 'uuid', patient_id: 'patient_id' } };
-      sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, null);
+      sinon.stub(acceptPatientReports, 'silenceRegistrations').resolves();
 
       return transition.triggers.clear_schedule({ doc, params: [] }).then(() => {
         utils.getSubjectIds.callCount.should.equal(2);
@@ -2516,7 +2516,7 @@ describe('registration', () => {
         .returns(['uuid', 'place_id'])
         .withArgs(undefined).returns([]);
       const doc = { place: { _id: 'uuid', place_id: 'place_id' } };
-      sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, null);
+      sinon.stub(acceptPatientReports, 'silenceRegistrations').resolves();
 
       return transition.triggers.clear_schedule({ doc, params: [] }).then(() => {
         utils.getSubjectIds.callCount.should.equal(2);
@@ -2539,7 +2539,7 @@ describe('registration', () => {
       sinon.stub(utils, 'getSubjectIds')
         .withArgs(doc.patient).returns(['uuid', 'patient_id'])
         .withArgs(doc.place).returns(['place_uuid', 'place_id']);
-      sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, null);
+      sinon.stub(acceptPatientReports, 'silenceRegistrations').resolves();
 
       return transition.triggers.clear_schedule({ doc, params: [] }).then(() => {
         utils.getSubjectIds.callCount.should.equal(2);
@@ -2559,7 +2559,7 @@ describe('registration', () => {
       const registrations = ['a', 'b', 'c'];
       sinon.stub(utils, 'getReportsBySubject').resolves(registrations);
       sinon.stub(utils, 'getSubjectIds').returns(['uuid', 'patient_id']);
-      sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, null);
+      sinon.stub(acceptPatientReports, 'silenceRegistrations').resolves();
 
       return transition.triggers.clear_schedule({ doc, params }).then(() => {
         acceptPatientReports.silenceRegistrations.callCount.should.equal(1);
@@ -2591,7 +2591,7 @@ describe('registration', () => {
     it('should catch silenceRegistrations errors', () => {
       sinon.stub(utils, 'getReportsBySubject').resolves([]);
       sinon.stub(utils, 'getSubjectIds').returns([]);
-      sinon.stub(acceptPatientReports, 'silenceRegistrations').callsArgWith(3, { some: 'err' });
+      sinon.stub(acceptPatientReports, 'silenceRegistrations').rejects({ some: 'err' });
       return transition.triggers
         .clear_schedule({ doc: {}, params: [] })
         .then(r => r.should.deep.equal('Should have thrown'))

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -1731,13 +1731,15 @@ describe('registration', () => {
       };
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
-      const getRegistrations = sinon
+      sinon
         .stub(utils, 'getRegistrations')
-        .resolves([{ _id: 'xyz' }]);
+        .withArgs({ id: '05649' }).resolves([{ _id: 'xyz' }])
+        .withArgs({ id: undefined }).resolves([]);
       sinon.stub(schedules, 'getScheduleConfig').returns('someschedule');
       const assignSchedule = sinon
         .stub(schedules, 'assignSchedule')
         .returns(true);
+
       return transition.onMatch(change).then(() => {
         assignSchedule.callCount.should.equal(1);
         assignSchedule.args[0].should.deep.equal([
@@ -1750,8 +1752,8 @@ describe('registration', () => {
             placeRegistrations: [],
           },
         ]);
-        getRegistrations.callCount.should.equal(1);
-        getRegistrations.args[0].should.deep.equal([{ id: '05649' }]);
+        utils.getRegistrations.callCount.should.equal(2);
+        utils.getRegistrations.args[0].should.deep.equal([{ id: '05649' }]);
       });
     });
 
@@ -1780,7 +1782,9 @@ describe('registration', () => {
       };
       sinon.stub(config, 'get').returns([eventConfig]);
       sinon.stub(validation, 'validate').callsArgWith(2, null);
-      sinon.stub(utils, 'getRegistrations').resolves([{ _id: 'place_registration' }]);
+      sinon.stub(utils, 'getRegistrations')
+        .withArgs({ id: '79999' }).resolves([{ _id: 'place_registration' }])
+        .withArgs({ id: undefined }).resolves([]);
 
       sinon.stub(schedules, 'getScheduleConfig').returns('myschedule');
       sinon.stub(schedules, 'assignSchedule').returns(true);
@@ -1799,8 +1803,9 @@ describe('registration', () => {
           },
         ]);
 
-        utils.getRegistrations.callCount.should.equal(1);
-        utils.getRegistrations.args[0].should.deep.equal([{ id: '79999' }]);
+        utils.getRegistrations.callCount.should.equal(2);
+        utils.getRegistrations.args[0].should.deep.equal([{ id: undefined }]);
+        utils.getRegistrations.args[1].should.deep.equal([{ id: '79999' }]);
       });
     });
 
@@ -2235,7 +2240,8 @@ describe('registration', () => {
 
       sinon
         .stub(utils, 'getRegistrations')
-        .resolves(testRegistration);
+        .withArgs({ id: '12345' }).resolves(testRegistration)
+        .withArgs({ id: undefined }).resolves([]);
 
       const testConfig = { messages: [testMessage1, testMessage2] };
       const testDoc = {
@@ -2278,8 +2284,9 @@ describe('registration', () => {
           expectedContext,
         ]);
 
-        utils.getRegistrations.callCount.should.equal(1);
+        utils.getRegistrations.callCount.should.equal(2);
         utils.getRegistrations.args[0].should.deep.equal([{ id: '12345' }]);
+        utils.getRegistrations.args[1].should.deep.equal([{ id: undefined }]);
       });
     });
 
@@ -2298,7 +2305,9 @@ describe('registration', () => {
       const placeRegistrations = [{ _id: 'some registration' }];
 
       sinon.stub(messages, 'addMessage');
-      sinon.stub(utils, 'getRegistrations').resolves(placeRegistrations);
+      sinon.stub(utils, 'getRegistrations')
+        .withArgs({ id: undefined }).resolves([])
+        .withArgs({ id: '65498' }).resolves(placeRegistrations);
 
       const testConfig = { messages: [testMessage1, testMessage2] };
       const testDoc = {
@@ -2340,8 +2349,9 @@ describe('registration', () => {
           testPhone,
           expectedContext,
         ]);
-        utils.getRegistrations.callCount.should.equal(1);
-        utils.getRegistrations.args[0].should.deep.equal([{ id: '65498' }]);
+        utils.getRegistrations.callCount.should.equal(2);
+        utils.getRegistrations.args[0].should.deep.equal([{ id: undefined }]);
+        utils.getRegistrations.args[1].should.deep.equal([{ id: '65498' }]);
       });
     });
 
@@ -2432,9 +2442,9 @@ describe('registration', () => {
 
       const addMessage = sinon.stub(messages, 'addMessage');
 
-      sinon
-        .stub(utils, 'getRegistrations')
-        .resolves(testRegistration);
+      sinon.stub(utils, 'getRegistrations')
+        .withArgs({ id: '12345' }).resolves(testRegistration)
+        .withArgs({ id: undefined }).resolves([]);
 
       const testConfig = { messages: [testMessage1, testMessage2] };
       const testDoc = {

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -1743,10 +1743,12 @@ describe('registration', () => {
         assignSchedule.args[0].should.deep.equal([
           change.doc,
           'someschedule',
-          [{ _id: 'xyz' }],
-          change.doc.patient,
-          [],
-          undefined,
+          {
+            patient: change.doc.patient,
+            place: undefined,
+            patientRegistrations: [{ _id: 'xyz' }],
+            placeRegistrations: [],
+          },
         ]);
         getRegistrations.callCount.should.equal(1);
         getRegistrations.args[0].should.deep.equal([{ id: '05649' }]);
@@ -1791,10 +1793,12 @@ describe('registration', () => {
         schedules.assignSchedule.args[0].should.deep.equal([
           change.doc,
           'myschedule',
-          [],
-          undefined,
-          [{ _id: 'place_registration' }],
-          change.doc.place,
+          {
+            patient: undefined,
+            patientRegistrations: [],
+            place: change.doc.place,
+            placeRegistrations: [{ _id: 'place_registration' }],
+          },
         ]);
 
         utils.getRegistrations.callCount.should.equal(1);
@@ -1844,10 +1848,12 @@ describe('registration', () => {
         schedules.assignSchedule.args[0].should.deep.equal([
           change.doc,
           'myschedule',
-          [{ _id: 'patient_registration' }],
-          change.doc.patient,
-          [{ _id: 'place_registration' }],
-          change.doc.place,
+          {
+            patient: change.doc.patient,
+            patientRegistrations: [{ _id: 'patient_registration' }],
+            place: change.doc.place,
+            placeRegistrations: [{ _id: 'place_registration' }],
+          },
         ]);
 
         utils.getRegistrations.callCount.should.equal(2);

--- a/shared-libs/transitions/test/unit/transitions/registration.js
+++ b/shared-libs/transitions/test/unit/transitions/registration.js
@@ -2144,6 +2144,7 @@ describe('registration', () => {
           patient: testPatient,
           place: undefined,
           registrations: testRegistration,
+          placeRegistrations: [],
           templateContext: {
             next_msg: {
               minutes: 0,
@@ -2202,6 +2203,7 @@ describe('registration', () => {
           patient: testPatient,
           place: undefined,
           registrations: testRegistration,
+          placeRegistrations: [],
           templateContext: {
             next_msg: {
               minutes: 0,

--- a/tests/e2e/reports-subject.js
+++ b/tests/e2e/reports-subject.js
@@ -29,6 +29,7 @@ describe('Reports Summary', () => {
     reported_date: 1,
     type: 'clinic',
     name: 'Bob Place',
+    place_id: 'bob_place',
     parent: { _id: HEALTH_CENTER._id, parent: { _id: DISTRICT._id } }
   };
 
@@ -37,6 +38,7 @@ describe('Reports Summary', () => {
     reported_date: 1,
     type: 'clinic',
     name: 'TAG Place',
+    place_id: 'tag-place',
     parent: { _id: HEALTH_CENTER._id, parent: { _id: DISTRICT._id } }
   };
 
@@ -508,7 +510,7 @@ describe('Reports Summary', () => {
       expect(await getElementText(reportsTab.submitterPhone())).toBe(CAROL.phone);
     });
 
-    it('Concerning reports using place_id', async () => {
+    it('Concerning reports using place_id with a place_uuid', async () => {
       const REPORT = {
         _id: 'PREF_PREF_V',
         form: 'P',
@@ -521,6 +523,46 @@ describe('Reports Summary', () => {
           message_id: 23,
           from: PHONE_CAROL,
           message: `1!P!${TAG_PLACE._id}`,
+          form: 'RR',
+          locale: 'en'
+        },
+        reported_date: moment().subtract(60, 'minutes').valueOf()
+      };
+
+      await saveReport(REPORT);
+      await sentinelUtils.waitForSentinel([REPORT._id]);
+      await commonElements.goToReportsNative();
+
+      // LHS
+      const report = await reportsTab.loadReport(REPORT._id);
+      expect(await getElementText(reportsTab.subject(report))).toBe(TAG_PLACE.name);
+      expect(await getElementText(reportsTab.formName(report))).toBe('PID_PID');
+      //shows subject lineage breadcrumbs
+      await testLineageList(['Health Center', 'District']);
+
+      //RHS
+      expect(await getElementText(reportsTab.subjectName())).toBe(TAG_PLACE.name);
+      expect(await getElementText(reportsTab.summaryFormName())).toBe('PID_PID');
+
+      await testLineageSummary(['Health Center', 'District']);
+
+      expect(await getElementText(reportsTab.submitterName())).toMatch(`Submitted by ${CAROL.name}`);
+      expect(await getElementText(reportsTab.submitterPhone())).toBe(CAROL.phone);
+    });
+
+    it('Concerning reports using place_id with a shortcode', async () => {
+      const REPORT = {
+        _id: 'PREF_PREF_V',
+        form: 'P',
+        type: 'data_record',
+        from: PHONE_CAROL,
+        fields: {
+          place_id: TAG_PLACE.place_id
+        },
+        sms_message: {
+          message_id: 23,
+          from: PHONE_CAROL,
+          message: `1!P!${TAG_PLACE.place_id}`,
           form: 'RR',
           locale: 'en'
         },

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -992,19 +992,21 @@ describe('accept_patient_reports', () => {
       content_type: 'xml'
     };
 
+    const registrationIds = getIds(registrations);
+
     return utils
       .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(registrations))
       .then(() => utils.saveDoc(noSilence))
       .then(() => sentinelUtils.waitForSentinel(noSilence._id))
-      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(() => utils.getDocs(registrationIds))
       .then(updated => {
         // none of the scheduled tasks should be cleared
         expect(updated.every(doc => !doc.scheduled_tasks.find(task => task.state === 'cleared'))).toBe(true);
       })
       .then(() => utils.saveDoc(silence1Patient))
       .then(() => sentinelUtils.waitForSentinel(silence1Patient._id))
-      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(() => utils.getDocs(registrationIds))
       .then(updated => {
         expect(updated[0].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
         expect(updated[0].scheduled_tasks.find(task => task.id === 2).state).toEqual('cleared');
@@ -1033,7 +1035,7 @@ describe('accept_patient_reports', () => {
       })
       .then(() => utils.saveDoc(silence2Patient2))
       .then(() => sentinelUtils.waitForSentinel(silence2Patient2._id))
-      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(() => utils.getDocs(registrationIds))
       .then(updated => {
         expect(updated[2].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
         expect(updated[2].scheduled_tasks.find(task => task.id === 2).state).toEqual('pending');
@@ -1054,7 +1056,7 @@ describe('accept_patient_reports', () => {
       })
       .then(() => utils.saveDoc(silence2Clinic))
       .then(() => sentinelUtils.waitForSentinel(silence2Clinic._id))
-      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(() => utils.getDocs(registrationIds))
       .then(updated => {
         expect(updated[4].scheduled_tasks.find(task => task.id === 1).state).toEqual('scheduled');
         expect(updated[4].scheduled_tasks.find(task => task.id === 2).state).toEqual('pending');
@@ -1072,7 +1074,7 @@ describe('accept_patient_reports', () => {
       })
       .then(() => utils.saveDoc(silence0PatientAndClinic))
       .then(() => sentinelUtils.waitForSentinel(silence0PatientAndClinic._id))
-      .then(() => utils.getDocs(registrations.map(r => r._id)))
+      .then(() => utils.getDocs(registrationIds))
       .then(updated => {
         const getScheduledTasks = (doc) => doc.scheduled_tasks.filter(task => task.state === 'scheduled');
         // this should have cleared everything that is left

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -20,6 +20,7 @@ const contacts = [
     _id: 'clinic',
     name: 'Clinic',
     type: 'clinic',
+    place_id: 'the_clinic',
     parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
     contact: {
       _id: 'person',
@@ -43,6 +44,7 @@ const extraContacts = [
     _id: 'clinic2',
     name: 'Clinic',
     type: 'clinic',
+    place_id: 'the_other_clinic',
     parent: { _id: 'health_center', parent: { _id: 'district_hospital' } },
     contact: {
       _id: 'person2',
@@ -875,7 +877,95 @@ describe('muting', () => {
             due: new Date().getTime() - notToday },
           { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
         ]
-      }
+      },
+      { // not a registration
+        _id: 'no_registration_config_clinic',
+        type: 'data_record',
+        content_type: 'xml',
+        form: 'test_form',
+        fields: {
+          place_id: 'the_clinic',
+        },
+        scheduled_tasks: [
+          { group: 1, state: 'pending', translation_key: 'beta', recipient: 'clinic', },
+          { group: 2, state: 'scheduled', translation_key: 'beta', recipient: 'clinic' },
+          { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
+        ]
+      },
+      { // not a registration
+        _id: 'incorrect_content_clinic',
+        type: 'data_record',
+        form: 'xml_form',
+        fields: {
+          place_id: 'the_clinic',
+        },
+        scheduled_tasks: [
+          { group: 1, state: 'scheduled', translation_key: 'beta', recipient: 'clinic' },
+          { group: 2, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
+          { group: 3, state: 'pending', translation_key: 'beta', recipient: 'clinic' },
+        ],
+      },
+      { // not a registration
+        _id: 'sms_without_contact_clinic',
+        type: 'data_record',
+        form: 'sms_form_2',
+        fields: {
+          place_id: 'the_clinic',
+        },
+        scheduled_tasks: [
+          { group: 1, state: 'pending', translation_key: 'beta', recipient: 'clinic' },
+          { group: 2, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
+          { group: 3, state: 'scheduled', translation_key: 'beta', recipient: 'clinic' },
+        ]
+      },
+      { // valid registration
+        _id: 'registration_1_clinic',
+        type: 'data_record',
+        content_type: 'xml',
+        form: 'xml_form',
+        fields: {
+          place_id: 'the_clinic',
+        },
+        scheduled_tasks: [
+          { group: 1, state: 'pending', translation_key: 'beta', recipient: 'clinic',
+            due: new Date().getTime() + notToday },
+          { group: 2, state: 'scheduled', translation_key: 'beta', recipient: 'clinic',
+            due: new Date().getTime() - notToday },
+          { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
+        ]
+      },
+      { // valid registration
+        _id: 'registration_3_clinic',
+        type: 'data_record',
+        form: 'sms_form_2',
+        fields: {
+          place_id: 'the_clinic',
+        },
+        contact: { _id: 'person' },
+        scheduled_tasks: [
+          { group: 1, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
+          { group: 2, state: 'pending', translation_key: 'beta', recipient: 'clinic',
+            due: new Date().getTime() + notToday },
+          { group: 3, state: 'scheduled', translation_key: 'beta', recipient: 'clinic',
+            due: new Date().getTime() - notToday },
+        ]
+      },
+      { // valid registration from other "branch"
+        _id: 'registration_4_clinic',
+        type: 'data_record',
+        form: 'sms_form_2',
+        fields: {
+          place_id: 'the_other_clinic',
+        },
+        contact: { _id: 'person2' },
+        scheduled_tasks: [
+          { group: 1, state: 'pending', translation_key: 'beta', recipient: 'clinic',
+            due: new Date().getTime() + notToday },
+          { group: 2, state: 'scheduled', translation_key: 'beta', recipient: 'clinic',
+            due: new Date().getTime() - notToday },
+          { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
+        ]
+      },
     ];
 
     const mute = {
@@ -900,81 +990,67 @@ describe('muting', () => {
       reported_date: new Date().getTime()
     };
 
+    const expectSameState = (original, updated) => {
+      expect(original.scheduled_tasks.length).toBe(updated.scheduled_tasks.length, `length not equal ${original._id}`);
+      original.scheduled_tasks.forEach((task, i) => {
+        expect(task.state).toBe(updated.scheduled_tasks[i].state, `state not equal ${original._id}, task ${i}`);
+      });
+    };
+
+    const expectStates = (updated, ...states) => {
+      expect(updated.scheduled_tasks.length).toBe(states.length);
+      updated.scheduled_tasks.forEach((task, i) => {
+        expect(task.state).toBe(states[i], `state not equal ${updated._id}, task ${i}`);
+      });
+    };
+
+    const nonRegistrationIds = [
+      'no_registration_config', 'incorrect_content', 'sms_without_contact', 'registration_4',
+      'no_registration_config_clinic', 'incorrect_content_clinic',
+      'sms_without_contact_clinic', 'registration_4_clinic',
+    ];
+    const registrationIds = [
+      'registration_1', 'registration_2', 'registration_3',
+      'registration_1_clinic', 'registration_3_clinic',
+    ];
+
+    const getReportById = (id) => reports.find(report => report._id === id);
+
     return utils
       .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(extraContacts))
       .then(() => utils.saveDocs(reports))
       .then(() => utils.saveDoc(mute))
       .then(() => sentinelUtils.waitForSentinel(mute._id))
-      .then(() => utils.getDocs(
-        ['no_registration_config', 'incorrect_content', 'sms_without_contact', 'registration_4']
-      ))
-      .then(reports => {
-        expect(reports[0].scheduled_tasks[0].state).toEqual('pending');
-        expect(reports[0].scheduled_tasks[1].state).toEqual('scheduled');
-        expect(reports[0].scheduled_tasks[2].state).toEqual('something_else');
-
-        expect(reports[1].scheduled_tasks[0].state).toEqual('scheduled');
-        expect(reports[1].scheduled_tasks[1].state).toEqual('something_else');
-        expect(reports[1].scheduled_tasks[2].state).toEqual('pending');
-
-        expect(reports[2].scheduled_tasks[0].state).toEqual('pending');
-        expect(reports[2].scheduled_tasks[1].state).toEqual('something_else');
-        expect(reports[2].scheduled_tasks[2].state).toEqual('scheduled');
-
-        expect(reports[3].scheduled_tasks[0].state).toEqual('pending');
-        expect(reports[3].scheduled_tasks[1].state).toEqual('scheduled');
-        expect(reports[3].scheduled_tasks[2].state).toEqual('something_else');
+      .then(() => utils.getDocs(nonRegistrationIds))
+      .then(updated => {
+        // none of the statuses changed!
+        nonRegistrationIds.forEach((id, idx) => expectSameState(getReportById(id), updated[idx]));
       })
-      .then(() => utils.getDocs(['registration_1', 'registration_2', 'registration_3']))
-      .then(reports => {
-        expect(reports[0].scheduled_tasks[0].state).toEqual('muted');
-        expect(reports[0].scheduled_tasks[1].state).toEqual('muted');
-        expect(reports[0].scheduled_tasks[2].state).toEqual('something_else');
+      .then(() => utils.getDocs(registrationIds))
+      .then(updated => {
+        expectStates(updated[0], 'muted', 'muted', 'something_else');
+        expectStates(updated[1], 'muted', 'something_else', 'muted');
+        expectStates(updated[2], 'something_else', 'muted', 'muted');
 
-        expect(reports[1].scheduled_tasks[0].state).toEqual('muted');
-        expect(reports[1].scheduled_tasks[1].state).toEqual('something_else');
-        expect(reports[1].scheduled_tasks[2].state).toEqual('muted');
-
-        expect(reports[2].scheduled_tasks[0].state).toEqual('something_else');
-        expect(reports[2].scheduled_tasks[1].state).toEqual('muted');
-        expect(reports[2].scheduled_tasks[2].state).toEqual('muted');
+        expectStates(updated[3], 'muted', 'muted', 'something_else');
+        expectStates(updated[4], 'something_else', 'muted', 'muted');
       })
       .then(() => utils.saveDoc(unmute))
       .then(() => sentinelUtils.waitForSentinel(unmute._id))
-      .then(() => utils.getDocs(
-        ['no_registration_config', 'incorrect_content', 'sms_without_contact', 'registration_4']
-      ))
-      .then(reports => {
-        expect(reports[0].scheduled_tasks[0].state).toEqual('pending');
-        expect(reports[0].scheduled_tasks[1].state).toEqual('scheduled');
-        expect(reports[0].scheduled_tasks[2].state).toEqual('something_else');
-
-        expect(reports[1].scheduled_tasks[0].state).toEqual('scheduled');
-        expect(reports[1].scheduled_tasks[1].state).toEqual('something_else');
-        expect(reports[1].scheduled_tasks[2].state).toEqual('pending');
-
-        expect(reports[2].scheduled_tasks[0].state).toEqual('pending');
-        expect(reports[2].scheduled_tasks[1].state).toEqual('something_else');
-        expect(reports[2].scheduled_tasks[2].state).toEqual('scheduled');
-
-        expect(reports[3].scheduled_tasks[0].state).toEqual('pending');
-        expect(reports[3].scheduled_tasks[1].state).toEqual('scheduled');
-        expect(reports[3].scheduled_tasks[2].state).toEqual('something_else');
+      .then(() => utils.getDocs(nonRegistrationIds))
+      .then(updated => {
+        // none of the statuses changed!
+        nonRegistrationIds.forEach((id, idx) => expectSameState(getReportById(id), updated[idx]));
       })
-      .then(() => utils.getDocs(['registration_1', 'registration_2', 'registration_3']))
-      .then(reports => {
-        expect(reports[0].scheduled_tasks[0].state).toEqual('scheduled');
-        expect(reports[0].scheduled_tasks[1].state).toEqual('muted'); // due date in the past
-        expect(reports[0].scheduled_tasks[2].state).toEqual('something_else');
+      .then(() => utils.getDocs(registrationIds))
+      .then(updated => {
+        expectStates(updated[0], 'scheduled', 'muted' /*due date in the past*/, 'something_else');
+        expectStates(updated[1], 'muted'/*due date in the past*/, 'something_else', 'scheduled');
+        expectStates(updated[2], 'something_else', 'scheduled', 'muted'/*due date in the past*/);
 
-        expect(reports[1].scheduled_tasks[0].state).toEqual('muted'); // due date in the past
-        expect(reports[1].scheduled_tasks[1].state).toEqual('something_else');
-        expect(reports[1].scheduled_tasks[2].state).toEqual('scheduled');
-
-        expect(reports[2].scheduled_tasks[0].state).toEqual('something_else');
-        expect(reports[2].scheduled_tasks[1].state).toEqual('scheduled');
-        expect(reports[2].scheduled_tasks[2].state).toEqual('muted'); // due date in the past
+        expectStates(updated[3], 'scheduled', 'muted'/*due date in the past*/, 'something_else');
+        expectStates(updated[4], 'something_else', 'scheduled', 'muted'/*due date in the past*/);
       });
   });
 });

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -878,7 +878,7 @@ describe('muting', () => {
           { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
         ]
       },
-      { // not a registration
+      { // not a registration for place
         _id: 'no_registration_config_clinic',
         type: 'data_record',
         content_type: 'xml',
@@ -892,7 +892,7 @@ describe('muting', () => {
           { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
         ]
       },
-      { // not a registration
+      { // not a registration for place
         _id: 'incorrect_content_clinic',
         type: 'data_record',
         form: 'xml_form',
@@ -905,7 +905,7 @@ describe('muting', () => {
           { group: 3, state: 'pending', translation_key: 'beta', recipient: 'clinic' },
         ],
       },
-      { // not a registration
+      { // not a registration for place
         _id: 'sms_without_contact_clinic',
         type: 'data_record',
         form: 'sms_form_2',
@@ -918,7 +918,7 @@ describe('muting', () => {
           { group: 3, state: 'scheduled', translation_key: 'beta', recipient: 'clinic' },
         ]
       },
-      { // valid registration
+      { // valid registration for place
         _id: 'registration_1_clinic',
         type: 'data_record',
         content_type: 'xml',
@@ -934,7 +934,7 @@ describe('muting', () => {
           { group: 3, state: 'something_else', translation_key: 'beta', recipient: 'clinic' },
         ]
       },
-      { // valid registration
+      { // valid registration for place
         _id: 'registration_3_clinic',
         type: 'data_record',
         form: 'sms_form_2',

--- a/webapp/src/ts/services/format-data-record.service.ts
+++ b/webapp/src/ts/services/format-data-record.service.ts
@@ -7,9 +7,7 @@ import { LanguageService } from '@mm-services/language.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { TranslateLocaleService } from '@mm-services/translate-locale.service';
 
-
 import * as messages from '@medic/message-utils';
-import * as lineageFactory from '@medic/lineage';
 import * as registrationUtils from '@medic/registration-utils';
 
 @Injectable({
@@ -26,7 +24,6 @@ export class FormatDataRecordService {
   ) {
   }
 
-  private lineage = lineageFactory(Promise, this.dbService.get());
   private readonly patientFields = ['patient_id', 'patient_uuid', 'patient_name'];
   private readonly placeFields = ['place_id'];
 
@@ -44,22 +41,6 @@ export class FormatDataRecordService {
       .query('medic-client/registered_patients', options)
       .then((result) => {
         return result.rows.map(row => row.doc);
-      });
-  }
-
-  private getSubject(shortcode) {
-    const options = { key: ['shortcode', shortcode] };
-    return this.dbService
-      .get()
-      .query('medic-client/contacts_by_reference', options)
-      .then((result) => {
-        if (!result.rows.length) {
-          return;
-        }
-        if (result.rows.length > 1) {
-          console.warn('More than one contact document for shortcode "' + shortcode + '"');
-        }
-        return this.lineage.fetchHydratedDoc(result.rows[0].id);
       });
   }
 
@@ -125,7 +106,7 @@ export class FormatDataRecordService {
         return { filter: `case_id:${id}` };
       }
     } else if (this.placeFields.includes(key)) {
-      const id = doc.place?.id;
+      const id = doc.place?._id;
       if (id) {
         return { url: ['/contacts', id] };
       }

--- a/webapp/src/ts/services/format-data-record.service.ts
+++ b/webapp/src/ts/services/format-data-record.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import * as _ from 'lodash-es';
 
 import { DbService } from '@mm-services/db.service';
@@ -22,15 +22,21 @@ export class FormatDataRecordService {
     private languageService:LanguageService,
     private settingsService:SettingsService,
     private translateLocaleService:TranslateLocaleService,
+    private ngZone:NgZone,
   ) {
   }
 
   private lineage = lineageFactory(Promise, this.dbService.get());
   private readonly patientFields = ['patient_id', 'patient_uuid', 'patient_name'];
+  private readonly placeFields = ['place_id'];
 
-  private getRegistrations(patientId) {
+  private getRegistrations(shortcode) {
+    if (!shortcode) {
+      return;
+    }
+
     const options = {
-      key: patientId,
+      key: shortcode,
       include_docs: true,
     };
     return this.dbService
@@ -41,8 +47,8 @@ export class FormatDataRecordService {
       });
   }
 
-  private getPatient(patientId) {
-    const options = { key: ['shortcode', patientId] };
+  private getSubject(shortcode) {
+    const options = { key: ['shortcode', shortcode] };
     return this.dbService
       .get()
       .query('medic-client/contacts_by_reference', options)
@@ -51,7 +57,7 @@ export class FormatDataRecordService {
           return;
         }
         if (result.rows.length > 1) {
-          console.warn('More than one patient person document for shortcode "' + patientId + '"');
+          console.warn('More than one contact document for shortcode "' + shortcode + '"');
         }
         return this.lineage.fetchHydratedDoc(result.rows[0].id);
       });
@@ -109,15 +115,19 @@ export class FormatDataRecordService {
 
   private getClickTarget(key, doc) {
     if (this.patientFields.includes(key)) {
-      const id = (doc.patient && doc.patient._id) ||
-        (doc.fields && doc.fields.patient_uuid);
+      const id = doc.patient?._id || doc.fields?.patient_uuid;
       if (id) {
         return { url: ['/contacts', id] };
       }
     } else if (key === 'case_id') {
-      const id = doc.case_id || doc.fields.case_id;
+      const id = doc.case_id || doc.fields?.case_id;
       if (id) {
         return { filter: `case_id:${id}` };
+      }
+    } else if (this.placeFields.includes(key)) {
+      const id = doc.place?.id;
+      if (id) {
+        return { url: ['/contacts', id] };
       }
     }
   }
@@ -689,27 +699,39 @@ export class FormatDataRecordService {
   }
 
   format(doc) {
-    const promises = [this.settingsService.get(), this.languageService.get()];
-    const patientId = doc.patient_id || (doc.fields && doc.fields.patient_id);
-    if (doc.scheduled_tasks && patientId) {
-      promises.push(this.getPatient(patientId));
-      promises.push(this.getRegistrations(patientId));
-    }
-    return Promise.all(promises).then((results) => {
-      const settings = results[0];
-      const language = results[1];
-      const context:any = {};
-      if (results.length === 4) {
-        context.patient = results[2];
-        context.registrations = (<[]>results[3]).filter((registration) => {
-          return registrationUtils.isValidRegistration(
-            registration,
-            settings
-          );
-        });
-      }
-      return this.makeDataRecordReadable(doc, settings, language, context);
-    });
+    return this.ngZone.runOutsideAngular(() => this._format(doc));
+  }
+
+  private _format(doc) {
+    const patientId = doc.patient_id || doc.fields?.patient_id;
+    const placeId = doc.place_id || doc.fields?.place_id;
+
+    return Promise
+      .all([
+        this.settingsService.get(),
+        this.languageService.get(),
+        doc.scheduled_tasks && this.getRegistrations(patientId),
+        doc.scheduled_tasks && this.getRegistrations(placeId),
+      ])
+      .then(([ settings, language, patientRegistrations=[], placeRegistrations=[] ]) => {
+        const context:any = {};
+
+        if (patientId) {
+          context.patient = doc.patient;
+          context.registrations = patientRegistrations.filter((registration) => {
+            return registrationUtils.isValidRegistration(registration, settings);
+          });
+        }
+
+        if (placeId) {
+          context.place = doc.place;
+          context.placeRegistrations = placeRegistrations.filter((registration) => {
+            return registrationUtils.isValidRegistration(registration, settings);
+          });
+        }
+
+        return this.makeDataRecordReadable(doc, settings, language, context);
+      });
   }
 }
 

--- a/webapp/src/ts/services/get-summaries.service.ts
+++ b/webapp/src/ts/services/get-summaries.service.ts
@@ -35,9 +35,11 @@ export class GetSummariesService {
 
   private getSubject(doc) {
     const subject:any = {};
-    const reference = doc.patient_id ||
+    const reference =
+      doc.patient_id ||
       (doc.fields && doc.fields.patient_id) ||
-      doc.place_id;
+      doc.place_id ||
+      (doc.fields && doc.fields.place_id);
     const patientName = doc.fields && doc.fields.patient_name;
     if (patientName) {
       subject.name = patientName;
@@ -46,9 +48,6 @@ export class GetSummariesService {
     if (reference) {
       subject.value = reference;
       subject.type = 'reference';
-    } else if (doc.fields && doc.fields.place_id) {
-      subject.value = doc.fields.place_id;
-      subject.type = 'id';
     } else if (patientName) {
       subject.value = patientName;
       subject.type = 'name';
@@ -57,6 +56,8 @@ export class GetSummariesService {
         subject.type = 'unknown';
       }
     }
+
+    console.log(doc, subject);
 
     return subject;
   }

--- a/webapp/src/ts/services/get-summaries.service.ts
+++ b/webapp/src/ts/services/get-summaries.service.ts
@@ -57,8 +57,6 @@ export class GetSummariesService {
       }
     }
 
-    console.log(doc, subject);
-
     return subject;
   }
 

--- a/webapp/tests/karma/ts/services/format-data-record.service.spec.ts
+++ b/webapp/tests/karma/ts/services/format-data-record.service.spec.ts
@@ -1,6 +1,10 @@
 import { TestBed } from '@angular/core/testing';
 import sinon from 'sinon';
 import { expect } from 'chai';
+import * as chai from 'chai';
+import * as chaiExclude from 'chai-exclude';
+//@ts-ignore
+chai.use(chaiExclude);
 
 import { FormatDataRecordService } from '@mm-services/format-data-record.service';
 import { SettingsService } from '@mm-services/settings.service';
@@ -10,23 +14,26 @@ import { DbService } from '@mm-services/db.service';
 import { TranslateLocaleService } from '@mm-services/translate-locale.service';
 
 describe('FormatDataRecord service', () => {
-
   let Settings;
   let Language;
+  let db;
+  let translateLocaleService;
 
   let service;
 
   beforeEach(() => {
     Settings = sinon.stub();
     Language = sinon.stub();
+    db = { query: sinon.stub() };
+    translateLocaleService = { instant: sinon.stub().returnsArg(0) };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: SettingsService, useValue: { get: Settings } },
         { provide: LanguageService, useValue: { get: Language } },
         { provide: FormatDateService, useValue: { relative: sinon.stub().returns('sometime') } },
-        { provide: DbService, useValue: { get: () => ({}) } },
-        { provide: TranslateLocaleService, useValue: { instant: sinon.stub().returnsArg(0) } },
+        { provide: DbService, useValue: { get: () => db } },
+        { provide: TranslateLocaleService, useValue: translateLocaleService },
       ]
     });
     service = TestBed.inject(FormatDataRecordService);
@@ -262,6 +269,36 @@ describe('FormatDataRecord service', () => {
     });
   });
 
+  it('detects links to places', () => {
+    const report = {
+      _id: 'my-report',
+      form: 'my-form',
+      content_type: 'xml',
+      place: { _id: 'some-place-id' },
+      fields: {
+        place_id: '1234',
+        not_place_id: 'pass'
+      }
+    };
+
+    return service.format(report).then(result => {
+      expect(result.fields).to.deep.equal([
+        {
+          label: 'report.my-form.place_id',
+          value: '1234',
+          depth: 0,
+          target: { url: ['/contacts', 'some-place-id'] }
+        },
+        {
+          label: 'report.my-form.not_place_id',
+          value: 'pass',
+          depth: 0,
+          target: undefined
+        }
+      ]);
+    });
+  });
+
   it('detects generated case_id fields', () => {
     const report = {
       _id: 'my-report',
@@ -298,6 +335,296 @@ describe('FormatDataRecord service', () => {
           target: undefined
         }
       ]);
+    });
+  });
+
+  describe('generating messages', () => {
+    it('should generate messages with patient', () => {
+      const report = {
+        _id: 'report',
+        form: 'frm',
+        fields: { patient_id: '12345', },
+        patient: { _id: 'p_uuid', patient_id: '12345', name: 'alpha' },
+        contact: { _id: 'submitter', phone: '+40858585' },
+        scheduled_tasks: [
+          {
+            due: 10,
+            group: 1,
+            type: 1,
+            message_key: 'message1',
+            recipient: 'reporting_unit',
+          },
+          {
+            due: 20,
+            group: 1,
+            type: 1,
+            message_key: 'message2',
+            recipient: 'reporting_unit',
+          },
+        ],
+      };
+
+      translateLocaleService.instant
+        .withArgs('message1').returns('Patient {{patient_name}} was registered at {{registered_at}}')
+        .withArgs('message2').returns('Patient {{patient_name}} is {{age}} years old');
+
+      const registration = {
+        _id: 'reg',
+        form: 'reg',
+        type: 'data_record',
+        content_type: 'xml',
+        fields: { registered_at: 'mar 11', age: '22' },
+      };
+      db.query.resolves({ rows: [{ doc: registration }] });
+      Settings.resolves({ registrations: [{ form: 'reg' }]});
+
+      return service.format(report).then(formatted => {
+        expect(db.query.callCount).to.equal(1);
+        expect(db.query.args[0]).to.deep.equal([
+          'medic-client/registered_patients',
+          { key: '12345', include_docs: true }
+        ]);
+
+        expect(formatted.scheduled_tasks_by_group.length).to.equal(1);
+        expect(formatted.scheduled_tasks_by_group[0].rows.length).to.equal(2);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted.length).to.equal(2);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[0]).excludingEvery('uuid').to.deep.equal({
+          due: 10,
+          group: 1,
+          type: 1,
+          message_key: 'message1',
+          recipient: 'reporting_unit',
+          timestamp: 10,
+          messages: [{
+            to: report.contact.phone,
+            message: 'Patient alpha was registered at mar 11',
+          }]
+        });
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[1]).excludingEvery('uuid').to.deep.equal({
+          due: 20,
+          group: 1,
+          type: 1,
+          message_key: 'message2',
+          recipient: 'reporting_unit',
+          timestamp: 20,
+          messages: [{
+            to: report.contact.phone,
+            message: 'Patient alpha is 22 years old',
+          }]
+        });
+      });
+    });
+
+    it('should generate messages with place', () => {
+      const report = {
+        _id: 'report',
+        form: 'frm',
+        fields: { place_id: '789', },
+        place: { _id: 'p_uuid', place_id: '789', name: 'omega' },
+        contact: { _id: 'submitter', phone: '+40858585' },
+        scheduled_tasks: [
+          {
+            due: 100,
+            group: 1,
+            type: 1,
+            message_key: 'message1',
+            recipient: 'reporting_unit',
+          },
+          {
+            due: 200,
+            group: 1,
+            type: 1,
+            message_key: 'message2',
+            recipient: 'reporting_unit',
+          },
+        ],
+      };
+
+      translateLocaleService.instant
+        .withArgs('message1').returns('Place {{place.name}} was registered at {{registered_at}}')
+        .withArgs('message2').returns('Place {{place.name}} has a population of {{population}}');
+
+      const registration = {
+        _id: 'reg',
+        form: 'reg',
+        type: 'data_record',
+        content_type: 'xml',
+        fields: { registered_at: 'mar 21', population: '5000' },
+      };
+      db.query.resolves({ rows: [{ doc: registration }] });
+      Settings.resolves({ registrations: [{ form: 'reg' }]});
+
+      return service.format(report).then(formatted => {
+        expect(db.query.callCount).to.equal(1);
+        expect(db.query.args[0]).to.deep.equal([
+          'medic-client/registered_patients',
+          { key: '789', include_docs: true }
+        ]);
+
+        expect(formatted.scheduled_tasks_by_group.length).to.equal(1);
+        expect(formatted.scheduled_tasks_by_group[0].rows.length).to.equal(2);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted.length).to.equal(2);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[0]).excludingEvery('uuid').to.deep.equal({
+          due: 100,
+          group: 1,
+          type: 1,
+          message_key: 'message1',
+          recipient: 'reporting_unit',
+          timestamp: 100,
+          messages: [{
+            to: report.contact.phone,
+            message: 'Place omega was registered at mar 21',
+          }]
+        });
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[1]).excludingEvery('uuid').to.deep.equal({
+          due: 200,
+          group: 1,
+          type: 1,
+          message_key: 'message2',
+          recipient: 'reporting_unit',
+          timestamp: 200,
+          messages: [{
+            to: report.contact.phone,
+            message: 'Place omega has a population of 5000',
+          }]
+        });
+      });
+    });
+
+    it('should generate messages with patient and place', () => {
+      const report = {
+        _id: 'report',
+        form: 'frm',
+        fields: { place_id: '789', patient_id: '123456'},
+        patient: { _id: 'patient_uuid', patient_id: '123456', name: 'alpha' },
+        place: { _id: 'p_uuid', place_id: '789', name: 'omega' },
+        contact: { _id: 'submitter', phone: '+40858585' },
+        scheduled_tasks: [
+          {
+            due: 100,
+            group: 1,
+            type: 1,
+            message_key: 'message1',
+            recipient: 'reporting_unit',
+          },
+          {
+            due: 200,
+            group: 1,
+            type: 1,
+            message_key: 'message2',
+            recipient: 'reporting_unit',
+          },
+        ],
+      };
+
+      translateLocaleService.instant
+        .withArgs('message1').returns('Place {{place.name}}, population {{population}}, age {{age}}')
+        .withArgs('message2').returns('Patient {{patient_name}} belongs to {{place.name}}');
+
+      const placeRegistration = {
+        _id: 'reg',
+        form: 'reg',
+        type: 'data_record',
+        content_type: 'xml',
+        fields: { registered_at: 'mar 21', population: '5000' },
+      };
+
+      const patientRegistration = {
+        _id: 'reg',
+        form: 'reg',
+        type: 'data_record',
+        content_type: 'xml',
+        fields: { registered_at: 'mar 11', age: '22' },
+      };
+      db.query
+        .onCall(0).resolves({ rows: [{ doc: patientRegistration }] })
+        .onCall(1).resolves({ rows: [{ doc: placeRegistration }] });
+      Settings.resolves({ registrations: [{ form: 'reg' }]});
+
+      return service.format(report).then(formatted => {
+        expect(db.query.callCount).to.equal(2);
+        expect(db.query.args[0]).to.deep.equal([
+          'medic-client/registered_patients',
+          { key: '123456', include_docs: true }
+        ]);
+        expect(db.query.args[1]).to.deep.equal([
+          'medic-client/registered_patients',
+          { key: '789', include_docs: true }
+        ]);
+
+        expect(formatted.scheduled_tasks_by_group.length).to.equal(1);
+        expect(formatted.scheduled_tasks_by_group[0].rows.length).to.equal(2);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted.length).to.equal(2);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[0]).excludingEvery('uuid').to.deep.equal({
+          due: 100,
+          group: 1,
+          type: 1,
+          message_key: 'message1',
+          recipient: 'reporting_unit',
+          timestamp: 100,
+          messages: [{
+            to: report.contact.phone,
+            message: 'Place omega, population 5000, age 22',
+          }]
+        });
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[1]).excludingEvery('uuid').to.deep.equal({
+          due: 200,
+          group: 1,
+          type: 1,
+          message_key: 'message2',
+          recipient: 'reporting_unit',
+          timestamp: 200,
+          messages: [{
+            to: report.contact.phone,
+            message: 'Patient alpha belongs to omega',
+          }]
+        });
+      });
+    });
+
+    it('should generate messages in the correct language', () => {
+      const report = {
+        _id: 'report',
+        form: 'frm',
+        locale: 'fr',
+        fields: { place_id: '789', },
+        place: { _id: 'p_uuid', place_id: '789', name: 'omega' },
+        contact: { _id: 'submitter', phone: '+40858585' },
+        scheduled_tasks: [
+          {
+            due: 100,
+            group: 1,
+            type: 1,
+            message_key: 'message1',
+            recipient: 'reporting_unit',
+          },
+        ],
+      };
+
+      translateLocaleService.instant.withArgs('message1').returns('message contents');
+      db.query.resolves({ rows: [] });
+      Settings.resolves({});
+
+      return service.format(report).then(formatted => {
+        expect(translateLocaleService.instant.callCount).to.equal(1);
+        expect(translateLocaleService.instant.args[0]).to.deep.equal([ 'message1', null, 'fr', true ]);
+
+        expect(formatted.scheduled_tasks_by_group.length).to.equal(1);
+        expect(formatted.scheduled_tasks_by_group[0].rows.length).to.equal(1);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted.length).to.equal(1);
+        expect(formatted.scheduled_tasks_by_group[0].rows_sorted[0]).excludingEvery('uuid').to.deep.equal({
+          due: 100,
+          group: 1,
+          type: 1,
+          message_key: 'message1',
+          recipient: 'reporting_unit',
+          timestamp: 100,
+          messages: [{
+            to: report.contact.phone,
+            message: 'message contents',
+          }]
+        });
+      });
     });
   });
 

--- a/webapp/tests/karma/ts/services/get-summaries.service.spec.ts
+++ b/webapp/tests/karma/ts/services/get-summaries.service.spec.ts
@@ -113,7 +113,8 @@ describe('GetSummaries service', () => {
                 patient_name: 'jeff',
                 patient_id: 'f'
               }
-            } },
+            }
+          },
           {
             doc: {
               _id: 'b',
@@ -123,7 +124,32 @@ describe('GetSummaries service', () => {
               sent_by: '+321',
               errors: [ { code: 'sys.missing_fields', fields: [ 'patient_id' ] } ],
               reported_date: 200
-            } },
+            }
+          },
+          {
+            doc: {
+              _id: 'c',
+              _rev: '1',
+              type: 'data_record',
+              form: 'delivery',
+              from: '+123',
+              contact: {
+                _id: 'c',
+                phone: '+456',
+                parent: {
+                  _id: 'd',
+                  parent: {
+                    _id: 'e'
+                  }
+                }
+              },
+              verified: true,
+              reported_date: 100,
+              fields: {
+                place_id: 'd',
+              }
+            }
+          },
         ] });
       return service.get([ 'a', 'b' ]).then(actual => {
         expect(query.callCount).to.equal(0);
@@ -165,7 +191,25 @@ describe('GetSummaries service', () => {
               type: 'unknown'
             },
             case_id: undefined
-          }
+          },
+          {
+            _id: 'c',
+            _rev: '1',
+            from: '+123',
+            phone: '+456',
+            form: 'delivery',
+            read: undefined,
+            valid: true,
+            verified: true,
+            reported_date: 100,
+            contact: 'c',
+            lineage: [ 'd', 'e' ],
+            subject: {
+              value: 'd',
+              type: 'reference'
+            },
+            case_id: undefined
+          },
         ]);
       });
     });

--- a/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -288,7 +288,7 @@ describe('doc_summaries_by_id view', () => {
         contact: 'df28f38e-cd3c-475f-96b5-48080d863e34',
         lineage: ['1a1aac55-04d6-40dc-aae2-e67a75a1496d'],
         subject: {
-          type: 'id',
+          type: 'reference',
           value: '09f62048-ac69-4066-bf8b-bcaf534ef8b1'
         },
         case_id: undefined


### PR DESCRIPTION
# Description

Support is achieved by using the `place_id` field in reports. It's treated exactly like the `patient_id` field, with a slight precedence of patient_id when both are present. 

Updates hydration to always hydrate the `place` field. 
Updates `registration` transition to pass the `place` and related registrations when assigning schedules.
Updates `registration` transition to clear `place` schedules.
Updates `accept_patient_reports` to clear `place` schedules. 
Updates schedules to build correct message context that includes place and place registrations.
Updates `message-utils` to include place registrations.
Updates `due-tasks` to generate `place` messages correctly.
Updates admin `message-queue` to generate place SMSs correctly. 
Adds `registration` subject validation, where a report that uses `patient_id` and links to a place or uses `place_id` and links to a person will be marked with an error and not considered valid. 

medic/cht-core#6444

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
