### PR TITLE
4750 - Angular 10 - contacts specs errors

### DIFF
--- a/webapp/tests/karma/ts/effects/contacts.effects.spec.ts
+++ b/webapp/tests/karma/ts/effects/contacts.effects.spec.ts
@@ -146,13 +146,16 @@ describe('Contacts effects', () => {
     });
 
     it('should catch loadChildren errors', fakeAsync(() => {
-      contactViewModelGeneratorService.loadChildren.rejects({ error: 'we have a problem'});
+      const consoleErrorMock = sinon.stub(console, 'error');
+      contactViewModelGeneratorService.loadChildren.rejects({ error: 'we have a problem' });
       actions$ = of(ContactActionList.setSelectedContact({ _id: 'contactid', doc: {} }));
       effects.setSelectedContact.subscribe();
       flush();
 
       expect(contactViewModelGeneratorService.loadChildren.callCount).to.equal(1);
       expect(unsetSelected.callCount).to.equal(1);
+      expect(consoleErrorMock.callCount).to.equal(1);
+      expect(consoleErrorMock.args[0][0]).to.equal('Error fetching children');
     }));
   });
 
@@ -166,6 +169,7 @@ describe('Contacts effects', () => {
     });
 
     it('should catch loadReports errors', fakeAsync(() => {
+      const consoleErrorMock = sinon.stub(console, 'error');
       contactViewModelGeneratorService.loadReports.rejects({ error: 'we have a problem'});
       actions$ = of(ContactActionList.receiveSelectedContactChildren([]));
       effects.receiveSelectedContactReports.subscribe();
@@ -173,6 +177,8 @@ describe('Contacts effects', () => {
 
       expect(contactViewModelGeneratorService.loadReports.callCount).to.equal(1);
       expect(unsetSelected.callCount).to.equal(1);
+      expect(consoleErrorMock.callCount).to.equal(1);
+      expect(consoleErrorMock.args[0][0]).to.equal('Error loading reports');
     }));
 
     it('should call the receiveSelectedContactReports action', fakeAsync(() => {
@@ -215,6 +221,7 @@ describe('Contacts effects', () => {
     }));
 
     it('should catch contactSummaryService errors', fakeAsync(() => {
+      const consoleErrorMock = sinon.stub(console, 'error');
       contactSummaryService.get.rejects({ error: 'we have a problem'});
       actions$ = of(ContactActionList.receiveSelectedContactReports([]));
       effects.updateSelectedContactSummary.subscribe();
@@ -222,6 +229,8 @@ describe('Contacts effects', () => {
 
       expect(contactSummaryService.get.callCount).to.equal(1);
       expect(unsetSelected.callCount).to.equal(1);
+      expect(consoleErrorMock.callCount).to.equal(1);
+      expect(consoleErrorMock.args[0][0]).to.equal('Error loading summary');
     }));
   });
 
@@ -236,6 +245,7 @@ describe('Contacts effects', () => {
     }));
 
     it('should catch targetAggregateService errors', fakeAsync(() => {
+      const consoleErrorMock = sinon.stub(console, 'error');
       const unsetSelected = sinon.stub(GlobalActions.prototype, 'unsetSelected');
       targetAggregateService.getCurrentTargetDoc.rejects({ error: 'we have a problem'});
       actions$ = of(ContactActionList.updateSelectedContactSummary({}));
@@ -244,6 +254,8 @@ describe('Contacts effects', () => {
 
       expect(targetAggregateService.getCurrentTargetDoc.callCount).to.equal(1);
       expect(unsetSelected.callCount).to.equal(1);
+      expect(consoleErrorMock.callCount).to.equal(1);
+      expect(consoleErrorMock.args[0][0]).to.equal('Error loading target doc');
     }));
   });
 });

--- a/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
 import { ContactsContentComponent } from '@mm-modules/contacts/contacts-content.component';
 import { ContactsActions } from '@mm-actions/contacts';
@@ -54,6 +55,9 @@ describe('Contacts content component', () => {
 
     return TestBed
       .configureTestingModule({
+        imports: [
+          TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
+        ],
         declarations: [ ContactsContentComponent, ResourceIconPipe, FilterReportsPipe ],
         providers: [
           provideMockStore({ selectors: mockedSelectors }),


### PR DESCRIPTION
# Description

medic/cht-core#4750

New contact tests were running OK but:

1. There were unchecked errors logged in the `contacts.effects.spec.ts` tests:

   ```
   ERROR: 'Error fetching children', Object{error: 'we have a problem'}
         ✔ should catch loadChildren errors
   ERROR: 'Error loading reports', Object{error: 'we have a problem'}
       receiveSelectedContactReports
         ✔ should catch loadReports errors
         ✔ should call the receiveSelectedContactReports action
       updateSelectedContactSummary
         ✔ should call the right actions
   ERROR: 'Error loading summary', Object{error: 'we have a problem'}
         ✔ should catch contactSummaryService errors
       receiveSelectedContactTargetDoc
         ✔ should call the receiveSelectedContactTargetDoc action
   ERROR: 'Error loading target doc', Object{error: 'we have a problem'}
         ✔ should catch targetAggregateService errors
   ```

   So mocking the error console not just avoid the noise in the output but also ensure that the errors caught by the mock are the ones expected to happen.

2. In the `contacts.component.spec.ts` was needed to add a fake translate service to avoid errors like the following:

   ```
   ERROR: 'Can't bind to 'translateParams' since it isn't a known property of 'a'.'
   ERROR: 'Can't bind to 'translateParams' since it isn't a known property of 'a'.'
   ERROR: 'Can't bind to 'translateParams' since it isn't a known property of 'a'.'
   ERROR: 'Can't bind to 'translateParams' since it isn't a known property of 'a'.'
   ERROR: 'Can't bind to 'translateParams' since it isn't a known property of 'span'.'
   ERROR: 'Can't bind to 'translateParams' since it isn't a known property of 'span'.'
   ```

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
