### PR TITLE
Requires async arrow functions to have space between async and ()

### DIFF
--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -14,6 +14,11 @@
   "rules": {
     "no-only-tests/no-only-tests": "error",
     "jasmine/no-focused-tests": "error",
-    "no-console": "off"
+    "no-console": "off",
+    "space-before-function-paren": ["error", {
+      "anonymous": "ignore",
+      "named": "ignore",
+      "asyncArrow": "always"
+    }]
   }
 }


### PR DESCRIPTION
# Description

Add a eslint rule that requires a space on async arrow functions. 

medic/cht-core#https://github.com/medic/angular10-migration/issues/111

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
