### PR TITLE
4750 fix issues 101, 99, and 98

### DIFF
--- a/webapp/src/ts/effects/contacts.effects.ts
+++ b/webapp/src/ts/effects/contacts.effects.ts
@@ -38,6 +38,8 @@ export class ContactsEffects {
       exhaustMap(({ payload: { id, silent } }) => {
         if (!silent) {
           this.globalActions.setLoadingShowContent(id);
+          this.contactsActions.setLoadingSelectedContact();
+          this.contactsActions.setContactsLoadingSummary(true);
         }
         return from(this.contactViewModelGeneratorService.getContact(id, { getChildPlaces: true, merge: false })).pipe(
           map(model => this.contactsActions.setSelectedContact(model)),
@@ -62,8 +64,6 @@ export class ContactsEffects {
         }
         const refreshing = previousSelectedContact?.doc?._id === selected.id;
         this.globalActions.settingSelected(refreshing);
-        this.contactsActions.setLoadingSelectedContact();
-        this.contactsActions.setContactsLoadingSummary(true);
         this.globalActions.clearCancelCallback();
         const options = { getChildPlaces: true };
         const title = (selected.type && selected.type.name_key) || 'contact.profile';

--- a/webapp/src/ts/modules/contacts/contacts-content.component.html
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.html
@@ -83,7 +83,7 @@
           <ng-container *ngFor="let child of group.contacts" >
             <mm-content-row *ngIf="!child.deceased"
               [id]="child.doc._id"
-              [route]="['/', 'contacts', child.id]"
+              [route]="['/', 'contacts', child.doc._id]"
               [heading]="child.doc.name"
               [summary]="''"
               [primaryContact]="child.isPrimaryContact"

--- a/webapp/src/ts/modules/contacts/contacts.routes.ts
+++ b/webapp/src/ts/modules/contacts/contacts.routes.ts
@@ -27,6 +27,7 @@ export const routes: Routes = [
       {
         path: ':id/deceased',
         component: ContactsDeceasedComponent,
+        data: { name: 'contacts.deceased' },
       },
       {
         path: 'add/:type',

--- a/webapp/tests/karma/ts/effects/contacts.effects.spec.ts
+++ b/webapp/tests/karma/ts/effects/contacts.effects.spec.ts
@@ -67,6 +67,14 @@ describe('Contacts effects', () => {
   });
 
   describe('selectContact', () => {
+    let setLoadingSelectedContact;
+    let setContactsLoadingSummary;
+
+    beforeEach(() => {
+      setLoadingSelectedContact = sinon.stub(ContactsActions.prototype, 'setLoadingSelectedContact');
+      setContactsLoadingSummary = sinon.stub(ContactsActions.prototype, 'setContactsLoadingSummary');
+    });
+
     it('should skip when no provided id', async (() => {
       actions$ = of(ContactActionList.selectContact({  }));
       effects.selectContact.subscribe();
@@ -84,6 +92,9 @@ describe('Contacts effects', () => {
 
       expect(setSelected.callCount).to.equal(1);
       expect(setSelected.args[0]).to.deep.equal([{ _id: 'contactid', model: 'contact model' }]);
+      expect(setLoadingSelectedContact.callCount).to.equal(1);
+      expect(setContactsLoadingSummary.callCount).to.equal(1);
+      expect(setContactsLoadingSummary.args[0][0]).to.equal(true);
     });
 
     it('should load the contact when silent', async () => {
@@ -131,12 +142,9 @@ describe('Contacts effects', () => {
       effects.setSelectedContact.subscribe();
 
       expect(settingSelected.callCount).to.equal(1);
-      expect(setLoadingSelectedContact.callCount).to.equal(1);
-      expect(setContactsLoadingSummary.callCount).to.equal(1);
       expect(clearCancelCallback.callCount).to.equal(1);
       expect(contactViewModelGeneratorService.loadChildren.callCount).to.equal(1);
       expect(settingSelected.args[0][0]).to.equal(false);
-      expect(setContactsLoadingSummary.args[0][0]).to.equal(true);
       expect(contactViewModelGeneratorService.loadChildren.args[0][0]).to.deep.equal(
         { _id: 'contactid', doc: { _id: 'contactid' } }
       );


### PR DESCRIPTION
# Description

This PR fixes the following issues:

- [Navigating back from deceased contacts](https://github.com/medic/angular10-migration/issues/101)
- [Spinners being displayed on currently viewed contact](https://github.com/medic/angular10-migration/issues/98)
- [Incorrect primary contact link when primary contact is not a child of the place](https://github.com/medic/angular10-migration/issues/99)


# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
