### PR TITLE
4750 translation attr-title and messages redirect

### DIFF
--- a/webapp/src/ts/components/content-row-list-item/content-row-list-item.component.html
+++ b/webapp/src/ts/components/content-row-list-item/content-row-list-item.component.html
@@ -14,7 +14,7 @@
     <div class="content">
       <div class="heading">
         <h4>
-          <i *ngIf="primaryContact" class="fa fa-star primary" translate translate-attr-title="Primary contact"></i>
+          <i *ngIf="primaryContact" class="fa fa-star primary" title="{{'Primary contact' | translate}}"></i>
           <span [innerHTML]="heading | safeHtml"></span>
         </h4>
         <div class="date">

--- a/webapp/src/ts/components/filters/simprints-filter/simprints-filter.component.html
+++ b/webapp/src/ts/components/filters/simprints-filter/simprints-filter.component.html
@@ -1,5 +1,5 @@
 <span class="simprints-filter" *ngIf="simprintsEnabled">
-  <a tabindex="-1" (click)="simprintsIdentify()" translate-attr-title="simprints.search">
+  <a tabindex="-1" (click)="simprintsIdentify()" title="{{'simprints.search' | translate}}">
     <img src="/img/simprints.png" width="20" height="20"/>
   </a>
 </span>

--- a/webapp/src/ts/components/filters/sort-filter/sort-filter.component.html
+++ b/webapp/src/ts/components/filters/sort-filter/sort-filter.component.html
@@ -2,7 +2,7 @@
   <span class="sort-results">
     <a
       id="sort-results"
-      translate-attr-title="contacts.results.sort"
+      title="{{'contacts.results.sort' | translate}}"
       dropdownToggle
       (click)="false"
       aria-controls="sort-results-dropdown"

--- a/webapp/src/ts/modals/feedback/feedback.component.html
+++ b/webapp/src/ts/modals/feedback/feedback.component.html
@@ -9,7 +9,7 @@
 >
   <form action="" method="POST">
     <div class="form-group" [class.has-error]="error.message">
-      <textarea [(ngModel)]="model.message" class="form-control" name="message" translate translate-attr-placeholder="Bug description"></textarea>
+      <textarea [(ngModel)]="model.message" class="form-control" name="message" placeholder="{{'Bug description' | translate}}"></textarea>
       <span class="help-block" *ngIf="error.message">{{error.message}}</span>
     </div>
   </form>

--- a/webapp/src/ts/modules/messages/messages.routes.ts
+++ b/webapp/src/ts/modules/messages/messages.routes.ts
@@ -1,4 +1,4 @@
-import { Routes } from '@angular/router';
+import { Routes, UrlSegment } from '@angular/router';
 
 import { RouteGuardProvider } from '@mm-providers/route-guard.provider';
 import { MessagesComponent } from './messages.component';
@@ -14,6 +14,19 @@ export const routes: Routes = [
       {
         path: '',
         component: MessagesContentComponent
+      },
+      {
+        matcher: (url: UrlSegment[]) => {
+          if (url[0]?.path?.indexOf(':') === -1) {
+            return {
+              consumed: url,
+              posParams: {
+                type_id: new UrlSegment('contact:' + url[0].path, {})
+              }
+            };
+          }
+        },
+        redirectTo: ':type_id'
       },
       {
         path: ':type_id',

--- a/webapp/src/ts/modules/messages/messages.routes.ts
+++ b/webapp/src/ts/modules/messages/messages.routes.ts
@@ -15,6 +15,12 @@ export const routes: Routes = [
         path: '',
         component: MessagesContentComponent
       },
+      /** This child route with matcher will redirect from /messages/[uuid] to /messages/contacts:[uuid]
+       * Ignoring any extra URL parameters because messages-content component is
+       * currently using only one "type_id" ( format: [type]:[uuid] )
+       * Original ticket: https://github.com/medic/cht-core/issues/4024
+       * Original commit: https://github.com/medic/cht-core/commit/4c6ffce10b61f8dafdbb9d48e6bf9d7d5f36d200
+       */
       {
         matcher: (url: UrlSegment[]) => {
           if (url[0]?.path?.indexOf(':') === -1) {


### PR DESCRIPTION
# Description

Migrated instances of `translate-attr-title` in the codebase.
Implemented messages URL redirect when 'id' is specified but not 'type'.

https://github.com/medic/angular10-migration/issues/106
https://github.com/medic/angular10-migration/issues/108

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
