### PR TITLE
Contact content tests improvement

### DIFF
--- a/webapp/src/ts/components/actionbar/actionbar.component.html
+++ b/webapp/src/ts/components/actionbar/actionbar.component.html
@@ -238,7 +238,6 @@
           <a *ngIf="actionBar?.right?.sendTo"
             mmAuth="can_view_message_action"
             class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only"
-            [attr.data-send-to]="actionBar?.right?.sendTo?._id"
             [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
             (click)="actionBar?.right?.sendTo?.phone && actionBar?.right?.openSendMessageModal(actionBar?.right?.sendTo?._id)"
           >

--- a/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
@@ -80,9 +80,9 @@ describe('Contacts content component', () => {
     };
 
     selectedContact = {
-      doc: { _id: 'district-123', phone: '123', muted: true },
-      type: { person: true },
-      summary: { context: 'test' },
+      doc: {},
+      type: {},
+      summary: {},
       children: [],
       tasks: [],
       reports: []
@@ -296,6 +296,19 @@ describe('Contacts content component', () => {
 
   describe('Action bar', () => {
     it('should initialise action bar', fakeAsync(() => {
+      sinon.resetHistory();
+      store.overrideSelector(Selectors.getSelectedContact, {
+        doc: { _id: 'district-123', phone: '123', muted: true },
+        type: { person: true },
+        summary: { context: 'test' },
+        children: [],
+        tasks: [],
+        reports: []
+      });
+      store.refreshState();
+      fixture.detectChanges();
+
+      component.ngOnInit();
       flush();
 
       expect(globalActions.setRightActionBar.callCount).to.equal(1);
@@ -330,7 +343,7 @@ describe('Contacts content component', () => {
     it('should enable edit and delete in the right action bar when admin user', fakeAsync(() => {
       sinon.resetHistory();
       sessionService.isAdmin.returns(true);
-      store.overrideSelector(Selectors.getSelectedContactChildren, {
+      store.overrideSelector(Selectors.getSelectedContact, {
         type: { person: true },
         doc: { phone: '11', muted: true },
         summary: { context: 'test' },
@@ -358,6 +371,16 @@ describe('Contacts content component', () => {
       sinon.resetHistory();
       sessionService.isAdmin.returns(false);
       userSettingsService.get.resolves({ facility_id: 'district-123' });
+      store.overrideSelector(Selectors.getSelectedContact, {
+        doc: { _id: 'district-123', phone: '123', muted: true },
+        type: { person: true },
+        summary: { context: 'test' },
+        children: [],
+        tasks: [],
+        reports: []
+      });
+      store.refreshState();
+      fixture.detectChanges();
 
       component.ngOnInit();
       flush();
@@ -371,6 +394,16 @@ describe('Contacts content component', () => {
       sinon.resetHistory();
       sessionService.isAdmin.returns(false);
       component.userSettings = { facility_id: 'district-9' };
+      store.overrideSelector(Selectors.getSelectedContact, {
+        doc: { _id: 'district-123', phone: '123', muted: true },
+        type: { person: true },
+        summary: { context: 'test' },
+        children: [],
+        tasks: [],
+        reports: []
+      });
+      store.refreshState();
+      fixture.detectChanges();
 
       component.ngOnInit();
       flush();
@@ -434,24 +467,20 @@ describe('Contacts content component', () => {
 
     it('should set relevant report forms based on the selected contact', fakeAsync(() => {
       sinon.resetHistory();
-      contactTypesService.getChildren.resolves([
-        {
-          id: 'type1',
-          create_form: 'form:test_report:type1',
-        },
-        {
-          id: 'type2',
-          create_form: 'form:test_report:type2',
-        },
-        {
-          id: 'type3',
-          create_form: 'form:test_report:type3',
-        },
-      ]);
       const forms = [
         { _id: 'form:test_report:type3', title: 'Type 3', internalId: 3, icon: 'a' },
         { _id: 'form:test_report:type2', title: 'Type 2', internalId: 2, icon: 'b' },
       ];
+      store.overrideSelector(Selectors.getSelectedContact, {
+        doc: { _id: 'district-123', phone: '123', muted: true },
+        type: { person: true },
+        summary: { context: 'test' },
+        children: [],
+        tasks: [],
+        reports: []
+      });
+      store.refreshState();
+      fixture.detectChanges();
 
       component.ngOnInit();
       flush();


### PR DESCRIPTION
# Description

- Removed unnecessary attribute: `attr.data-send-to`
- Fixed override selector in unit test: `should enable edit and delete in the right action bar when admin user`
- Removed default value in beforeEach to improve test readability
- Removed unnecessary test data in unit test: `should set relevant report forms based on the selected contact`

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
