### PR TITLE
medic/cht-core#6849

### DIFF
--- a/webapp/src/js/enketo/bootstrap-datepicker.ceb.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.ceb.js
@@ -1,0 +1,17 @@
+/**
+ * Philippines Bisaya/Cebuano translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['ceb-ph'] = {
+		days: ["Domingo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+        months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
+        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
+		today: "Karon nga Adlaw",
+		monthsTitle: "Mga Bulan",
+		clear: "Palaon",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.hil.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.hil.js
@@ -1,0 +1,17 @@
+/**
+ * Philippines Ilonggo/Hiligaynon translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['hil-ph'] = {
+		days: ["Domingo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+        months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
+        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
+		today: "Subong nga Adlaw",
+		monthsTitle: "Mga Bulan",
+		clear: "Panaon",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.tl.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.tl.js
@@ -1,0 +1,18 @@
+
+/**
+ * Philippines Tagalog translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['tl-ph'] = {
+		days: ["Linggo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+		months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
+        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
+		today: "Ngayon Araw",
+		monthsTitle: "Mga Buwan",
+		clear: "Burahin",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));


### PR DESCRIPTION
# Description

Added new cebuano/bisaya (ceb-ph), hiligaynon/ilonggo (hil-ph), and tagalog (tl-ph) bootstrap datepicker files.

medic/cht-core#6849

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
