### PR TITLE
Update travis.yml to support external contributors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ before_install:
     fi
   - export PATH=$PATH:$HOME/.local/bin
   - export PATH=$HOME/.npm/bin:$PATH
-  - echo "$DOCKER_PASSWORD" | docker login -u "communityhealthtoolkit" --password-stdin
+  - |
+    if [[ ! -z "$DOCKER_PASSWORD" ]]; then
+      echo "$DOCKER_PASSWORD" | docker login -u "communityhealthtoolkit" --password-stdin
+    fi
   - ./scripts/travis/couch-start
   - sudo apt-get install xsltproc
 


### PR DESCRIPTION
# Description

Tries to fix issue where Travis builds don't run for external contributors. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
