### PR TITLE
Adds bootstrap datepicker locales

### DIFF
--- a/webapp/src/js/enketo/bootstrap-datepicker.ceb.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.ceb.js
@@ -1,17 +1,30 @@
 /**
  * Philippines Bisaya/Cebuano translation for bootstrap-datepicker
  */
-;(function($){
-	$.fn.datepicker.dates['ceb-ph'] = {
-		days: ["Domingo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
-		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
-        months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
-        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
-		today: "Karon nga Adlaw",
-		monthsTitle: "Mga Bulan",
-		clear: "Palaon",
-		weekStart: 0,
-		format: "m/d/yyyy"
-	};
+(function($){
+  $.fn.datepicker.dates['ceb'] = {
+    days: ['Domingo', 'Lunes', 'Martes', 'Miyerkules', 'Huwebes', 'Biyernes', 'Sabado'],
+    daysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    daysMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    months: [
+      'Enero',
+      'Pebrero',
+      'Marso',
+      'Abril',
+      'Mayo',
+      'Hunyo',
+      'Hulyo',
+      'Agosto',
+      'Setyembre',
+      'Oktubre',
+      'Nobyembre',
+      'Disyembre',
+    ],
+    monthsShort: ['Ene', 'Peb', 'Mar', 'Abr', 'May', 'Hun', 'Hul', 'Ago', 'Set', 'Okt', 'Nob', 'Dis'],
+    today: 'Karon nga Adlaw',
+    monthsTitle: 'Mga Bulan',
+    clear: 'Palaon',
+    weekStart: 0,
+    format: 'm/d/yyyy'
+  };
 }(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.ceb.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.ceb.js
@@ -1,0 +1,17 @@
+/**
+ * Philippines Bisaya/Cebuano translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['ceb-ph'] = {
+		days: ["Domingo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+        months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
+        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
+		today: "Karon nga Adlaw",
+		monthsTitle: "Mga Bulan",
+		clear: "Palaon",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.hil.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.hil.js
@@ -1,17 +1,30 @@
 /**
  * Philippines Ilonggo/Hiligaynon translation for bootstrap-datepicker
  */
-;(function($){
-	$.fn.datepicker.dates['hil-ph'] = {
-		days: ["Domingo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
-		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
-        months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
-        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
-		today: "Subong nga Adlaw",
-		monthsTitle: "Mga Bulan",
-		clear: "Panaon",
-		weekStart: 0,
-		format: "m/d/yyyy"
-	};
+(function($){
+  $.fn.datepicker.dates['hil'] = {
+    days: ['Domingo', 'Lunes', 'Martes', 'Miyerkules', 'Huwebes', 'Biyernes', 'Sabado'],
+    daysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    daysMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    months: [
+      'Enero',
+      'Pebrero',
+      'Marso',
+      'Abril',
+      'Mayo',
+      'Hunyo',
+      'Hulyo',
+      'Agosto',
+      'Setyembre',
+      'Oktubre',
+      'Nobyembre',
+      'Disyembre',
+    ],
+    monthsShort: ['Ene', 'Peb', 'Mar', 'Abr', 'May', 'Hun', 'Hul', 'Ago', 'Set', 'Okt', 'Nob', 'Dis'],
+    today: 'Subong nga Adlaw',
+    monthsTitle: 'Mga Bulan',
+    clear: 'Panaon',
+    weekStart: 0,
+    format: 'm/d/yyyy'
+  };
 }(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.hil.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.hil.js
@@ -1,0 +1,17 @@
+/**
+ * Philippines Ilonggo/Hiligaynon translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['hil-ph'] = {
+		days: ["Domingo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+        months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
+        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
+		today: "Subong nga Adlaw",
+		monthsTitle: "Mga Bulan",
+		clear: "Panaon",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.tl.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.tl.js
@@ -2,17 +2,30 @@
 /**
  * Philippines Tagalog translation for bootstrap-datepicker
  */
-;(function($){
-	$.fn.datepicker.dates['tl-ph'] = {
-		days: ["Linggo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
-		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
-		months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
-        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
-		today: "Ngayon Araw",
-		monthsTitle: "Mga Buwan",
-		clear: "Burahin",
-		weekStart: 0,
-		format: "m/d/yyyy"
-	};
+(function($){
+  $.fn.datepicker.dates['tl'] = {
+    days: ['Linggo', 'Lunes', 'Martes', 'Miyerkules', 'Huwebes', 'Biyernes', 'Sabado'],
+    daysShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    daysMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    months: [
+      'Enero',
+      'Pebrero',
+      'Marso',
+      'Abril',
+      'Mayo',
+      'Hunyo',
+      'Hulyo',
+      'Agosto',
+      'Setyembre',
+      'Oktubre',
+      'Nobyembre',
+      'Disyembre',
+    ],
+    monthsShort: ['Ene', 'Peb', 'Mar', 'Abr', 'May', 'Hun', 'Hul', 'Ago', 'Set', 'Okt', 'Nob', 'Dis'],
+    today: 'Ngayon Araw',
+    monthsTitle: 'Mga Buwan',
+    clear: 'Burahin',
+    weekStart: 0,
+    format: 'm/d/yyyy'
+  };
 }(jQuery));

--- a/webapp/src/js/enketo/bootstrap-datepicker.tl.js
+++ b/webapp/src/js/enketo/bootstrap-datepicker.tl.js
@@ -1,0 +1,18 @@
+
+/**
+ * Philippines Tagalog translation for bootstrap-datepicker
+ */
+;(function($){
+	$.fn.datepicker.dates['tl-ph'] = {
+		days: ["Linggo", "Lunes", "Martes", "Miyerkules", "Huwebes", "Biyernes", "Sabado"],
+		daysShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+		months: ["Enero", "Pebrero", "Marso", "Abril", "Mayo", "Hunyo", "Hulyo", "Agosto", "Setyembre", "Oktubre", "Nobyembre", "Disyembre"],
+        monthsShort: ["Ene", "Peb", "Mar", "Abr", "May", "Hun", "Hul", "Ago", "Set", "Okt", "Nob", "Dis"],
+		today: "Ngayon Araw",
+		monthsTitle: "Mga Buwan",
+		clear: "Burahin",
+		weekStart: 0,
+		format: "m/d/yyyy"
+	};
+}(jQuery));

--- a/webapp/src/js/enketo/main.js
+++ b/webapp/src/js/enketo/main.js
@@ -6,6 +6,9 @@ require('bootstrap-datepicker/js/locales/bootstrap-datepicker.sw');
 require('bootstrap-datepicker/js/locales/bootstrap-datepicker.id');
 require('./bootstrap-datepicker.bm');
 require('./bootstrap-datepicker.hi');
+require('./bootstrap-datepicker.ceb');
+require('./bootstrap-datepicker.hil');
+require('./bootstrap-datepicker.tl');
 
 $.fn.datepicker.defaults.container = '.content-pane .enketo';
 $.fn.datepicker.defaults.orientation = 'bottom';


### PR DESCRIPTION
# Description

Cherry picks locales from https://github.com/medic/cht-core/pull/6865
Fixes linting, enables the languages and normalizes locale codes, as agreed upon here: https://github.com/medic/cht-core/issues/6861#issuecomment-764478365

medic/cht-core#6849

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
