### PR TITLE
makes information about translating more accessible to first-time contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ The Core Framework of the Community Health Toolkit is powered by people like you
 
 ## [Ways to contribute](#ways-to-contribute)
   - [First time contributor? Start here!](#first-time-contributor)
+  - [Review or add a translation](#translations)
   - [Submitting code](#submitting-code)
   - [Improving our documentation](#improving-our-documentation)
   - [Disclosing vulnerabilities](#disclosing-vulnerabilities)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ We recommend you raise an issue on Github or start a conversation on our [Commun
 ### First time contributor?
 Issues labeled [help wanted](https://github.com/medic/cht-core/labels/Help%20wanted) are a great place to start. Looking for other ways to help? You can also:
 * Improve our [documentation](#improving-our-documentation)
+* Review or add a [translation](#translations)
 * Find and mark duplicate issues
 * Try to reproduce issues and help with troubleshooting
 * Or [share a new idea or question](https://forum.communityhealthtoolkit.org) with us!
@@ -39,6 +40,10 @@ Issues labeled [help wanted](https://github.com/medic/cht-core/labels/Help%20wan
 
 Is our documentation up to date? Have we covered everything we should? Could our wording be improved? Read our [Documentation Style Guide](https://docs.communityhealthtoolkit.org/contribute/docs/style-guide/) then open a pull request with your suggested changes or additions.
 Want to talk about Documentation generally? Join our [Community Forum](https://forum.communityhealthtoolkit.org)!
+
+### Translations
+
+If you are a translator but not a developer, we understand that you may need extra help to follow the [process of translating](https://docs.communityhealthtoolkit.org/apps/reference/translations/) software for the first time. If that is the case, please open an issue on the GitHub repo or start a topic on the community forum.
 
 ### Disclosing vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ First time contributor? Issues labeled [help wanted](https://github.com/medic/ch
 
 Looking for other ways to help? You can also:
 * Improve documentation. Check out our style guide [here](https://docs.communityhealthtoolkit.org/contribute/docs/style-guide/)
-* Review or add a [translation](CONTRIBUTING.md#translating)
+* Review or add a [translation](CONTRIBUTING.md#translations)
 * Find and mark duplicate issues
 * Try to reproduce issues and help with troubleshooting
 * Or share a new idea or question with us!

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ First time contributor? Issues labeled [help wanted](https://github.com/medic/ch
 
 Looking for other ways to help? You can also:
 * Improve documentation. Check out our style guide [here](https://docs.communityhealthtoolkit.org/contribute/docs/style-guide/)
+* Review or add a [translation](CONTRIBUTING.md#translating)
 * Find and mark duplicate issues
 * Try to reproduce issues and help with troubleshooting
 * Or share a new idea or question with us!


### PR DESCRIPTION
# Description

This makes information about translating more accessible to first-time contributors. It appeared to me that the info was a little too "buried" in the docs, especially for people who may be translators but not necessarily developers.

If you agree, then I'd suggest that some info also be added to [this page](https://docs.communityhealthtoolkit.org/contribute/) in the docs repo (https://github.com/medic/cht-docs/issues/420).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
