### PR TITLE
Migrating moment.js locales: Tagalog, Illonggo, Cebuano

### DIFF
--- a/webapp/src/js/moment-locales/ceb.js
+++ b/webapp/src/js/moment-locales/ceb.js
@@ -1,0 +1,56 @@
+//! moment.js locale configuration
+//! locale : Illonggo (Philippines) [ceb]
+//! author : Joy Kimmel : https:/github.com/joymkimmel
+
+const moment = require('moment');
+moment.defineLocale('ceb', {
+  months: 'Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre'.split(
+    '_'
+  ),
+  monthsShort: 'Ene_Peb_Mar_Abr_May_Hun_Hul_Ago_Set_Okt_Nob_Dis'.split('_'),
+  weekdays: 'Domingo_Lunes_Martes_Miyerkules_Huwebes_Biyernes_Sabado'.split(
+    '_'
+  ),
+  weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
+  weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
+  longDateFormat: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'MM/D/YYYY',
+    LL: 'MMMM D, YYYY',
+    LLL: 'MMMM D, YYYY HH:mm',
+    LLLL: 'dddd, MMMM DD, YYYY HH:mm',
+  },
+  calendar: {
+    sameDay: 'LT [karon nga adlaw]',
+    nextDay: '[sunod nga adlaw] LT',
+    nextWeek: 'LT [sunod nga semana] dddd',
+    lastDay: 'LT [gahapon]',
+    lastWeek: 'LT [niagi nga semana] dddd',
+    sameElse: 'L',
+  },
+  relativeTime: {
+    future: 'sa sulod sa %s',
+    past: '%s ang niagi',
+    s: 'usa ka segundo',
+    ss: '%d segundo',
+    m: 'usa ka minuto',
+    mm: '%d minuto',
+    h: 'usa ka oras',
+    hh: '%d oras',
+    d: 'usa ka adlaw',
+    dd: '%d adlaw',
+    M: 'usa ka bulan',
+    MM: '%d bulan',
+    y: 'usa ka tuig',
+    yy: '%d tuig',
+  },
+  dayOfMonthOrdinalParse: /\d{1,2}/,
+  ordinal: function (number) {
+    return number;
+  },
+  week: {
+    dow: 0, // Sunday is the first day of the week.
+    doy: 4, // The week that contains Jan 4th is the first week of the year.
+  },
+});

--- a/webapp/src/js/moment-locales/hil.js
+++ b/webapp/src/js/moment-locales/hil.js
@@ -1,0 +1,56 @@
+//! moment.js locale configuration
+//! locale : Illonggo (Philippines) [hil]
+//! author : Joy Kimmel : https:/github.com/joymkimmel
+
+const moment = require('moment');
+moment.defineLocale('hil', {
+  months: 'Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre'.split(
+    '_'
+  ),
+  monthsShort: 'Ene_Peb_Mar_Abr_May_Hun_Hul_Ago_Set_Okt_Nob_Dis'.split('_'),
+  weekdays: 'Domingo_Lunes_Martes_Miyerkules_Huwebes_Biyernes_Sabado'.split(
+    '_'
+  ),
+  weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
+  weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
+  longDateFormat: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'MM/D/YYYY',
+    LL: 'MMMM D, YYYY',
+    LLL: 'MMMM D, YYYY HH:mm',
+    LLLL: 'dddd, MMMM DD, YYYY HH:mm',
+  },
+  calendar: {
+    sameDay: 'LT [subong nga adlaw]',
+    nextDay: '[sunod nga adlaw] LT',
+    nextWeek: 'LT [sunod nga semana] dddd',
+    lastDay: 'LT [kahapon]',
+    lastWeek: 'LT [nagligad nga semana] dddd',
+    sameElse: 'L',
+  },
+  relativeTime: {
+    future: 'sa sulod sang %s',
+    past: '%s ang nagligad',
+    s: 'isa ka segundo',
+    ss: '%d segundo',
+    m: 'isa ka minuto',
+    mm: '%d minuto',
+    h: 'isa ka oras',
+    hh: '%d oras',
+    d: 'isa ka adlaw',
+    dd: '%d adlaw',
+    M: 'isa ka bulan',
+    MM: '%d bulan',
+    y: 'isa ka tuig',
+    yy: '%d tuig',
+  },
+  dayOfMonthOrdinalParse: /\d{1,2}/,
+  ordinal: function (number) {
+    return number;
+  },
+  week: {
+    dow: 0, // Sunday is the first day of the week.
+    doy: 4, // The week that contains Jan 4th is the first week of the year.
+  },
+});

--- a/webapp/src/js/moment-locales/tl.js
+++ b/webapp/src/js/moment-locales/tl.js
@@ -1,0 +1,56 @@
+//! moment.js locale configuration
+//! locale : Tagalog (Philippines) [tl]
+//! author : Joy Kimmel : https:/github.com/joymkimmel
+
+const moment = require('moment');
+moment.defineLocale('tl', {
+  months: 'Enero_Pebrero_Marso_Abril_Mayo_Hunyo_Hulyo_Agosto_Setyembre_Oktubre_Nobyembre_Disyembre'.split(
+    '_'
+  ),
+  monthsShort: 'Ene_Peb_Mar_Abr_May_Hun_Hul_Ago_Set_Okt_Nob_Dis'.split('_'),
+  weekdays: 'Linggo_Lunes_Martes_Miyerkules_Huwebes_Biyernes_Sabado'.split(
+    '_'
+  ),
+  weekdaysShort: 'Sun_Mon_Tue_Wed_Thu_Fri_Sat'.split('_'),
+  weekdaysMin: 'Su_Mo_Tu_We_Th_Fr_Sa'.split('_'),
+  longDateFormat: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'MM/D/YYYY',
+    LL: 'MMMM D, YYYY',
+    LLL: 'MMMM D, YYYY HH:mm',
+    LLLL: 'dddd, MMMM DD, YYYY HH:mm',
+  },
+  calendar: {
+    sameDay: 'LT [ngayong araw]',
+    nextDay: '[Bukas ng] LT',
+    nextWeek: 'LT [sa susunod na] dddd',
+    lastDay: 'LT [kahapon]',
+    lastWeek: 'LT [noong nakaraang linggo] dddd',
+    sameElse: 'L',
+  },
+  relativeTime: {
+    future: 'sa loob ng %s',
+    past: '%s ang nakalipas',
+    s: 'isang segundo',
+    ss: '%d segundo',
+    m: 'isang minuto',
+    mm: '%d minuto',
+    h: 'isang oras',
+    hh: '%d oras',
+    d: 'isang araw',
+    dd: '%d araw',
+    M: 'isang buwan',
+    MM: '%d buwan',
+    y: 'isang taon',
+    yy: '%d taon',
+  },
+  dayOfMonthOrdinalParse: /\d{1,2}/,
+  ordinal: function (number) {
+    return number;
+  },
+  week: {
+    dow: 0, // Sunday is the first day of the week.
+    doy: 4, // The week that contains Jan 4th is the first week of the year.
+  },
+});

--- a/webapp/src/ts/main.ts
+++ b/webapp/src/ts/main.ts
@@ -22,6 +22,10 @@ import { POUCHDB_OPTIONS } from './constants';
 
 import * as bootstrapper from '../js/bootstrapper';
 
+// Moment additional locales
+require('../js/moment-locales/tl');
+require('../js/moment-locales/hil');
+require('../js/moment-locales/ceb');
 
 require('select2');
 require('../js/enketo/main');


### PR DESCRIPTION
# Description

Migrating moment.js locales: Tagalog, Illonggo, Cebuano

Migration ticket:
https://github.com/medic/angular10-migration/issues/128

Original ticket:
https://github.com/medic/cht-core/issues/6861

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
