### PR TITLE
73 public form transitions again

### DIFF
--- a/tests/conf-disabled.js
+++ b/tests/conf-disabled.js
@@ -27,7 +27,7 @@ const baseConfig = {
       '**/docs-by-replication-key-view.js',
       'e2e/submit-enketo-form.js',
       'e2e/forms/submit-z-score-form.spec.js',
-      'e2e/transitions/public_form_transitions.spec.js'
+      'e2e/transitions/public_form_transitions.spec.js',
       'e2e/contacts/add-new-health-center.js',
       'e2e/contacts/add-new-person.js'
     ],

--- a/tests/conf-disabled.js
+++ b/tests/conf-disabled.js
@@ -27,6 +27,7 @@ const baseConfig = {
       'e2e/submit-enketo-form.js',
       'e2e/login/token-login.spec.js',
       'e2e/forms/submit-z-score-form.spec.js',
+      'e2e/transitions/public_form_transitions.spec.js'
     ],
     // performance: 'performance/**/*.js'
   },

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -47,6 +47,41 @@ const waitForSeq = (metadataId, docIds) => {
     });
 };
 
+const waitForSeqNative = async (metadataId, docIds) => {
+  return requestOnSentinelTestDbNative(metadataId)
+    .catch(err => {
+      if (err.statusCode === 404) { // maybe Sentinel hasn't started yet
+        return { value: 0 };
+      }
+      throw err;
+    })
+    .then(metaData => metaData.value)
+    .then(seq => {
+      const opts = {
+        path: '/_changes',
+        headers: { 'Content-Type': 'application/json' },
+      };
+      if (docIds) {
+        opts.path = `${opts.path}?${querystring.stringify({ since: seq, filter: '_doc_ids' })}`;
+        opts.method = 'POST';
+        opts.body = { doc_ids: Array.isArray(docIds) ? docIds : [ docIds ] };
+      } else {
+        opts.path = `${opts.path}?${querystring.stringify({ since: seq })}`;
+      }
+      return utils.requestOnTestDbNative(opts);
+    })
+    .then(response => {
+      // sentinel doesn't bump the `transitions_seq` in it's metadata doc when a change it ignores comes in
+      // so we ignore those too
+      if (!response.results.length || response.results.every(change => SKIPPED_BY_SENTINEL.test(change.id))) {
+        // sentinel has caught up and processed our doc
+        return;
+      }
+
+      return utils.delayPromise(() => waitForSeqNative(metadataId, docIds), 100);
+    });
+};
+
 const requestOnSentinelTestDb = (options) => {
   if (typeof options === 'string') {
     options = {
@@ -56,6 +91,17 @@ const requestOnSentinelTestDb = (options) => {
   options.path = '/' + constants.DB_NAME + '-sentinel' + (options.path || '');
   return utils.request(options);
 };
+
+const requestOnSentinelTestDbNative = (options) => {
+  if (typeof options === 'string') {
+    options = {
+      path: options,
+    };
+  }
+  options.path = '/' + constants.DB_NAME + '-sentinel' + (options.path || '');
+  return utils.requestNative(options);
+};
+
 
 const getInfoDoc = docId => {
   return requestOnSentinelTestDb('/' + docId + '-info');
@@ -73,6 +119,23 @@ const getInfoDocs = (docIds = []) => {
     },
   };
   return requestOnSentinelTestDb(opts).then(response => response.rows.map(row => row.doc));
+};
+
+const getInfoDocsNative = async (docIds = []) => {
+  docIds = Array.isArray(docIds) ? docIds : [docIds];
+  console.log('getInfoDocsNative native1');
+  const opts = {
+    path: '/_all_docs?include_docs=true',
+    body: { keys: docIds.map(id => id + '-info') },
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+  };
+  console.log('getInfoDocsNative native2');
+  const response = await requestOnSentinelTestDbNative(opts);
+  console.log('getInfoDocsNative native3');
+  return response.rows.map(row => row.doc);
 };
 
 const deletePurgeDbs = () => {
@@ -109,10 +172,12 @@ const getCurrentSeq = () => requestOnSentinelTestDb('').then(data => data.update
 
 module.exports = {
   waitForSentinel: docIds => waitForSeq('/_local/transitions-seq', docIds),
+  waitForSentinelNative: docIds => waitForSeqNative('/_local/transitions-seq', docIds),
   waitForBackgroundCleanup: docIds => waitForSeq('/_local/background-seq', docIds),
   requestOnSentinelTestDb: requestOnSentinelTestDb,
   getInfoDoc: getInfoDoc,
   getInfoDocs: getInfoDocs,
+  getInfoDocsNative:getInfoDocsNative,
   deletePurgeDbs: deletePurgeDbs,
   waitForPurgeCompletion: waitForPurgeCompletion,
   getCurrentSeq: getCurrentSeq,

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -1,6 +1,7 @@
 const utils = require('../../utils');
 const querystring = require('querystring');
 const constants = require('../../constants');
+const _ = require('lodash');
 
 const SKIPPED_BY_SENTINEL = /^_design\/|(-info|____tombstone)$/;
 
@@ -30,7 +31,7 @@ const waitForSeq = (metadataId, docIds) => {
       if (docIds) {
         opts.path = `${opts.path}?${querystring.stringify({ since: seq, filter: '_doc_ids' })}`;
         opts.method = 'POST';
-        opts.body = { doc_ids: Array.isArray(docIds) ? docIds : [ docIds ] };
+        opts.body = { doc_ids: _.castArray(docIds) };
       } else {
         opts.path = `${opts.path}?${querystring.stringify({ since: seq })}`;
       }
@@ -65,7 +66,7 @@ const waitForSeqNative = async (metadataId, docIds) => {
       if (docIds) {
         opts.path = `${opts.path}?${querystring.stringify({ since: seq, filter: '_doc_ids' })}`;
         opts.method = 'POST';
-        opts.body = { doc_ids: Array.isArray(docIds) ? docIds : [ docIds ] };
+        opts.body = { doc_ids: _.castArray(docIds) };
       } else {
         opts.path = `${opts.path}?${querystring.stringify({ since: seq })}`;
       }
@@ -110,11 +111,11 @@ const getInfoDoc = docId => {
 
 const getInfoDocs = (docIds = []) => {
   utils.deprecated('getInfoDocs','getInfoDocsNative');
-  docIds = Array.isArray(docIds) ? docIds : [docIds];
+  docIds = _.castArray(docIds);
 
   const opts = {
     path: '/_all_docs?include_docs=true',
-    body: { keys: docIds.map(id => id + '-info') },
+    body: { keys: docIds.map(id => `${id}-info`) },
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
@@ -124,8 +125,7 @@ const getInfoDocs = (docIds = []) => {
 };
 
 const getInfoDocsNative = async (docIds = []) => {
-  docIds = Array.isArray(docIds) ? docIds : [docIds];
-  console.log('getInfoDocsNative native1');
+  docIds = _.castArray(docIds);
   const opts = {
     path: '/_all_docs?include_docs=true',
     body: { keys: docIds.map(id => id + '-info') },
@@ -134,9 +134,7 @@ const getInfoDocsNative = async (docIds = []) => {
       'Content-Type': 'application/json'
     },
   };
-  console.log('getInfoDocsNative native2');
   const response = await requestOnSentinelTestDbNative(opts);
-  console.log('getInfoDocsNative native3');
   return response.rows.map(row => row.doc);
 };
 

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -13,6 +13,7 @@ const SKIPPED_BY_SENTINEL = /^_design\/|(-info|____tombstone)$/;
 // @return     {<promise>}        resolves once the wait is over
 //
 const waitForSeq = (metadataId, docIds) => {
+  utils.deprecated('waitForSeq','waitForSeqNative');
   return requestOnSentinelTestDb(metadataId)
     .catch(err => {
       if (err.statusCode === 404) { // maybe Sentinel hasn't started yet
@@ -108,6 +109,7 @@ const getInfoDoc = docId => {
 };
 
 const getInfoDocs = (docIds = []) => {
+  utils.deprecated('getInfoDocs','getInfoDocsNative');
   docIds = Array.isArray(docIds) ? docIds : [docIds];
 
   const opts = {

--- a/tests/e2e/transitions/public_form_transitions.spec.js
+++ b/tests/e2e/transitions/public_form_transitions.spec.js
@@ -230,16 +230,35 @@ const expectTransitions = (infodoc, ...transitions) => {
   });
 };
 
+const processSMS = (settings) => {
+  let ids;
+  return utils.updateSettingsNative(settings)
+    .then(() => Promise.all([
+      apiUtils.getApiSmsChanges(messages),
+      utils.requestNative(getPostOpts('/api/sms', { messages: messages }))
+    ]))
+    .then(([ changes ]) => {
+      ids = changes.map(change => change.id);
+    })
+    .then(() => sentinelUtils.waitForSentinelNative(ids))
+    .then(() => Promise.all([
+      utils.getDocsNative(ids),
+      sentinelUtils.getInfoDocsNative(ids),
+      utils.getDocNative('person1'),
+      utils.getDocNative('person2')
+    ]));
+};
+
 const chw1Lineage = { _id: contacts[3]._id,  parent: contacts[3].parent };
 const chw2Lineage = { _id: contacts[4]._id,  parent: contacts[4].parent };
 
 describe('Transitions public_form', () => {
-  beforeAll(done => utils.saveDocs(contacts).then(done));
-  beforeEach(done => utils.saveDocs(patients).then(done));
-  afterAll(done => utils.revertDb().then(done));
-  afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
+  beforeAll(async () => await utils.saveDocsNative(contacts));
+  beforeEach(async () => await utils.saveDocsNative(patients));
+  afterAll(async () => await utils.revertDbNative());
+  afterEach(async () => await utils.revertDbNative(contacts.map(c => c._id), true));
 
-  it('when false, reports from unknwon sources should not be accepted', () => {
+  it('when false, reports from unknwon sources should not be accepted', async () => {
     Object.keys(formsConfig).forEach(form => formsConfig[form].public_form = false);
     const settings = Object.assign(
       {},
@@ -248,88 +267,69 @@ describe('Transitions public_form', () => {
       transitionsConfig
     );
 
-    let ids;
+    const [ docs, infos, patient1, patient2 ] = await processSMS(settings);
+    let doc;
+    let info;
 
-    return utils
-      .updateSettings(settings)
-      .then(() => Promise.all([
-        apiUtils.getApiSmsChanges(messages),
-        utils.request(getPostOpts('/api/sms', { messages: messages }))
-      ]))
-      .then(([ changes ]) => {
-        ids = changes.map(change => change.id);
-      })
-      .then(() => sentinelUtils.waitForSentinel(ids))
-      .then(() => Promise.all([
-        utils.getDocs(ids),
-        sentinelUtils.getInfoDocs(ids),
-        utils.getDoc('person1'),
-        utils.getDoc('person2')
-      ]))
-      .then(([ docs, infos, patient1, patient2 ]) => {
-        let doc;
-        let info;
+    // temp_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'accept_patient_reports', 'conditional_alerts', 'registration');
+    expect(doc.contact).toEqual(chw1Lineage);
+    expect(doc.tasks.length).toEqual(3);
+    expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
+    expect(doc.scheduled_tasks.length).toEqual(1);
 
-        // temp_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'accept_patient_reports', 'conditional_alerts', 'registration');
-        expect(doc.contact).toEqual(chw1Lineage);
-        expect(doc.tasks.length).toEqual(3);
-        expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
-        expect(doc.scheduled_tasks.length).toEqual(1);
+    // temp_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(1);
+    expect(doc.tasks.length).toEqual(0);
+    expect(doc.scheduled_tasks).not.toBeDefined();
 
-        // temp_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(1);
-        expect(doc.tasks.length).toEqual(0);
-        expect(doc.scheduled_tasks).not.toBeDefined();
+    // death_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'death_reporting');
+    expect(doc.contact).toEqual(chw2Lineage);
+    expect(patient2.date_of_death).toEqual(doc.reported_date);
 
-        // death_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'death_reporting');
-        expect(doc.contact).toEqual(chw2Lineage);
-        expect(patient2.date_of_death).toEqual(doc.reported_date);
+    // death_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.tasks.length).toEqual(0);
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(doc.errors.length).toEqual(1);
+    expect(patient1.date_of_death).not.toBeDefined();
 
-        // death_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.tasks.length).toEqual(0);
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(doc.errors.length).toEqual(1);
-        expect(patient1.date_of_death).not.toBeDefined();
+    // mute_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'muting', 'multi_report_alerts');
+    expect(doc.contact).toEqual(chw2Lineage);
+    expect(doc.tasks.length).toEqual(1);
+    expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(patient2.muted).toBeDefined();
 
-        // mute_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'muting', 'multi_report_alerts');
-        expect(doc.contact).toEqual(chw2Lineage);
-        expect(doc.tasks.length).toEqual(1);
-        expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(patient2.muted).toBeDefined();
-
-        // mute_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(1);
-        expect(doc.tasks.length).toEqual(0);
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(patient1.muted).not.toBeDefined();
-      });
+    // mute_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(1);
+    expect(doc.tasks.length).toEqual(0);
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(patient1.muted).not.toBeDefined();
   });
 
-  it('when true, reports from unknwon sources should be accepted', () => {
+  it('when true, reports from unknwon sources should be accepted', async () => {
     Object.keys(formsConfig).forEach(form => formsConfig[form].public_form = true);
     const settings = Object.assign(
       {},
@@ -338,90 +338,71 @@ describe('Transitions public_form', () => {
       transitionsConfig
     );
 
-    let ids;
+    const [ docs, infos, patient1, patient2 ] = await processSMS(settings);
+    let doc;
+    let info;
 
-    return utils
-      .updateSettings(settings)
-      .then(() => Promise.all([
-        apiUtils.getApiSmsChanges(messages),
-        utils.request(getPostOpts('/api/sms', { messages: messages }))
-      ]))
-      .then(([ changes ]) => {
-        ids = changes.map(change => change.id);
-      })
-      .then(() => sentinelUtils.waitForSentinel(ids))
-      .then(() => Promise.all([
-        utils.getDocs(ids),
-        sentinelUtils.getInfoDocs(ids),
-        utils.getDoc('person1'),
-        utils.getDoc('person2')
-      ]))
-      .then(([ docs, infos, patient1, patient2 ]) => {
-        let doc;
-        let info;
+    // temp_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'accept_patient_reports', 'conditional_alerts', 'registration');
+    expect(doc.contact).toEqual(chw1Lineage);
+    expect(doc.tasks.length).toEqual(3);
+    expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
+    expect(doc.scheduled_tasks.length).toEqual(1);
 
-        // temp_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'accept_patient_reports', 'conditional_alerts', 'registration');
-        expect(doc.contact).toEqual(chw1Lineage);
-        expect(doc.tasks.length).toEqual(3);
-        expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
-        expect(doc.scheduled_tasks.length).toEqual(1);
+    // temp_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'accept_patient_reports', 'conditional_alerts', 'registration');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(0);
+    expect(doc.tasks.length).toEqual(3);
+    expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
+    expect(doc.scheduled_tasks.length).toEqual(1);
 
-        // temp_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'accept_patient_reports', 'conditional_alerts', 'registration');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(0);
-        expect(doc.tasks.length).toEqual(3);
-        expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
-        expect(doc.scheduled_tasks.length).toEqual(1);
+    // death_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'death_reporting');
+    expect(doc.contact).toEqual(chw2Lineage);
+    expect(patient2.date_of_death).toEqual(doc.reported_date);
 
-        // death_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'death_reporting');
-        expect(doc.contact).toEqual(chw2Lineage);
-        expect(patient2.date_of_death).toEqual(doc.reported_date);
+    // death_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'death_reporting');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(0);
+    expect(patient1.date_of_death).toEqual(doc.reported_date);
 
-        // death_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'death_reporting');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(0);
-        expect(patient1.date_of_death).toEqual(doc.reported_date);
+    // mute_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'muting', 'multi_report_alerts');
+    expect(doc.contact).toEqual(chw2Lineage);
+    expect(doc.tasks.length).toEqual(1);
+    expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(patient2.muted).toBeDefined();
 
-        // mute_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'muting', 'multi_report_alerts');
-        expect(doc.contact).toEqual(chw2Lineage);
-        expect(doc.tasks.length).toEqual(1);
-        expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(patient2.muted).toBeDefined();
-
-        // mute_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'muting', 'multi_report_alerts');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(0);
-        expect(doc.tasks.length).toEqual(1);
-        expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(patient1.muted).toBeDefined();
-      });
+    // mute_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'muting', 'multi_report_alerts');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(0);
+    expect(doc.tasks.length).toEqual(1);
+    expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(patient1.muted).toBeDefined();
   });
 
-  it('should default to false', () => {
+  it('should default to false', async () => {
     Object.keys(formsConfig).forEach(form => delete formsConfig[form].public_form);
 
     const settings = Object.assign(
@@ -431,84 +412,65 @@ describe('Transitions public_form', () => {
       transitionsConfig
     );
 
-    let ids;
+    const [ docs, infos, patient1, patient2 ] = await processSMS(settings);
+    let doc;
+    let info;
 
-    return utils
-      .updateSettings(settings)
-      .then(() => Promise.all([
-        apiUtils.getApiSmsChanges(messages),
-        utils.request(getPostOpts('/api/sms', { messages: messages }))
-      ]))
-      .then(([ changes ]) => {
-        ids = changes.map(change => change.id);
-      })
-      .then(() => sentinelUtils.waitForSentinel(ids))
-      .then(() => Promise.all([
-        utils.getDocs(ids),
-        sentinelUtils.getInfoDocs(ids),
-        utils.getDoc('person1'),
-        utils.getDoc('person2')
-      ]))
-      .then(([ docs, infos, patient1, patient2 ]) => {
-        let doc;
-        let info;
+    // temp_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'accept_patient_reports', 'conditional_alerts', 'registration');
+    expect(doc.contact).toEqual(chw1Lineage);
+    expect(doc.tasks.length).toEqual(3);
+    expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
+    expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
+    expect(doc.scheduled_tasks.length).toEqual(1);
 
-        // temp_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'accept_patient_reports', 'conditional_alerts', 'registration');
-        expect(doc.contact).toEqual(chw1Lineage);
-        expect(doc.tasks.length).toEqual(3);
-        expect(doc.tasks.find(task => task.messages[0].message === 'registration msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'conditional_alerts msg')).toBeDefined();
-        expect(doc.tasks.find(task => task.messages[0].message === 'accept_patient_reports msg')).toBeDefined();
-        expect(doc.scheduled_tasks.length).toEqual(1);
+    // temp_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(1);
+    expect(doc.tasks.length).toEqual(0);
+    expect(doc.scheduled_tasks).not.toBeDefined();
 
-        // temp_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'temp_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(1);
-        expect(doc.tasks.length).toEqual(0);
-        expect(doc.scheduled_tasks).not.toBeDefined();
+    // death_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'death_reporting');
+    expect(doc.contact).toEqual(chw2Lineage);
+    expect(patient2.date_of_death).toEqual(doc.reported_date);
 
-        // death_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'death_reporting');
-        expect(doc.contact).toEqual(chw2Lineage);
-        expect(patient2.date_of_death).toEqual(doc.reported_date);
+    // death_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.tasks.length).toEqual(0);
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(doc.errors.length).toEqual(1);
+    expect(patient1.date_of_death).not.toBeDefined();
 
-        // death_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'death_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.tasks.length).toEqual(0);
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(doc.errors.length).toEqual(1);
-        expect(patient1.date_of_death).not.toBeDefined();
+    // mute_known_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_known_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics', 'muting', 'multi_report_alerts');
+    expect(doc.contact).toEqual(chw2Lineage);
+    expect(doc.tasks.length).toEqual(1);
+    expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(patient2.muted).toBeDefined();
 
-        // mute_known_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_known_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics', 'muting', 'multi_report_alerts');
-        expect(doc.contact).toEqual(chw2Lineage);
-        expect(doc.tasks.length).toEqual(1);
-        expect(doc.tasks[0].messages[0].message).toEqual('multi_report_alerts msg');
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(patient2.muted).toBeDefined();
-
-        // mute_unknown_contact
-        doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_unknown_contact');
-        info = infos.find(info => info.doc_id === doc._id);
-        expectTransitions(info, 'update_clinics');
-        expect(doc.contact).not.toBeDefined();
-        expect(doc.errors.length).toEqual(1);
-        expect(doc.tasks.length).toEqual(0);
-        expect(doc.scheduled_tasks).not.toBeDefined();
-        expect(patient1.muted).not.toBeDefined();
-      });
+    // mute_unknown_contact
+    doc = docs.find(doc => doc.sms_message.gateway_ref === 'mute_unknown_contact');
+    info = infos.find(info => info.doc_id === doc._id);
+    expectTransitions(info, 'update_clinics');
+    expect(doc.contact).not.toBeDefined();
+    expect(doc.errors.length).toEqual(1);
+    expect(doc.tasks.length).toEqual(0);
+    expect(doc.scheduled_tasks).not.toBeDefined();
+    expect(patient1.muted).not.toBeDefined();
   });
 });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -586,6 +586,7 @@ module.exports = {
   }),
 
   requestOnTestDb: (options, debug) => {
+    deprecated('requestOnTestDb','requestOnTestDbNative');
     if (typeof options === 'string') {
       options = {
         path: options,
@@ -614,6 +615,7 @@ module.exports = {
   },
 
   requestOnTestMetaDb: (options, debug) => {
+    deprecated('requestOnTestMetaDb','requestOnTestMetaDbNative');
     if (typeof options === 'string') {
       options = {
         path: options,
@@ -665,8 +667,9 @@ module.exports = {
     });
   },
 
-  saveDocs: docs =>
-    module.exports
+  saveDocs: docs => {
+    deprecated('saveDocs','saveDocsNative');
+    return module.exports
       .requestOnTestDb({
         path: '/_bulk_docs',
         method: 'POST',
@@ -678,7 +681,8 @@ module.exports = {
         } else {
           return results;
         }
-      }),
+      });
+  },
 
   saveDocsNative: async (docs) =>{
     const results = await module.exports
@@ -696,6 +700,7 @@ module.exports = {
   },
 
   getDoc: id => {
+    deprecated('getDoc','getDocNative');
     deprecated('utils.getDoc', 'utils.getDocNative');
     return module.exports.requestOnTestDbNative({
       path: `/${id}`,
@@ -711,6 +716,7 @@ module.exports = {
   },
 
   getDocs: ids => {
+    deprecated('getDocs','getDocsNative');
     return module.exports
       .requestOnTestDb({
         path: `/_all_docs?include_docs=true`,
@@ -722,7 +728,6 @@ module.exports = {
   },
 
   getDocsNative: async ids => {
-    console.log('docs native1');
     const response = await module.exports
       .requestOnTestDbNative({
         path: `/_all_docs?include_docs=true`,
@@ -730,7 +735,6 @@ module.exports = {
         body: { keys: ids || []},
         headers: { 'content-type': 'application/json' },
       });
-    console.log('docs native2');
     return response.rows.map(row => row.doc);
   },
 
@@ -780,12 +784,14 @@ module.exports = {
    * @param      {Boolean}  ignoreRefresh  don't bother refreshing
    * @return     {Promise}  completion promise
    */
-  updateSettings: (updates, ignoreRefresh = false) =>
-    updateSettings(updates).then(() => {
+  updateSettings: (updates, ignoreRefresh = false) => {
+    deprecated('updateSettings','updateSettingsNative');
+    return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();
       }
-    }),
+    });
+  },
   
   updateSettingsNative: async (updates, ignoreRefresh = false) => {
     await updateSettingsNative(updates);
@@ -836,6 +842,7 @@ module.exports = {
    * and also returns a promise - pick one!
    */
   afterEach: done => {
+    deprecated('afterEach','afterEachNative');
     return revertDb()
       .then(() => {
         if (done) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -680,6 +680,21 @@ module.exports = {
         }
       }),
 
+  saveDocsNative: async (docs) =>{
+    const results = await module.exports
+      .requestOnTestDbNative({
+        path: '/_bulk_docs',
+        method: 'POST',
+        body: { docs: docs }
+      });
+
+    if (results.find(r => !r.ok)) {
+      throw Error(JSON.stringify(results, null, 2));
+    } else {
+      return results;
+    }
+  },
+
   getDoc: id => {
     deprecated('utils.getDoc', 'utils.getDocNative');
     return module.exports.requestOnTestDbNative({
@@ -704,6 +719,19 @@ module.exports = {
         headers: { 'content-type': 'application/json' },
       })
       .then(response => response.rows.map(row => row.doc));
+  },
+
+  getDocsNative: async ids => {
+    console.log('docs native1');
+    const response = await module.exports
+      .requestOnTestDbNative({
+        path: `/_all_docs?include_docs=true`,
+        method: 'POST',
+        body: { keys: ids || []},
+        headers: { 'content-type': 'application/json' },
+      });
+    console.log('docs native2');
+    return response.rows.map(row => row.doc);
   },
 
   deleteDoc: id => {


### PR DESCRIPTION
# Description

Updating public_form_transitions to async/await. Added more methods to switch to disabled control flow.

https://github.com/medic/angular10-migration/issues/73

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
