### PR TITLE
GH actions: skip "Login to Docker Hub" if no username is provided

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,16 @@ jobs:
     name: Compile the app 
     runs-on: ubuntu-18.04
 
-    steps: 
+    steps:
+    - name: Get Docker Hub username
+      id: get-docker-hub-username
+      run: echo '::set-output name=dockerhub_username::${{ secrets.DOCKERHUB_USERNAME }}'
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: steps.get-docker-hub-username.outputs.dockerhub_username
     - name: Set MARKET_URL var
       run: |
         if [[ -z "$MARKET_URL" ]]; then
@@ -67,7 +71,7 @@ jobs:
     name: Default Config Testst
     runs-on: ubuntu-18.04
 
-    steps: 
+    steps:
     - uses: actions/checkout@v2
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
@@ -85,7 +89,7 @@ jobs:
     name: Standard Config Testst
     runs-on: ubuntu-18.04
 
-    steps: 
+    steps:
     - uses: actions/checkout@v2
     - name: Use Node.js 12.x
       uses: actions/setup-node@v1
@@ -108,11 +112,15 @@ jobs:
         node-version: [8.x, 10.x, 12.x]
 
     steps:
+    - name: Get Docker Hub username
+      id: get-docker-hub-username
+      run: echo '::set-output name=dockerhub_username::${{ secrets.DOCKERHUB_USERNAME }}'
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: steps.get-docker-hub-username.outputs.dockerhub_username
     - name: Set Travis Vars
       run: |
         echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV
@@ -178,11 +186,15 @@ jobs:
         node-version: [8.x, 10.x, 12.x]
 
     steps:
+    - name: Get Docker Hub username
+      id: get-docker-hub-username
+      run: echo '::set-output name=dockerhub_username::${{ secrets.DOCKERHUB_USERNAME }}'
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
+      if: steps.get-docker-hub-username.outputs.dockerhub_username
     - name: Set Travis Vars
       run: |
         echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV


### PR DESCRIPTION
# Description

Fix the issue of PRs from contributors failing in CI because the first step try to login at Docker Hub without having user credentials. The changes makes CI to omit the step if there are no credentials set.

Issue: https://github.com/medic/angular10-migration/issues/131

### Testing

In this [build](https://github.com/medic/cht-core/actions/runs/521120685) I have tested both scenarios pushing a commit that then I removed from the branch where the first job _"Compile the app"_ uses a different variable that does not exist to signup so the result was the expected: the step _"Login to Docker Hub"_ were skipped, while the rest of the jobs in the pipeline used the right variable name (`DOCKERHUB_USERNAME`) and the login process did happen also as expected.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
