### PR TITLE
setting the 2.3.1 couchdb tag

### DIFF
--- a/scripts/travis/couch-start
+++ b/scripts/travis/couch-start
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # start couchdb 2.x docker instance
-docker run -d -p 5984:5984 --name couch couchdb:2
+docker run -d -p 5984:5984 --name couch couchdb:2.3.1
 echo "Starting CouchDB 2.x"
 until nc -z localhost 5984; do sleep 1; done
 echo "CouchDB Started"


### PR DESCRIPTION
# Description

setting version 2.3.1 to fix an issue with couchdb:2 tag on docker hub. 

medic/cht-core#https://github.com/medic/cht-core/issues/6901

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
