### PR TITLE
Added some more detail about e2e tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -207,7 +207,11 @@ They live in the `tests` directories of each app. Run them with grunt: `grunt un
 
 ## End to End tests
 
-They live in [tests](tests). Run them with grunt: `grunt e2e`. Docker is required (it should be available on the command line as `docker`).
+The end to end UI tests leverage the [protractor](https://www.protractortest.org/#/) framework. They are located in the 
+[tests](tests) directory. As of right now there are two states with control flow and without control flow. The former handles async implicitly but is being removed. The config file is located at `tests/conf.js`. The disabled state requires you to manage promises. We are using async/await syntax to manage these. The config file is located at`tests/conf-disabled.js`. The dual state is temporary and `conf-disabled` with async/await will be the normal.  
+
+To run the tests, first build the app with `grunt` command. Then to run with control flow use `grunt e2e`. To run the tests without control flow use `grunt e2e-disabled`. In both cases the grunt command will start couchdb in docker, download the chrome driver, start webdriver, start api, start sentinel, and execute tests.  
+
 
 ## API integration tests
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -208,7 +208,7 @@ They live in the `tests` directories of each app. Run them with grunt: `grunt un
 ## End to End tests
 
 The end to end UI tests leverage the [protractor](https://www.protractortest.org/#/) framework. They are located in the 
-[tests](tests) directory. As of right now there are two states with control flow and without control flow. The former handles async implicitly but is being removed. The config file is located at `tests/conf.js`. The disabled state requires you to manage promises. We are using async/await syntax to manage these. The config file is located at`tests/conf-disabled.js`. The dual state is temporary and `conf-disabled` with async/await will be the normal.  
+[tests](tests) directory. As of right now there are two states with control flow and without control flow. The former handles async implicitly but is being removed. The config file is located at `tests/conf.js`. With out control flow, this requires you to manage promises. We are using async/await syntax to handle this change. The config file is located at`tests/conf-disabled.js`. The dual state is temporary and `conf-disabled` with async/await will be the normal.  
 
 To run the tests, first build the app with `grunt` command. Then to run with control flow use `grunt e2e`. To run the tests without control flow use `grunt e2e-disabled`. In both cases the grunt command will start couchdb in docker, download the chrome driver, start webdriver, start api, start sentinel, and execute tests.  
 


### PR DESCRIPTION
# Description

Adding a bit more detail about the process for e2e and the managing of both controlflow being enabled and disabled.  Looking to help clarify any questions about this process that might be had by someone knew picking up our project and adding e2e tests. 



# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
