### PR TITLE
Remove jsdocs for webapp

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -868,17 +868,6 @@ module.exports = function(grunt) {
           destination: 'jsdocs/shared-libs'
         }
       },
-      webapp: {
-        src: [
-          'webapp/src/js/**/*.js'
-        ],
-        options: {
-          destination: 'jsdocs/webapp',
-          configure: 'node_modules/angular-jsdoc/common/conf.json',
-          template: 'node_modules/angular-jsdoc/angular-template',
-          readme: './README.md'
-        }
-      },
     },
   });
 


### PR DESCRIPTION
# Description

Removing grunt command that generates jsdocs for webapp. The original package isn't compatible with new angular and:

> Because must of us jump into the code directly to get understanding and because running a command isn't the most friendly/straight forward way for getting documentation...

More info in the ticket: https://github.com/medic/angular10-migration/issues/120

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
