### PR TITLE
Enables api and sentinel e2e tests 

### DIFF
--- a/sentinel/tests/unit/lib/feed.js
+++ b/sentinel/tests/unit/lib/feed.js
@@ -7,6 +7,7 @@ const assert = require('chai').assert;
 const db = require('../../../src/db');
 const feed = require('../../../src/lib/feed');
 const metadata = require('../../../src/lib/metadata');
+const logger = require('../../../src/lib/logger');
 const tombstoneUtils = require('@medic/tombstone-utils');
 
 describe('feed', () => {
@@ -203,6 +204,26 @@ describe('feed', () => {
         });
     });
 
+    it('should restart the queue', () => {
+      feed.cancel();
+      sinon.stub(metadata, 'getTransitionSeq').resolves('123');
+      sinon.stub(tombstoneUtils, 'isTombstoneId').returns(false);
+      const change = { id: 'some-uuid' };
+      sinon.stub(feed._changeQueue, 'push');
+      sinon.spy(feed._changeQueue, 'resume');
+
+      return feed
+        .listen()
+        .then(() => {
+          const callbackFn = handler.on.args[0][1];
+          callbackFn(change);
+        })
+        .then(() => {
+          chai.expect(feed._changeQueue.resume.callCount).to.equal(1);
+          chai.expect(feed._changeQueue.push.callCount).to.equal(1);
+          chai.expect(feed._changeQueue.push.args[0][0]).to.deep.equal(change);
+        });
+    });
   });
 
   describe('cancel', () => {
@@ -212,11 +233,13 @@ describe('feed', () => {
 
       const push = sinon.stub(feed._changeQueue, 'push');
       const change = { id: 'some-uuid' };
+      sinon.spy(feed._changeQueue, 'pause');
 
       return feed
         .listen()
         .then(() => feed.cancel())
         .then(() => {
+          chai.expect(feed._changeQueue.pause.callCount).to.equal(1);
           chai.expect(handler.cancel.callCount).to.equal(1);
           // resume listening
           return feed.listen();
@@ -234,6 +257,32 @@ describe('feed', () => {
   });
 
   describe('changeQueue', () => {
+    it('should not resume feed if drain happens while queue is paused', (done) => {
+      let resolvePromise;
+      const delayedPromise = new Promise(resolve => resolvePromise = resolve);
+      sinon.stub(feed._transitionsLib, 'processChange').callsFake((change, cb) => {
+        return delayedPromise.then(() => cb());
+      });
+      sinon.spy(logger, 'debug');
+      sinon.spy(feed._changeQueue, 'resume');
+      sinon.stub(metadata, 'getTransitionSeq');
+      sinon.stub(metadata, 'setTransitionSeq').resolves();
+
+      feed._enqueue({ id: 'somechange', seq: 65558 });
+      feed._changeQueue.process();
+      feed.cancel(); // feed is now canceled
+      resolvePromise(); // queue is now drained
+      setTimeout(() => {
+        chai.expect(logger.debug.withArgs('transitions: queue drained').callCount).to.equal(1);
+        chai.expect(feed._changeQueue.resume.callCount).to.equal(0);
+        chai.expect(metadata.setTransitionSeq.callCount).to.equal(1);
+        chai.expect(metadata.setTransitionSeq.args[0]).to.deep.equal([65558]);
+        chai.expect(metadata.getTransitionSeq.callCount).to.equal(1); // we get the seq anyway
+        chai.expect(db.medic.changes.callCount).to.equal(0); // but we don't restart the watcher
+        done();
+      });
+    });
+
     it('handles an empty change', done => {
       sinon.stub(feed._changeQueue, 'length').returns(0);
       sinon.stub(metadata, 'setTransitionSeq').resolves();

--- a/tests/conf-disabled.js
+++ b/tests/conf-disabled.js
@@ -7,6 +7,7 @@ const browserLogStream = fs.createWriteStream(
   __dirname + '/../tests/logs/browser.console.log'
 );
 
+process.env.protractorControlFlow = false;
 
 const chai = require('chai');
 // so the .to.have.members will display the array members when assertions fail instead of [ Array(6) ]
@@ -22,6 +23,8 @@ const baseConfig = {
   suites: {
     // e2e:'e2e/**/*.js',
     e2e: [
+      'e2e/api/**/*.js',
+      'e2e/sentinel/**/*.js',
       'e2e/service-worker.js',
       'e2e/create-meta-db.js',
       'e2e/login/login.specs.js',

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -7,6 +7,8 @@ const browserLogStream = fs.createWriteStream(
   __dirname + '/../tests/logs/browser.console.log'
 );
 
+process.env.protractorControlFlow = true;
+
 const chai = require('chai');
 // so the .to.have.members will display the array members when assertions fail instead of [ Array(6) ]
 chai.config.truncateThreshold = 0;

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -59,9 +59,7 @@ describe('Users API', () => {
         body: _usersUser
       })
         .then(() => utils.saveDocs(medicData))
-        .then(() => {
-          const deferred = protractor.promise.defer();
-
+        .then(() => new Promise((resolve, reject) => {
           const options = {
             hostname: constants.API_HOST,
             port: constants.API_PORT,
@@ -76,7 +74,7 @@ describe('Users API', () => {
           // Use http service to extract cookie
           const req = http.request(options, res => {
             if (res.statusCode !== 200) {
-              return deferred.reject('Expected 200 from _session authing');
+              return reject('Expected 200 from _session authing');
             }
 
             // Example header:
@@ -84,10 +82,10 @@ describe('Users API', () => {
             try {
               cookie = res.headers['set-cookie'][0].match(/^(AuthSession=[^;]+)/)[0];
             } catch (err) {
-              return deferred.reject(err);
+              return reject(err);
             }
 
-            deferred.fulfill(cookie);
+            resolve(cookie);
           });
 
           req.write(JSON.stringify({
@@ -95,9 +93,7 @@ describe('Users API', () => {
             password: password
           }));
           req.end();
-
-          return deferred.promise;
-        }));
+        })));
 
     afterAll(() =>
       utils.request(`/_users/${getUserId(username)}`)

--- a/tests/e2e/sentinel/transitions/mark_for_outbound.js
+++ b/tests/e2e/sentinel/transitions/mark_for_outbound.js
@@ -104,7 +104,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config)
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -1041,9 +1041,6 @@ describe('registration', () => {
 
     return utils
       .updateSettings(settings)
-      // allow Sentinel to update settings
-      // todo tail logs to check settings were updated
-      .then(() => utils.delayPromise(() => Promise.resolve(), 1000))
       .then(() => utils.saveDoc(createPlace))
       // Sentinel won't process these, so we can't wait for a metadata update, but let's give it 5 seconds just in case
       .then(() => utils.delayPromise(() => Promise.resolve(), 5000))

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -1041,6 +1041,9 @@ describe('registration', () => {
 
     return utils
       .updateSettings(settings)
+      // allow Sentinel to update settings
+      // todo tail logs to check settings were updated
+      .then(() => utils.delayPromise(() => Promise.resolve(), 1000))
       .then(() => utils.saveDoc(createPlace))
       // Sentinel won't process these, so we can't wait for a metadata update, but let's give it 5 seconds just in case
       .then(() => utils.delayPromise(() => Promise.resolve(), 5000))


### PR DESCRIPTION
# Description

Takes a different approach to enabling/disabling protractor control flow and performs switch at the lowest level, and reduce the number of lines of changes to a minimum. 

Cherry picks a commit from `master` to fix an e2e test. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
