### PR TITLE
Fix flacky registration e2e test

### DIFF
--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -126,7 +126,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -165,7 +165,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -244,7 +244,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDocs([ doc1, doc2 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -385,7 +385,7 @@ describe('registration', () => {
     let newPatientId;
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDocs([ doc1, doc2, doc3, doc4 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id, doc3._id, doc4._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id, doc3._id, doc4._id]))
@@ -902,7 +902,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDocs([ doc1, doc2 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -992,7 +992,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDocs([ doc1, doc2, doc3 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id, doc3._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id, doc3._id]))
@@ -1825,7 +1825,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDoc(doc1))
       .then(() => sentinelUtils.waitForSentinel(doc1._id))
       .then(() => sentinelUtils.getInfoDoc(doc1._id))
@@ -1943,7 +1943,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings)
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))


### PR DESCRIPTION
# Description

This test was failing because we started to run tests before actually waiting for sentinel to update its settings. (this was a problem in travis as well, but aparently travis was fast enough that this was not an issue). 

https://github.com/medic/angular10-migration/issues/143

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
