### PR TITLE
Small e2e tests fixes

### DIFF
--- a/tests/e2e/registration-by-sms.js
+++ b/tests/e2e/registration-by-sms.js
@@ -236,18 +236,19 @@ describe('registration transition', () => {
         }]
       };
       await utils.updateSettings(CONFIG);
-      await Promise.all(DOCS.map(async doc => await utils.saveDoc(doc)));
+      await utils.saveDocs(DOCS);
       await submit(body);
       await sUtils.waitForSentinel();
     });
-    beforeEach(function() {
+
+    beforeEach(() => {
       //increasing DEFAULT_TIMEOUT_INTERVAL for this page is very slow and it takes long for the report details to load
       originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
       jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
     });
 
-    afterEach(async () => await utils.afterEach());
-    afterAll(function() {
+    afterEach(() => utils.afterEach());
+    afterAll(() => {
       jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
     });
 
@@ -279,12 +280,12 @@ describe('registration transition', () => {
 
     it('shows content', async () => {
       await commonElements.goToReportsNative();
-      const firstReprot = reportsPo.firstReport();
-      await helper.waitElementToBeClickable(firstReprot);
+      const firstReport = reportsPo.firstReport();
+      await helper.waitElementToBeClickable(firstReport);
       await browser.wait(() => element(
-        by.cssContainingText(reportsPo.subject(firstReprot).locator().value, 'Siobhan')
+        by.cssContainingText(reportsPo.subject(firstReport).locator().value, 'Siobhan')
       ).isPresent(), 10000);
-      await helper.clickElementNative(reportsPo.formName(firstReprot));
+      await helper.clickElementNative(reportsPo.formName(firstReport));
 
       // wait for content to load
       await browser.wait(() => element(

--- a/tests/e2e/transitions/sms_workflows.spec.js
+++ b/tests/e2e/transitions/sms_workflows.spec.js
@@ -113,9 +113,9 @@ describe('SMS workflows', () => {
     await utils.saveDocs(contacts);
   });
 
-  afterAll(async () => await utils.revertDb());
+  afterAll(() => utils.revertDb());
 
-  afterEach(async () => utils.revertDb(contacts.map(c => c._id)));
+  afterEach(() => utils.revertDb(contacts.map(c => c._id)));
 
   describe('mapping recipients', () => {
     it('should correctly map parent for patient', async () => {

--- a/tests/e2e/users/add-user.specs.js
+++ b/tests/e2e/users/add-user.specs.js
@@ -2,20 +2,21 @@ const utils = require('../../utils');
 const usersPage = require('../../page-objects/users/users.po.js');
 const helper = require('../../helper');
 const addUserModal = require('../../page-objects/users/add-user-modal.po.js');
+const commonElements = require('../../page-objects/common/common.po');
 
 const addedUser = 'fulltester' + new Date().getTime();
 const fullName = 'Bede Ngaruko';
 
 
 describe('Add user  : ', () => {
-  describe('creating a users ', ()=> {
+
+  afterAll(() => commonElements.goToMessagesNative());
+
+  describe('creating a users ', () => {
+
     afterEach(async () => {
-      const userPath = `/_users/org.couchdb.user:${addedUser}`;
-      const doc = await utils.request(userPath);
-      await utils.request({
-        path: `${userPath}?rev=${doc._rev}`,
-        method: 'DELETE'
-      });
+      await utils.deleteUsers([{ username: addedUser }]);
+      await utils.revertDb();
     });
 
     it('should add user with valid password', async () => {
@@ -29,8 +30,10 @@ describe('Add user  : ', () => {
     });
   });
 
-  describe('invalid entries ', ()=> {
-    afterEach(async () => { await addUserModal.closeButton().click(); });
+  describe('invalid entries ', () => {
+
+    afterEach(() => addUserModal.closeButton().click());
+
     it('should reject passwords shorter than 8 characters', async () => {
       await usersPage.openAddUserModal();
       await addUserModal.fillForm('user0', 'Not Saved', 'short');


### PR DESCRIPTION
# Description

Refactors create-users-meta-dbs to use existent functions. 
Fixes sms_workflows afterEach not waiting for execution. 
Bulk saveDocs in registration_by_sms
Redirects back to webapp after users e2e tests.

https://github.com/medic/angular10-migration/issues/148
https://github.com/medic/angular10-migration/issues/147

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
