### PR TITLE
Dedupes lodash and adds webpack-bundle-analyzer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,6 +3225,12 @@
         }
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.11",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.11.tgz",
+      "integrity": "sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==",
+      "dev": true
+    },
     "@schematics/angular": {
       "version": "10.0.8",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-10.0.8.tgz",
@@ -16451,6 +16457,12 @@
         "is-wsl": "^2.1.1"
       }
     },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -20289,6 +20301,25 @@
         }
       }
     },
+    "sirv": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.11.tgz",
+      "integrity": "sha512-SR36i3/LSWja7AJNRBz4fF/Xjpn7lQFI30tZ434dIy+bitLYSP+ZEenHg36i23V2SGEz+kqjksg0uOGZ5LPiqg==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.9",
+        "mime": "^2.3.1",
+        "totalist": "^1.0.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
+          "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag==",
+          "dev": true
+        }
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -21914,6 +21945,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "totalist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
+      "integrity": "sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==",
+      "dev": true
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -22895,6 +22932,119 @@
             "ajv-errors": "^1.0.0",
             "ajv-keywords": "^3.1.0"
           }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.0.tgz",
+      "integrity": "sha512-9DhNa+aXpqdHk8LkLPTBU/dMfl84Y+WE2+KnfI6rSpNRNVKa0VGLjPd2pjFubDeqnWmulFggxmWBxhfJXZnR0g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "chalk": "^4.1.0",
+        "commander": "^6.2.0",
+        "gzip-size": "^6.0.0",
+        "lodash": "^4.17.20",
+        "opener": "^1.5.2",
+        "sirv": "^1.0.7",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.0.5",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+          "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.0.2.tgz",
+          "integrity": "sha512-+bpA9MJsHdZ4bgfDcpk0ozQyhhVct7rzOmO0s1IIr0AGGgKBljss8n2zp11rRP2wid5VGeh04CgeKzgat5/25A==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        },
+        "duplexer": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+          "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+          "dev": true
+        },
+        "gzip-size": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+          "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+          "dev": true,
+          "requires": {
+            "duplexer": "^0.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "ws": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+          "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
     "sw-precache": "^5.2.1",
     "tail": "^2.0.3",
     "time-grunt": "^2.0.0",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "webpack-bundle-analyzer": "^4.4.0"
   },
   "bundlesize": [
     {

--- a/webapp/custom-webpack.config.js
+++ b/webapp/custom-webpack.config.js
@@ -17,11 +17,11 @@ module.exports = {
       'bikram-sambat': 'node_modules/bikram-sambat',
       'messageformat': 'node_modules/messageformat/index',
       'lodash/core': 'node_modules/lodash/core',
-      'lodash/uniqBy': 'node_modules/lodash/uniqBy',
-      'lodash/flatten': 'node_modules/lodash/flatten',
-      'lodash/intersection': 'node_modules/lodash/intersection',
-      'lodash/partial': 'node_modules/lodash/partial',
-      'lodash/uniq': 'node_modules/lodash/uniq',
+      'lodash/uniqBy': 'node_modules/lodash-es/uniqBy',
+      'lodash/flatten': 'node_modules/lodash-es/flatten',
+      'lodash/intersection': 'node_modules/lodash-es/intersection',
+      'lodash/partial': 'node_modules/lodash-es/partial',
+      'lodash/uniq': 'node_modules/lodash-es/uniq',
 
       // enketo geopicker widget css requires these two images as backgrounds
       // they don't exist in the enketo source and the styles are commented out in the latest version

--- a/webapp/custom-webpack.config.js
+++ b/webapp/custom-webpack.config.js
@@ -1,4 +1,5 @@
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 module.exports = {
   resolve: {
@@ -15,6 +16,12 @@ module.exports = {
       '../../js/dropdown.jquery': 'node_modules/bootstrap/js/dropdown',
       'bikram-sambat': 'node_modules/bikram-sambat',
       'messageformat': 'node_modules/messageformat/index',
+      'lodash/core': 'node_modules/lodash/core',
+      'lodash/uniqBy': 'node_modules/lodash/uniqBy',
+      'lodash/flatten': 'node_modules/lodash/flatten',
+      'lodash/intersection': 'node_modules/lodash/intersection',
+      'lodash/partial': 'node_modules/lodash/partial',
+      'lodash/uniq': 'node_modules/lodash/uniq',
 
       // enketo geopicker widget css requires these two images as backgrounds
       // they don't exist in the enketo source and the styles are commented out in the latest version
@@ -30,6 +37,11 @@ module.exports = {
     // https://www.npmjs.com/package/moment-locales-webpack-plugin
     new MomentLocalesPlugin({
       localesToKeep: ['en', 'fr', 'es', 'bm', 'hi', 'id', 'ne', 'sw'],
+    }),
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      reportFilename: '../../../analyzer.report.html',
+      openAnalyzer: false,
     }),
   ]
 };

--- a/webapp/custom-webpack.config.js
+++ b/webapp/custom-webpack.config.js
@@ -17,11 +17,11 @@ module.exports = {
       'bikram-sambat': 'node_modules/bikram-sambat',
       'messageformat': 'node_modules/messageformat/index',
       'lodash/core': 'node_modules/lodash/core',
-      'lodash/uniqBy': 'node_modules/lodash-es/uniqBy',
-      'lodash/flatten': 'node_modules/lodash-es/flatten',
-      'lodash/intersection': 'node_modules/lodash-es/intersection',
-      'lodash/partial': 'node_modules/lodash-es/partial',
-      'lodash/uniq': 'node_modules/lodash-es/uniq',
+      'lodash/uniqBy': 'node_modules/lodash/uniqBy',
+      'lodash/flatten': 'node_modules/lodash/flatten',
+      'lodash/intersection': 'node_modules/lodash/intersection',
+      'lodash/partial': 'node_modules/lodash/partial',
+      'lodash/uniq': 'node_modules/lodash/uniq',
 
       // enketo geopicker widget css requires these two images as backgrounds
       // they don't exist in the enketo source and the styles are commented out in the latest version

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -231,6 +231,11 @@
         "immediate": "~3.0.5"
       }
     },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -37,6 +37,7 @@
     "google-libphonenumber": "^3.2.10",
     "gsm": "^0.1.4",
     "jquery": "3.2.x",
+    "lodash": "^4.17.20",
     "lodash-es": "^4.17.15",
     "messageformat": "^2.3.0",
     "moment": "^2.26.0",

--- a/webapp/tests/karma/ts/services/translate-from.service.spec.ts
+++ b/webapp/tests/karma/ts/services/translate-from.service.spec.ts
@@ -1,0 +1,81 @@
+import { TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import { TranslateService } from '@ngx-translate/core';
+
+import { TranslateFromService } from '@mm-services/translate-from.service';
+
+// this code exists in app.module, which apparently isn't loaded in individual tests
+import * as _ from 'lodash-es';
+_.templateSettings.interpolate = /\{\{(.+?)\}\}/g;
+
+describe('TranslateFrom Service', () => {
+  let service:TranslateFromService;
+  let translateService;
+  let currentLang;
+
+  beforeEach(() => {
+    currentLang = 'en';
+    translateService = {
+      get currentLang() {
+        return currentLang;
+      },
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: TranslateService, useValue: translateService }
+      ],
+    });
+    service = TestBed.inject(TranslateFromService);
+  });
+
+  it('should return nothing when no labels', () => {
+    expect(service.get(false)).to.equal(undefined);
+    expect(service.get([])).to.equal(undefined);
+  });
+
+  it('should return label from Array format', () => {
+    const labels = [
+      { content: 'hello-es', locale: 'es' },
+      { content: 'hello-fr', locale: 'fr' },
+      { content: 'hello-en', locale: 'en' },
+    ];
+    expect(service.get(labels)).to.equal('hello-en');
+    currentLang = 'fr';
+    expect(service.get(labels)).to.equal('hello-fr');
+    currentLang = 'nl'; // language doesn't exist
+    expect(service.get(labels)).to.equal('hello-es'); // returns 1st
+  });
+
+  it('should return label from Object format', () => {
+    const labels = {
+      ne: 'hello-ne',
+      en: 'hello-en',
+      fr: 'hello-fr',
+      es: 'hello-es',
+    };
+    expect(service.get(labels)).to.equal('hello-en');
+    currentLang = 'fr';
+    expect(service.get(labels)).to.equal('hello-fr');
+    currentLang = 'nl'; // language doesn't exist
+    expect(service.get(labels)).to.equal('hello-ne'); // return 1st
+  });
+
+  it('should work with scope', () => {
+    const scope = {
+      personA: 'mary',
+      personB: 'jacob'
+    };
+    const labels = { 'en': '{{personA}} goes to meet {{personB}}' };
+    expect(service.get(labels, scope)).to.equal('mary goes to meet jacob');
+  });
+
+  it('should work with a string label', () => {
+    expect(service.get('whatever')).to.equal('whatever');
+  });
+
+  // I doubt this can ever happen, but I am going for 100% coverage :D
+  it('should work with no current lang', () => {
+    currentLang = false;
+    expect(service.get({ en: 'whatever' })).to.equal('whatever');
+  });
+});


### PR DESCRIPTION
# Description

Saves 20KB of minified bundle size. 

https://github.com/medic/angular10-migration/issues/39

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
