### PR TITLE
Update settings watches api and sentinel logs in e2e tests

### DIFF
--- a/tests/conf-disabled.js
+++ b/tests/conf-disabled.js
@@ -13,7 +13,6 @@ const chai = require('chai');
 // so the .to.have.members will display the array members when assertions fail instead of [ Array(6) ]
 chai.config.truncateThreshold = 0;
 
-
 const baseConfig = {
   params:{
     pathToConfig: false

--- a/tests/conf-disabled.js
+++ b/tests/conf-disabled.js
@@ -13,6 +13,7 @@ const chai = require('chai');
 // so the .to.have.members will display the array members when assertions fail instead of [ Array(6) ]
 chai.config.truncateThreshold = 0;
 
+
 const baseConfig = {
   params:{
     pathToConfig: false

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -1013,7 +1013,7 @@ describe('changes handler', () => {
   describe('replication depth', () => {
 
     it('should show contacts to a user only if they are within the configured depth', () =>
-      utils.updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]})
+      utils.updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]}, true)
         .then(() => utils.saveDoc({ _id:'should-be-visible', type:'clinic', parent: { _id:'fixture:chwville' } }))
         .then(() => utils.saveDoc({
           _id:'should-be-hidden', reported_date: 1, type:'person',
@@ -1118,7 +1118,7 @@ describe('changes handler', () => {
         ];
 
         return utils
-          .updateSettings({ replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] })
+          .updateSettings({ replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] }, true)
           .then(() => utils.saveDocs(contacts))
           .then(() => utils.saveDocs(reports))
           .then(() => requestChanges('chw-boss'))
@@ -1164,7 +1164,7 @@ describe('changes handler', () => {
         ];
 
         return utils
-          .updateSettings({ replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] })
+          .updateSettings({ replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] }, true)
           .then(() => utils.saveDocs(docs))
           .then(() => requestChanges('chw-boss'))
           .then(changes => {
@@ -1227,7 +1227,7 @@ describe('changes handler', () => {
         ];
 
         return utils
-          .updateSettings({ replication_depth: [{ role: 'district_admin', depth: 1, report_depth: 0 }] })
+          .updateSettings({ replication_depth: [{ role: 'district_admin', depth: 1, report_depth: 0 }] }, true)
           .then(() => utils.saveDocs(docs))
           .then(() => requestChanges('chw'))
           .then(changes => {
@@ -1309,7 +1309,7 @@ describe('changes handler', () => {
         };
 
         return utils
-          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]})
+          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
           .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport, bobReport ]))
           .then(() => Promise.all([
             requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place
@@ -1399,7 +1399,7 @@ describe('changes handler', () => {
         };
 
         return utils
-          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]})
+          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1 }]}, true)
           .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport, bobReport ]))
           .then(() => Promise.all([
             requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place
@@ -1494,7 +1494,7 @@ describe('changes handler', () => {
         };
 
         return utils
-          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1, report_depth: 0 }]})
+          .updateSettings({replication_depth: [{ role:'district_admin', depth: 1, report_depth: 0 }]}, true)
           .then(() => utils.saveDocs([ clinicReport, clinicReport2, healthCenterReport, bobReport ]))
           .then(() => Promise.all([
             requestChanges('chw'), // chw > chwvillw > chw-bossville > parent_place

--- a/tests/e2e/api/controllers/_changes.spec.js
+++ b/tests/e2e/api/controllers/_changes.spec.js
@@ -242,12 +242,11 @@ describe('changes handler', () => {
     /^org.couchdb.user/,
   ];
 
-  beforeAll(done => {
+  beforeAll(() => {
     // Bootstrap users
     return utils
       .saveDoc(parentPlace)
-      .then(() => utils.createUsers(users, true))
-      .then(done);
+      .then(() => utils.createUsers(users, true));
   });
 
   afterAll(done =>
@@ -258,8 +257,8 @@ describe('changes handler', () => {
       .then(() => utils.deleteUsers(users, true))
       .then(done));
 
-  beforeEach(done => getCurrentSeq().then(done));
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP).then(done));
+  beforeEach(() => getCurrentSeq());
+  afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
 
   describe('requests', () => {
     it('should allow DB admins to POST to _changes', () => {

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -672,7 +672,7 @@ describe('all_docs handler', () => {
 
       const settings = { replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] };
       return utils
-        .updateSettings(settings)
+        .updateSettings(settings, true)
         .then(() => utils.saveDocs(docs))
         .then(() => Promise.all([
           utils.requestOnMedicDb(Object.assign({ qs: { keys: keys  } }, supervisorRequestOptions)),

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -96,14 +96,13 @@ describe('all_docs handler', () => {
       .then(() => utils.createUsers(users));
   });
 
-  afterAll(done =>
+  afterAll(() =>
     utils
       .revertDb()
       .then(() => utils.deleteUsers(users))
-      .then(done)
   );
 
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+  afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
   beforeEach(() => {
     offlineRequestOptions = {
       path: '/_all_docs',

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -796,7 +796,7 @@ describe('bulk-docs handler', () => {
 
     const settings = { replication_depth: [{ role: 'district_admin', depth: 1 }] };
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => utils.saveDocs(existentDocs))
       .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
       .then(() => {
@@ -945,7 +945,7 @@ describe('bulk-docs handler', () => {
 
     const settings = { replication_depth: [{ role: 'district_admin', depth: 1 }] };
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => utils.saveDocs(existentDocs))
       .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
       .then(() => {
@@ -1093,7 +1093,7 @@ describe('bulk-docs handler', () => {
 
     const settings = { replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] };
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => utils.saveDocs(existentDocs))
       .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
       .then(() => {

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -75,13 +75,12 @@ describe('bulk-docs handler', () => {
       .then(() => utils.createUsers(users));
   });
 
-  afterAll(done =>
+  afterAll(() =>
     utils
       .revertDb()
-      .then(() => utils.deleteUsers(users))
-      .then(done));
+      .then(() => utils.deleteUsers(users)));
 
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+  afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
   beforeEach(() => {
     offlineRequestOptions = {
       path: '/_bulk_docs',

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -586,7 +586,7 @@ describe('bulk-get handler', () => {
 
     const settings = { replication_depth: [{ role: 'district_admin', depth: 1 }] };
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => utils.saveDocs(existentDocs))
       .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
       .then(() => {
@@ -672,7 +672,7 @@ describe('bulk-get handler', () => {
 
     const settings = { replication_depth: [{ role: 'district_admin', depth: 1 }] };
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => utils.saveDocs(existentDocs))
       .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
       .then(() => {
@@ -758,7 +758,7 @@ describe('bulk-get handler', () => {
 
     const settings = { replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }] };
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => utils.saveDocs(existentDocs))
       .then(result => result.forEach((item, idx) => existentDocs[idx]._rev = item.rev))
       .then(() => {

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -73,14 +73,13 @@ describe('bulk-get handler', () => {
       .then(() => utils.createUsers(users));
   });
 
-  afterAll(done =>
+  afterAll(() =>
     utils
       .revertDb()
       .then(() => utils.deleteUsers(users))
-      .then(done)
   );
 
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+  afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
   beforeEach(() => {
     offlineRequestOptions = {
       path: '/_bulk_get',

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -164,13 +164,12 @@ describe('db-doc handler', () => {
       .then(() => utils.saveDocs([...clinics, ...patients]));
   });
 
-  afterAll(done =>
+  afterAll(() =>
     utils
       .revertDb()
-      .then(() => utils.deleteUsers(users))
-      .then(done));
+      .then(() => utils.deleteUsers(users)));
 
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+  afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
 
   beforeEach(() => {
     offlineRequestOptions = { auth: { username: 'offline', password }, };

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -447,7 +447,7 @@ describe('db-doc handler', () => {
       ];
       const docs = reportScenarios.map(scenario => scenario.doc);
       return utils
-        .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]})
+        .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]}, true)
         .then(() => utils.saveDocs(docs))
         .then(() => Promise.all(reportScenarios.map(scenario => utils.requestOnTestDb(
           _.defaults({ path: `/${scenario.doc._id}` }, offlineRequestOptions)
@@ -482,7 +482,7 @@ describe('db-doc handler', () => {
 
       const docs = reportScenarios.map(scenario => scenario.doc);
       return utils
-        .updateSettings({replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }]})
+        .updateSettings({replication_depth: [{ role: 'district_admin', depth: 2, report_depth: 1 }]}, true)
         .then(() => utils.saveDocs(docs))
         .then(() => Promise.all(
           reportScenarios.map(scenario =>
@@ -769,7 +769,7 @@ describe('db-doc handler', () => {
 
         const docs = reportScenarios.map(scenario => scenario.doc);
         return utils
-          .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]})
+          .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]}, true)
           .then(()=> utils.saveDocs([...patientsToDelete, ...docs, ...submittersToDelete]))
           .then(() => Promise.all(patientsToDelete.map(patient => utils.requestOnTestDb(
             _.defaults({ path: `/${patient._id}` }, offlineRequestOptions)
@@ -1130,7 +1130,7 @@ describe('db-doc handler', () => {
       };
 
       return utils
-        .updateSettings({ replication_depth: [{ role:'district_admin', depth: 2 }]})
+        .updateSettings({ replication_depth: [{ role:'district_admin', depth: 2 }]}, true)
         .then(() => utils.saveDocs([ allowedTask, deniedTask, allowedTarget, deniedTarget ]))
         .then(() => Promise.all([
           utils.requestOnTestDb(_.defaults({ path: '/task1' }, offlineRequestOptions)),
@@ -1203,7 +1203,7 @@ describe('db-doc handler', () => {
           // user can't see the unallocated report without permissions
           chai.expect(result).to.deep.nested.include({ statusCode: 403, 'responseBody.error': 'forbidden'});
         })
-        .then(() => utils.updateSettings(settings))
+        .then(() => utils.updateSettings(settings, true))
         .then(() => utils.requestOnTestDb(_.defaults({ path: `/${doc._id}` }, offlineRequestOptions)).catch(err => err))
         .then(result => {
           // user can see the unallocated report with permissions
@@ -1400,7 +1400,7 @@ describe('db-doc handler', () => {
         { doc: reportForPatient('fixture:online:clinic:patient', 'online', ['patient_id'], true), allowed: false },
       ];
       return utils
-        .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]})
+        .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]}, true)
         .then(() => Promise.all(reportScenarios.map(scenario => utils.requestOnTestDb(
           _.defaults({ path: '/', body: scenario.doc }, offlineRequestOptions)
         ).catch(err => err))))
@@ -1708,7 +1708,7 @@ describe('db-doc handler', () => {
         { doc: reportForPatient('fixture:online:clinic:patient', 'online', ['patient_id'], true), allowed: false },
       ];
       return utils
-        .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]})
+        .updateSettings({replication_depth: [{ role:'district_admin', depth:1 }]}, true)
         .then(() => Promise.all(reportScenarios.map(scenario => utils.requestOnTestDb(
           _.defaults({ path: `/${scenario.doc._id}`, body:scenario.doc }, offlineRequestOptions)
         ).catch(err => err))))

--- a/tests/e2e/api/controllers/login.spec.js
+++ b/tests/e2e/api/controllers/login.spec.js
@@ -60,7 +60,7 @@ const setupTokenLoginSettings = (configureAppUrl = false) => {
     settings.app_url = utils.getOrigin();
   }
   return utils
-    .updateSettings(settings)
+    .updateSettings(settings, true)
     .then(() => utils.addTranslations('en', { login_sms: 'Instructions sms' }));
 };
 

--- a/tests/e2e/api/controllers/login.spec.js
+++ b/tests/e2e/api/controllers/login.spec.js
@@ -85,7 +85,7 @@ describe('login', () => {
       },
     };
   });
-  afterEach(() => utils.deleteUsers([user]).then(() => utils.revertDb(['PARENT_PLACE'], [])));
+  afterEach(() => utils.deleteUsers([user]).then(() => utils.revertDb(['PARENT_PLACE'], true)));
 
   describe('default login', () => {
     it('should fail with no data', () => {

--- a/tests/e2e/api/controllers/records.spec.js
+++ b/tests/e2e/api/controllers/records.spec.js
@@ -33,7 +33,7 @@ describe('Import Records', () => {
         }
       }
     }
-  }));
+  }, true));
 
   describe('JSON', () => {
     it('parses and stores the passed JSON', () => {

--- a/tests/e2e/api/controllers/settings.js
+++ b/tests/e2e/api/controllers/settings.js
@@ -9,7 +9,7 @@ const getDoc = () => {
 
 describe('Settings API', () => {
   beforeAll(() => utils.updateSettings({}, true));
-  afterAll(done => utils.revertSettings().then(done));
+  afterAll(() => utils.revertSettings());
 
   describe('old api', () => {
 

--- a/tests/e2e/api/controllers/settings.js
+++ b/tests/e2e/api/controllers/settings.js
@@ -8,7 +8,7 @@ const getDoc = () => {
 };
 
 describe('Settings API', () => {
-  beforeAll(() => utils.updateSettings({}));
+  beforeAll(() => utils.updateSettings({}, true));
   afterAll(done => utils.revertSettings().then(done));
 
   describe('old api', () => {

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -484,7 +484,7 @@ describe('Users API', () => {
         },
       };
     });
-    afterEach(() => utils.deleteUsers([user]).then(() => utils.revertDb(['PARENT_PLACE'], [])));
+    afterEach(() => utils.deleteUsers([user]).then(() => utils.revertDb(['PARENT_PLACE'], true)));
 
     const expectCorrectUser = (user, extra = {}) => {
       const defaultProps = {

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -218,7 +218,7 @@ describe('Users API', () => {
         reported_date: new Date().getTime()
       };
       return utils
-        .updateSettings({ transitions: { generate_patient_id_on_people: true }})
+        .updateSettings({ transitions: { generate_patient_id_on_people: true }}, true)
         .then(() => utils.saveDoc(parentPlace))
         .then(() => {
           const opts = {
@@ -692,7 +692,7 @@ describe('Users API', () => {
       it('should create and update a user correctly w/o token_login', () => {
         const settings = { token_login: { translation_key: 'token_login_sms', enabled: true } };
         return utils
-          .updateSettings(settings, 'api')
+          .updateSettings(settings, true)
           .then(() => utils.addTranslations('en', { token_login_sms: 'Instructions sms' }))
           .then(() => utils.request({ path: '/api/v1/users', method: 'POST', body: user }))
           .then(response => {

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -730,7 +730,7 @@ describe('routing', () => {
     it('should still route to deprecated apiV0 settings endpoints', () => {
       let settings;
       return utils
-        .updateSettings({}) // this test will update settings that we want successfully reverted afterwards
+        .updateSettings({}, true) // this test will update settings that we want successfully reverted afterwards
         .then(() => utils.getDoc('settings'))
         .then(result => settings = result.settings)
         .then(() => Promise.all([

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -67,19 +67,18 @@ const DOCS_TO_KEEP = [
 ];
 
 describe('routing', () => {
-  beforeAll(done => {
+  beforeAll(() => {
     return utils
       .saveDoc(parentPlace)
-      .then(() => utils.createUsers(users))
-      .then(done);
+      .then(() => utils.createUsers(users));
   });
 
-  afterAll(done =>
+  afterAll(() =>
     utils
       .revertDb()
       .then(() => utils.deleteUsers(users))
-      .then(done));
-  afterEach(done => utils.revertDb(DOCS_TO_KEEP, true).then(done));
+  );
+  afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
 
   describe('unauthenticated routing', () => {
     it('API restricts endpoints which need authorization', () => {
@@ -725,7 +724,7 @@ describe('routing', () => {
   });
 
   describe('legacy endpoints', () => {
-    afterEach(done => utils.revertSettings().then(done));
+    afterEach(() => utils.revertSettings(true));
 
     it('should still route to deprecated apiV0 settings endpoints', () => {
       let settings;

--- a/tests/e2e/login/db-sync-filter.spec.js
+++ b/tests/e2e/login/db-sync-filter.spec.js
@@ -189,7 +189,7 @@ describe('db-sync-filter', () => {
   };
 
   const getServerRevs = async (docIds) => {
-    const result = await utils.requestOnMedicDb({ path: '/_all_docs', params: { keys: docIds } });
+    const result = await utils.requestOnMedicDb({ path: '/_all_docs', qs: { keys: JSON.stringify(docIds) } });
     return result.rows;
   };
 

--- a/tests/e2e/login/token-login.spec.js
+++ b/tests/e2e/login/token-login.spec.js
@@ -13,7 +13,7 @@ const ERROR = 'Something went wrong when processing your request';
 let user;
 
 const getUrl = token => `${utils.getOrigin()}/medic/login/token/${token}`;
-const setupTokenLoginSettings = async () => {
+const setupTokenLoginSettings = () => {
   // we're configuring app_url here because we're serving api on a port, and in express4 req.hostname strips the port
   // https://expressjs.com/en/guide/migrating-5.html#req.host
   const settings = {
@@ -23,8 +23,7 @@ const setupTokenLoginSettings = async () => {
     },
     app_url: utils.getOrigin()
   };
-  const waitForApiUpdate = await utils.waitForLogs('api.e2e.log', /Settings updated/);
-  return utils.updateSettings(settings, 'api').then(() => waitForApiUpdate.promise);
+  return utils.updateSettings(settings, true);
 };
 
 const createUser = (user) => {

--- a/tests/e2e/login/token-login.spec.js
+++ b/tests/e2e/login/token-login.spec.js
@@ -61,7 +61,7 @@ describe('Token login', () => {
 
   afterEach(async () => {
     await utils.deleteUsers([user]);
-    await utils.revertDb([], []);
+    await utils.revertDb([], true);
   });
 
   afterAll(async () => {

--- a/tests/e2e/sentinel/queue.spec.js
+++ b/tests/e2e/sentinel/queue.spec.js
@@ -96,7 +96,7 @@ describe('Sentinel queue drain', () => {
     let tombstonesIds;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(docs))
       .then(() => sentinelUtils.waitForSentinel(ids))
       .then(() => utils.getDocs(ids))

--- a/tests/e2e/sentinel/schedules/due_tasks.spec.js
+++ b/tests/e2e/sentinel/schedules/due_tasks.spec.js
@@ -281,7 +281,7 @@ describe('Due Tasks', () => {
   beforeAll(() => utils
     .saveDocs(contacts)
     .then(() => utils.addTranslations('test', translations))
-    .then(() => utils.updateSettings(settings))
+    .then(() => utils.updateSettings(settings, 'sentinel'))
   );
   afterAll(() => utils.revertDb());
 

--- a/tests/e2e/sentinel/schedules/outbound.spec.js
+++ b/tests/e2e/sentinel/schedules/outbound.spec.js
@@ -86,7 +86,7 @@ describe('Outbound', () => {
 
   it('should find existing outbound tasks and execute them, leaving them if the send was unsuccessful', () => {
     return utils
-      .updateSettings({ outbound: outboundConfig(server.address().port) })
+      .updateSettings({ outbound: outboundConfig(server.address().port) }, true)
       .then(() => utils.stopSentinel())
       .then(() => utils.saveDocs(docs))
       .then(() => utils.sentinelDb.bulkDocs(tasks))

--- a/tests/e2e/sentinel/schedules/purging.spec.js
+++ b/tests/e2e/sentinel/schedules/purging.spec.js
@@ -389,7 +389,7 @@ describe('server side purge', () => {
     return sentinelUtils.getCurrentSeq()
       .then(result => {
         seq = result;
-        return utils.updateSettings({ purge: purgeSettings });
+        return utils.updateSettings({ purge: purgeSettings }, true);
       })
       .then(() => restartSentinel())
       .then(() => sentinelUtils.waitForPurgeCompletion(seq))
@@ -443,8 +443,8 @@ describe('server side purge', () => {
           'report2', 'report5', 'report6', 'message2', 'message4', 'task4~user2', ...targetIdsToPurge
         ]);
       })
-      .then(() => utils.revertSettings())
-      .then(() => utils.updateSettings({ district_admins_access_unallocated_messages: true }))
+      .then(() => utils.revertSettings(true))
+      .then(() => utils.updateSettings({ district_admins_access_unallocated_messages: true }, true))
       .then(() => Promise.all([
         requestChanges('user1'),
         requestChanges('user2'),
@@ -470,7 +470,7 @@ describe('server side purge', () => {
       .then(() => sentinelUtils.getCurrentSeq())
       .then(result => {
         seq = result;
-        return utils.updateSettings({ purge: purgeSettings });
+        return utils.updateSettings({ purge: purgeSettings }, true);
       })
       .then(() => restartSentinel())
       .then(() => sentinelUtils.waitForPurgeCompletion(seq))
@@ -526,7 +526,7 @@ describe('server side purge', () => {
       .then(result => {
         seq = result;
         purgeSettings.fn = reversePurgeFn.toString();
-        return utils.updateSettings({ purge: purgeSettings });
+        return utils.updateSettings({ purge: purgeSettings }, true);
       })
       .then(() => restartSentinel())
       .then(() => sentinelUtils.waitForPurgeCompletion(seq))

--- a/tests/e2e/sentinel/schedules/reminders.spec.js
+++ b/tests/e2e/sentinel/schedules/reminders.spec.js
@@ -205,7 +205,7 @@ const restartSentinel = () => utils.stopSentinel().then(() => utils.startSentine
 describe('reminders', () => {
   beforeAll(() => {
     return utils
-      .updateSettings({ transitions, forms, 'contact_types': contactTypes, reminders: remindersConfig })
+      .updateSettings({ transitions, forms, 'contact_types': contactTypes, reminders: remindersConfig }, 'sentinel')
       .then(() => utils.saveDocs(contacts));
   });
 

--- a/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/accept_patient_reports.spec.js
@@ -73,7 +73,7 @@ describe('accept_patient_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -102,7 +102,7 @@ describe('accept_patient_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -173,7 +173,7 @@ describe('accept_patient_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -288,7 +288,7 @@ describe('accept_patient_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -439,7 +439,7 @@ describe('accept_patient_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(reports))
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
@@ -608,7 +608,7 @@ describe('accept_patient_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(registrations))
       .then(() => utils.saveDoc(noSilence))
       .then(() => sentinelUtils.waitForSentinel(noSilence._id))

--- a/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/conditional_alerts.spec.js
@@ -69,7 +69,7 @@ describe('conditional_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -103,7 +103,7 @@ describe('conditional_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -141,7 +141,7 @@ describe('conditional_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -176,7 +176,7 @@ describe('conditional_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -240,7 +240,7 @@ describe('conditional_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(form1))
       .then(() => sentinelUtils.waitForSentinel(form1._id))
       .then(() => sentinelUtils.getInfoDoc(form1._id))

--- a/tests/e2e/sentinel/transitions/death_reporting.spec.js
+++ b/tests/e2e/sentinel/transitions/death_reporting.spec.js
@@ -47,7 +47,7 @@ describe('death_reporting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -83,7 +83,7 @@ describe('death_reporting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -119,7 +119,7 @@ describe('death_reporting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -156,7 +156,7 @@ describe('death_reporting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -192,7 +192,7 @@ describe('death_reporting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -256,7 +256,7 @@ describe('death_reporting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))

--- a/tests/e2e/sentinel/transitions/default_responses.spec.js
+++ b/tests/e2e/sentinel/transitions/default_responses.spec.js
@@ -22,7 +22,7 @@ describe('default_responses', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -50,7 +50,7 @@ describe('default_responses', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -88,7 +88,7 @@ describe('default_responses', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -126,7 +126,7 @@ describe('default_responses', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))

--- a/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_patient_id_on_people.spec.js
@@ -19,7 +19,7 @@ describe('generate_patient_id_on_people', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -45,7 +45,7 @@ describe('generate_patient_id_on_people', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -72,7 +72,7 @@ describe('generate_patient_id_on_people', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -97,7 +97,7 @@ describe('generate_patient_id_on_people', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -124,7 +124,7 @@ describe('generate_patient_id_on_people', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))

--- a/tests/e2e/sentinel/transitions/generate_shortcode_on_contacts.spec.js
+++ b/tests/e2e/sentinel/transitions/generate_shortcode_on_contacts.spec.js
@@ -19,7 +19,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -53,7 +53,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([contact, report]))
       .then(() => sentinelUtils.waitForSentinel([contact._id, report._id]))
       .then(() => sentinelUtils.getInfoDocs([contact._id, report._id]))
@@ -83,7 +83,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -110,7 +110,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -136,7 +136,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -161,7 +161,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -188,7 +188,7 @@ describe('generate_shortcode_on_contacts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))

--- a/tests/e2e/sentinel/transitions/mark_for_outbound.js
+++ b/tests/e2e/sentinel/transitions/mark_for_outbound.js
@@ -104,7 +104,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config)
+        .updateSettings(config, true)
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)

--- a/tests/e2e/sentinel/transitions/mark_for_outbound.js
+++ b/tests/e2e/sentinel/transitions/mark_for_outbound.js
@@ -104,7 +104,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -154,7 +154,7 @@ describe('mark_for_outbound', () => {
 
       // First round
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -219,7 +219,7 @@ describe('mark_for_outbound', () => {
 
       // First round
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -289,7 +289,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -324,7 +324,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -347,7 +347,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -370,7 +370,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -401,7 +401,7 @@ describe('mark_for_outbound', () => {
       };
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
         .then(getTasks)
@@ -452,7 +452,7 @@ describe('mark_for_outbound', () => {
       let collect;
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => collect = utils.collectLogs('sentinel.e2e.log', /Mapping error.+_idddddddddddddddd/))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
@@ -485,7 +485,7 @@ describe('mark_for_outbound', () => {
       let collect;
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => collect = utils.collectLogs('sentinel.e2e.log', /Failed to push/, /Response body.+error response/))
         .then(() => sentinelUtils.waitForSentinel([report._id]))
@@ -519,7 +519,7 @@ describe('mark_for_outbound', () => {
       let collect;
 
       return utils
-        .updateSettings(config, true)
+        .updateSettings(config, 'sentinel')
         .then(() => utils.saveDoc(report))
         .then(() => collect = utils.collectLogs('sentinel.e2e.log', /Failed to push.+ECONNREFUSED/))
         .then(() => sentinelUtils.waitForSentinel([report._id]))

--- a/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
+++ b/tests/e2e/sentinel/transitions/multi_report_alerts.spec.js
@@ -38,7 +38,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -71,7 +71,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -105,7 +105,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -170,7 +170,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(contacts))
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
@@ -242,7 +242,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -310,7 +310,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -395,7 +395,7 @@ describe('multi_report_alerts', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(contacts))
       .then(() => utils.saveDoc(doc_unknown))
       .then(() => sentinelUtils.waitForSentinel(doc_unknown._id))

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -90,7 +90,7 @@ describe('muting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -124,7 +124,7 @@ describe('muting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -195,7 +195,7 @@ describe('muting', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -331,7 +331,7 @@ describe('muting', () => {
     let unmuteTime;
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(extraContacts))
       .then(() => utils.saveDoc(mute1))
       .then(() => sentinelUtils.waitForSentinel(mute1._id))
@@ -474,7 +474,7 @@ describe('muting', () => {
     let muteTime;
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(extraContacts))
       .then(() => utils.saveDoc(mute))
       .then(() => sentinelUtils.waitForSentinel(mute._id))
@@ -606,7 +606,7 @@ describe('muting', () => {
     let muteHCTime;
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(mute))
       .then(() => sentinelUtils.waitForSentinel(mute._id))
       .then(() => sentinelUtils.getInfoDocs([mute._id, 'person', 'clinic', 'health_center']))

--- a/tests/e2e/sentinel/transitions/registration.spec.js
+++ b/tests/e2e/sentinel/transitions/registration.spec.js
@@ -126,7 +126,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -165,7 +165,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -244,7 +244,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([ doc1, doc2 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -385,7 +385,7 @@ describe('registration', () => {
     let newPatientId;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([ doc1, doc2, doc3, doc4 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id, doc3._id, doc4._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id, doc3._id, doc4._id]))
@@ -605,7 +605,7 @@ describe('registration', () => {
     const ids = [chwNoParent._id, chwNonExistingParent._id, invalidParent1._id, invalidParent2._id, invalidParent3._id];
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([chwNoParent, chwNonExistingParent, invalidParent1, invalidParent2, invalidParent3]))
       .then(() => sentinelUtils.waitForSentinel(ids))
       .then(() => sentinelUtils.getInfoDocs(ids))
@@ -784,7 +784,7 @@ describe('registration', () => {
     let updatedDocs;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([createPerson, createChw, createNurse]))
       .then(() => sentinelUtils.waitForSentinel(ids))
       .then(() => sentinelUtils.getInfoDocs(ids))
@@ -902,7 +902,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([ doc1, doc2 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -992,7 +992,7 @@ describe('registration', () => {
     };
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([ doc1, doc2, doc3 ]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id, doc3._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id, doc3._id]))

--- a/tests/e2e/sentinel/transitions/resolve_pending.spec.js
+++ b/tests/e2e/sentinel/transitions/resolve_pending.spec.js
@@ -18,7 +18,7 @@ describe('resolve_pending', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -36,7 +36,7 @@ describe('resolve_pending', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -98,7 +98,7 @@ describe('resolve_pending', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))

--- a/tests/e2e/sentinel/transitions/self_report.spec.js
+++ b/tests/e2e/sentinel/transitions/self_report.spec.js
@@ -42,7 +42,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -66,7 +66,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -92,7 +92,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -116,7 +116,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -165,7 +165,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -204,7 +204,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -232,7 +232,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -272,7 +272,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -325,7 +325,7 @@ describe('self_report', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))

--- a/tests/e2e/sentinel/transitions/update_clinics.spec.js
+++ b/tests/e2e/sentinel/transitions/update_clinics.spec.js
@@ -24,7 +24,7 @@ describe('update_clinics', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(contact))
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
@@ -63,7 +63,7 @@ describe('update_clinics', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(contact))
       .then(() => utils.saveDoc(doc1))
       .then(() => sentinelUtils.waitForSentinel(doc1._id))

--- a/tests/e2e/sentinel/transitions/update_notifications.spec.js
+++ b/tests/e2e/sentinel/transitions/update_notifications.spec.js
@@ -65,7 +65,7 @@ describe('update_notifications', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -96,7 +96,7 @@ describe('update_notifications', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -160,7 +160,7 @@ describe('update_notifications', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2]))
       .then(() => sentinelUtils.waitForSentinel([doc1._id, doc2._id]))
       .then(() => sentinelUtils.getInfoDocs([doc1._id, doc2._id]))
@@ -267,7 +267,7 @@ describe('update_notifications', () => {
     let unmuteTime;
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(mute1))
       .then(() => sentinelUtils.waitForSentinel(mute1._id))
       .then(() => sentinelUtils.getInfoDocs([mute1._id, 'person', 'clinic']))

--- a/tests/e2e/sentinel/transitions/update_scheduled_reports.spec.js
+++ b/tests/e2e/sentinel/transitions/update_scheduled_reports.spec.js
@@ -98,7 +98,7 @@ describe('update_scheduled_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -134,7 +134,7 @@ describe('update_scheduled_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2]))
       .then(() => sentinelUtils.waitForSentinel([ doc1._id, doc2._id ]))
       .then(() => sentinelUtils.getInfoDocs([ doc1._id, doc2._id ]))
@@ -198,7 +198,7 @@ describe('update_scheduled_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2, doc3, doc4]))
       .then(() => sentinelUtils.waitForSentinel([ doc1._id, doc2._id, doc3._id, doc4._id ]))
       .then(() => sentinelUtils.getInfoDocs([ doc1._id, doc2._id, doc3._id, doc4._id ]))
@@ -280,7 +280,7 @@ describe('update_scheduled_reports', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([doc1, doc2, doc3, doc4, doc5]))
       .then(() => sentinelUtils.waitForSentinel([ doc1._id, doc2._id, doc3._id, doc4._id, doc5._id ]))
       .then(() => utils.getDocs([ doc1._id, doc2._id, doc3._id, doc4._id, doc5._id ]))

--- a/tests/e2e/sentinel/transitions/update_sent_by.spec.js
+++ b/tests/e2e/sentinel/transitions/update_sent_by.spec.js
@@ -19,7 +19,7 @@ describe('update_sent_by', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(doc))
       .then(() => sentinelUtils.waitForSentinel(doc._id))
       .then(() => sentinelUtils.getInfoDoc(doc._id))
@@ -69,7 +69,7 @@ describe('update_sent_by', () => {
     };
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDoc(contact))
       .then(() => utils.saveDocs([report1, report2, report3, report4]))
       .then(() => sentinelUtils.waitForSentinel([report1._id, report2._id, report3._id, report4._id]))
@@ -112,7 +112,7 @@ describe('update_sent_by', () => {
     ];
 
     return utils
-      .updateSettings(settings, true)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs(contacts))
       .then(() => utils.saveDoc(report))
       .then(() => sentinelUtils.waitForSentinel(report._id))

--- a/tests/e2e/transitions/message_duplicates.spec.js
+++ b/tests/e2e/transitions/message_duplicates.spec.js
@@ -82,7 +82,7 @@ describe('message duplicates', () => {
     ];
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => postMessages(firstMessages))
       .then(ids => utils.getDocs(ids))
       .then(docs => {
@@ -152,7 +152,7 @@ describe('message duplicates', () => {
     ];
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => postMessages(firstMessages))
       .then(ids => utils.getDocs(ids))
       .then(docs => {

--- a/tests/e2e/transitions/message_duplicates.spec.js
+++ b/tests/e2e/transitions/message_duplicates.spec.js
@@ -37,9 +37,10 @@ const getPostOpts = (path, body) => ({
 });
 
 const postMessages = (messages) => {
+  const watchChanges = apiUtils.getApiSmsChanges(messages);
   return Promise
     .all([
-      apiUtils.getApiSmsChanges(messages),
+      watchChanges,
       utils.request(getPostOpts('/api/sms', { messages: messages }))
     ])
     .then(([changes]) => changes.map(change => change.id));

--- a/tests/e2e/transitions/message_duplicates.spec.js
+++ b/tests/e2e/transitions/message_duplicates.spec.js
@@ -121,7 +121,7 @@ describe('message duplicates', () => {
 
           const recipient = getRecipient(doc);
           const task = doc.tasks[0];
-          // message1 is duplicated (7x), message2 not duplicate (3x)
+          // message1 is duplicated (7x), message2 not duplicated (3x)
           if (recipient === message1.from) {
             chai.expect(task.messages[0]).to.include({ message: 'Await further instructions' });
             chai.expect(task.state).to.equal('duplicate');
@@ -158,6 +158,10 @@ describe('message duplicates', () => {
       .then(ids => utils.getDocs(ids))
       .then(docs => {
         docs.forEach(doc => {
+          if (doc.tasks.length > 1) {
+            // this test has been flaking on GHA only (no repro locally)
+            console.log(JSON.stringify(doc, null, 2));
+          }
           chai.expect(doc.tasks.length).to.equal(1);
           chai.expect(doc.tasks[0].messages.length).to.equal(1);
 

--- a/tests/e2e/transitions/public_form_transitions.spec.js
+++ b/tests/e2e/transitions/public_form_transitions.spec.js
@@ -232,7 +232,7 @@ const expectTransitions = (infodoc, ...transitions) => {
 
 const processSMS = (settings) => {
   let ids;
-  return utils.updateSettings(settings)
+  return utils.updateSettings(settings, true)
     .then(() => Promise.all([
       apiUtils.getApiSmsChanges(messages),
       utils.request(getPostOpts('/api/sms', { messages: messages }))
@@ -253,7 +253,10 @@ const chw1Lineage = { _id: contacts[3]._id,  parent: contacts[3].parent };
 const chw2Lineage = { _id: contacts[4]._id,  parent: contacts[4].parent };
 
 describe('Transitions public_form', () => {
-  beforeAll(async () => await utils.saveDocs(contacts));
+  beforeAll(async () => {
+    await utils.saveDocs(contacts);
+    await sentinelUtils.waitForSentinel();
+  });
   beforeEach(async () => await utils.saveDocs(patients));
   afterAll(async () => await utils.revertDb());
   afterEach(async () => await utils.revertDb(contacts.map(c => c._id), true));

--- a/tests/e2e/transitions/public_form_transitions.spec.js
+++ b/tests/e2e/transitions/public_form_transitions.spec.js
@@ -232,9 +232,10 @@ const expectTransitions = (infodoc, ...transitions) => {
 
 const processSMS = (settings) => {
   let ids;
+  const watchChanges = apiUtils.getApiSmsChanges(messages);
   return utils.updateSettings(settings, true)
     .then(() => Promise.all([
-      apiUtils.getApiSmsChanges(messages),
+      watchChanges,
       utils.request(getPostOpts('/api/sms', { messages: messages }))
     ]))
     .then(([ changes ]) => {

--- a/tests/e2e/transitions/sentinel_api_transitions.spec.js
+++ b/tests/e2e/transitions/sentinel_api_transitions.spec.js
@@ -1016,7 +1016,7 @@ describe('transitions', () => {
     };
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, 'sentinel')
       .then(() => utils.saveDocs([place, person]))
       .then(() => sentinelUtils.waitForSentinel([ place._id, person._id ]))
       .then(() => sentinelUtils.getInfoDocs([ place._id, person._id ]))

--- a/tests/e2e/transitions/sentinel_api_transitions.spec.js
+++ b/tests/e2e/transitions/sentinel_api_transitions.spec.js
@@ -321,7 +321,11 @@ const isUntransitionedDoc = doc => {
 };
 
 describe('transitions', () => {
-  beforeAll(done => utils.saveDocs(contacts).then(done));
+  beforeAll(() => {
+    return utils
+      .saveDocs(contacts)
+      .then(() => sentinelUtils.waitForSentinel());
+  });
   afterAll(done => utils.revertDb().then(done));
   afterEach(done => utils.revertDb(contacts.map(c => c._id), true).then(done));
 
@@ -344,7 +348,7 @@ describe('transitions', () => {
     let ids;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => Promise.all([
         apiUtils.getApiSmsChanges(messages),
         utils.request(getPostOpts('/api/sms', { messages })),
@@ -663,7 +667,7 @@ describe('transitions', () => {
     let ids;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => Promise.all([
         apiUtils.getApiSmsChanges(messages),
         utils.request(getPostOpts('/api/sms', { messages: messages })),
@@ -779,7 +783,7 @@ describe('transitions', () => {
     let ids;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => Promise.all([
         apiUtils.getApiSmsChanges(messages),
         utils.request(getPostOpts('/api/sms', { messages: messages })),
@@ -877,7 +881,7 @@ describe('transitions', () => {
     let docId;
 
     return utils
-      .updateSettings(settings, false)
+      .updateSettings(settings, true)
       .then(() => Promise.all([
         apiUtils.getApiSmsChanges(messages),
         utils.request(getPostOpts('/api/sms', { messages: messages })),
@@ -948,7 +952,7 @@ describe('transitions', () => {
     let docId;
 
     return utils
-      .updateSettings(settings)
+      .updateSettings(settings, true)
       .then(() => Promise.all([
         apiUtils.getApiSmsChanges(messages),
         utils.request(getPostOpts('/api/sms', { messages: messages })),
@@ -1012,7 +1016,7 @@ describe('transitions', () => {
     };
 
     return utils
-      .updateSettings(settings, false)
+      .updateSettings(settings)
       .then(() => utils.saveDocs([place, person]))
       .then(() => sentinelUtils.waitForSentinel([ place._id, person._id ]))
       .then(() => sentinelUtils.getInfoDocs([ place._id, person._id ]))

--- a/tests/e2e/transitions/sms_workflows.spec.js
+++ b/tests/e2e/transitions/sms_workflows.spec.js
@@ -101,7 +101,7 @@ const expectTasks = (doc, expectations) => {
 
 const processReportsAndSetings = async (reports, settings) => {
   const ids = reports.map(report => report._id);
-  await utils.updateSettings(settings);
+  await utils.updateSettings(settings, 'sentinel');
   await utils.saveDocs(reports);
   await sentinelUtils.waitForSentinel(ids);
   return utils.getDocs(ids);

--- a/tests/e2e/transitions/utils.js
+++ b/tests/e2e/transitions/utils.js
@@ -10,7 +10,11 @@ const getApiSmsChanges = (messages) => {
     since: 'now'
   });
 
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      listener.cancel();
+      reject('timer expired');
+    }, 5000);
     listener.on('change', change => {
       if (change.doc.sms_message) {
         if (ids.includes(change.id)) {
@@ -23,6 +27,7 @@ const getApiSmsChanges = (messages) => {
         ids.push(change.id);
         if (!expectedMessages.length) {
           listener.cancel();
+          clearTimeout(timeout);
           resolve(changes);
         }
       }

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -505,10 +505,12 @@ module.exports = {
    * @return     {Promise}  completion promise
    */
   updateSettings: (updates, ignoreRefresh = false) => {
+    const watcher = !ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
     return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();
       }
+      return watcher.promise;
     });
   },
   /**
@@ -517,12 +519,16 @@ module.exports = {
    * @param      {Boolean}  ignoreRefresh  don't bother refreshing
    * @return     {Promise}  completion promise
    */
-  revertSettings: ignoreRefresh =>
-    revertSettings().then(() => {
+  revertSettings: ignoreRefresh => {
+    const watcher = !ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+    return revertSettings().then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();
       }
-    }),
+
+      return watcher.promise;
+    });
+  },
 
   seedTestData: (userContactDoc, documents) => {
     return module.exports

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -526,7 +526,7 @@ module.exports = {
   updateSettings: (updates, ignoreRefresh = false) => {
     const watcher = ignoreRefresh &&
                     Object.keys(updates).length &&
-                    waitForSettingsUpdateLogs();
+                    waitForSettingsUpdateLogs(ignoreRefresh);
 
     return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -587,10 +587,10 @@ module.exports = {
   /**
    * Reverts the db's settings and documents
    *
-   * @param      {Array}    except          documents to ignore, see deleteAllDocs
-   * @param      {Boolean|String}  ignoreRefresh if false, will wait for reload modal and reload. if true, will tail api logs
-   *                                      and resolve when new settings are loaded.
-   * @return     {Promise}  promise
+   * @param  {Array}            except       documents to ignore, see deleteAllDocs
+   * @param  {Boolean|String}  ignoreRefresh if false, will wait for reload modal and reload. if true, will tail api
+   *                                         logs and resolve when new settings are loaded.
+   * @return {Promise}
    */
   revertDb: revertDb,
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -349,6 +349,14 @@ const deprecated = (name, replacement) => {
   }
 };
 
+const waitForApiSettingsUpdateLogs = () => {
+  return module.exports.waitForLogs(
+    'api.e2e.log',
+    /Settings updated/,
+    /Not updating settings - the existing settings are already up to date/,
+  );
+};
+
 module.exports = {
   deprecated,
   db: db,
@@ -507,7 +515,7 @@ module.exports = {
   updateSettings: (updates, ignoreRefresh = false) => {
     const watcher = ignoreRefresh &&
                     Object.keys(updates).length &&
-                    module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+                    waitForApiSettingsUpdateLogs();
 
     return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {
@@ -523,7 +531,7 @@ module.exports = {
    * @return     {Promise}  completion promise
    */
   revertSettings: ignoreRefresh => {
-    const watcher = ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+    const watcher = ignoreRefresh && waitForApiSettingsUpdateLogs();
     return revertSettings().then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -518,18 +518,20 @@ module.exports = {
   /**
    * Update settings and refresh if required
    *
-   * @param      {Object}   updates  Object containing all updates you wish to
-   *                                 make
-   * @param      {Boolean}  ignoreRefresh  don't bother refreshing
-   * @return     {Promise}  completion promise
+   * @param {Object}         updates  Object containing all updates you wish to
+   *                                  make
+   * @param  {Boolean|String} ignoreReload if false, will wait for reload modal and reload. if truthy, will tail
+   *                                       service logs and resolve when new settings are loaded. By default, watches
+   *                                       api logs, if value equals 'sentinel', will watch sentinel logs instead.
+   * @return {Promise}        completion promise
    */
-  updateSettings: (updates, ignoreRefresh = false) => {
-    const watcher = ignoreRefresh &&
+  updateSettings: (updates, ignoreReload) => {
+    const watcher = ignoreReload &&
                     Object.keys(updates).length &&
-                    waitForSettingsUpdateLogs(ignoreRefresh);
+                    waitForSettingsUpdateLogs(ignoreReload);
 
     return updateSettings(updates).then(() => {
-      if (!ignoreRefresh) {
+      if (!ignoreReload) {
         return refreshToGetNewSettings();
       }
       return watcher && watcher.promise;
@@ -538,8 +540,9 @@ module.exports = {
   /**
    * Revert settings and refresh if required
    *
-   * @param      {Boolean}  ignoreRefresh  don't bother refreshing
-   * @return     {Promise}  completion promise
+   * @param {Boolean|String} ignoreRefresh if false, will wait for reload modal and reload. if true, will tail api logs
+   *                                       and resolve when new settings are loaded.
+   * @return {Promise}       completion promise
    */
   revertSettings: ignoreRefresh => {
     const watcher = ignoreRefresh && waitForSettingsUpdateLogs();
@@ -584,8 +587,9 @@ module.exports = {
   /**
    * Reverts the db's settings and documents
    *
-   * @param      {Array}  except         documents to ignore, see deleteAllDocs
-   * @param      {Boolean}  ignoreRefresh  don't bother refreshing
+   * @param      {Array}    except          documents to ignore, see deleteAllDocs
+   * @param      {Boolean|String}  ignoreRefresh if false, will wait for reload modal and reload. if true, will tail api logs
+   *                                      and resolve when new settings are loaded.
    * @return     {Promise}  promise
    */
   revertDb: revertDb,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -505,7 +505,7 @@ module.exports = {
    * @return     {Promise}  completion promise
    */
   updateSettings: (updates, ignoreRefresh = false) => {
-    const watcher = !ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+    const watcher = ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
     return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();
@@ -520,7 +520,7 @@ module.exports = {
    * @return     {Promise}  completion promise
    */
   revertSettings: ignoreRefresh => {
-    const watcher = !ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+    const watcher = ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
     return revertSettings().then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -505,12 +505,15 @@ module.exports = {
    * @return     {Promise}  completion promise
    */
   updateSettings: (updates, ignoreRefresh = false) => {
-    const watcher = ignoreRefresh && module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+    const watcher = ignoreRefresh &&
+                    Object.keys(updates).length &&
+                    module.exports.waitForLogs('api.e2e.log', /Settings updated/);
+
     return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();
       }
-      return watcher.promise;
+      return watcher && watcher.promise;
     });
   },
   /**

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -247,7 +247,7 @@ const setUserContactDoc = () => {
 };
 
 const revertDb = (except, ignoreRefresh) => {
-  const watcher = ignoreRefresh && waitForApiSettingsUpdateLogs();
+  const watcher = ignoreRefresh && waitForSettingsUpdateLogs();
   return revertSettings().then(needsRefresh => {
     return deleteAll(except).then(() => {
       // only need to refresh if the settings were changed
@@ -354,7 +354,14 @@ const deprecated = (name, replacement) => {
   }
 };
 
-const waitForApiSettingsUpdateLogs = () => {
+const waitForSettingsUpdateLogs = (type) => {
+  if (type === 'sentinel') {
+    return module.exports.waitForLogs(
+      'sentinel.e2e.log',
+      /Reminder messages allowed between/,
+    );
+  }
+
   return module.exports.waitForLogs(
     'api.e2e.log',
     /Settings updated/,
@@ -519,7 +526,7 @@ module.exports = {
   updateSettings: (updates, ignoreRefresh = false) => {
     const watcher = ignoreRefresh &&
                     Object.keys(updates).length &&
-                    waitForApiSettingsUpdateLogs();
+                    waitForSettingsUpdateLogs();
 
     return updateSettings(updates).then(() => {
       if (!ignoreRefresh) {
@@ -535,7 +542,7 @@ module.exports = {
    * @return     {Promise}  completion promise
    */
   revertSettings: ignoreRefresh => {
-    const watcher = ignoreRefresh && waitForApiSettingsUpdateLogs();
+    const watcher = ignoreRefresh && waitForSettingsUpdateLogs();
     return revertSettings().then((needsRefresh) => {
       if (!ignoreRefresh) {
         return refreshToGetNewSettings();


### PR DESCRIPTION
# Description

Stabilize and reduce duration of e2e tests that require updating settings and interacting with an API endpoint or when expecting sentinel to process docs in a certain way.
Speeds up the e2e test job by ~ 1.5 minutes (on GHA)

https://github.com/medic/angular10-migration/issues/160


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
