### PR TITLE
attempt at send-message flakey fix by using waituntilnative

### DIFF
--- a/tests/page-objects/messages/messages.po.js
+++ b/tests/page-objects/messages/messages.po.js
@@ -80,8 +80,7 @@ module.exports = {
   },
   openSendMessageModal: async ()=> {
     await helper.clickElementNative(module.exports.sendMessage());
-    await helper.waitElementToPresent(module.exports.sendMessageModal(), 5000);
-    await helper.waitElementToBeVisibleNative(module.exports.sendMessageModal(), 5000);
+    await helper.waitUntilReadyNative(module.exports.sendMessageModal());
   },
   getSendMessageButton: ()=> {
     helper.waitUntilReady(sendMessageButton);


### PR DESCRIPTION
# Description

Reviewed what's happening before and test wise. I've updated to use the `waitUntilReadyNative()` instead of two separate functions that per the docs do the same thing. 

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
