### PR TITLE
Only display actionbar buttons when they have actions attached to them

### DIFF
--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -1,6 +1,6 @@
 import { ActivationEnd, ActivationStart, Router, RouterEvent } from '@angular/router';
 import * as moment from 'moment';
-import { Component, NgZone, OnInit } from '@angular/core';
+import { Component, NgZone, OnInit, HostListener } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
 import { setTheme as setBootstrapTheme} from 'ngx-bootstrap/utils';
@@ -622,5 +622,11 @@ export class AppComponent implements OnInit {
       window.startupTimes.angularBootstrapped - window.startupTimes.bootstrapped
     );
     this.telemetryService.record('boot_time', window.startupTimes.angularBootstrapped - window.startupTimes.start);
+  }
+
+  @HostListener('window:beforeunload')
+  private stopWatchingChanges() {
+    // avoid Failed to fetch errors being logged when the browser window is reloaded
+    this.changesService.killWatchers();
   }
 }

--- a/webapp/src/ts/components/actionbar/actionbar.component.html
+++ b/webapp/src/ts/components/actionbar/actionbar.component.html
@@ -43,7 +43,7 @@
             <span class="fa fa-check-circle"></span>
             <p>{{'select.mode.start' | translate}}</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" *ngIf="isAdmin" (click)="actionBar?.left?.exportFn($event)" [ngClass]="{'mm-icon-disabled': !actionBar?.left?.hasResults}">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" *ngIf="isAdmin && !actionBar?.left?.exportFn" (click)="actionBar?.left?.exportFn($event)" [ngClass]="{'mm-icon-disabled':  !actionBar?.left?.hasResults}">
             <span class="fa fa-arrow-down"></span>
             <p>{{'Export' | translate}}</p>
           </a>
@@ -53,9 +53,9 @@
       <div class="col-sm-4 general-actions left-pane" *ngIf="currentTab === 'contacts'">
         <div class="actions dropup" mmAuth [mmAuthAny]="[ isAdmin, actionBar?.left?.childPlaces && 'can_create_places' ]">
           <a *ngIf="actionBar?.left?.childPlaces?.length > 1"
-            mmAuth="can_create_places"
-            class="mm-icon mm-icon-inverse mm-icon-caption dropdown-toggle"
-            data-toggle="dropdown"
+             mmAuth="can_create_places"
+             class="mm-icon mm-icon-inverse mm-icon-caption dropdown-toggle"
+             data-toggle="dropdown"
           >
             <span class="fa fa-plus"></span>
             <p>{{'Add place' | translate}}</p>
@@ -67,7 +67,7 @@
           >
             <li *ngFor="let child of actionBar.left.childPlaces; trackBy: trackById">
               <a [routerLink]="actionBar.left.userFacilityId ? ['/', 'contacts', actionBar.left.userFacilityId, 'add', child.id] : ['/', 'contacts', 'add', child.id]"
-                [queryParams]="{ from: 'list' }"
+                 [queryParams]="{ from: 'list' }"
               >
                 <span [innerHTML]="child.icon | resourceIcon"></span>
                 <span class="content">{{ child.create_key | translate }}</span>
@@ -76,10 +76,10 @@
           </ul>
 
           <a *ngIf="actionBar?.left?.childPlaces?.length === 1"
-            mmAuth="can_create_places"
-            class="mm-icon mm-icon-inverse mm-icon-caption"
-            [routerLink]="actionBar.left.userFacilityId ? ['/', 'contacts', actionBar.left.userFacilityId, 'add', actionBar.left.childPlaces[0]?.id] : ['/', 'contacts', 'add', actionBar.left.childPlaces[0]?.id]"
-            [queryParams]="{ from: 'list' }"
+             mmAuth="can_create_places"
+             class="mm-icon mm-icon-inverse mm-icon-caption"
+             [routerLink]="actionBar.left.userFacilityId ? ['/', 'contacts', actionBar.left.userFacilityId, 'add', actionBar.left.childPlaces[0]?.id] : ['/', 'contacts', 'add', actionBar.left.childPlaces[0]?.id]"
+             [queryParams]="{ from: 'list' }"
           >
             <span class="fa-stack">
               <i [innerHTML]="actionBar.left.childPlaces[0].icon | resourceIcon"></i>
@@ -88,10 +88,10 @@
             <p>{{ actionBar.left.childPlaces[0].create_key | translate}}</p>
           </a>
 
-          <a *ngIf="isAdmin"
-            class="mm-icon mm-icon-inverse mm-icon-caption"
-            (click)="actionBar?.left?.exportFn()"
-            [ngClass]="{ 'mm-icon-disabled': !actionBar.left.hasResults }"
+          <a *ngIf="isAdmin && actionBar?.left?.exportFn"
+             class="mm-icon mm-icon-inverse mm-icon-caption"
+             (click)="actionBar?.left?.exportFn()"
+             [ngClass]="{ 'mm-icon-disabled': !actionBar.left.hasResults }"
           >
             <span class="fa fa-arrow-down"></span>
             <p>{{'Export' | translate}}</p>
@@ -101,11 +101,11 @@
 
       <div class="col-sm-4 general-actions left-pane" *ngIf="currentTab === 'messages'">
         <div class="actions dropup">
-          <a class="mm-icon mm-icon-inverse mm-icon-caption send-message" (click)="actionBar?.left?.openSendMessageModal($event)">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption send-message" *ngIf="actionBar?.left?.openSendMessageModal" (click)="actionBar?.left?.openSendMessageModal($event)">
             <span class="fa fa-plus"></span>
             <p>{{'Send Message' | translate}}</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" *ngIf="isAdmin" (click)="actionBar?.left?.exportFn()" [ngClass]="{'mm-icon-disabled': !actionBar?.left?.hasResults}">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption" *ngIf="isAdmin && actionBar?.left?.exportFn" (click)="actionBar?.left?.exportFn()" [ngClass]="{'mm-icon-disabled': !actionBar?.left?.hasResults}">
             <span class="fa fa-arrow-down"></span>
             <p>{{'Export' | translate}}</p>
           </a>
@@ -130,7 +130,7 @@
               <span class="fa fa-envelope"></span>
               <p>{{'Send Message' | translate}}</p>
             </a>
-            <a class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only" (click)="actionBar?.right?.sendTo?.phone && actionBar?.right?.openSendMessageModal(actionBar?.right?.sendTo?._id)" [ngClass]="{'mm-icon-disabled': !actionBar?.right?.sendTo?.phone}">
+            <a class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only" *ngIf="actionBar?.right?.openSendMessageModal" (click)="actionBar?.right?.sendTo?.phone && actionBar?.right?.openSendMessageModal(actionBar?.right?.sendTo?._id)" [ngClass]="{'mm-icon-disabled': !actionBar?.right?.sendTo?.phone}">
               <span class="fa fa-envelope"></span>
               <p>{{'Send Message' | translate}}</p>
             </a>
@@ -204,8 +204,8 @@
             </ng-container>
 
             <a *ngIf="group.types?.length === 1"
-              class="mm-icon mm-icon-inverse mm-icon-caption"
-              [routerLink]="['/', 'contacts', selectedContactDoc._id, 'add', group.types[0]?.id]"
+               class="mm-icon mm-icon-inverse mm-icon-caption"
+               [routerLink]="['/', 'contacts', selectedContactDoc._id, 'add', group.types[0]?.id]"
             >
               <span class="fa-stack">
                 <i [innerHTML]="group.types[0]?.icon | resourceIcon"></i>
@@ -216,45 +216,45 @@
           </span>
 
           <a *ngIf="actionBar?.right?.sendTo"
-            mmAuth="can_view_call_action"
-            class="mm-icon mm-icon-inverse mm-icon-caption mobile-only"
-            [attr.href]="'tel:' + actionBar?.right?.sendTo?.phone | safeHtml:'url'"
-            [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
+             mmAuth="can_view_call_action"
+             class="mm-icon mm-icon-inverse mm-icon-caption mobile-only"
+             [attr.href]="'tel:' + actionBar?.right?.sendTo?.phone | safeHtml:'url'"
+             [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
           >
             <span class="fa fa-phone"></span>
             <p>{{'call' | translate}}</p>
           </a>
           <a *ngIf="actionBar?.right?.sendTo"
-            mmAuth="can_view_message_action"
-            class="mm-icon mm-icon-inverse mm-icon-caption mobile-only"
-            [attr.href]="'sms:' + actionBar?.right?.sendTo?.phone | safeHtml:'url'"
-            [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
+             mmAuth="can_view_message_action"
+             class="mm-icon mm-icon-inverse mm-icon-caption mobile-only"
+             [attr.href]="'sms:' + actionBar?.right?.sendTo?.phone | safeHtml:'url'"
+             [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
           >
             <span class="fa fa-envelope"></span>
             <p>{{'Send Message' | translate}}</p>
           </a>
           <a *ngIf="actionBar?.right?.sendTo"
-            mmAuth="can_view_message_action"
-            class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only"
-            [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
-            (click)="actionBar?.right?.sendTo?.phone && actionBar?.right?.openSendMessageModal(actionBar?.right?.sendTo?._id)"
+             mmAuth="can_view_message_action"
+             class="mm-icon mm-icon-inverse mm-icon-caption send-message desktop-only"
+             [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.sendTo?.phone }"
+             (click)="actionBar?.right?.sendTo?.phone && actionBar?.right?.openSendMessageModal(actionBar?.right?.sendTo?._id)"
           >
             <span class="fa fa-envelope"></span>
             <p>{{'Send Message' | translate}}</p>
           </a>
 
           <a class="mm-icon mm-icon-inverse mm-icon-caption"
-            [routerLink]="['/', 'contacts', selectedContactDoc._id, 'edit']"
-            [ngClass]="{'mm-icon-disabled': !actionBar?.right?.canEdit}"
+             [routerLink]="['/', 'contacts', selectedContactDoc._id, 'edit']"
+             [ngClass]="{'mm-icon-disabled': !actionBar?.right?.canEdit}"
           >
             <span class="fa fa-pencil"></span>
             <p>{{'Edit' | translate}}</p>
           </a>
 
           <a mmAuth="can_delete_contacts"
-            class="mm-icon mm-icon-inverse mm-icon-caption"
-            (click)="deleteDoc(selectedContactDoc)"
-            [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.canDelete }"
+             class="mm-icon mm-icon-inverse mm-icon-caption"
+             (click)="deleteDoc(selectedContactDoc)"
+             [ngClass]="{ 'mm-icon-disabled': !actionBar?.right?.canDelete }"
           >
             <span class="fa fa-trash-o"></span>
             <p>{{'Delete' | translate}}</p>

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -281,7 +281,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
 
   save() {
     if (this.enketoSaving) {
-      console.debug('Attempted to call reports-add:$scope.save more than once');
+      console.debug('Attempted to call reports-add.component:save more than once');
       return;
     }
 
@@ -293,8 +293,8 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
     this.globalActions.setEnketoSavingStatus(true);
     this.resetFormError();
     const model = this.selectedReports[0];
-    const reportId = model.doc && model.doc._id;
-    const formInternalId = model.formInternalId;
+    const reportId = model?.doc?._id;
+    const formInternalId = model?.formInternalId;
 
     return this.enketoService
       .save(formInternalId, this.form, this.geoHandle, reportId)

--- a/webapp/src/ts/reducers/messages.ts
+++ b/webapp/src/ts/reducers/messages.ts
@@ -59,7 +59,7 @@ const updateSelectedConversation = (state, selected) => {
 };
 
 const markSelectedConversationRead = (state) => {
-  if (!state.conversations || !state.selected.messages) {
+  if (!state.conversations || !state.selected?.messages) {
     return state;
   }
 

--- a/webapp/src/ts/services/changes.service.ts
+++ b/webapp/src/ts/services/changes.service.ts
@@ -103,7 +103,7 @@ export class ChangesService {
       .catch((err) => {
         console.error('Error initialising watching for db changes', err);
         console.error('Attempting changes initialisation in ' + (RETRY_MILLIS / 1000) + ' seconds');
-        setTimeout(this.init, RETRY_MILLIS);
+        setTimeout(() => this.init(), RETRY_MILLIS);
       });
   }
 

--- a/webapp/src/ts/services/get-subject-summaries.service.ts
+++ b/webapp/src/ts/services/get-subject-summaries.service.ts
@@ -182,6 +182,6 @@ export class GetSubjectSummariesService {
         }
         return summaries;
       })
-      .then(this.validateSubjects);
+      .then(summaries => this.validateSubjects(summaries));
   }
 }

--- a/webapp/src/ts/services/hydrate-messages.service.ts
+++ b/webapp/src/ts/services/hydrate-messages.service.ts
@@ -93,7 +93,7 @@ export class HydrateMessagesService {
         });
 
         return rows.map((row) => {
-          return this.buildMessageModel(row.doc, row.key[0], row.value.date, row.report);
+          return this.buildMessageModel(row.doc || {}, row.key[0], row.value.date, row.report);
         });
       });
   }

--- a/webapp/src/ts/services/resource-icons.service.ts
+++ b/webapp/src/ts/services/resource-icons.service.ts
@@ -11,7 +11,6 @@ export class ResourceIconsService {
   private readonly DOC_IDS = ['resources', 'branding', 'partners'];
 
   private initResources;
-  private $ = (<any>window).jQuery;
 
   private readonly cache = {
     resources: {
@@ -82,10 +81,10 @@ export class ResourceIconsService {
   }
 
   private updateDom ($elem, doc) {
-    $elem = $elem || this.$(document.body);
+    $elem = $elem || $(document.body);
     const css = this.CSS_CLASS[this.DOC_IDS.indexOf(doc)];
     $elem.find(`.${css}`).each((i, child) => {
-      const $this = this.$(child);
+      const $this = $(child);
       const name = $this.data('title') || $this.attr('title');
       const faPlaceholder = $this.data('faPlaceholder');
       $this.html(this.getHtmlContent(name, doc, faPlaceholder));
@@ -98,7 +97,7 @@ export class ResourceIconsService {
       .then(res => {
         this.cache[docId].doc = res;
         this.cache[docId].htmlContent = {};
-        this.updateDom(this.$(document.body), docId);
+        this.updateDom($(document.body), docId);
       })
       .catch(err => {
         if (err.status !== 404) {


### PR DESCRIPTION
# Description

Fix changes service not restarting correctly after being disconnected.
Add beforeunload listener to stop watchers and avoid unnecessary e2e test log pollution.
Minor refactor in resource icons service.
Fix get subject summaries calling with incorrect scope.
Adds more nullchecks. 

https://github.com/medic/angular10-migration/issues/163
https://github.com/medic/angular10-migration/issues/157
https://github.com/medic/angular10-migration/issues/156

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
