### PR TITLE
Fixes race condition in displaying tasks after submission

### DIFF
--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -79,9 +79,8 @@ export class TasksComponent implements OnInit, OnDestroy {
     this.subscription.add(changesSubscription);
   }
 
-  private subscribeToRulesEngineChanges() {
-    const rulesEngineSubscription = this.rulesEngineService.subscribeToChangesProcessed(() => {
-      // Rules engine emits when it's finished marking contacts as dirty
+  private subscribeToRulesEngine() {
+    const rulesEngineSubscription = this.rulesEngineService.contactsMarkedAsDirty(() => {
       this.debouncedReload.cancel();
       return this.debouncedReload();
     });
@@ -92,7 +91,7 @@ export class TasksComponent implements OnInit, OnDestroy {
     this.tasksActions.setSelectedTask(null);
     this.subscribeToStore();
     this.subscribeToChanges();
-    this.subscribeToRulesEngineChanges();
+    this.subscribeToRulesEngine();
 
     this.error = false;
     this.hasTasks = false;

--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -79,10 +79,20 @@ export class TasksComponent implements OnInit, OnDestroy {
     this.subscription.add(changesSubscription);
   }
 
+  private subscribeToRulesEngineChanges() {
+    const rulesEngineSubscription = this.rulesEngineService.subscribeToChangesProcessed(() => {
+      // Rules engine emits when it's finished marking contacts as dirty
+      this.debouncedReload.cancel();
+      return this.debouncedReload();
+    });
+    this.subscription.add(rulesEngineSubscription);
+  }
+
   ngOnInit() {
     this.tasksActions.setSelectedTask(null);
     this.subscribeToStore();
     this.subscribeToChanges();
+    this.subscribeToRulesEngineChanges();
 
     this.error = false;
     this.hasTasks = false;

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NgZone, OnDestroy } from '@angular/core';
 import * as RegistrationUtils from '@medic/registration-utils';
 import * as RulesEngineCore from '@medic/rules-engine';
 import { TranslateService } from '@ngx-translate/core';
-import { Subscription } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { debounce as _debounce, uniq as _uniq } from 'lodash-es';
 
 import { AuthService } from '@mm-services/auth.service';
@@ -53,6 +53,7 @@ export class RulesEngineService implements OnDestroy {
   private initialized;
   private uhcMonthStartDate;
   private debounceActive: DebounceActive = {};
+  private observable = new Subject();
 
   constructor(
     private translateService:TranslateService,
@@ -228,7 +229,10 @@ export class RulesEngineService implements OnDestroy {
 
         return this.rulesEngineCore
           .updateEmissionsFor(subjectIds)
-          .then(telemetryData.passThrough);
+          .then((result) => {
+            this.observable.next(subjectIds);
+            return telemetryData.passThrough(result);
+          });
       }
     });
     this.subscriptions.add(dirtyContactsSubscription);
@@ -391,5 +395,9 @@ export class RulesEngineService implements OnDestroy {
         && replicationResult.docs
         && this.updateEmissionExternalChanges(replicationResult.docs);
     });
+  }
+
+  subscribeToChangesProcessed(callback) {
+    return this.observable.subscribe(callback);
   }
 }

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -397,7 +397,7 @@ export class RulesEngineService implements OnDestroy {
     });
   }
 
-  subscribeToChangesProcessed(callback) {
+  contactsMarkedAsDirty(callback) {
     return this.observable.subscribe(callback);
   }
 }

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -34,7 +34,7 @@ describe('TasksComponent', () => {
     rulesEngineService = {
       isEnabled: sinon.stub().resolves(true),
       fetchTaskDocsForAllContacts: sinon.stub().resolves([]),
-      subscribeToChangesProcessed: sinon.stub(),
+      contactsMarkedAsDirty: sinon.stub(),
     };
 
     tourService = { startIfNeeded: sinon.stub() };
@@ -204,10 +204,10 @@ describe('TasksComponent', () => {
       getComponent();
     });
 
-    expect(rulesEngineService.subscribeToChangesProcessed.callCount).to.equal(1);
+    expect(rulesEngineService.contactsMarkedAsDirty.callCount).to.equal(1);
     expect(rulesEngineService.fetchTaskDocsForAllContacts.callCount).to.equal(1);
 
-    const callback = rulesEngineService.subscribeToChangesProcessed.args[0][0];
+    const callback = rulesEngineService.contactsMarkedAsDirty.args[0][0];
     callback();
     tick(1000); // the refresh tasks call is debounced for 1 second
 

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -34,6 +34,7 @@ describe('TasksComponent', () => {
     rulesEngineService = {
       isEnabled: sinon.stub().resolves(true),
       fetchTaskDocsForAllContacts: sinon.stub().resolves([]),
+      subscribeToChangesProcessed: sinon.stub(),
     };
 
     tourService = { startIfNeeded: sinon.stub() };
@@ -196,6 +197,22 @@ describe('TasksComponent', () => {
 
     expect(changesFeed.filter({ id: 'foo', doc: { _id: 'a', type: 'data_record', form: undefined }})).to.be.false;
   });
+
+  it('should react to rulesEngine emissions', fakeAsync(async () => {
+    await new Promise(resolve => {
+      sinon.stub(TasksActions.prototype, 'setTasksList').callsFake(resolve);
+      getComponent();
+    });
+
+    expect(rulesEngineService.subscribeToChangesProcessed.callCount).to.equal(1);
+    expect(rulesEngineService.fetchTaskDocsForAllContacts.callCount).to.equal(1);
+
+    const callback = rulesEngineService.subscribeToChangesProcessed.args[0][0];
+    callback();
+    tick(1000); // the refresh tasks call is debounced for 1 second
+
+    expect(rulesEngineService.fetchTaskDocsForAllContacts.callCount).to.equal(2);
+  }));
 
   it('should record telemetry on initial load', async () => {
     await new Promise(resolve => {

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -349,7 +349,7 @@ describe('RulesEngineService', () => {
       await service.isEnabled();
 
       const callback = sinon.stub();
-      const subscription = service.subscribeToChangesProcessed(callback);
+      const subscription = service.contactsMarkedAsDirty(callback);
 
       const change = changesService.subscribe.args[0][0];
       const doc = { _id: 'doc', type: 'data_record', form: 'theform', fields: { patient_id: '65479' } };

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -16,7 +16,6 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { RulesEngineCoreFactoryService, RulesEngineService } from '@mm-services/rules-engine.service';
 import { PipesService } from '@mm-services/pipes.service';
-import { wrapFunctionExpressionsInParens } from '@angular/compiler-cli/src/ngtsc/annotations/src/util';
 
 describe('RulesEngineService', () => {
   let service: RulesEngineService;


### PR DESCRIPTION
# Description

Rules-Engine now has an observable that emits when contacts have been marked as dirty. 
The tasks component subscribes to this observable and refreshes the task like for every emission. 

medic/cht-core#6839

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
