### PR TITLE
Enable webapp exporting for online roles

### DIFF
--- a/webapp/src/ts/components/actionbar/actionbar.component.html
+++ b/webapp/src/ts/components/actionbar/actionbar.component.html
@@ -43,7 +43,12 @@
             <span class="fa fa-check-circle"></span>
             <p>{{'select.mode.start' | translate}}</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" *ngIf="isAdmin && actionBar?.left?.exportFn" (click)="actionBar?.left?.exportFn($event)" [ngClass]="{'mm-icon-disabled':  !actionBar?.left?.hasResults}">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption"
+             mmAuth [mmAuthOnline]="true" [mmAuthAny]="['can_export_all', 'can_export_messages']"
+             *ngIf="actionBar?.left?.exportFn"
+             (click)="actionBar?.left?.exportFn($event)"
+             [ngClass]="{'mm-icon-disabled':  !actionBar?.left?.hasResults}"
+          >
             <span class="fa fa-arrow-down"></span>
             <p>{{'Export' | translate}}</p>
           </a>
@@ -51,7 +56,7 @@
       </div>
 
       <div class="col-sm-4 general-actions left-pane" *ngIf="currentTab === 'contacts'">
-        <div class="actions dropup" mmAuth [mmAuthAny]="[ isAdmin, actionBar?.left?.childPlaces && 'can_create_places' ]">
+        <div class="actions dropup" mmAuth [mmAuthAny]="[ actionBar?.left?.childPlaces && 'can_create_places' ]">
           <a *ngIf="actionBar?.left?.childPlaces?.length > 1"
              mmAuth="can_create_places"
              class="mm-icon mm-icon-inverse mm-icon-caption dropdown-toggle"
@@ -88,7 +93,8 @@
             <p>{{ actionBar.left.childPlaces[0].create_key | translate}}</p>
           </a>
 
-          <a *ngIf="isAdmin && actionBar?.left?.exportFn"
+          <a *ngIf="actionBar?.left?.exportFn"
+             mmAuth [mmAuthOnline]="true" [mmAuthAny]="['can_export_all', 'can_export_contacts']"
              class="mm-icon mm-icon-inverse mm-icon-caption"
              (click)="actionBar?.left?.exportFn()"
              [ngClass]="{ 'mm-icon-disabled': !actionBar.left.hasResults }"
@@ -105,7 +111,12 @@
             <span class="fa fa-plus"></span>
             <p>{{'Send Message' | translate}}</p>
           </a>
-          <a class="mm-icon mm-icon-inverse mm-icon-caption" *ngIf="isAdmin && actionBar?.left?.exportFn" (click)="actionBar?.left?.exportFn()" [ngClass]="{'mm-icon-disabled': !actionBar?.left?.hasResults}">
+          <a class="mm-icon mm-icon-inverse mm-icon-caption"
+             *ngIf="actionBar?.left?.exportFn"
+             mmAuth [mmAuthOnline]="true" [mmAuthAny]="['can_export_all', 'can_export_messages']"
+             (click)="actionBar?.left?.exportFn()"
+             [ngClass]="{'mm-icon-disabled': !actionBar?.left?.hasResults}"
+          >
             <span class="fa fa-arrow-down"></span>
             <p>{{'Export' | translate}}</p>
           </a>

--- a/webapp/src/ts/components/actionbar/actionbar.component.ts
+++ b/webapp/src/ts/components/actionbar/actionbar.component.ts
@@ -23,7 +23,6 @@ export class ActionbarComponent implements OnInit, OnDestroy {
   selectMode;
   selectedReportsDocs = [];
   actionBar;
-  isAdmin;
   showActionBar;
   loadingContent;
   loadingSubActionBar;
@@ -42,7 +41,6 @@ export class ActionbarComponent implements OnInit, OnDestroy {
       this.store.select(Selectors.getActionBar),
       this.store.select(Selectors.getCurrentTab),
       this.store.select(Selectors.getSnapshotData),
-      this.store.select(Selectors.getIsAdmin),
       this.store.select(Selectors.getLoadingContent),
       this.store.select(Selectors.getLoadingSubActionBar),
       this.store.select(Selectors.getSelectMode),
@@ -53,7 +51,6 @@ export class ActionbarComponent implements OnInit, OnDestroy {
       actionBar,
       currentTab,
       snapshotData,
-      isAdmin,
       loadingContent,
       loadingSubActionBar,
       selectMode,
@@ -65,7 +62,6 @@ export class ActionbarComponent implements OnInit, OnDestroy {
       this.snapshotData = snapshotData;
       this.selectMode = selectMode;
       this.actionBar = actionBar;
-      this.isAdmin = isAdmin;
       this.showActionBar = showActionBar;
       this.loadingContent = loadingContent;
       this.loadingSubActionBar = loadingSubActionBar;

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -19,9 +19,9 @@ import { ContactsMutedComponent } from '@mm-modals/contacts-muted/contacts-muted
 import { SendMessageComponent } from '@mm-modals/send-message/send-message.component';
 import { ModalService } from '@mm-modals/mm-modal/mm-modal';
 import { ContactTypesService } from '@mm-services/contact-types.service';
-import { SessionService } from '@mm-services/session.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { SettingsService } from '@mm-services/settings.service';
+import { SessionService } from '@mm-services/session.service';
 
 @Component({
   selector: 'contacts-content',
@@ -33,6 +33,8 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   private subscriptionAllContactForms;
   private globalActions;
   private contactsActions;
+
+  private isOnlineOnly;
   loadingContent;
   selectedContact;
   contactsLoadingSummary;
@@ -60,15 +62,17 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
     private modalService: ModalService,
     private contactTypesService: ContactTypesService,
     private settingsService: SettingsService,
-    private sessionService: SessionService,
     private userSettingsService: UserSettingsService,
     private responsiveService: ResponsiveService,
+    private sessionService:SessionService,
   ) {
     this.globalActions = new GlobalActions(store);
     this.contactsActions = new ContactsActions(store);
   }
 
   ngOnInit() {
+    this.isOnlineOnly = this.sessionService.isOnlineOnly();
+
     this.subscribeToStore();
     this.subscribeToRoute();
     this.subscribeToChanges();
@@ -223,7 +227,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
       relevantForms: [], // This disables the "New Action" button until forms load
       sendTo: this.selectedContact?.type?.person ? this.selectedContact?.doc : '',
       canDelete: this.canDeleteContact,
-      canEdit: this.sessionService.isAdmin() || this.userSettings?.facility_id !== this.selectedContact?.doc?._id,
+      canEdit: this.isOnlineOnly || this.userSettings?.facility_id !== this.selectedContact?.doc?._id,
       openContactMutedModal:
         this.openContactMutedModal.bind({}, this.router, this.modalService, this.selectedContact._id),
       openSendMessageModal: this.openSendMessageModal.bind({}, this.modalService),

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -36,6 +36,7 @@ export class ContactsComponent implements OnInit, OnDestroy{
   private servicesActions;
   private listContains;
   private destroyed;
+  private isOnlineOnly;
 
   contactsList;
   loading = false;
@@ -47,7 +48,6 @@ export class ContactsComponent implements OnInit, OnDestroy{
   moreItems;
   usersHomePlace;
   contactTypes;
-  isAdmin;
   childPlaces;
   allowedChildPlaces = [];
   lastVisitedDateExtras;
@@ -86,16 +86,16 @@ export class ContactsComponent implements OnInit, OnDestroy{
   }
 
   ngOnInit() {
+    this.isOnlineOnly = this.sessionService.isOnlineOnly();
+
     this.globalActions.clearFilters(); // clear any global filters first
     const reduxSubscription = combineLatest(
       this.store.select(Selectors.getContactsList),
-      this.store.select(Selectors.getIsAdmin),
       this.store.select(Selectors.getFilters),
       this.store.select(Selectors.contactListContains),
       this.store.select(Selectors.getSelectedContact),
-    ).subscribe(([contactsList, isAdmin, filters, listContains, selectedContact]) => {
+    ).subscribe(([contactsList, filters, listContains, selectedContact]) => {
       this.contactsList = contactsList;
-      this.isAdmin = isAdmin;
       this.filters = filters;
       this.listContains = listContains;
       this.selectedContact = selectedContact;
@@ -282,7 +282,7 @@ export class ContactsComponent implements OnInit, OnDestroy{
         .then(filterChildPlaces);
     }
 
-    if (this.isAdmin) {
+    if (this.isOnlineOnly) {
       return this.contactTypesService
         .getChildren()
         .then(filterChildPlaces);

--- a/webapp/tests/karma/ts/components/filters/facility-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/facility-filter.component.spec.ts
@@ -17,12 +17,13 @@ import {
 } from '@mm-components/filters/multi-dropdown-filter/multi-dropdown-filter.component';
 import { PlaceHierarchyService } from '@mm-services/place-hierarchy.service';
 import { GlobalActions } from '@mm-actions/global';
-import { Selectors } from '@mm-selectors/index';
+import { SessionService } from '@mm-services/session.service';
 
 describe('Facility Filter Component', () => {
   let component:FacilityFilterComponent;
   let fixture:ComponentFixture<FacilityFilterComponent>;
-  let store:MockStore;
+  let sessionService;
+
   let placeHierarchyService;
 
   beforeEach(async(() => {
@@ -30,9 +31,9 @@ describe('Facility Filter Component', () => {
       get: sinon.stub(),
     };
 
-    const mockedSelectors = [
-      { selector: Selectors.getIsAdmin, value: true },
-    ];
+    sessionService = {
+      isOnlineOnly: sinon.stub().returns(true),
+    };
 
     return TestBed
       .configureTestingModule({
@@ -47,7 +48,8 @@ describe('Facility Filter Component', () => {
           MultiDropdownFilterComponent,
         ],
         providers: [
-          provideMockStore({ selectors: mockedSelectors }),
+          provideMockStore(),
+          { provide: SessionService, useValue: sessionService },
           { provide: PlaceHierarchyService, useValue: placeHierarchyService },
         ]
       })
@@ -55,7 +57,6 @@ describe('Facility Filter Component', () => {
       .then(() => {
         fixture = TestBed.createComponent(FacilityFilterComponent);
         component = fixture.componentInstance;
-        store = TestBed.inject(MockStore);
         fixture.detectChanges();
       });
   }));
@@ -256,12 +257,6 @@ describe('Facility Filter Component', () => {
     expect(spySearch.callCount).to.equal(1);
   });
 
-  it('ngOnDestroy() should unsubscribe from observables', () => {
-    const spySubscriptionsUnsubscribe = sinon.spy(component.subscription, 'unsubscribe');
-    component.ngOnDestroy();
-    expect(spySubscriptionsUnsubscribe.callCount).to.equal(1);
-  });
-
   it('trackByFn should return unique value', () => {
     const facility = { doc: { _id: 'a', _rev: 'b' } };
     expect(component.trackByFn(0, facility)).to.equal('ab');
@@ -302,9 +297,9 @@ describe('Facility Filter Component', () => {
       });
     }));
 
-    it('should return unavailable for non-admins when name is not set', async(() => {
-      store.overrideSelector(Selectors.getIsAdmin, false);
-      store.refreshState();
+    it('should return unavailable for offline users when name is not set', async(() => {
+      sessionService.isOnlineOnly.returns(false);
+      component.ngOnInit();
       fixture.detectChanges();
       const facility = { doc: { _id: 'fancy' } };
       component.itemLabel(facility).subscribe(value => {

--- a/webapp/tests/karma/ts/components/filters/facility-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/facility-filter.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { provideMockStore } from '@ngrx/store/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';

--- a/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
@@ -56,7 +56,7 @@ describe('Contacts content component', () => {
     modalService = { show: sinon.stub().resolves() };
     sessionService = {
       isDbAdmin: sinon.stub().returns(false),
-      isAdmin: sinon.stub().returns(false)
+      isOnlineOnly: sinon.stub().returns(false),
     };
     changesService = {
       subscribe: sinon.stub().resolves(of({}))
@@ -333,9 +333,9 @@ describe('Contacts content component', () => {
       expect(contactTypesService.getChildren.callCount).to.equal(0);
     }));
 
-    it('should enable edit and delete in the right action bar when admin user', fakeAsync(() => {
+    it('should enable edit and delete in the right action bar when user is online only', fakeAsync(() => {
       sinon.resetHistory();
-      sessionService.isAdmin.returns(true);
+      sessionService.isOnlineOnly.returns(true);
       store.overrideSelector(Selectors.getSelectedContact, {
         type: { person: true },
         doc: { phone: '11', muted: true },
@@ -360,9 +360,9 @@ describe('Contacts content component', () => {
       expect(globalActions.setRightActionBar.args[0][0].canEdit).to.equal(true);
     }));
 
-    it('should disable edit when user is not admin and facility is home place ', fakeAsync(() => {
+    it('should disable edit when user is not online only and facility is home place ', fakeAsync(() => {
       sinon.resetHistory();
-      sessionService.isAdmin.returns(false);
+      sessionService.isOnlineOnly.returns(false);
       userSettingsService.get.resolves({ facility_id: 'district-123' });
       store.overrideSelector(Selectors.getSelectedContact, {
         doc: { _id: 'district-123', phone: '123', muted: true },
@@ -383,9 +383,9 @@ describe('Contacts content component', () => {
       expect(globalActions.setRightActionBar.args[0][0].canEdit).to.equal(false);
     }));
 
-    it('should enable edit when user is not admin and facility is not home place ', fakeAsync(() => {
+    it('should enable edit when user is not online only and facility is not home place ', fakeAsync(() => {
       sinon.resetHistory();
-      sessionService.isAdmin.returns(false);
+      sessionService.isOnlineOnly.returns(false);
       component.userSettings = { facility_id: 'district-9' };
       store.overrideSelector(Selectors.getSelectedContact, {
         doc: { _id: 'district-123', phone: '123', muted: true },

--- a/webapp/tests/karma/ts/modules/contacts/contacts.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts.component.spec.ts
@@ -57,7 +57,8 @@ describe('Contacts component', () => {
     searchService = { search: sinon.stub().resolves([]) };
     settingsService = { get: sinon.stub().resolves([]) };
     sessionService = {
-      isDbAdmin: sinon.stub().returns(false)
+      isDbAdmin: sinon.stub().returns(false),
+      isOnlineOnly: sinon.stub().returns(false),
     };
     tourService = { startIfNeeded: sinon.stub() };
     authService = { has: sinon.stub().resolves(false) };
@@ -104,7 +105,6 @@ describe('Contacts component', () => {
     const mockedSelectors = [
       { selector: Selectors.getContactsList, value: [] },
       { selector: Selectors.getFilters, value: {} },
-      { selector: Selectors.getIsAdmin, value: false },
       { selector: Selectors.contactListContains, value: contactListContains },
       { selector: Selectors.getSelectedContact, value: selectedContact },
     ];
@@ -162,7 +162,7 @@ describe('Contacts component', () => {
   it('should create ContactsComponent', () => {
     expect(component).to.exist;
   });
-  
+
   it('ngOnInit() should load and filter contacts and watch for changes', () => {
     changesService.subscribe.reset();
     const spySubscriptionsAdd = sinon.spy(component.subscription, 'add');
@@ -294,7 +294,7 @@ describe('Contacts component', () => {
     }));
 
     it('Only searches for top-level places as an admin', fakeAsync(() => {
-      store.overrideSelector(Selectors.getIsAdmin, true);
+      sessionService.isOnlineOnly.returns(true);
       userSettingsService.get.resolves({ facility_id: undefined });
       getDataRecordsService.get.resolves({});
       searchResults = [
@@ -483,7 +483,7 @@ describe('Contacts component', () => {
       searchResults = mockResults(49, 50);
       searchService.search.resolves(searchResults.concat(contacts));
       store.overrideSelector(Selectors.getContactsList, searchResults.concat(contacts));
-      
+
       scrollLoaderCallback();
       flush();
       const updatedContacts = component.contactsActions.updateContactsList.args[1][0];

--- a/webapp/tests/karma/ts/modules/reports/report-filters.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/report-filters.component.spec.ts
@@ -21,6 +21,7 @@ import { PlaceHierarchyService } from '@mm-services/place-hierarchy.service';
 import { ResetFiltersComponent } from '@mm-components/filters/reset-filters/reset-filters.component';
 import { MultiDropdownFilterComponent } from
   '@mm-components/filters/multi-dropdown-filter/multi-dropdown-filter.component';
+import { SessionService } from '@mm-services/session.service';
 
 describe('Reports Filters Component', () => {
   let component: ReportsFiltersComponent;
@@ -53,6 +54,8 @@ describe('Reports Filters Component', () => {
           provideMockStore(),
           { provide: SearchFiltersService, useValue: searchFiltersService },
           { provide: PlaceHierarchyService, useValue: { get: sinon.stub().resolves([]) } },
+          { provide: SessionService, useValue: { isOnlineOnly: sinon.stub() } },
+
         ]
       })
       .compileComponents()

--- a/webapp/tests/karma/ts/modules/reports/report-filters.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/report-filters.component.spec.ts
@@ -29,7 +29,7 @@ describe('Reports Filters Component', () => {
   let searchFiltersService;
 
   beforeEach(async(() => {
-    searchFiltersService = { init: sinon.stub() };
+    searchFiltersService = { init: sinon.stub(), destroy: sinon.stub() };
     return TestBed
       .configureTestingModule({
         imports: [

--- a/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
@@ -21,6 +21,7 @@ import { ComponentsModule } from '@mm-components/components.module';
 import { PlaceHierarchyService } from '@mm-services/place-hierarchy.service';
 import { NavigationComponent } from '@mm-components/navigation/navigation.component';
 import { TourService } from '@mm-services/tour.service';
+import { SessionService } from '@mm-services/session.service';
 
 describe('Reports Component', () => {
   let component: ReportsComponent;
@@ -76,6 +77,7 @@ describe('Reports Component', () => {
           // Needed because of facility filter
           { provide: PlaceHierarchyService, useValue: { get: sinon.stub().resolves() } },
           { provide: TourService, useValue: tourServiceMock },
+          { provide: SessionService, useValue: { isOnlineOnly: sinon.stub() } },
         ]
       })
       .compileComponents()


### PR DESCRIPTION
# Description

Also changes:
- contacts lists for online roles that don't have a home place to show top level contacts (just like admins) instead of ALL contacts
- contacts content to enable editing of home-place for online users. 
- facility filter to display deleted label for all online users, not just admins

medic/cht-core#6611

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
