### PR TITLE
Use contact-type-utils to determine contact type throughout webapp (3.10)

### DIFF
--- a/ddocs/medic-db/medic-client/views/contacts_by_parent/map.js
+++ b/ddocs/medic-db/medic-client/views/contacts_by_parent/map.js
@@ -5,8 +5,9 @@ function(doc) {
       doc.type === 'district_hospital' ||
       doc.type === 'person') {
     var parentId = doc.parent && doc.parent._id;
+    var type = doc.type === 'contact' ? doc.contact_type : doc.type;
     if (parentId) {
-      emit([parentId, doc.contact_type || doc.type]);
+      emit([parentId, type]);
     }
   }
 }

--- a/webapp/src/js/actions/contacts.js
+++ b/webapp/src/js/actions/contacts.js
@@ -1,5 +1,6 @@
 const _ = require('lodash/core');
 const actionTypes = require('./actionTypes');
+const contactTypeUtils = require('@medic/contact-types-utils');
 
 angular.module('inboxServices').factory('ContactsActions',
   function(
@@ -82,7 +83,7 @@ angular.module('inboxServices').factory('ContactsActions',
 
       const getChildTypes = selected => {
         if (!selected.type) {
-          const type = selected.doc.contact_type || selected.doc.type;
+          const type = contactTypeUtils.getTypeId(selected.doc);
           $log.error(`Unknown contact type "${type}" for contact "${selected.doc._id}"`);
           return [];
         }

--- a/webapp/src/js/actions/contacts.js
+++ b/webapp/src/js/actions/contacts.js
@@ -1,6 +1,5 @@
 const _ = require('lodash/core');
 const actionTypes = require('./actionTypes');
-const contactTypeUtils = require('@medic/contact-types-utils');
 
 angular.module('inboxServices').factory('ContactsActions',
   function(
@@ -83,7 +82,7 @@ angular.module('inboxServices').factory('ContactsActions',
 
       const getChildTypes = selected => {
         if (!selected.type) {
-          const type = contactTypeUtils.getTypeId(selected.doc);
+          const type = ContactTypes.getTypeId(selected.doc);
           $log.error(`Unknown contact type "${type}" for contact "${selected.doc._id}"`);
           return [];
         }

--- a/webapp/src/js/controllers/contacts-edit.js
+++ b/webapp/src/js/controllers/contacts-edit.js
@@ -62,7 +62,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     });
 
     const getFormInstanceData = function() {
-      const type = ctrl.contact && (ctrl.contact.contact_type || ctrl.contact.type);
+      const type = ctrl.contact && ContactTypes.getTypeId(ctrl.contact);
       if (!type) {
         return null;
       }
@@ -85,7 +85,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     const getForm = function(contact) {
       let formId;
       let titleKey;
-      const typeId = contact ? (contact.contact_type || contact.type) : $state.params.type;
+      const typeId = contact ? ContactTypes.getTypeId(contact) : $state.params.type;
       return ContactTypes.get(typeId).then(type => {
         if (!type) {
           $log.error(`Unknown contact type "${typeId}"`);
@@ -146,7 +146,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
 
     const setEnketoContact = function(formInstance) {
       ctrl.enketoContact = {
-        type: ctrl.contact.contact_type || ctrl.contact.type,
+        type: ContactTypes.getTypeId(ctrl.contact),
         formInstance: formInstance,
         docId: ctrl.contactId,
       };

--- a/webapp/src/js/controllers/contacts-edit.js
+++ b/webapp/src/js/controllers/contacts-edit.js
@@ -62,7 +62,7 @@ angular.module('inboxControllers').controller('ContactsEditCtrl',
     });
 
     const getFormInstanceData = function() {
-      const type = ctrl.contact && ContactTypes.getTypeId(ctrl.contact);
+      const type = ContactTypes.getTypeId(ctrl.contact);
       if (!type) {
         return null;
       }

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -233,7 +233,7 @@ const PAGE_SIZE = 50;
       let p;
       if (usersHomePlace) {
         // backwards compatibility with pre-flexible hierarchy users
-        const homeType = usersHomePlace.contact_type || usersHomePlace.type;
+        const homeType = ContactTypes.getTypeId(usersHomePlace);
         p = ContactTypes.getChildren(homeType);
       } else if (Session.isAdmin()) {
         p = ContactTypes.getChildren();

--- a/webapp/src/js/controllers/contacts.js
+++ b/webapp/src/js/controllers/contacts.js
@@ -232,7 +232,6 @@ const PAGE_SIZE = 50;
     const getChildren = () => {
       let p;
       if (usersHomePlace) {
-        // backwards compatibility with pre-flexible hierarchy users
         const homeType = ContactTypes.getTypeId(usersHomePlace);
         p = ContactTypes.getChildren(homeType);
       } else if (Session.isAdmin()) {

--- a/webapp/src/js/controllers/send-message.js
+++ b/webapp/src/js/controllers/send-message.js
@@ -83,7 +83,7 @@ angular.module('inboxControllers').controller('SendMessageCtrl',
         return row.text;
       }
 
-      const typeId = row.doc.contact_type || row.doc.type;
+      const typeId = ContactTypes.getTypeId(row.doc);
       const type = contactTypes.find(type => type.id === typeId);
 
       let contact;
@@ -133,7 +133,7 @@ angular.module('inboxControllers').controller('SendMessageCtrl',
             sendMessageExtras: function(results) {
               const messages = [...results];
               results.forEach(result => {
-                if (personTypes.includes(result.doc.contact_type || result.doc.type)) {
+                if (personTypes.includes(ContactTypes.getTypeId(result.doc))) {
                   return;
                 }
                 messages.push({

--- a/webapp/src/js/services/contact-view-model-generator.js
+++ b/webapp/src/js/services/contact-view-model-generator.js
@@ -1,6 +1,5 @@
 const _ = require('lodash/core');
 const registrationUtils = require('@medic/registration-utils');
-const contactTypeUtils = require('@medic/contact-types-utils');
 
 /**
  * Hydrates the given contact by uuid and creates a model which
@@ -128,7 +127,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
     };
 
     const groupChildrenByType = children => {
-      return _.groupBy(children, child => child.doc.contact_type || child.doc.type);
+      return _.groupBy(children, child => ContactTypes.getTypeId(child.doc));
     };
 
     const addPrimaryContact = function(doc, children) {
@@ -305,7 +304,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
     };
 
     const setType = function(model, types) {
-      const typeId = contactTypeUtils.getTypeId(model.doc);
+      const typeId = ContactTypes.getTypeId(model.doc);
       model.type = types.find(type => type.id === typeId);
     };
 

--- a/webapp/src/js/services/contact-view-model-generator.js
+++ b/webapp/src/js/services/contact-view-model-generator.js
@@ -1,5 +1,6 @@
 const _ = require('lodash/core');
 const registrationUtils = require('@medic/registration-utils');
+const contactTypeUtils = require('@medic/contact-types-utils');
 
 /**
  * Hydrates the given contact by uuid and creates a model which
@@ -304,7 +305,7 @@ angular.module('inboxServices').factory('ContactViewModelGenerator',
     };
 
     const setType = function(model, types) {
-      const typeId = model.doc.contact_type || model.doc.type;
+      const typeId = contactTypeUtils.getTypeId(model.doc);
       model.type = types.find(type => type.id === typeId);
     };
 

--- a/webapp/src/js/services/contacts.js
+++ b/webapp/src/js/services/contacts.js
@@ -23,7 +23,7 @@ angular.module('inboxServices').factory('Contacts',
               .catch(callback);
           },
           invalidate: function(doc) {
-            return type.id === (doc.contact_type || doc.type);
+            return type.id === ContactTypes.getTypeId(doc);
           }
         });
       });

--- a/webapp/src/js/services/live-list.js
+++ b/webapp/src/js/services/live-list.js
@@ -86,7 +86,7 @@ angular.module('inboxServices').factory('LiveListConfig',
           return (c1.name || '').toLowerCase() < (c2.name || '').toLowerCase() ? -1 : 1;
         },
         listItem: function(contact, contactTypes) {
-          const typeId = contact.contact_type || contact.type;
+          const typeId = ContactTypes.getTypeId(contact);
           const type = contactTypes.find(type => type.id === typeId);
           const scope = {};
           scope.id = contact._id;

--- a/webapp/src/js/services/xml-forms.js
+++ b/webapp/src/js/services/xml-forms.js
@@ -93,7 +93,7 @@ angular.module('inboxServices').factory('XmlForms',
       if (!doc) {
         return $q.resolve(true);
       }
-      const contactType = doc.contact_type || doc.type;
+      const contactType = ContactTypes.getTypeId(doc);
       return ContactTypes.get(contactType).then(type => {
         if (!type) {
           // not a contact type

--- a/webapp/tests/karma/unit/controllers/contacts-edit.js
+++ b/webapp/tests/karma/unit/controllers/contacts-edit.js
@@ -9,6 +9,9 @@ describe('Contacts Edit controller', () => {
   let $rootScope;
   let contactForm;
   let spyState;
+  let lineageModelGenerator;
+  let db;
+  let enketo;
 
   beforeEach(() => {
     module('inboxApp');
@@ -22,10 +25,14 @@ describe('Contacts Edit controller', () => {
     $rootScope = _$rootScope_;
     scope = $rootScope.$new();
     scope.clearSelected = sinon.stub();
-    contactTypes = { get: sinon.stub().resolves({}) };
+    contactTypes = { get: sinon.stub(), getTypeId: sinon.stub() };
     scope.settingSelected = sinon.stub();
     const $translate = key => Promise.resolve(key + 'translated');
     $translate.instant = key => key + 'translated';
+    $translate.onReady = sinon.stub().resolves();
+    lineageModelGenerator = { contact: sinon.stub() };
+    db = { get: sinon.stub() };
+    enketo = { renderContactForm: sinon.stub() };
 
     spyState = {
       go: sinon.spy(),
@@ -46,14 +53,17 @@ describe('Contacts Edit controller', () => {
         'ContactForm': contactForm,
         'ContactSave': sinon.stub(),
         'ContactTypes': contactTypes,
-        'Enketo': sinon.stub(),
-        'LineageModelGenerator': { contact: sinon.stub().resolves() },
+        'DB': sinon.stub().returns(db),
+        'Enketo': enketo,
+        'LineageModelGenerator': lineageModelGenerator,
         'Snackbar': sinon.stub(),
         'SessionStorage': sessionStorage,
         'XmlForms': sinon.stub().resolves()
       });
     };
   }));
+
+  const tick = () => new Promise(resolve => setTimeout(resolve, 20));
 
   it('cancelling redirects to contacts list when query has `from` param equal to `list`', () => {
     let cancelCallback;
@@ -91,6 +101,7 @@ describe('Contacts Edit controller', () => {
     let cancelCallback;
     spyState.params.id = 'id';
     globalActions.setCancelCallback.callsFake(func => cancelCallback = func);
+    lineageModelGenerator.contact.resolves({});
 
     createController();
     cancelCallback();
@@ -98,4 +109,43 @@ describe('Contacts Edit controller', () => {
     chai.expect(spyState.go.args[0]).to.deep.equal([ 'contacts.detail', { 'id': 'id' } ]);
   });
 
+  it('should select correct form for correct type', () => {
+    const contact = {
+      _id: 'contact_uuid',
+      type: 'person',
+      contact_type: 'whatever',
+    };
+    const form = {
+      _id: 'form:correct_edit_form',
+      internal_id: 'correct_edit_form',
+      type: 'form',
+    };
+
+    lineageModelGenerator.contact.resolves({ doc: contact });
+    spyState.params.id = contact._id;
+    contactTypes.getTypeId.returns('the correct type id');
+    contactTypes.get.resolves({ id: 'the correct type id', edit_form: 'correct_edit_form' });
+    db.get.resolves(form);
+
+    const controller = createController();
+    return tick().then(() => {
+      chai.expect(lineageModelGenerator.contact.callCount).to.equal(1);
+      chai.expect(lineageModelGenerator.contact.args[0]).to.deep.equal(['contact_uuid', { merge: true }]);
+      chai.expect(contactTypes.getTypeId.callCount).to.equal(3);
+      chai.expect(contactTypes.getTypeId.args[0]).to.deep.equal([contact]);
+      chai.expect(contactTypes.getTypeId.args[1]).to.deep.equal([contact]);
+      chai.expect(contactTypes.get.callCount).to.equal(1);
+      chai.expect(contactTypes.get.args[0]).to.deep.equal(['the correct type id']);
+      chai.expect(db.get.callCount).to.equal(1);
+      chai.expect(db.get.args[0]).to.deep.equal(['correct_edit_form']);
+      chai.expect(enketo.renderContactForm.callCount).to.equal(1);
+      chai.expect(enketo.renderContactForm.args[0][1]).to.deep.equal(form);
+      chai.expect(controller.contact).to.deep.equal(contact);
+      chai.expect(controller.enketoContact).to.deep.equal({
+        type: 'the correct type id',
+        docId: 'contact_uuid',
+        formInstance: undefined,
+      });
+    });
+  });
 });

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -276,6 +276,21 @@ describe('Contacts controller', () => {
         });
     });
 
+    it('should search for homeplace children of the correct type', () => {
+      searchResults = [ { _id: 'search-result' } ];
+      district.contact_type = 'whatever';
+      contactTypes.getTypeId.returns('some type');
+
+      return createController()
+        .getSetupPromiseForTesting()
+        .then(() => {
+          assert.equal(contactTypes.getTypeId.callCount, 1);
+          assert.deepEqual(contactTypes.getTypeId.args[0], [district]);
+          assert.equal(contactTypes.getChildren.callCount, 1);
+          assert.deepEqual(contactTypes.getChildren.args[0], ['some type']);
+        });
+    });
+
     it('Only displays the home place once', () => {
       searchResults = [
         {

--- a/webapp/tests/karma/unit/controllers/contacts.js
+++ b/webapp/tests/karma/unit/controllers/contacts.js
@@ -79,7 +79,8 @@ describe('Contacts controller', () => {
     scope.clearSelection = sinon.stub();
     contactTypes = {
       getChildren: sinon.stub(),
-      includes: sinon.stub()
+      includes: sinon.stub(),
+      getTypeId: sinon.stub().callsFake(doc => doc.type === 'contact' ? doc.contact_type : doc.type),
     };
     contactTypes.getChildren.resolves([{
       id: childType,

--- a/webapp/tests/karma/unit/services/contact-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/contact-view-model-generator.js
@@ -65,7 +65,10 @@ describe('ContactViewModelGenerator service', () => {
         { id: 'clinic', parents: [ 'mushroom' ] },
         { id: 'mushroom', name_key: 'label.mushroom' }
       ];
-      ContactTypes = { getAll: sinon.stub().resolves(types) };
+      ContactTypes = {
+        getAll: sinon.stub().resolves(types),
+        getTypeId: sinon.stub().callsFake(doc => doc.type === 'contact' ? doc.contact_type : doc.type),
+      };
       lineageModelGenerator = { contact: sinon.stub() };
       GetDataRecords = sinon.stub();
       Session = { isOnlineOnly: function() {} };

--- a/webapp/tests/karma/unit/services/contact-view-model-generator.js
+++ b/webapp/tests/karma/unit/services/contact-view-model-generator.js
@@ -20,6 +20,7 @@ describe('ContactViewModelGenerator service', () => {
   let GetDataRecords;
   let Session;
   let forms;
+  let types;
 
   const childPlaceIcon = 'fa-mushroom';
 
@@ -57,7 +58,7 @@ describe('ContactViewModelGenerator service', () => {
       dbGet = sinon.stub();
       dbQuery = sinon.stub();
       dbAllDocs = sinon.stub();
-      const types = [
+      types = [
         { id: 'family' },
         { id: 'person', sort_by_dob: true, icon: childPlaceIcon, person: true, parents: [ 'family', 'clinic' ] },
         { id: 'chp', person: true, parents: [ 'mushroom' ] },
@@ -142,6 +143,49 @@ describe('ContactViewModelGenerator service', () => {
         assert.deepEqual(model.children[0].contacts[0].doc, childContactPerson);
         assert.equal(model.children[1].contacts.length, 1);
         assert.deepEqual(model.children[1].contacts[0].doc, childPlace);
+      });
+    });
+
+    it('sets correct contact types', () => {
+      doc.contact_type = 'whatever';
+      childContactPerson.contact_type = 'something';
+      childPlace.contact_type = 'otherthing';
+
+      ContactTypes.getTypeId
+        .withArgs(doc).returns('correct doc type')
+        .withArgs(childContactPerson).returns('correct childContactPerson type')
+        .withArgs(childPlace).returns('correct childPlace type');
+
+      types.push(
+        { id: 'correct doc type', parents: ['correct parent type'], person: false, },
+        { id: 'correct childContactPerson type', parents: ['correct doc type'], person: true },
+        { id: 'correct childPlace type', parents: ['correct doc type'], person: false },
+      );
+      ContactTypes.getAll.resolves(types);
+
+      return runPlaceTest([childContactPerson, childPlace]).then(model => {
+        assert.deepEqual(model.doc, Object.assign({ muted: false }, doc));
+        assert.deepEqual(model.type, { id: 'correct doc type', parents: ['correct parent type'], person: false });
+        assert.equal(model.children.length, 2);
+        assert.deepEqual(
+          model.children[0].type,
+          { id: 'correct childContactPerson type', parents: ['correct doc type'], person: true },
+        );
+        assert.deepEqual(
+          model.children[0].contacts,
+          [{ isPrimaryContact: true, doc: childContactPerson }]
+        );
+        assert.deepEqual(
+          model.children[1].type,
+          { id: 'correct childPlace type', parents: ['correct doc type'], person: false },
+        );
+        assert.deepEqual(
+          model.children[1].contacts,
+          [{ doc: childPlace }]
+        );
+
+        assert.equal(ContactTypes.getTypeId.callCount, 3);
+        assert.deepEqual(ContactTypes.getTypeId.args, [[doc], [childContactPerson], [childPlace]]);
       });
     });
 

--- a/webapp/tests/karma/unit/services/xml-forms.js
+++ b/webapp/tests/karma/unit/services/xml-forms.js
@@ -8,6 +8,7 @@ describe('XmlForms service', () => {
   let hasAuth;
   let UserContact;
   let getContactType;
+  let getTypeId;
   let contextUtils;
   let error;
 
@@ -33,6 +34,7 @@ describe('XmlForms service', () => {
     hasAuth = sinon.stub();
     UserContact = sinon.stub();
     getContactType = sinon.stub();
+    getTypeId = sinon.stub().callsFake(doc => doc.type === 'contact' ? doc.contact_type : doc.type);
     error = sinon.stub();
     contextUtils = {};
     module($provide => {
@@ -44,7 +46,7 @@ describe('XmlForms service', () => {
       $provide.value('Auth', { has: hasAuth });
       $provide.value('UserContact', UserContact);
       $provide.value('XmlFormsContextUtils', contextUtils);
-      $provide.value('ContactTypes', { get: getContactType });
+      $provide.value('ContactTypes', { get: getContactType, getTypeId: getTypeId });
       $provide.value('$q', Q); // bypass $q so we don't have to digest
       $provide.value('$log', {error: error});
     });

--- a/webapp/tests/karma/unit/services/xml-forms.js
+++ b/webapp/tests/karma/unit/services/xml-forms.js
@@ -283,6 +283,90 @@ describe('XmlForms service', () => {
       });
     });
 
+    it('filter with correct type', () => {
+      const given = [
+        {
+          id: 'form-0',
+          doc: {
+            internalId: 'zero',
+            _attachments: { xml: { something: true } },
+          },
+        },
+        {
+          id: 'form-1',
+          doc: {
+            internalId: 'one',
+            context: {},
+            _attachments: { xml: { something: true } },
+          },
+        },
+        {
+          id: 'form-2',
+          doc: {
+            internalId: 'two',
+            context: { person: true },
+            _attachments: { xml: { something: true } },
+          },
+        },
+        {
+          id: 'form-3',
+          doc: {
+            internalId: 'three',
+            context: { place: true },
+            _attachments: { xml: { something: true } },
+          },
+        },
+        {
+          id: 'form-4',
+          doc: {
+            internalId: 'four',
+            context: { person: true, place: false },
+            _attachments: { xml: { something: true } },
+          },
+        },
+        {
+          id: 'form-5',
+          doc: {
+            internalId: 'five',
+            context: { person: false, place: true },
+            _attachments: { xml: { something: true } },
+          },
+        },
+        {
+          id: 'form-6',
+          doc: {
+            internalId: 'six',
+            context: { person: true, place: true },
+            _attachments: { xml: { something: true } },
+          },
+        },
+      ];
+      dbQuery.resolves({ rows: given });
+      UserContact.resolves();
+      const service = $injector.get('XmlForms');
+      getContactType.resolves({ person: false });
+      getTypeId.returns('the correct type');
+
+      const doc = { type: 'clinic', contact_type: 'not_a_clinic', _id: 'uuid' };
+
+      return service.list({ doc }).then(result => {
+        chai.assert.equal(getTypeId.callCount, 6);
+        chai.assert.deepEqual(getTypeId.args, [[doc], [doc], [doc], [doc], [doc], [doc], ]);
+        chai.assert.equal(getContactType.callCount, 6);
+        chai.assert.deepEqual(getContactType.args, [
+          ['the correct type'],
+          ['the correct type'],
+          ['the correct type'],
+          ['the correct type'],
+          ['the correct type'],
+          ['the correct type'],
+        ]);
+
+        const ids = result.map(form => form.internalId);
+        chai.assert.deepEqual(ids, [ 'zero', 'one', 'three', 'five', 'six', ]);
+      });
+    });
+
     it('filter with custom function', () => {
       const given = [
         {

--- a/webapp/tests/karma/unit/store/contacts.js
+++ b/webapp/tests/karma/unit/store/contacts.js
@@ -8,6 +8,7 @@ describe('Contacts store', () => {
   let isAdmin;
   let userSettings;
   let getChildren;
+  let getTypeId;
   let contactSummary;
   let settings;
   let hasAuth;
@@ -33,6 +34,7 @@ describe('Contacts store', () => {
     isAdmin = sinon.stub();
     userSettings = sinon.stub();
     getChildren = sinon.stub();
+    getTypeId = sinon.stub().callsFake(doc => doc.type === 'contact' ? doc.contact_type : doc.type);
     contactSummary = sinon.stub();
     settings = sinon.stub();
     hasAuth = sinon.stub();
@@ -58,7 +60,7 @@ describe('Contacts store', () => {
       });
       $provide.value('Session', { isAdmin });
       $provide.value('UserSettings', userSettings);
-      $provide.value('ContactTypes', { getChildren });
+      $provide.value('ContactTypes', { getChildren, getTypeId });
       $provide.value('ContactSummary', contactSummary);
       $provide.value('Settings', settings);
       $provide.value('Auth', { has: hasAuth });


### PR DESCRIPTION
# Description

When a contact of a hardcoded type has a `contact_type` property, fixes: 
- tasks not displaying
- not being listed in parent's contact detail page, or being listed in a separate untitled section
- editing throwing errors
- icons not displaying in list or content
- actionbar new action list when contact is selected
- error when focusing the send-message select2 
- visit count not displaying when UHC is enabled and contact is a `clinic`

medic/cht-core#6993

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
