### PR TITLE
Update muting, update_clinics, update_scheduled_reports and admin import contacts (3.10)

### DIFF
--- a/admin/src/js/services/import-contacts.js
+++ b/admin/src/js/services/import-contacts.js
@@ -13,7 +13,7 @@ angular.module('services').factory('ImportContacts',
 
     const getPersonType = contact => {
       return ContactTypes.getPersonTypes().then(types => {
-        const provided = contact.contact_type || contact.type;
+        const provided = ContactTypes.getTypeId(contact);
         if (provided) {
           const type = types.find(type => type.id === provided);
           if (type) {

--- a/admin/tests/unit/services/import-contacts.js
+++ b/admin/tests/unit/services/import-contacts.js
@@ -12,11 +12,18 @@ describe('ImportContacts service', function() {
     module('adminApp');
 
     const types = [ { id: 'person' }, { id: 'chp' } ];
+    const ContactTypes = {
+      getPersonTypes: sinon.stub().resolves(types),
+      getTypeId: sinon.stub().callsFake(doc => {
+        console.log(doc);
+        return doc.type === 'contact' ? doc.contact_type : doc.type;
+      }),
+    };
 
     module(function ($provide) {
       $provide.factory('DB', KarmaUtils.mockDB({ put: put }));
       $provide.value('Location', { url: 'BASEURL' });
-      $provide.value('ContactTypes', { getPersonTypes: sinon.stub().resolves(types) });
+      $provide.value('ContactTypes', ContactTypes);
     });
     inject(function($injector, _$rootScope_) {
       $rootScope = _$rootScope_;
@@ -169,16 +176,21 @@ describe('ImportContacts service', function() {
     $httpBackend
       .expect('HEAD', 'BASEURL/2')
       .respond(404);
+    $httpBackend
+      .expect('HEAD', 'BASEURL/5')
+      .respond(404);
     put.onCall(0).returns(Promise.resolve({ _id: 1, _rev: 1 }));
-    put.onCall(1).returns(Promise.resolve({ }));
-    put.onCall(2).returns(Promise.resolve({ _id: 4, _rev: 1 }));
-    put.onCall(3).returns(Promise.resolve({ }));
+    put.onCall(1).returns(Promise.resolve({ _id: 2, _rev: 1 }));
+    put.onCall(2).returns(Promise.resolve({ _id: 5, _rev: 1 }));
+    put.onCall(3).returns(Promise.resolve({ _id: 4, _rev: 1 }));
+    put.onCall(4).resolves({});
     const contact1 = { _id: 1, contact: { name: 'john', phone: '+123', type: 'contact', contact_type: 'chp' } };
     const contact2 = { _id: 2, contact: { _id: 3, name: 'jack', phone: '+123' } };
+    const contact3 = { _id: 5, name: 'mary', phone: '+123', type: 'person', contact_type: 'omg' };
 
-    service([contact1, contact2], true)
+    service([contact1, contact2, contact3], true)
       .then(function() {
-        chai.expect(put.callCount).to.equal(4);
+        chai.expect(put.callCount).to.equal(5);
 
         // save first place
         chai.expect(put.args[0][0]._id).to.equal(1);
@@ -190,16 +202,19 @@ describe('ImportContacts service', function() {
         // save second place
         chai.expect(put.args[1][0]).to.deep.equal(contact2);
 
+        // save 3rd contact
+        chai.expect(put.args[2][0]).to.deep.equal(contact3);
+
         // save contact
-        chai.expect(put.args[2][0].type).to.equal('contact');
-        chai.expect(put.args[2][0].contact_type).to.equal('chp');
-        chai.expect(put.args[2][0].name).to.equal('john');
-        chai.expect(put.args[2][0].phone).to.equal('+123');
-        chai.expect(put.args[2][0].parent._id).to.equal(1);
+        chai.expect(put.args[3][0].type).to.equal('contact');
+        chai.expect(put.args[3][0].contact_type).to.equal('chp');
+        chai.expect(put.args[3][0].name).to.equal('john');
+        chai.expect(put.args[3][0].phone).to.equal('+123');
+        chai.expect(put.args[3][0].parent._id).to.equal(1);
 
         // updated place with contact
-        chai.expect(put.args[3][0].contact._id).to.equal(4);
-        chai.expect(put.args[3][0].contact._rev).to.equal(1);
+        chai.expect(put.args[4][0].contact._id).to.equal(4);
+        chai.expect(put.args[4][0].contact._rev).to.equal(1);
         done();
       })
       .catch(done);

--- a/admin/tests/unit/services/import-contacts.js
+++ b/admin/tests/unit/services/import-contacts.js
@@ -14,10 +14,7 @@ describe('ImportContacts service', function() {
     const types = [ { id: 'person' }, { id: 'chp' } ];
     const ContactTypes = {
       getPersonTypes: sinon.stub().resolves(types),
-      getTypeId: sinon.stub().callsFake(doc => {
-        console.log(doc);
-        return doc.type === 'contact' ? doc.contact_type : doc.type;
-      }),
+      getTypeId: sinon.stub().callsFake(doc => doc.type === 'contact' ? doc.contact_type : doc.type),
     };
 
     module(function ($provide) {

--- a/shared-libs/transitions/src/transitions/muting.js
+++ b/shared-libs/transitions/src/transitions/muting.js
@@ -5,6 +5,7 @@ const utils = require('../lib/utils');
 const messages = require('../lib/messages');
 const validation = require('../lib/validation');
 const mutingUtils = require('../lib/muting_utils');
+const contactTypesUtils = require('@medic/contact-types-utils');
 
 const TRANSITION_NAME = 'muting';
 const CONFIG_NAME = 'muting';
@@ -26,11 +27,7 @@ const isUnmuteForm = form => {
 
 const getEventType = muted => muted ? 'mute' : 'unmute';
 
-const isContact = doc => {
-  const contactTypes = config.get('contact_types') || [];
-  const typeId = doc.contact_type || doc.type;
-  return contactTypes.some(type => type.id === typeId);
-};
+const isContact = doc => !!contactTypesUtils.getContactType(config.getAll(), doc);
 
 const isRelevantReport = (doc, info = {}) =>
   Boolean(doc &&

--- a/shared-libs/transitions/src/transitions/update_clinics.js
+++ b/shared-libs/transitions/src/transitions/update_clinics.js
@@ -2,16 +2,11 @@ const transitionUtils = require('./utils');
 const db = require('../db');
 const lineage = require('@medic/lineage')(Promise, db.medic);
 const utils = require('../lib/utils');
+const contactTypesUtils = require('@medic/contact-types-utils');
 const NAME = 'update_clinics';
 const FACILITY_NOT_FOUND = 'sys.facility_not_found';
 
 const config = require('../config');
-
-const getContactType = doc => {
-  const typeId = doc.contact_type || doc.type;
-  const contactTypes = config.get('contact_types') || [];
-  return contactTypes.find(type => type.id === typeId);
-};
 
 const getContactByRefid = doc => {
   const params = {
@@ -28,7 +23,7 @@ const getContactByRefid = doc => {
       }
 
       const result = data.rows[0].doc;
-      const contactType = getContactType(result);
+      const contactType = contactTypesUtils.getContactType(config.getAll(), result);
       // not a contact
       if (!contactType) {
         return;

--- a/shared-libs/transitions/src/transitions/update_scheduled_reports.js
+++ b/shared-libs/transitions/src/transitions/update_scheduled_reports.js
@@ -18,9 +18,7 @@ const getLeafPlaceTypeIds = () => {
  * Returns the ID of the parent iff that parent is a leaf type.
  */
 const getParentId = contact => {
-  const parentType = contact &&
-                     contact.parent &&
-                     contactTypeUtils.getTypeId(contact.parent);
+  const parentType = contact && contactTypeUtils.getTypeId(contact.parent);
   if (parentType) {
     const leafPlaceTypeIds = getLeafPlaceTypeIds();
     if (leafPlaceTypeIds.includes(parentType)) {

--- a/shared-libs/transitions/src/transitions/update_scheduled_reports.js
+++ b/shared-libs/transitions/src/transitions/update_scheduled_reports.js
@@ -2,6 +2,7 @@ const db = require('../db');
 const config = require('../config');
 const logger = require('../lib/logger');
 const transitionUtils = require('./utils');
+const contactTypeUtils = require('@medic/contact-types-utils');
 const NAME = 'update_scheduled_reports';
 
 const getLeafPlaceTypeIds = () => {
@@ -19,7 +20,7 @@ const getLeafPlaceTypeIds = () => {
 const getParentId = contact => {
   const parentType = contact &&
                      contact.parent &&
-                     (contact.parent.contact_type || contact.parent.type);
+                     contactTypeUtils.getTypeId(contact.parent);
   if (parentType) {
     const leafPlaceTypeIds = getLeafPlaceTypeIds();
     if (leafPlaceTypeIds.includes(parentType)) {

--- a/shared-libs/transitions/test/unit/update_clinics.js
+++ b/shared-libs/transitions/test/unit/update_clinics.js
@@ -150,7 +150,7 @@ describe('update clinic', () => {
       },
     };
 
-    sinon.stub(config, 'get').returns([ { id: 'clinic' } ]);
+    sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'clinic' } ] });
     sinon.stub(db.medic, 'query').resolves({ rows: [{ doc: contact }] });
     lineageStub.returns(Promise.resolve(contact));
     return transition.onMatch({ doc: doc }).then(changed => {
@@ -202,7 +202,7 @@ describe('update clinic', () => {
       name: 'zenith',
       phone: '+12345',
     };
-    sinon.stub(config, 'get').returns([ { id: 'clinic' } ]);
+    sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'clinic' } ] });
     sinon.stub(db.medic, 'query').resolves({ rows: [{ doc: clinic }] });
     lineageStub.resolves(contact);
     return transition.onMatch({ doc: doc }).then(changed => {
@@ -345,6 +345,50 @@ describe('update clinic', () => {
       assert(!changed);
       assert(!doc.contact);
       assert(!doc.errors);
+    });
+  });
+
+  it('should handle contacts of hardcoded type with a contact_type property', () => {
+    const doc = {
+      type: 'data_record',
+      from: '+12345',
+      refid: '1000',
+    };
+
+    const contact = {
+      type: 'clinic',
+      contact_type: 'soemthing',
+      name: 'Clinic',
+      place_id: '1000',
+      contact: {
+        name: 'CCN',
+        phone: '+34567890123',
+      },
+      parent: {
+        type: 'health_center',
+        name: 'Health Center',
+        contact: {
+          name: 'HCCN',
+          phone: '+23456789012',
+        },
+        parent: {
+          type: 'district_hospital',
+          name: 'District',
+          contact: {
+            name: 'DCN',
+            phone: '+12345678901',
+          },
+        },
+      },
+    };
+
+    sinon.stub(config, 'getAll').returns({ contact_types: [ { id: 'clinic' } ] });
+    sinon.stub(db.medic, 'query').resolves({ rows: [{ doc: contact }] });
+    lineageStub.resolves(contact);
+    return transition.onMatch({ doc: doc }).then(changed => {
+      assert(changed);
+      assert(doc.contact);
+      assert.deepEqual(doc.contact, contact.contact);
     });
   });
 

--- a/tests/e2e/sentinel/transitions/muting.spec.js
+++ b/tests/e2e/sentinel/transitions/muting.spec.js
@@ -735,26 +735,40 @@ describe('muting', () => {
       phone: '+444999'
     };
 
+    const personWithContactType = {
+      _id: 'person4',
+      name: 'Person',
+      type: 'person',
+      contact_type: 'not a person',
+      parent: { _id: 'clinic', parent: { _id: 'health_center', parent: { _id: 'district_hospital' } } },
+      phone: '+444999'
+    };
+
     return utils
       .updateSettings(settings, true)
       .then(() => utils.saveDoc(mute))
       .then(() => sentinelUtils.waitForSentinel(mute._id))
-      .then(() => utils.saveDoc(person))
-      .then(() => sentinelUtils.waitForSentinel(person._id))
-      .then(() => sentinelUtils.getInfoDoc(person._id))
-      .then((info) => {
-        expect(info.transitions).toBeDefined();
-        expect(info.transitions.muting).toBeDefined();
-        expect(info.transitions.muting.ok).toBe(true);
+      .then(() => utils.saveDocs([person, personWithContactType]))
+      .then(() => sentinelUtils.waitForSentinel([person._id, personWithContactType._id]))
+      .then(() => sentinelUtils.getInfoDocs([person._id, personWithContactType._id]))
+      .then(([infoPerson, infoPersonWithContactType]) => {
+        expect(infoPerson.transitions).toBeDefined();
+        expect(infoPerson.transitions.muting).toBeDefined();
+        expect(infoPerson.transitions.muting.ok).toBe(true);
 
-        expect(info.muting_history).toBeDefined();
-        expect(info.muting_history.length).toEqual(1);
-        expect(info.muting_history[0].muted).toEqual(true);
-        expect(info.muting_history[0].report_id).toEqual(mute._id);
+        expect(infoPerson.muting_history).toBeDefined();
+        expect(infoPerson.muting_history.length).toEqual(1);
+        expect(infoPerson.muting_history[0].muted).toEqual(true);
+        expect(infoPerson.muting_history[0].report_id).toEqual(mute._id);
+
+        expect(infoPersonWithContactType.transitions.muting.ok).toBe(true);
+        expect(infoPersonWithContactType.muting_history.length).toEqual(1);
+        expect(infoPersonWithContactType.muting_history[0].report_id).toEqual(mute._id);
       })
-      .then(() => utils.getDoc(person._id))
-      .then(updated => {
-        expect(updated.muted).toBeDefined();
+      .then(() => utils.getDocs([person._id, personWithContactType._id]))
+      .then(([updatedPerson, updatedPersonWithContactType]) => {
+        expect(updatedPerson.muted).toBeDefined();
+        expect(updatedPersonWithContactType.muted).toBeDefined();
       });
   });
 

--- a/tests/e2e/sentinel/transitions/update_clinics.spec.js
+++ b/tests/e2e/sentinel/transitions/update_clinics.spec.js
@@ -195,6 +195,13 @@ describe('update_clinics', () => {
         reported_date: new Date().getTime(),
       },
       {
+        _id: 'person_with_contact_type',
+        type: 'person',
+        contact_type: 'some value', // check that `type` is prioritized
+        rc_code: 'sms_person_ct',
+        reported_date: new Date().getTime(),
+      },
+      {
         _id: 'clinic',
         type: 'clinic',
         rc_code: 'sms_clinic',
@@ -216,6 +223,13 @@ describe('update_clinics', () => {
       reported_date: new Date().getTime()
     };
 
+    const refidPersonContactType = {
+      _id: uuid(),
+      type: 'data_record',
+      refid: 'SMS_PERSON_CT', // view indexes with uppercase only
+      reported_date: new Date().getTime()
+    };
+
     const refidClinic = {
       _id: uuid(),
       type: 'data_record',
@@ -230,22 +244,26 @@ describe('update_clinics', () => {
       reported_date: new Date().getTime()
     };
 
+    const docs = [ refidClinic, refidPerson, phonePerson, refidPersonContactType ];
+    const docIds = docs.map(doc => doc._id);
+
     return utils
       .updateSettings(settings, true)
       .then(() => utils.saveDocs(contacts))
-      .then(() => utils.saveDocs([ refidClinic, refidPerson, phonePerson ]))
-      .then(() => sentinelUtils.waitForSentinel([refidClinic._id, refidPerson._id, phonePerson._id]))
-      .then(() => sentinelUtils.getInfoDocs([refidClinic._id, refidPerson._id, phonePerson._id]))
+      .then(() => utils.saveDocs(docs))
+      .then(() => sentinelUtils.waitForSentinel(docIds))
+      .then(() => sentinelUtils.getInfoDocs(docIds))
       .then(infos => {
         expect(infos[0].transitions).toBeDefined();
         expect(infos[0].transitions.update_clinics).toBeDefined();
         expect(infos[0].transitions.update_clinics.ok).toEqual(true);
       })
-      .then(() => utils.getDocs([refidClinic._id, refidPerson._id, phonePerson._id]))
+      .then(() => utils.getDocs(docIds))
       .then(updated => {
         expect(updated[0].contact).toEqual({ _id: 'person' });
         expect(updated[1].contact).toEqual({ _id: 'person' });
         expect(updated[2].contact).toEqual({ _id: 'person2' });
+        expect(updated[3].contact).toEqual({ _id: 'person_with_contact_type' });
       });
   });
 });


### PR DESCRIPTION
# Description

Fixes new contacts with muted parent not getting the muted state when the contact has a hardcoded type and a contact_type. 
Fixes update_clinics refid contact link not working when the connected contact  has a hardcoded type and a contact_type. 
Uses contact-type-utils in admin import-contacts. 

medic/cht-core#6996

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
