### PR TITLE
Fix CI cleanup script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ env:
   STAGING_SERVER: _couch/builds
   MARKET_URL: ${{ secrets.MARKET_URL }}
 
-
 jobs:
   build:
     name: Compile the app
@@ -62,7 +61,7 @@ jobs:
     - name: Publish
       run: |
         cd scripts/travis
-        npm install
+        npm ci
         node ./publish.js
       if: ${{ github.event_name != 'pull_request' }}
 
@@ -175,3 +174,16 @@ jobs:
           tests/results
           tests/logs
       if: ${{ failure() }}
+
+  cleanup:
+    needs: test-e2e
+    name: Deleting old published artefacts
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Cleanup
+      if: ${{ github.repository_owner == "medic" }} # don't run for external contributors - they don't have credentials
+      run: |
+        cd scripts/travis
+        npm ci
+        node ./cleanup.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,6 +181,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+    - uses: actions/checkout@v2
     - name: Cleanup
       if: ${{ github.repository_owner == 'medic' }} # don't run for external contributors - they don't have credentials
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
 
     steps:
     - name: Cleanup
-      if: ${{ github.repository_owner == "medic" }} # don't run for external contributors - they don't have credentials
+      if: ${{ github.repository_owner == 'medic' }} # don't run for external contributors - they don't have credentials
       run: |
         cd scripts/travis
         npm ci

--- a/scripts/travis/cleanup.js
+++ b/scripts/travis/cleanup.js
@@ -2,11 +2,11 @@
  * Delete old artefacts from the testing and staging dbs
  */
 const { UPLOAD_URL, BUILDS_SERVER, STAGING_SERVER, TRAVIS_BUILD_NUMBER } = process.env;
-const BUILDS_TO_KEEP = 50;
-const END_BUILD_TO_DELETE = TRAVIS_BUILD_NUMBER - BUILDS_TO_KEEP;
-const MAX_BUILDS_TO_DELETE = 50;
-const BETAS_TO_KEEP = 5;
-const DAYS_TO_KEEP = 100;
+
+const MAX_BUILDS_TO_DELETE = 50; // don't try and delete too many at once
+const BETAS_TO_KEEP = 5; // keep the most recent 5 beta builds
+const DAYS_TO_KEEP_BRANCH = 100; // branch builds are kept for 100 days to allow for AT
+const DAYS_TO_KEEP_TEST = 7; // testing builds are kept for 7 days to allow for CI re-runs
 
 const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
@@ -18,14 +18,6 @@ const stagingDb = new PouchDB(`${UPLOAD_URL}/${STAGING_SERVER}`);
 process.on('unhandledRejection', error => {
   console.error('unhandledRejection', error);
 });
-
-const getTestingBuilds = db => {
-  console.log('Getting old testing builds...');
-  return db.allDocs({
-    endkey: `medic:medic:test-${END_BUILD_TO_DELETE}`,
-    limit: MAX_BUILDS_TO_DELETE
-  });
-};
 
 const remove = (db, response) => {
   const docs = response.rows
@@ -50,30 +42,10 @@ const remove = (db, response) => {
   }
 };
 
-const getEndDate = () => {
+const getEndDate = (daysToKeep) => {
   const d = new Date();
-  d.setDate(d.getDate() - DAYS_TO_KEEP);
+  d.setDate(d.getDate() - daysToKeep);
   return d.toISOString();
-};
-
-const getBranchBuilds = db => {
-  console.log('Querying for old branches...');
-  return db.query('builds/releases', {
-    startkey: [ 'branch', 'medic', 'medic' ],
-    endkey: [ 'branch', 'medic', 'medic', getEndDate() ],
-    limit: MAX_BUILDS_TO_DELETE
-  });
-};
-
-const getBetaBuilds = db => {
-  console.log('Querying for old beta releases...');
-  return db.query('builds/releases', {
-    startkey: [ 'beta', 'medic', 'medic', 10000 ],
-    endkey: [ 'beta', 'medic', 'medic', 0 ],
-    limit: MAX_BUILDS_TO_DELETE,
-    descending: true,
-    skip: BETAS_TO_KEEP // leave the last n beta releases
-  });
 };
 
 const getCurrentRevs = (db, response) => {
@@ -84,6 +56,39 @@ const getCurrentRevs = (db, response) => {
   return db.allDocs({ keys: ids });
 };
 
+const queryReleases = (db, daysToKeep) => {
+  return db
+    .query('builds/releases', {
+      startkey: [ 'branch', 'medic', 'medic' ],
+      endkey: [ 'branch', 'medic', 'medic', getEndDate(daysToKeep) ],
+      limit: MAX_BUILDS_TO_DELETE
+    })
+    .then(response => getCurrentRevs(db, response))
+};
+
+const getTestingBuilds = db => {
+  console.log('Querying for old testing builds...');
+  return queryReleases(db, DAYS_TO_KEEP_TEST);
+};
+
+const getBranchBuilds = db => {
+  console.log('Querying for old branch builds...');
+  return queryReleases(db, DAYS_TO_KEEP_BRANCH);
+};
+
+const getBetaBuilds = db => {
+  console.log('Querying for old beta releases...');
+  return db
+    .query('builds/releases', {
+      startkey: [ 'beta', 'medic', 'medic', 10000 ],
+      endkey: [ 'beta', 'medic', 'medic', 0 ],
+      limit: MAX_BUILDS_TO_DELETE,
+      descending: true,
+      skip: BETAS_TO_KEEP // leave the last n beta releases
+    })
+    .then(response => getCurrentRevs(stagingDb, response));
+};
+
 const testingBuilds = () => {
   return getTestingBuilds(testingDb)
     .then(response => remove(testingDb, response));
@@ -91,13 +96,11 @@ const testingBuilds = () => {
 
 const branchBuilds = () => {
   return getBranchBuilds(stagingDb)
-    .then(response => getCurrentRevs(stagingDb, response))
     .then(response => remove(stagingDb, response));
 };
 
 const betaBuilds = () => {
   return getBetaBuilds(stagingDb)
-    .then(response => getCurrentRevs(stagingDb, response))
     .then(response => remove(stagingDb, response));
 };
 

--- a/scripts/travis/cleanup.js
+++ b/scripts/travis/cleanup.js
@@ -1,7 +1,7 @@
 /**
  * Delete old artefacts from the testing and staging dbs
  */
-const { UPLOAD_URL, BUILDS_SERVER, STAGING_SERVER, TRAVIS_BUILD_NUMBER } = process.env;
+const { UPLOAD_URL, BUILDS_SERVER, STAGING_SERVER } = process.env;
 
 const MAX_BUILDS_TO_DELETE = 50; // don't try and delete too many at once
 const BETAS_TO_KEEP = 5; // keep the most recent 5 beta builds
@@ -63,7 +63,7 @@ const queryReleases = (db, daysToKeep) => {
       endkey: [ 'branch', 'medic', 'medic', getEndDate(daysToKeep) ],
       limit: MAX_BUILDS_TO_DELETE
     })
-    .then(response => getCurrentRevs(db, response))
+    .then(response => getCurrentRevs(db, response));
 };
 
 const getTestingBuilds = db => {

--- a/scripts/travis/cleanup.js
+++ b/scripts/travis/cleanup.js
@@ -1,7 +1,7 @@
 /**
  * Delete old artefacts from the testing and staging dbs
  */
-const { UPLOAD_URL, BUILDS_SERVER, STAGING_SERVER } = process.env;
+const { MARKET_URL, BUILDS_SERVER, STAGING_SERVER } = process.env;
 
 const MAX_BUILDS_TO_DELETE = 50; // don't try and delete too many at once
 const BETAS_TO_KEEP = 5; // keep the most recent 5 beta builds
@@ -12,8 +12,8 @@ const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 PouchDB.plugin(require('pouchdb-mapreduce'));
 
-const testingDb = new PouchDB(`${UPLOAD_URL}/${BUILDS_SERVER}`);
-const stagingDb = new PouchDB(`${UPLOAD_URL}/${STAGING_SERVER}`);
+const testingDb = new PouchDB(`${MARKET_URL}/${BUILDS_SERVER}`);
+const stagingDb = new PouchDB(`${MARKET_URL}/${STAGING_SERVER}`);
 
 process.on('unhandledRejection', error => {
   console.error('unhandledRejection', error);


### PR DESCRIPTION
It's better to clean up based on timestamp than build number. Now
instead of keeping the last 50 builds, which was broken with GitHub
Actions anyway, we keep the last 7 days of builds.

medic/cht-core#7000

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
