### PR TITLE
6811 Fix targets with property "passesIfGroupCount.gte" counting 'pass:false'

### DIFF
--- a/shared-libs/rules-engine/src/target-state.js
+++ b/shared-libs/rules-engine/src/target-state.js
@@ -125,20 +125,26 @@ module.exports = {
         };
       }
 
+      const reducer = (agg, curr) => {
+        if (!agg[curr.groupBy]) {
+          agg[curr.groupBy] = 0;
+        }
+        agg[curr.groupBy]++;
+        return agg;
+      };
+
+      const countEmissionsByGroupAndPass = relevantEmissions
+        .filter(emission => emission.groupBy && emission.pass)
+        .reduce(reducer, {});
+
       const countEmissionsByGroup = relevantEmissions
         .filter(emission => emission.groupBy)
-        .reduce((agg, curr) => {
-          if (!agg[curr.groupBy]) {
-            agg[curr.groupBy] = 0;
-          }
-
-          agg[curr.groupBy]++;
-          return agg;
-        }, {});
+        .reduce(reducer, {});
 
       const groups = Object.keys(countEmissionsByGroup);
+
       return {
-        pass: groups.filter(group => countEmissionsByGroup[group] > passingThreshold).length,
+        pass: groups.filter(group => countEmissionsByGroupAndPass[group] >= passingThreshold).length,
         total: groups.length,
       };
     };

--- a/shared-libs/rules-engine/src/target-state.js
+++ b/shared-libs/rules-engine/src/target-state.js
@@ -125,26 +125,28 @@ module.exports = {
         };
       }
 
-      const reducer = (agg, curr) => {
-        if (!agg[curr.groupBy]) {
-          agg[curr.groupBy] = 0;
+      const countPassedEmissionsByGroup = {};
+      const countEmissionsByGroup = {};
+
+      relevantEmissions.forEach(emission => {
+        const groupBy = emission.groupBy;
+        if (!groupBy) {
+          return;
         }
-        agg[curr.groupBy]++;
-        return agg;
-      };
-
-      const countEmissionsByGroupAndPass = relevantEmissions
-        .filter(emission => emission.groupBy && emission.pass)
-        .reduce(reducer, {});
-
-      const countEmissionsByGroup = relevantEmissions
-        .filter(emission => emission.groupBy)
-        .reduce(reducer, {});
+        if (!countPassedEmissionsByGroup[groupBy]) {
+          countPassedEmissionsByGroup[groupBy] = 0;
+          countEmissionsByGroup[groupBy] = 0;
+        }
+        countEmissionsByGroup[groupBy]++;
+        if (emission.pass) {
+          countPassedEmissionsByGroup[groupBy]++;
+        }
+      });
 
       const groups = Object.keys(countEmissionsByGroup);
 
       return {
-        pass: groups.filter(group => countEmissionsByGroupAndPass[group] >= passingThreshold).length,
+        pass: groups.filter(group => countPassedEmissionsByGroup[group] >= passingThreshold).length,
         total: groups.length,
       };
     };

--- a/shared-libs/rules-engine/src/target-state.js
+++ b/shared-libs/rules-engine/src/target-state.js
@@ -138,7 +138,7 @@ module.exports = {
 
       const groups = Object.keys(countEmissionsByGroup);
       return {
-        pass: groups.filter(group => countEmissionsByGroup[group] >= passingThreshold).length,
+        pass: groups.filter(group => countEmissionsByGroup[group] > passingThreshold).length,
         total: groups.length,
       };
     };

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -490,8 +490,8 @@ describe('provider-wireup integration tests', () => {
       expect(targets).to.deep.eq([{
         id: 'uhc',
         value: {
-          pass: 3, // 1, 2 and 5
-          total: 4, // not 4
+          pass: 1, // 1
+          total: 4, // not 2, 4, and 5
         },
       }]);
     });

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -467,7 +467,7 @@ describe('provider-wireup integration tests', () => {
       const refreshRulesEmissions = sinon.stub().resolves({
         targetEmissions: [
           hhEmission(1, 'family1', 'patient-1-1', true),
-          hhEmission(2, 'family1', 'patient-1-2', true), // redundant
+          hhEmission(2, 'family1', 'patient-1-2', true),
           hhEmission(3, 'family1', 'patient-1-1', false),
 
           hhEmission(3, 'family2', 'patient-2-1', true),
@@ -475,6 +475,14 @@ describe('provider-wireup integration tests', () => {
 
           hhEmission(4, 'family3', 'patient-3-1'),
           hhEmission(35, 'family4', 'patient-4-1'), // outside filter
+
+          hhEmission(6, 'family6', 'patient-6-1', true),
+          hhEmission(6, 'family6', 'patient-6-1', true),
+
+          hhEmission(6, 'family7', 'patient-7-1', false),
+          hhEmission(6, 'family7', 'patient-7-1', true),
+          hhEmission(7, 'family7', 'patient-7-1', false),
+          hhEmission(7, 'family7', 'patient-7-1', true),
 
           ...[1,2,3,4,5].map(day => hhEmission(day, 'family5', 'patient-5-1', true)),
         ],
@@ -491,8 +499,8 @@ describe('provider-wireup integration tests', () => {
       expect(targets).to.deep.eq([{
         id: 'uhc',
         value: {
-          pass: 2, // 1, 5
-          total: 4, // not 2
+          pass: 3, // 1, 5, and 7
+          total: 6,
         },
       }]);
     });

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -453,29 +453,30 @@ describe('provider-wireup integration tests', () => {
       };
       await wireup.initialize(provider, settings, {});
 
-      const hhEmission = (day, family, patient) => {
+      const hhEmission = (day, family, patient, pass) => {
         const date = moment(`2000-01-${day}`);
         return {
           _id: `${family}~${date.format('YYYY-MM-DD')}`,
           contact: { _id: patient },
           type: 'uhc',
           groupBy: family,
-          date: date.valueOf()
+          date: date.valueOf(),
+          pass
         };
       };
       const refreshRulesEmissions = sinon.stub().resolves({
         targetEmissions: [
-          hhEmission(1, 'family1', 'patient-1-1'),
-          hhEmission(1, 'family1', 'patient-1-2'), // redundant
-          hhEmission(3, 'family1', 'patient-1-1'),
+          hhEmission(1, 'family1', 'patient-1-1', true),
+          hhEmission(2, 'family1', 'patient-1-2', true), // redundant
+          hhEmission(3, 'family1', 'patient-1-1', false),
 
-          hhEmission(3, 'family2', 'patient-2-1'),
-          hhEmission(28, 'family2', 'patient-2-1'),
+          hhEmission(3, 'family2', 'patient-2-1', true),
+          hhEmission(28, 'family2', 'patient-2-1', false),
 
           hhEmission(4, 'family3', 'patient-3-1'),
           hhEmission(35, 'family4', 'patient-4-1'), // outside filter
 
-          ...[1,2,3,4,5].map(day => hhEmission(day, 'family5', 'patient-5-1')),
+          ...[1,2,3,4,5].map(day => hhEmission(day, 'family5', 'patient-5-1', true)),
         ],
       });
       const withMockRefresher = wireup.__with__({ refreshRulesEmissions });
@@ -490,8 +491,8 @@ describe('provider-wireup integration tests', () => {
       expect(targets).to.deep.eq([{
         id: 'uhc',
         value: {
-          pass: 1, // 1
-          total: 4, // not 2, 4, and 5
+          pass: 2, // 1, 5
+          total: 4, // not 2
         },
       }]);
     });

--- a/shared-libs/rules-engine/test/target-state.spec.js
+++ b/shared-libs/rules-engine/test/target-state.spec.js
@@ -182,6 +182,7 @@ describe('target-state', () => {
         mockEmission({ _id: 'a', groupBy: '1', pass: true }),
         mockEmission({ _id: 'b', groupBy: '2', pass: false }), // pass should have no effect
         mockEmission({ _id: 'c', groupBy: '1' }),
+        mockEmission({ _id: 'd', groupBy: '1', pass: false }),
       ]);
       expect(targetState.aggregateStoredTargetEmissions(state)).to.deep.eq([{
         id: 'target',

--- a/shared-libs/rules-engine/test/target-state.spec.js
+++ b/shared-libs/rules-engine/test/target-state.spec.js
@@ -183,10 +183,12 @@ describe('target-state', () => {
         mockEmission({ _id: 'b', groupBy: '2', pass: false }), // pass should have no effect
         mockEmission({ _id: 'c', groupBy: '1', pass: true }),
         mockEmission({ _id: 'd', groupBy: '1', pass: false }),
+        mockEmission({ _id: 'e', groupBy: '3', pass: false }),
+        mockEmission({ _id: 'f', groupBy: '3', pass: true }),
       ]);
       expect(targetState.aggregateStoredTargetEmissions(state)).to.deep.eq([{
         id: 'target',
-        value: { pass: 1, total: 2 },
+        value: { pass: 1, total: 3 },
       }]);
     });
 

--- a/shared-libs/rules-engine/test/target-state.spec.js
+++ b/shared-libs/rules-engine/test/target-state.spec.js
@@ -181,7 +181,7 @@ describe('target-state', () => {
       targetState.storeTargetEmissions(state, [], [
         mockEmission({ _id: 'a', groupBy: '1', pass: true }),
         mockEmission({ _id: 'b', groupBy: '2', pass: false }), // pass should have no effect
-        mockEmission({ _id: 'c', groupBy: '1' }),
+        mockEmission({ _id: 'c', groupBy: '1', pass: true }),
         mockEmission({ _id: 'd', groupBy: '1', pass: false }),
       ]);
       expect(targetState.aggregateStoredTargetEmissions(state)).to.deep.eq([{


### PR DESCRIPTION
# Description

Fix a bug where the incorrect target was being shown for targets that use `passesIfGroupCount.gte`

medic/cht-core#6811

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
