### PR TITLE
Moves publish from build to own final job.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,8 +155,8 @@ jobs:
       run: |
         echo "COUCH_URL=$COUCH_URL HORTI_BUILDS_SERVER=$MARKET_URL/$BUILDS_SERVER"
         COUCH_URL=$COUCH_URL HORTI_BUILDS_SERVER=$MARKET_URL/$BUILDS_SERVER horti --local --install=medic:medic:test-$TRAVIS_BUILD_NUMBER > tests/logs/horti.log &
-    - name: Test it!
-      run: node --stack_size=10000 `which grunt` ci-e2e
+    #- name: Test it!
+      #run: node --stack_size=10000 `which grunt` ci-e2e
     - name: Dump Couch logs
       run: docker logs couch > tests/logs/couch.log 2>&1
       if: ${{ always() }}
@@ -176,6 +176,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set MARKET_URL var
+      run: |
+        if [[ -z "$MARKET_URL" ]]; then
+        echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
+        echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
+        echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
+        fi
+    - name: Get branch name
+      uses: nelonoel/branch-name@1ea5c86cb559a8c4e623da7f188496208232e49f
     - name: Set Travis Vars
       run: |
         echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,12 +58,6 @@ jobs:
     - name: Publish for testing
       run: |
         node --stack_size=10000 `which grunt` publish-for-testing
-    - name: Publish
-      run: |
-        cd scripts/travis
-        npm ci
-        node ./publish.js
-      if: ${{ github.event_name != 'pull_request' }}
 
   default-config-tests:
     needs: build
@@ -174,3 +168,17 @@ jobs:
           tests/results
           tests/logs
       if: ${{ failure() }}
+
+  publish:
+    needs: test-e2e
+    name: Publish branch build
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Publish
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          cd scripts/travis
+          npm ci
+          node ./publish.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
       if: ${{ failure() }}
 
   publish:
-    needs: test-e2e
+    needs: [test-e2e, standard-config-tests, default-config-tests]
     name: Publish branch build
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,8 +190,8 @@ jobs:
         echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV
         echo "TRAVIS_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
     - name: Publish
-        if: ${{ github.event_name != 'pull_request' }}
-        run: |
-          cd scripts/travis
-          npm ci
-          node ./publish.js
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        cd scripts/travis
+        npm ci
+        node ./publish.js

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set Travis Vars
+      run: |
+        echo "TRAVIS_BUILD_NUMBER=$GITHUB_RUN_ID" >> $GITHUB_ENV
+        echo "TRAVIS_BRANCH=$BRANCH_NAME" >> $GITHUB_ENV
     - name: Publish
         if: ${{ github.event_name != 'pull_request' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,8 +155,8 @@ jobs:
       run: |
         echo "COUCH_URL=$COUCH_URL HORTI_BUILDS_SERVER=$MARKET_URL/$BUILDS_SERVER"
         COUCH_URL=$COUCH_URL HORTI_BUILDS_SERVER=$MARKET_URL/$BUILDS_SERVER horti --local --install=medic:medic:test-$TRAVIS_BUILD_NUMBER > tests/logs/horti.log &
-    #- name: Test it!
-      #run: node --stack_size=10000 `which grunt` ci-e2e
+    - name: Test it!
+      run: node --stack_size=10000 `which grunt` ci-e2e
     - name: Dump Couch logs
       run: docker logs couch > tests/logs/couch.log 2>&1
       if: ${{ always() }}


### PR DESCRIPTION
# Description

Because we were not running e2e tests when we first drafted the build.yml, the `publish` job was run immediately after the build, for every build. instead of running after e2e tests passed successfully. 
Now, `publish` will run as part of a separate job, depending on e2e tests passing successfully. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
