### PR TITLE
Clean up request errors for security.

### DIFF
--- a/api/src/config.js
+++ b/api/src/config.js
@@ -98,7 +98,7 @@ const loadTranslations = () => {
 const loadViewMaps = () => {
   db.medic.get('_design/medic', function(err, ddoc) {
     if (err) {
-      logger.error('Error loading view maps for medic ddoc', err);
+      logger.error('Error loading view maps for medic ddoc: %o', err);
       return;
     }
     viewMapUtils.loadViewMaps(

--- a/api/src/logger.js
+++ b/api/src/logger.js
@@ -10,9 +10,8 @@ const cleanUpRequestError = (error) => {
   }
 };
 
-
 const enumerateErrorFormat = format(info => {
-  // errors can be passed as "splat" objects, like: logger.error('message: %o', actualError);
+  // errors can be passed as "Symbol('splat')" properties, when doing: logger.error('message: %o', actualError);
   const symbolProperties = Object.getOwnPropertySymbols(info);
   if (symbolProperties && symbolProperties.length) {
     symbolProperties.forEach(property => {

--- a/api/src/logger.js
+++ b/api/src/logger.js
@@ -1,7 +1,31 @@
 const { createLogger, format, transports } = require('winston');
 const env = process.env.NODE_ENV || 'development';
 
+const cleanUpRequestError = (error) => {
+  const requestErrorConstructors = ['RequestError', 'StatusCodeError', 'TransformError'];
+  if (error && requestErrorConstructors.includes(error.constructor.name)) {
+    delete error.options;
+    delete error.request;
+    delete error.response;
+  }
+};
+
+
 const enumerateErrorFormat = format(info => {
+  // errors can be passed as "splat" objects, like: logger.error('message: %o', actualError);
+  const symbolProperties = Object.getOwnPropertySymbols(info);
+  if (symbolProperties && symbolProperties.length) {
+    symbolProperties.forEach(property => {
+      const values = info[property];
+      if (!values || !Array.isArray(values)) {
+        return;
+      }
+      values.forEach(value => cleanUpRequestError(value));
+    });
+  }
+  cleanUpRequestError(info);
+  cleanUpRequestError(info.message);
+
   if (info.message instanceof Error) {
     info.message = Object.assign({
       message: info.message.message,

--- a/api/src/logger.js
+++ b/api/src/logger.js
@@ -1,9 +1,27 @@
 const { createLogger, format, transports } = require('winston');
 const env = process.env.NODE_ENV || 'development';
 
+const cleanUpErrorsFromSymbolProperties = (info) => {
+  if (!info) {
+    return;
+  }
+
+  // errors can be passed as "Symbol('splat')" properties, when doing: logger.error('message: %o', actualError);
+  // see https://github.com/winstonjs/winston/blob/2625f60c5c85b8c4926c65e98a591f8b42e0db9a/README.md#streams-objectmode-and-info-objects
+  Object.getOwnPropertySymbols(info).forEach(property => {
+    const values = info[property];
+    if (Array.isArray(values)) {
+      values.forEach(value => cleanUpRequestError(value));
+    }
+  });
+};
+
 const cleanUpRequestError = (error) => {
+  // These are the error types that we're expecting from request-promise-native
+  // https://github.com/request/promise-core/blob/v1.1.4/lib/errors.js
   const requestErrorConstructors = ['RequestError', 'StatusCodeError', 'TransformError'];
-  if (error && requestErrorConstructors.includes(error.constructor.name)) {
+  if (error && error.constructor && requestErrorConstructors.includes(error.constructor.name)) {
+    // these properties could contain sensitive information, like passwords or auth tokens, and are not safe to log
     delete error.options;
     delete error.request;
     delete error.response;
@@ -11,17 +29,7 @@ const cleanUpRequestError = (error) => {
 };
 
 const enumerateErrorFormat = format(info => {
-  // errors can be passed as "Symbol('splat')" properties, when doing: logger.error('message: %o', actualError);
-  const symbolProperties = Object.getOwnPropertySymbols(info);
-  if (symbolProperties && symbolProperties.length) {
-    symbolProperties.forEach(property => {
-      const values = info[property];
-      if (!values || !Array.isArray(values)) {
-        return;
-      }
-      values.forEach(value => cleanUpRequestError(value));
-    });
-  }
+  cleanUpErrorsFromSymbolProperties(info);
   cleanUpRequestError(info);
   cleanUpRequestError(info.message);
 

--- a/sentinel/src/lib/logger.js
+++ b/sentinel/src/lib/logger.js
@@ -11,7 +11,7 @@ const cleanUpRequestError = (error) => {
 };
 
 const enumerateErrorFormat = format((info) => {
-  // errors can be passed as "splat" objects, like: logger.error('message: %o', actualError);
+  // errors can be passed as "Symbol('splat')" properties, when doing: logger.error('message: %o', actualError);
   const symbolProperties = Object.getOwnPropertySymbols(info);
   if (symbolProperties && symbolProperties.length) {
     symbolProperties.forEach(property => {

--- a/sentinel/src/lib/logger.js
+++ b/sentinel/src/lib/logger.js
@@ -1,27 +1,35 @@
 const { createLogger, format, transports } = require('winston');
 const env = process.env.NODE_ENV || 'development';
 
+const cleanUpSymbolProperties = (info) => {
+  if (!info) {
+    return;
+  }
+
+  // errors can be passed as "Symbol('splat')" properties, when doing: logger.error('message: %o', actualError);
+  // see https://github.com/winstonjs/winston/blob/2625f60c5c85b8c4926c65e98a591f8b42e0db9a/README.md#streams-objectmode-and-info-objects
+  Object.getOwnPropertySymbols(info).forEach(property => {
+    const values = info[property];
+    if (Array.isArray(values)) {
+      values.forEach(value => cleanUpRequestError(value));
+    }
+  });
+};
+
 const cleanUpRequestError = (error) => {
+  // These are the error types that we're expecting from request-promise-native
+  // https://github.com/request/promise-core/blob/v1.1.4/lib/errors.js
   const requestErrorConstructors = ['RequestError', 'StatusCodeError', 'TransformError'];
-  if (error && requestErrorConstructors.includes(error.constructor.name)) {
+  if (error && error.constructor && requestErrorConstructors.includes(error.constructor.name)) {
+    // these properties could contain sensitive information, like passwords or auth tokens, and are not safe to log
     delete error.options;
     delete error.request;
     delete error.response;
   }
 };
 
-const enumerateErrorFormat = format((info) => {
-  // errors can be passed as "Symbol('splat')" properties, when doing: logger.error('message: %o', actualError);
-  const symbolProperties = Object.getOwnPropertySymbols(info);
-  if (symbolProperties && symbolProperties.length) {
-    symbolProperties.forEach(property => {
-      const values = info[property];
-      if (!values || !Array.isArray(values)) {
-        return;
-      }
-      values.forEach(value => cleanUpRequestError(value));
-    });
-  }
+const enumerateErrorFormat = format(info => {
+  cleanUpSymbolProperties(info);
   cleanUpRequestError(info);
   cleanUpRequestError(info.message);
 

--- a/sentinel/src/schedule/reminders.js
+++ b/sentinel/src/schedule/reminders.js
@@ -266,7 +266,7 @@ const sendReminders = (reminder, scheduledDate, startDocId) => {
         .then(results => {
           const errors = results.filter(result => result.error);
           if (errors.length) {
-            logger.error('Errors saving reminders', errors);
+            logger.error('Errors saving reminders: %o', errors);
             throw new Error('Errors saving reminders');
           }
         })

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -155,7 +155,7 @@ const sendPayload = (payload, config) => {
             .then(result => {
               // No that's not a spelling mistake, this API is sometimes French!
               if (result.statut !== 200) {
-                logger.error('Non-200 status from Muso auth', result);
+                logger.error('Non-200 status from Muso auth: %o', result);
                 throw new OutboundError(`Got ${result.statut} when requesting auth`);
               }
 

--- a/shared-libs/tombstone-utils/src/tombstone-utils.js
+++ b/shared-libs/tombstone-utils/src/tombstone-utils.js
@@ -108,7 +108,7 @@ module.exports = {
         return doc.type !== TOMBSTONE_TYPE && saveTombstone(DB, doc, change, logger);
       })
       .catch(function(err) {
-        logger.error('Tombstone: could not process doc id:' + change.id + ' seq:' + change.seq, err);
+        logger.error(`Tombstone: could not process doc id: ${change.id} seq: ${change.seq}: %o`, err);
         throw err;
       });
   },

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -115,7 +115,7 @@ const processDocs = docs => {
       });
     })
     .catch(err => {
-      logger.error('Error when running transitions over docs', err);
+      logger.error('Error when running transitions over docs: %o', err);
       return db.medic.bulkDocs(docs);
     });
 };


### PR DESCRIPTION
# Description

Deletes `options`, `request` and `response` properties from `request-promise-native` errors before logging. 

medic/cht-core#7023

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
