### PR TITLE
Update set env

### DIFF
--- a/.github/workflows/scalability.yml
+++ b/.github/workflows/scalability.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set TAG_NAME var
-        run: echo "{TAG_NAME}={GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        run: echo "TAG_NAME=$GITHUB_REF#refs/tags/" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
       - name: Configure AWS Credentials

--- a/.github/workflows/scalability.yml
+++ b/.github/workflows/scalability.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set TAG_NAME var
-        run: echo "TAG_NAME=$GITHUB_REF#refs/tags/" >> $GITHUB_ENV
+        run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
       - name: Configure AWS Credentials

--- a/.github/workflows/scalability.yml
+++ b/.github/workflows/scalability.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set TAG_NAME var
-        run: echo "::set-env name=TAG_NAME::${GITHUB_REF#refs/tags/}"
+        run: echo "{TAG_NAME}={GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
       - name: Configure AWS Credentials

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -20,8 +20,8 @@ node -p "const fs = require('fs');var path = './config.json';var config = JSON.s
 echo "npm install for jmeter suite"
 npm install
 echo "jmeter install"
-wget https://apache.claz.org//jmeter/binaries/apache-jmeter-5.4.1.tgz && 
-mkdir ./jmeter && tar -xf apache-jmeter-5.3.tgz -C ./jmeter --strip-components=1
+wget https://apache.claz.org//jmeter/binaries/apache-jmeter-5.4.1.tgz -O ./apache-jmeter.tgz && 
+mkdir ./jmeter && tar -xf apache-jmeter.tgz -C ./jmeter --strip-components=1
 echo "Installing Plugins" && 
 wget  https://repo1.maven.org/maven2/kg/apc/jmeter-plugins-manager/1.4/jmeter-plugins-manager-1.4.jar -O ./jmeter/lib/ext/jmeter-plugins-manager-1.4.jar &&
 wget 'http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar' -O ./jmeter/lib/cmdrunner-2.2.jar &&

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -9,22 +9,22 @@ export NODE_TLS_REJECT_UNAUTHORIZED=0
 sudo apt-get update
 
 echo installing JAVA
-sudo apt-get -q install default-jre -y
+sudo apt-get install default-jre -y
 
 echo installing node
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-sudo apt-get -q install -y nodejs
+sudo apt-get install -y nodejs
 
 echo "Changing config to match url arg"
 node -p "const fs = require('fs');var path = './config.json';var config = JSON.stringify({...require(path), url: '$MEDIC_URL/medic'}, null, 2);fs.writeFileSync(path,config,{encoding:'utf8',flag:'w'});" 
 echo "npm install for jmeter suite"
 npm install
 echo "jmeter install"
-wget http://www.gtlib.gatech.edu/pub/apache//jmeter/binaries/apache-jmeter-5.3.tgz -q && 
+wget https://apache.claz.org//jmeter/binaries/apache-jmeter-5.4.1.tgz && 
 mkdir ./jmeter && tar -xf apache-jmeter-5.3.tgz -C ./jmeter --strip-components=1
 echo "Installing Plugins" && 
-wget  https://repo1.maven.org/maven2/kg/apc/jmeter-plugins-manager/1.4/jmeter-plugins-manager-1.4.jar -O ./jmeter/lib/ext/jmeter-plugins-manager-1.4.jar -q &&
-wget 'http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar' -O ./jmeter/lib/cmdrunner-2.2.jar -q &&
+wget  https://repo1.maven.org/maven2/kg/apc/jmeter-plugins-manager/1.4/jmeter-plugins-manager-1.4.jar -O ./jmeter/lib/ext/jmeter-plugins-manager-1.4.jar &&
+wget 'http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar' -O ./jmeter/lib/cmdrunner-2.2.jar &&
 java -cp jmeter/lib/ext/jmeter-plugins-manager-1.4.jar org.jmeterplugins.repository.PluginManagerCMDInstaller &&
 ./jmeter/bin/PluginsManagerCMD.sh install jpgc-mergeresults &&
 echo "jmeter do it!"

--- a/tests/scalability/start_ec2_medic.sh
+++ b/tests/scalability/start_ec2_medic.sh
@@ -33,7 +33,7 @@ fi
 
 url=https://$PublicDnsName
 
-echo "::set-env name=MEDIC_URL::$url"
+echo "{MEDIC_URL}={$url}" >> $GITHUB_ENV
 
 echo Begin Checking $url/api/info is up
 version=$(curl -s $url/api/info -k  | jq .version -r)


### PR DESCRIPTION
# Description

Fixes a few things related to the stale state of scalability runs.  

the set-env is no longer the way to set env vars.
Removed the quiet flag for logs
updated jmeter and setting the wget output name. 

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
