### PR TITLE
Sort of form filter and awaiting for language

### DIFF
--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -133,10 +133,8 @@ export class AppComponent implements OnInit {
   private loadTranslations() {
     this.translationsLoaded = this.languageService
       .get()
-      .then((language) => {
-        this.setLanguageService.set(language, false);
-        this.globalActions.setTranslationsLoaded();
-      })
+      .then((language) => this.setLanguageService.set(language, false))
+      .then(() => this.globalActions.setTranslationsLoaded())
       .catch(err => {
         console.error('Error loading language', err);
       });

--- a/webapp/src/ts/components/filters/form-type-filter/form-type-filter.component.ts
+++ b/webapp/src/ts/components/filters/form-type-filter/form-type-filter.component.ts
@@ -46,7 +46,7 @@ export class FormTypeFilterComponent implements OnDestroy, OnInit, AbstractFilte
     ).subscribe(([
       forms,
     ]) => {
-      this.forms = _sortBy(forms, 'name');
+      this.forms = _sortBy(forms, 'title');
     });
     this.subscription.add(subscription);
   }

--- a/webapp/src/ts/modals/edit-user/edit-user-settings.component.ts
+++ b/webapp/src/ts/modals/edit-user/edit-user-settings.component.ts
@@ -61,8 +61,10 @@ export class EditUserSettingsComponent extends EditUserAbstract implements OnIni
           })
           .then(() => {
             if (updates.language) {
-              this.setLanguageService.set(updates.language);
+              return this.setLanguageService.set(updates.language);
             }
+          })
+          .then(() => {
             this.setFinished();
             this.close();
           })

--- a/webapp/src/ts/services/language.service.ts
+++ b/webapp/src/ts/services/language.service.ts
@@ -43,10 +43,10 @@ export class SetLanguageService {
     (<any>$.fn).datepicker.defaults.language = calendarLanguage;
   }
 
-  set(code, setLanguageCookie?) {
+  async set(code, setLanguageCookie?) {
     moment.locale([ code, 'en' ]);
     this.setDatepickerLanguage(code);
-    this.translateService.use(code);
+    await this.translateService.use(code).toPromise();
 
     if (setLanguageCookie !== false) {
       this.setLanguageCookieService.set(code);

--- a/webapp/tests/karma/ts/components/filters/form-type-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/form-type-filter.component.spec.ts
@@ -1,5 +1,5 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideMockStore } from '@ngrx/store/testing';
+import { async, ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -18,6 +18,7 @@ import { Selectors } from '@mm-selectors/index';
 describe('Form Type Filter Component', () => {
   let component:FormTypeFilterComponent;
   let fixture:ComponentFixture<FormTypeFilterComponent>;
+  let store;
 
   beforeEach(async(() => {
     const mockedSelectors = [
@@ -46,6 +47,7 @@ describe('Form Type Filter Component', () => {
         fixture = TestBed.createComponent(FormTypeFilterComponent);
         component = fixture.componentInstance;
         fixture.detectChanges();
+        store = TestBed.inject(MockStore);
       });
   }));
 
@@ -94,4 +96,47 @@ describe('Form Type Filter Component', () => {
     expect(dropdownFilterClearSpy.callCount).to.equal(1);
     expect(dropdownFilterClearSpy.args[0]).to.deep.equal([false]);
   });
+
+  it('should sort forms by title', fakeAsync(() => {
+    const forms = [
+      {
+        _id: 'id-A',
+        code: 'code-A',
+        title: 'Form A'
+      },
+      {
+        _id: 'id-C',
+        code: 'code-C',
+        title: 'Form C'
+      },
+      {
+        _id: 'id-B',
+        code: 'code-B',
+        title: 'Form B'
+      }
+    ];
+    store.overrideSelector(Selectors.getForms, forms);
+    store.refreshState();
+
+    component.ngOnInit();
+    flush();
+
+    expect(component.forms).to.have.deep.members([
+      {
+        _id: 'id-A',
+        code: 'code-A',
+        title: 'Form A'
+      },
+      {
+        _id: 'id-B',
+        code: 'code-B',
+        title: 'Form B'
+      },
+      {
+        _id: 'id-C',
+        code: 'code-C',
+        title: 'Form C'
+      }
+    ]);
+  }));
 });

--- a/webapp/tests/karma/ts/modals/edit-user/edit-user-settings.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/edit-user/edit-user-settings.component.spec.ts
@@ -1,6 +1,6 @@
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, fakeAsync, TestBed, flush } from '@angular/core/testing';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { Subject } from 'rxjs';
@@ -49,7 +49,7 @@ describe('EditUserSettingsComponent', () => {
         ]
       )
     };
-    setLanguageService = { set: sinon.stub() };
+    setLanguageService = { set: sinon.stub().resolves() };
     bdModalRef = { hide: sinon.stub(), onHide: new Subject() };
 
     return TestBed
@@ -102,7 +102,7 @@ describe('EditUserSettingsComponent', () => {
     expect(component.errors).to.deep.equal({});
   });
 
-  it('editUserSettings() should not trigger any error', async(async () => {
+  it('editUserSettings() should not trigger any error', fakeAsync(async () => {
     component.editUserModel.language.code = 'en';
     component.editUserModel.fullname = 'Sir Admin';
     component.editUserModel.phone = '11 123 4567';
@@ -114,13 +114,13 @@ describe('EditUserSettingsComponent', () => {
     };
 
     await component.editUserSettings();
+
     expect(component.status).to.deep.equal({
       processing: true,   // Processing ...
       error: false,       // The error was cleared
       severity: false,
     });
-    await fixture.whenStable();
-    fixture.detectChanges();
+    flush();
     expect(component.status).to.deep.equal({
       processing: false,    // Processing finished
       error: false,         // No more errors


### PR DESCRIPTION
# Description

This PR:
- Adds sort form filter options by title and ascending.
- Adds await for setting language before continuing loading forms. 

Ticket: https://github.com/medic/cht-core/issues/7066

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
