### PR TITLE
6915  - Telemetry daily frequency

### DIFF
--- a/scripts/get_users_meta_docs.js
+++ b/scripts/get_users_meta_docs.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const inquirer = require('inquirer');
 const PouchDB = require('pouchdb-core');
 const fs = require('fs');
@@ -86,7 +88,7 @@ const actionQuestions = [{
           }
           docs.forEach(doc => console.log(JSON.stringify(doc, null, 2) + ','));
         } else if (i === 0) {
-          console.log('\x1b[31m%s\x1b[0m', `There are no documents of type ${type}`);
+          console.error('\x1b[31m%s\x1b[0m', `There are no documents of type ${type}`);
           break;
         } else {
           console.log('{}]');
@@ -100,7 +102,7 @@ const actionQuestions = [{
       let docIndex = 0;
 
       if (docs.length === 0) {
-        console.log('\x1b[31m%s\x1b[0m', `There are no documents of type ${type}`);
+        console.error('\x1b[31m%s\x1b[0m', `There are no documents of type ${type}`);
       } else {
         console.log(JSON.stringify(docs[docIndex], null, 2));
 
@@ -125,7 +127,7 @@ const actionQuestions = [{
 
             console.log(JSON.stringify(docs[docIndex], null, 2));
             if (printMessage) {
-              console.log('\x1b[31m%s\x1b[0m', `No next document. This is the last one.`);
+              console.error('\x1b[31m%s\x1b[0m', `No next document. This is the last one.`);
             }
           } else if (response.action === 'save_current') {
             const filePath = path.join(path.resolve(__dirname), docs[docIndex]._id + '.json');
@@ -154,6 +156,6 @@ const actionQuestions = [{
       }
     }
   } catch(err) {
-    console.log(err);
+    console.error(err);
   }
 })();

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -84,8 +84,7 @@ export class TelemetryService {
     //return moment().startOf('minute');
   }
 
-  // if there is telemetry data to aggregate and is before the current date,
-  // aggregation is performed and the data destroyed
+  // if there is telemetry data from previous days, aggregation is performed and the data destroyed
   private submitIfNeeded(db) {
     const startOf = this.aggregateStartsAt();
     const dbDate = moment(this.getFirstAggregatedDate());

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -55,9 +55,10 @@ export class TelemetryService {
   }
 
   /**
-   * Returns the time in milliseconds (since Unix epoch) when the first telemetry record was created.
+   * Returns a Moment object when the first telemetry record was created.
    *
-   * This date is computed and stored when we call this method for the first time and after every aggregation.
+   * This date is computed and stored in milliseconds (since Unix epoch)
+   * when we call this method for the first time and after every aggregation.
    */
   private getFirstAggregatedDate() {
     let date = parseInt(window.localStorage.getItem(this.FIRST_AGGREGATED_DATE_KEY));
@@ -67,7 +68,7 @@ export class TelemetryService {
       window.localStorage.setItem(this.FIRST_AGGREGATED_DATE_KEY, date.toString());
     }
 
-    return date;
+    return moment(date);
   }
 
   private storeIt(db, key, value) {
@@ -86,7 +87,7 @@ export class TelemetryService {
   // if there is telemetry data from previous days, aggregation is performed and the data destroyed
   private submitIfNeeded(db) {
     const startOf = this.aggregateStartsAt();
-    const dbDate = moment(this.getFirstAggregatedDate());
+    const dbDate = this.getFirstAggregatedDate();
 
     if (dbDate.isBefore(startOf)) {
       return this
@@ -121,7 +122,7 @@ export class TelemetryService {
         this.dbService.get().query('medic-client/doc_by_type', { key: ['form'], include_docs: true })
       ])
       .then(([ddoc, formResults]) => {
-        const date = moment(this.getFirstAggregatedDate());
+        const date = this.getFirstAggregatedDate();
         const version = (ddoc.deploy_info && ddoc.deploy_info.version) || 'unknown';
         const forms = formResults.rows.reduce((keyToVersion, row) => {
           keyToVersion[row.doc.internalId] = row.doc._rev;

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -81,7 +81,6 @@ export class TelemetryService {
   // moment when the aggregation starts (the beginning of the current day)
   private aggregateStartsAt() {
     return moment().startOf('day');
-    //return moment().startOf('minute');
   }
 
   // if there is telemetry data from previous days, aggregation is performed and the data destroyed
@@ -90,13 +89,9 @@ export class TelemetryService {
     const dbDate = moment(this.getFirstAggregatedDate());
 
     if (dbDate.isBefore(startOf)) {
-      return db.info()
-        .then(info => {
-          if (info.doc_count > 0) {
-            return this.aggregate(db)
-              .then(() => this.reset(db));
-          }
-        });
+      return this
+        .aggregate(db)
+        .then(() => this.reset(db));
     }
   }
 
@@ -114,8 +109,6 @@ export class TelemetryService {
       metadata.year,
       metadata.month,
       metadata.day,
-      //metadata.hour,
-      //metadata.minute,
       metadata.user,
       metadata.deviceId,
     ].join('-');
@@ -140,8 +133,6 @@ export class TelemetryService {
           year: date.year(),
           month: date.month() + 1,
           day: date.date(),
-          //hour: date.hour(),
-          //minute: date.minute(),
           user: this.sessionService.userCtx().name,
           deviceId: this.getUniqueDeviceId(),
           versions: {

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -55,8 +55,7 @@ export class TelemetryService {
   }
 
   /**
-   * Returns the time in milliseconds (since Unix epoch) when the first telemetry
-   * record was created within the day that is going to be aggregated.
+   * Returns the time in milliseconds (since Unix epoch) when the first telemetry record was created
    *
    * The date is stored locally once computed by this method, either because is
    * the first time is called or because the aggregation was performed last time

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -57,10 +57,7 @@ export class TelemetryService {
   /**
    * Returns the time in milliseconds (since Unix epoch) when the first telemetry record was created
    *
-   * The date is stored locally once computed by this method, either because is
-   * the first time is called or because the aggregation was performed last time
-   * a record was created, therefore `reset(db)' deleted it, and next time this
-   * method is called the date need to be fetched from the system again.
+   * This date is computed and stored when we call this method for the first time and after every aggregation.
    */
   private getFirstAggregatedDate() {
     let date = parseInt(window.localStorage.getItem(this.LAST_AGGREGATED_DATE_KEY));

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -15,7 +15,7 @@ export class TelemetryService {
   // Intentionally scoped to the whole browser (for this domain). We can then tell if multiple users use the same device
   private readonly DEVICE_ID_KEY = 'medic-telemetry-device-id';
   private DB_ID_KEY;
-  private LAST_AGGREGATED_DATE_KEY;
+  private FIRST_AGGREGATED_DATE_KEY;
 
   private queue = Promise.resolve();
 
@@ -27,7 +27,7 @@ export class TelemetryService {
     // Intentionally scoped to the specific user, as they may perform a
     // different role (online vs. offline being being the most obvious) with different performance implications
     this.DB_ID_KEY = ['medic', this.sessionService.userCtx().name, 'telemetry-db'].join('-');
-    this.LAST_AGGREGATED_DATE_KEY = ['medic', this.sessionService.userCtx().name, 'telemetry-date'].join('-');
+    this.FIRST_AGGREGATED_DATE_KEY = ['medic', this.sessionService.userCtx().name, 'telemetry-date'].join('-');
   }
 
   private getDb() {
@@ -55,16 +55,16 @@ export class TelemetryService {
   }
 
   /**
-   * Returns the time in milliseconds (since Unix epoch) when the first telemetry record was created
+   * Returns the time in milliseconds (since Unix epoch) when the first telemetry record was created.
    *
    * This date is computed and stored when we call this method for the first time and after every aggregation.
    */
   private getFirstAggregatedDate() {
-    let date = parseInt(window.localStorage.getItem(this.LAST_AGGREGATED_DATE_KEY));
+    let date = parseInt(window.localStorage.getItem(this.FIRST_AGGREGATED_DATE_KEY));
 
     if (!date) {
       date = Date.now();
-      window.localStorage.setItem(this.LAST_AGGREGATED_DATE_KEY, date.toString());
+      window.localStorage.setItem(this.FIRST_AGGREGATED_DATE_KEY, date.toString());
     }
 
     return date;
@@ -217,7 +217,7 @@ export class TelemetryService {
 
   private reset(db) {
     window.localStorage.removeItem(this.DB_ID_KEY);
-    window.localStorage.removeItem(this.LAST_AGGREGATED_DATE_KEY);
+    window.localStorage.removeItem(this.FIRST_AGGREGATED_DATE_KEY);
 
     return db.destroy();
   }

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -8,7 +8,7 @@ import { DbService } from '@mm-services/db.service';
 import { SessionService } from '@mm-services/session.service';
 
 describe('TelemetryService', () => {
-  const NOW = new Date(2018, 10, 10, 12, 33).getTime();
+  const NOW = new Date(2018, 10, 10, 12, 33).getTime(); // -> 2018-11-10T12:33:00
   let service: TelemetryService;
   let dbService;
   let dbInstance;
@@ -18,7 +18,9 @@ describe('TelemetryService', () => {
   let storageGetItemStub;
   let storageSetItemStub;
   let consoleErrorSpy;
+
   const windowPouchOriginal = window.PouchDB;
+
   const windowScreenOriginal = {
     availWidth: window.screen.availWidth,
     availHeight: window.screen.availHeight
@@ -28,7 +30,43 @@ describe('TelemetryService', () => {
     hardwareConcurrency: window.navigator.hardwareConcurrency
   };
 
+  function defineWindow() {
+    Object.defineProperty(window.navigator, 'userAgent',
+      { value: 'Agent Smith', configurable: true });
+    Object.defineProperty(window.navigator, 'hardwareConcurrency',
+      { value: 4, configurable: true });
+    Object.defineProperty(window.screen, 'availWidth',
+      { value: 768, configurable: true });
+    Object.defineProperty(window.screen, 'availHeight',
+      { value: 1024, configurable: true });
+  }
+
+  function restoreWindow() {
+    Object.defineProperty(window.navigator, 'userAgent',
+      { value: windowNavigatorOriginal.userAgent, configurable: true });
+    Object.defineProperty(window.navigator, 'hardwareConcurrency',
+      { value: windowNavigatorOriginal.hardwareConcurrency, configurable: true });
+    Object.defineProperty(window.screen, 'availWidth',
+      { value: windowScreenOriginal.availWidth, configurable: true });
+    Object.defineProperty(window.screen, 'availHeight',
+      { value: windowScreenOriginal.availHeight, configurable: true });
+  }
+
+  function subtractDays(numDays) {
+    return moment()
+      .subtract(numDays, 'days')
+      .valueOf()
+      .toString();
+  }
+
+  function sameDay() {
+    return moment()
+      .valueOf()
+      .toString();
+  }
+
   beforeEach(() => {
+    defineWindow();
     dbInstance = {
       info: sinon.stub(),
       put: sinon.stub(),
@@ -38,8 +76,13 @@ describe('TelemetryService', () => {
     dbService = { get: () => dbInstance };
     consoleErrorSpy = sinon.spy(console, 'error');
     pouchDb = {
+      info: sinon.stub().resolves({doc_count: 10}),
       post: sinon.stub().resolves(),
-      close: sinon.stub()
+      close: sinon.stub(),
+      destroy: sinon.stub().callsFake(() => {
+        pouchDb._destroyed = true;
+        return Promise.resolve();
+      })
     };
     sessionService = { userCtx: sinon.stub().returns({ name: 'greg' }) };
     storageGetItemStub = sinon.stub(window.localStorage, 'getItem');
@@ -61,38 +104,13 @@ describe('TelemetryService', () => {
     clock.restore();
     sinon.restore();
     window.PouchDB = windowPouchOriginal;
-    Object.defineProperty(
-      window.navigator,
-      'userAgent',
-      { value: windowNavigatorOriginal.userAgent, configurable: true }
-    );
-    Object.defineProperty(
-      window.navigator,
-      'hardwareConcurrency',
-      { value: windowNavigatorOriginal.hardwareConcurrency, configurable: true }
-    );
-    Object.defineProperty(
-      window.screen,
-      'availWidth',
-      { value: windowScreenOriginal.availWidth, configurable: true }
-    );
-    Object.defineProperty(
-      window.screen,
-      'availHeight',
-      { value: windowScreenOriginal.availHeight, configurable: true }
-    );
+    restoreWindow();
   });
 
   describe('record()', () => {
     it('should record a piece of telemetry', async () => {
-      pouchDb.post = sinon.stub().resolves();
-      pouchDb.close = sinon.stub();
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-db')
-        .returns('dbname');
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-date')
-        .returns(Date.now().toString());
+      storageGetItemStub.withArgs('medic-greg-telemetry-db').returns('dbname');
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(Date.now().toString());
 
       await service.record('test', 100);
 
@@ -100,19 +118,13 @@ describe('TelemetryService', () => {
       expect(pouchDb.post.callCount).to.equal(1);
       expect(pouchDb.post.args[0][0]).to.deep.include({ key: 'test', value: 100 });
       expect(pouchDb.post.args[0][0].date_recorded).to.be.above(0);
-      expect(storageGetItemStub.callCount).to.equal(2);
+      expect(storageGetItemStub.callCount).to.equal(3);
       expect(pouchDb.close.callCount).to.equal(1);
     });
 
     it('should default the value to 1 if not passed', async () => {
-      pouchDb.post = sinon.stub().resolves();
-      pouchDb.close = sinon.stub();
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-db')
-        .returns('dbname');
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-date')
-        .returns(Date.now().toString());
+      storageGetItemStub.withArgs('medic-greg-telemetry-db').returns('dbname');
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(Date.now().toString());
 
       await service.record('test');
 
@@ -121,52 +133,14 @@ describe('TelemetryService', () => {
       expect(pouchDb.close.callCount).to.equal(1);
     });
 
-    it('should set localStorage values', async () => {
-      pouchDb.post = sinon.stub().resolves();
-      pouchDb.close = sinon.stub();
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-db')
-        .returns(undefined);
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-date')
-        .returns(undefined);
-
-      await service.record('test', 1);
-
-      expect(consoleErrorSpy.callCount).to.equal(0);
-      expect(storageSetItemStub.callCount).to.equal(2);
-      expect(storageSetItemStub.args[0][0]).to.equal('medic-greg-telemetry-db');
-      expect(storageSetItemStub.args[0][1]).to.match(/medic-user-greg-telemetry-/); // ends with a UUID
-      expect(storageSetItemStub.args[1][0]).to.equal('medic-greg-telemetry-date');
-      expect(storageSetItemStub.args[1][1]).to.equal(NOW.toString());
-    });
-
-    it('should aggregate once a month and resets the db', async () => {
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-db')
-        .returns('dbname');
-      storageGetItemStub
-        .withArgs('medic-greg-telemetry-date')
-        .returns(
-          moment()
-            .subtract(5, 'weeks')
-            .valueOf()
-            .toString()
-        );
-
-      pouchDb.post = sinon.stub().resolves();
+    function setupDbMocks() {
+      storageGetItemStub.returns('dbname');
       pouchDb.query = sinon.stub().resolves({
         rows: [
-          { key: 'foo', value: 'stats' },
-          { key: 'bar', value: 'more stats' },
+          { key: 'foo', value: {sum:2876, min:581, max:2295, count:2, sumsqr:5604586} },
+          { key: 'bar', value: {sum:93, min:43, max:50, count:2, sumsqr:4349} },
         ],
       });
-      pouchDb.destroy = sinon.stub().callsFake(() => {
-        pouchDb._destroyed = true;
-        return Promise.resolve();
-      });
-      pouchDb.close = sinon.stub();
-
       dbInstance.info.resolves({ some: 'stats' });
       dbInstance.put.resolves();
       dbInstance.get
@@ -188,28 +162,28 @@ describe('TelemetryService', () => {
           }
         ]
       });
+    }
 
-      Object.defineProperty(window.navigator, 'userAgent', { value: 'Agent Smith', configurable: true });
-      Object.defineProperty(window.navigator, 'hardwareConcurrency', { value: 4, configurable: true });
-      Object.defineProperty(window.screen, 'availWidth', { value: 768, configurable: true });
-      Object.defineProperty(window.screen, 'availHeight', { value: 1024, configurable: true });
+    it('should aggregate once a day and resets the db first', async () => {
+      setupDbMocks();
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(subtractDays(5));
 
       await service.record('test', 1);
 
-      expect(consoleErrorSpy.callCount).to.equal(0);
       expect(pouchDb.post.callCount).to.equal(1);
       expect(pouchDb.post.args[0][0]).to.deep.include({ key: 'test', value: 1 });
-      expect(dbInstance.put.callCount).to.equal(1);
 
+      expect(dbInstance.put.callCount).to.equal(1);
       const aggregatedDoc = dbInstance.put.args[0][0];
-      expect(aggregatedDoc._id).to.match(/telemetry-2018-10-greg/);
+      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-5-greg/);
       expect(aggregatedDoc.metrics).to.deep.equal({
-        foo: 'stats',
-        bar: 'more stats',
+        foo: {sum:2876, min:581, max:2295, count:2, sumsqr:5604586},
+        bar: {sum:93, min:43, max:50, count:2, sumsqr:4349},
       });
       expect(aggregatedDoc.type).to.equal('telemetry');
       expect(aggregatedDoc.metadata.year).to.equal(2018);
-      expect(aggregatedDoc.metadata.month).to.equal(10);
+      expect(aggregatedDoc.metadata.month).to.equal(11);
+      expect(aggregatedDoc.metadata.day).to.equal(5);
       expect(aggregatedDoc.metadata.user).to.equal('greg');
       expect(aggregatedDoc.metadata.versions).to.deep.equal({
         app: '3.0.0',
@@ -227,23 +201,122 @@ describe('TelemetryService', () => {
         },
         deviceInfo: {}
       });
+
       expect(dbInstance.query.callCount).to.equal(1);
       expect(dbInstance.query.args[0][0]).to.equal('medic-client/doc_by_type');
       expect(dbInstance.query.args[0][1]).to.deep.equal({ key: ['form'], include_docs: true });
       expect(pouchDb.destroy.callCount).to.equal(1);
       expect(pouchDb.close.callCount).to.equal(0);
+
+      expect(consoleErrorSpy.callCount).to.equal(0);  // no errors
     });
+
+    it('should not aggregate when recording the day the db was created and next day it should aggregate', async () => {
+      setupDbMocks();
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(sameDay());
+
+      await service.record('test', 10);
+
+      expect(pouchDb.post.callCount).to.equal(1);
+      expect(pouchDb.post.args[0][0]).to.deep.include({ key: 'test', value: 10 });
+      expect(dbInstance.put.callCount).to.equal(0);   // NO telemetry has been recorded yet
+
+      clock = sinon.useFakeTimers(moment(NOW).add(1, 'minutes').valueOf()); // 1 min later ...
+      await service.record('test', 5);
+
+      expect(pouchDb.post.callCount).to.equal(2); // second call
+      expect(pouchDb.post.args[1][0]).to.deep.include({ key: 'test', value: 5 });
+      expect(dbInstance.put.callCount).to.equal(0);   // still NO telemetry has been recorded (same day)
+
+      clock = sinon.useFakeTimers(moment(NOW).add(1, 'days').valueOf()); // 1 day later ...
+      await service.record('test', 2);
+
+      expect(pouchDb.post.callCount).to.equal(3); // third call
+      expect(pouchDb.post.args[2][0]).to.deep.include({ key: 'test', value: 2 });
+      expect(dbInstance.put.callCount).to.equal(1);   // Now telemetry has been recorded
+
+      const aggregatedDoc = dbInstance.put.args[0][0];
+      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-10-greg/);  // Now is 2018-11-11 but aggregation
+      expect(pouchDb.destroy.callCount).to.equal(1);                    // is from from previous day
+
+      expect(consoleErrorSpy.callCount).to.equal(0);  // no errors
+    });
+
+    it('should aggregate from days with records skipping days without records', async () => {
+      setupDbMocks();
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(sameDay());
+
+      await service.record('datapoint', 12);
+
+      expect(pouchDb.post.callCount).to.equal(1);
+      expect(dbInstance.put.callCount).to.equal(0);   // NO telemetry has been recorded yet
+
+      clock = sinon.useFakeTimers(moment(NOW).add(1, 'minutes').valueOf()); // 1 min later ...
+      await service.record('another.datapoint');
+
+      expect(pouchDb.post.callCount).to.equal(2);       // second call
+      expect(dbInstance.put.callCount).to.equal(0);     // still NO telemetry has been recorded (same day)
+
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(sameDay());
+      clock = sinon.useFakeTimers(moment(NOW).add(2, 'days').valueOf()); // 2 days later ...
+      await service.record('test', 2);
+
+      expect(pouchDb.post.callCount).to.equal(3);       // third call
+      expect(dbInstance.put.callCount).to.equal(1);     // Now telemetry IS recorded
+
+      let aggregatedDoc = dbInstance.put.args[0][0];
+      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-10-greg/);  // Today is 2018-11-12 but aggregation
+      expect(pouchDb.destroy.callCount).to.equal(1);                    // is from from 2 days ago (not Yesterday)
+
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(sameDay());  // same day now is 2 days ahead
+
+      clock = sinon.useFakeTimers(moment(NOW).add(7, 'days').valueOf()); // 7 days later ...
+      await service.record('point.a', 1);
+
+      expect(pouchDb.post.callCount).to.equal(4);       // 4th call
+      expect(dbInstance.put.callCount).to.equal(2);     // Telemetry IS recorded again
+      aggregatedDoc = dbInstance.put.args[1][0];
+      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-12-greg/);  // Today is 2018-11-19 but aggregation
+                                                                        // is from 2018-11-12
+
+      // A new record is added ...
+      clock = sinon.useFakeTimers(moment(NOW).add(2, 'hours').valueOf()); // ... 2 hours later ...
+      await service.record('point.b', 0); // 1 record added
+      // ...the aggregation count is the same because
+      // the aggregation was already performed 2 hours ago within the same day
+      expect(pouchDb.post.callCount).to.equal(5);       // 5th call
+      expect(dbInstance.put.callCount).to.equal(2);     // Telemetry count is the same
+
+      expect(consoleErrorSpy.callCount).to.equal(0);    // no errors
+    });
+  });
+
+  describe('getDb()', () => {
+    it('should set localStorage values', async () => {
+      storageGetItemStub
+        .withArgs('medic-greg-telemetry-db')
+        .returns(undefined);
+      storageGetItemStub
+        .withArgs('medic-greg-telemetry-date')
+        .returns(undefined);
+
+      await service.record('test', 1);
+
+      expect(consoleErrorSpy.callCount).to.equal(0);
+      expect(storageSetItemStub.callCount).to.equal(3);
+      expect(storageSetItemStub.args[0][0]).to.equal('medic-greg-telemetry-db');
+      expect(storageSetItemStub.args[0][1]).to.match(/medic-user-greg-telemetry-/); // ends with a UUID
+      expect(storageSetItemStub.args[1][0]).to.equal('medic-greg-telemetry-date');
+      expect(storageSetItemStub.args[1][1]).to.equal(NOW.toString());
+    });
+  });
+
+  describe('storeConflictedAggregate()', () => {
 
     it('should deal with conflicts by making the ID unique and noting the conflict in the new document', async () => {
       storageGetItemStub.withArgs('medic-greg-telemetry-db').returns('dbname');
-      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(
-        moment()
-          .subtract(5, 'weeks')
-          .valueOf()
-          .toString()
-      );
+      storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(subtractDays(5));
 
-      pouchDb.post = sinon.stub().resolves();
       pouchDb.query = sinon.stub().resolves({
         rows: [
           {
@@ -266,16 +339,6 @@ describe('TelemetryService', () => {
         }
       });
       dbInstance.query.resolves({ rows: [] });
-      pouchDb.destroy = sinon.stub().callsFake(() => {
-        pouchDb._destroyed = true;
-        return Promise.resolve();
-      });
-      pouchDb.close = sinon.stub();
-
-      Object.defineProperty(window.navigator, 'userAgent', { value: 'Agent Smith', configurable: true });
-      Object.defineProperty(window.navigator, 'hardwareConcurrency', { value: 4, configurable: true });
-      Object.defineProperty(window.screen, 'availWidth', { value: 768, configurable: true });
-      Object.defineProperty(window.screen, 'availHeight', { value: 1024, configurable: true });
 
       await service.record('test', 1);
 
@@ -287,5 +350,4 @@ describe('TelemetryService', () => {
       expect(pouchDb.close.callCount).to.equal(0);
     });
   });
-
 });

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -276,8 +276,7 @@ describe('TelemetryService', () => {
       expect(pouchDb.post.callCount).to.equal(4);       // 4th call
       expect(dbInstance.put.callCount).to.equal(2);     // Telemetry IS recorded again
       aggregatedDoc = dbInstance.put.args[1][0];
-      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-12-greg/);  // Today is 2018-11-19 but aggregation
-                                                                        // is from 2018-11-12
+      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-12-greg/);  // It's Nov 19 but aggregation is from Nov 12
 
       // A new record is added ...
       clock = sinon.useFakeTimers(moment(NOW).add(2, 'hours').valueOf()); // ... 2 hours later ...

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -304,7 +304,7 @@ describe('TelemetryService', () => {
       expect(consoleErrorSpy.callCount).to.equal(0);
       expect(storageSetItemStub.callCount).to.equal(3);
       expect(storageSetItemStub.args[0][0]).to.equal('medic-greg-telemetry-db');
-      expect(storageSetItemStub.args[0][1]).to.match(/medic-user-greg-telemetry-/); // ends with a UUID
+      expect(storageSetItemStub.args[0][1]).to.match(/^medic-user-greg-telemetry-/)
       expect(storageSetItemStub.args[1][0]).to.equal('medic-greg-telemetry-date');
       expect(storageSetItemStub.args[1][1]).to.equal(NOW.toString());
     });

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -142,6 +142,9 @@ describe('TelemetryService', () => {
       expect(pouchDb.post.args[0][0]).to.deep.include({ key: 'test', value: 100 });
       expect(pouchDb.post.args[0][0].date_recorded).to.be.above(0);
       expect(storageGetItemStub.callCount).to.equal(3);
+      expect(storageGetItemStub.args[0]).to.deep.equal(['medic-greg-telemetry-db']);
+      expect(storageGetItemStub.args[1]).to.deep.equal(["medic-greg-telemetry-date"]);
+      expect(storageGetItemStub.args[2]).to.deep.equal(['medic-greg-telemetry-db']);
       expect(pouchDb.close.callCount).to.equal(1);
     });
 
@@ -242,25 +245,25 @@ describe('TelemetryService', () => {
 
       expect(pouchDb.post.callCount).to.equal(1);
       expect(pouchDb.post.args[0][0]).to.deep.include({ key: 'test', value: 10 });
-      expect(dbInstance.put.callCount).to.equal(0);   // NO telemetry has been recorded yet
+      expect(dbInstance.put.callCount).to.equal(0);   // NO telemetry aggregation has been recorded yet
 
       clock = sinon.useFakeTimers(moment(NOW).add(1, 'minutes').valueOf()); // 1 min later ...
       await service.record('test', 5);
 
-      expect(pouchDb.post.callCount).to.equal(2); // second call
+      expect(pouchDb.post.callCount).to.equal(2);     // second call
       expect(pouchDb.post.args[1][0]).to.deep.include({ key: 'test', value: 5 });
-      expect(dbInstance.put.callCount).to.equal(0);   // still NO telemetry has been recorded (same day)
+      expect(dbInstance.put.callCount).to.equal(0);   // still NO aggregation has been recorded (same day)
 
       clock = sinon.useFakeTimers(moment(NOW).add(1, 'days').valueOf()); // 1 day later ...
       await service.record('test', 2);
 
-      expect(pouchDb.post.callCount).to.equal(3); // third call
+      expect(pouchDb.post.callCount).to.equal(3);     // third call
       expect(pouchDb.post.args[2][0]).to.deep.include({ key: 'test', value: 2 });
       expect(dbInstance.put.callCount).to.equal(1);   // Now telemetry has been recorded
 
       const aggregatedDoc = dbInstance.put.args[0][0];
       expect(aggregatedDoc._id).to.match(/^telemetry-2018-11-10-greg-[\w-]+$/); // Now is 2018-11-11 but aggregation
-      expect(pouchDb.destroy.callCount).to.equal(1);                            // is from from previous day
+      expect(pouchDb.destroy.callCount).to.equal(1);                            // is from the previous day
 
       expect(consoleErrorSpy.callCount).to.equal(0);  // no errors
     });

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -31,25 +31,49 @@ describe('TelemetryService', () => {
   };
 
   function defineWindow() {
-    Object.defineProperty(window.navigator, 'userAgent',
-      { value: 'Agent Smith', configurable: true });
-    Object.defineProperty(window.navigator, 'hardwareConcurrency',
-      { value: 4, configurable: true });
-    Object.defineProperty(window.screen, 'availWidth',
-      { value: 768, configurable: true });
-    Object.defineProperty(window.screen, 'availHeight',
-      { value: 1024, configurable: true });
+    Object.defineProperty(
+      window.navigator,
+      'userAgent',
+      { value: 'Agent Smith', configurable: true }
+    );
+    Object.defineProperty(
+      window.navigator,
+      'hardwareConcurrency',
+      { value: 4, configurable: true }
+    );
+    Object.defineProperty(
+      window.screen,
+      'availWidth',
+      { value: 768, configurable: true }
+    );
+    Object.defineProperty(
+      window.screen,
+      'availHeight',
+      { value: 1024, configurable: true }
+    );
   }
 
   function restoreWindow() {
-    Object.defineProperty(window.navigator, 'userAgent',
-      { value: windowNavigatorOriginal.userAgent, configurable: true });
-    Object.defineProperty(window.navigator, 'hardwareConcurrency',
-      { value: windowNavigatorOriginal.hardwareConcurrency, configurable: true });
-    Object.defineProperty(window.screen, 'availWidth',
-      { value: windowScreenOriginal.availWidth, configurable: true });
-    Object.defineProperty(window.screen, 'availHeight',
-      { value: windowScreenOriginal.availHeight, configurable: true });
+    Object.defineProperty(
+      window.navigator,
+      'userAgent',
+      { value: windowNavigatorOriginal.userAgent, configurable: true }
+    );
+    Object.defineProperty(
+      window.navigator,
+      'hardwareConcurrency',
+      { value: windowNavigatorOriginal.hardwareConcurrency, configurable: true }
+    );
+    Object.defineProperty(
+      window.screen,
+      'availWidth',
+      { value: windowScreenOriginal.availWidth, configurable: true }
+    );
+    Object.defineProperty(
+      window.screen,
+      'availHeight',
+      { value: windowScreenOriginal.availHeight, configurable: true }
+    );
   }
 
   function subtractDays(numDays) {

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -76,7 +76,6 @@ describe('TelemetryService', () => {
     dbService = { get: () => dbInstance };
     consoleErrorSpy = sinon.spy(console, 'error');
     pouchDb = {
-      info: sinon.stub().resolves({doc_count: 10}),
       post: sinon.stub().resolves(),
       close: sinon.stub(),
       destroy: sinon.stub().callsFake(() => {

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -144,7 +144,7 @@ describe('TelemetryService', () => {
       expect(telemetryDb.post.args[0][0].date_recorded).to.be.above(0);
       expect(storageGetItemStub.callCount).to.equal(3);
       expect(storageGetItemStub.args[0]).to.deep.equal(['medic-greg-telemetry-db']);
-      expect(storageGetItemStub.args[1]).to.deep.equal(["medic-greg-telemetry-date"]);
+      expect(storageGetItemStub.args[1]).to.deep.equal(['medic-greg-telemetry-date']);
       expect(storageGetItemStub.args[2]).to.deep.equal(['medic-greg-telemetry-db']);
       expect(telemetryDb.close.callCount).to.equal(1);
     });

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -175,7 +175,7 @@ describe('TelemetryService', () => {
 
       expect(dbInstance.put.callCount).to.equal(1);
       const aggregatedDoc = dbInstance.put.args[0][0];
-      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-5-greg/);
+      expect(aggregatedDoc._id).to.match(/^telemetry-2018-11-5-greg-[\w-]+$/);
       expect(aggregatedDoc.metrics).to.deep.equal({
         foo: {sum:2876, min:581, max:2295, count:2, sumsqr:5604586},
         bar: {sum:93, min:43, max:50, count:2, sumsqr:4349},
@@ -236,8 +236,8 @@ describe('TelemetryService', () => {
       expect(dbInstance.put.callCount).to.equal(1);   // Now telemetry has been recorded
 
       const aggregatedDoc = dbInstance.put.args[0][0];
-      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-10-greg/);  // Now is 2018-11-11 but aggregation
-      expect(pouchDb.destroy.callCount).to.equal(1);                    // is from from previous day
+      expect(aggregatedDoc._id).to.match(/^telemetry-2018-11-10-greg-[\w-]+$/); // Now is 2018-11-11 but aggregation
+      expect(pouchDb.destroy.callCount).to.equal(1);                            // is from from previous day
 
       expect(consoleErrorSpy.callCount).to.equal(0);  // no errors
     });
@@ -265,8 +265,8 @@ describe('TelemetryService', () => {
       expect(dbInstance.put.callCount).to.equal(1);     // Now telemetry IS recorded
 
       let aggregatedDoc = dbInstance.put.args[0][0];
-      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-10-greg/);  // Today is 2018-11-12 but aggregation
-      expect(pouchDb.destroy.callCount).to.equal(1);                    // is from from 2 days ago (not Yesterday)
+      expect(aggregatedDoc._id).to.match(/^telemetry-2018-11-10-greg-[\w-]+$/); // Today 2018-11-12 but aggregation is
+      expect(pouchDb.destroy.callCount).to.equal(1);                            // from from 2 days ago (not Yesterday)
 
       storageGetItemStub.withArgs('medic-greg-telemetry-date').returns(sameDay());  // same day now is 2 days ahead
 
@@ -276,7 +276,7 @@ describe('TelemetryService', () => {
       expect(pouchDb.post.callCount).to.equal(4);       // 4th call
       expect(dbInstance.put.callCount).to.equal(2);     // Telemetry IS recorded again
       aggregatedDoc = dbInstance.put.args[1][0];
-      expect(aggregatedDoc._id).to.match(/telemetry-2018-11-12-greg/);  // It's Nov 19 but aggregation is from Nov 12
+      expect(aggregatedDoc._id).to.match(/^telemetry-2018-11-12-greg-[\w-]+$/); // Now is Nov 19 but agg. is from Nov 12
 
       // A new record is added ...
       clock = sinon.useFakeTimers(moment(NOW).add(2, 'hours').valueOf()); // ... 2 hours later ...
@@ -304,7 +304,7 @@ describe('TelemetryService', () => {
       expect(consoleErrorSpy.callCount).to.equal(0);
       expect(storageSetItemStub.callCount).to.equal(3);
       expect(storageSetItemStub.args[0][0]).to.equal('medic-greg-telemetry-db');
-      expect(storageSetItemStub.args[0][1]).to.match(/^medic-user-greg-telemetry-/)
+      expect(storageSetItemStub.args[0][1]).to.match(/^medic-user-greg-telemetry-[\w-]+$/);
       expect(storageSetItemStub.args[1][0]).to.equal('medic-greg-telemetry-date');
       expect(storageSetItemStub.args[1][1]).to.equal(NOW.toString());
     });
@@ -343,7 +343,7 @@ describe('TelemetryService', () => {
 
       expect(consoleErrorSpy.callCount).to.equal(0);
       expect(dbInstance.put.callCount).to.equal(2);
-      expect(dbInstance.put.args[1][0]._id).to.match(/conflicted/);
+      expect(dbInstance.put.args[1][0]._id).to.match(/^telemetry-2018-11-5-greg-[\w-]+-conflicted-[\w-]+$/);
       expect(dbInstance.put.args[1][0].metadata.conflicted).to.equal(true);
       expect(pouchDb.destroy.callCount).to.equal(1);
       expect(pouchDb.close.callCount).to.equal(0);


### PR DESCRIPTION
# Description

Change telemetry frequency from monthly to **daily**.

medic/cht-core#6915

### Improvements

- Telemetry frequency changed from monthly to daily.
- The id of a telemetry record now looks like `telemetry-<year>-<month>-<day>-<username>-<uuid>`. Also in the `metadata` section a new field `day` is added with the day of the month the data belongs to.
- More test coverage in the telemetry spec.
- Minor improvements in the script to collect meta data from a terminal (`scripts/get_users_meta_docs.js`):
  - Output errors in the standard error stream to see the errors in the console while piping results to a JSON file.
  - Add Unix exec permission and header to execute the script without the `node ` prefix.

Please also review the documentation changes [here](https://github.com/medic/cht-docs/pull/493).

### Bug fixed

It also fix the following ~bugs~ bug found in the current implementation:

When `record()` is called for the first time in the period (a period was a month, now is a day), the record is added to the telemetry DB and then the aggregation is executed with the data that was stored previously, so the aggregation process aggregates all the records from the previous period + a record that is actually from the current period. The last record shouldn't be taken into account in the aggregation submitted.

This represents a minor issue even for daily reports, and it is fixed in this PR just changing the order of the execution: executing first the aggregation if a new period started, and then add the new record.

### Backward compatibility

Systems that rely on telemetry data will need to adequate to the new frequency, but so far the data collected and the schema is the same, with the only addition of the new field `metadata.day`.

There is no special code to "migrate" existent data collected in the devices where the new version is installed: if a device was collecting telemetry data to send next month and then the new version is installed, the app will aggregate the data collected the same day the device is used, and send the aggregation when connection is available, but the record will look like a "daily" aggregation, not monthly, or more precisely "partially monthly". E.g.:

1. A device is in sync with a CHT v3.11 deployment and has been sending monthly aggregation for a while. Last time it sent an aggregation report was May 2nd with the data collected previous month (April). So the id of that reports is something like `telemetry-2021-4-greg-aaabbb1234`.
2. Now is May 12, so the device was recording telemetry data since May 2. All these records were not aggregated yet.
3. On May 13 CHT v3.12.0 is deployed, and the same day the app is synced. The new frequency algorithm is applied so data collected from May 2 to May 13 is aggregated and sent as it was data collected from the last recorded day May 2, the id of the record will be: `telemetry-2021-4-2-greg-aaabbb1234`.
4. Next day data sent will be truly daily aggregated. On May 14 the device will aggregate the data collected on May 13 and the record id will be: `telemetry-2021-5-13-greg-aaabbb1234`. Next day if there is data collected will be `telemetry-2021-5-14-...` and son on. Days that the devices is not used won't have telemetry recorded therefore no reports to send.

So once a upgrade of the CHT is rolled out, first reports will include data from many days, but should be easy to identify these reports because the month in the id (or the field `metadata.month`) will be from the past month, not the current month. If we want to implement a more smooth transition, like send one report for each day the telemetry data has not been aggregated, will require more changes, specially in the device webapp, and not sure if it worth the effort.

CC @helizabetholsen and @dianabarsan on this, let me know if is not clear enough.

### ~To-do~ in another app / issue

medic-couch2pg has a PG view [useview_telemetry](https://github.com/medic/medic-couch2pg/blob/master/libs/medic-users-meta/migrations/202102191153.do.54-create-couchdb-users-meta-table.sql#L20-L31) with the telemetry data, and there is a field field `period_start` that we need to adapt to support these changes. I've created a ticket to keep track of it: [medic-couch2pg#85](https://github.com/medic/medic-couch2pg/issues/85)  →  released in 3.3.0

### Checklist

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on https://github.com/medic/cht-docs/pull/493
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes. --> discussion above.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.