### PR TITLE
Adds telemetry for replication requests

### DIFF
--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -112,6 +112,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   replicate() {
     this.dbSyncService.sync(true);
-    this.telemetryService.record('replication:user-action');
+    this.telemetryService.record('replication:user-initiated');
   }
 }

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -15,6 +15,7 @@ import { DBSyncService } from '@mm-services/db-sync.service';
 import { GuidedSetupComponent } from '@mm-modals/guided-setup/guided-setup.component';
 import { TourSelectComponent } from '@mm-modals/tour/tour-select.component';
 import { TourService } from '@mm-services/tour.service';
+import { TelemetryService } from '@mm-services/telemetry.service';
 
 
 @Component({
@@ -44,6 +45,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private modalService: ModalService,
     private dbSyncService: DBSyncService,
     private tourService: TourService,
+    private telemetryService:TelemetryService,
   ) {
     this.globalActions = new GlobalActions(store);
   }
@@ -110,5 +112,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   replicate() {
     this.dbSyncService.sync(true);
+    this.telemetryService.record('replication:user-action');
   }
 }

--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NgZone } from '@angular/core';
+import { Inject, Injectable, NgZone } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { SessionService } from '@mm-services/session.service';
@@ -275,7 +275,6 @@ export class DBSyncService {
   }
 }
 
-@Injectable()
 class DbSyncTelemetry {
   private readonly telemetryKeyword = 'replication';
   private readonly offlineErrorMessage = 'Failed to fetch';

--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NgZone } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { SessionService } from '@mm-services/session.service';

--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -76,7 +76,7 @@ export class DBSyncService {
     }
   ];
   private inProgressSync;
-  private knownOnlineState = true; // assume the user is online
+  private knownOnlineState = window.navigator.onLine;
   private syncIsRecent = false; // true when a replication has succeeded within one interval
   private readonly intervalPromises = {
     sync: undefined,
@@ -324,7 +324,7 @@ class DbSyncTelemetry {
   }
 
   private getLastReplicatedKey() {
-    return `${this.key}:last-replicated-date`;
+    return `${this.key}:ms-since-last-replicated-date`;
   }
 
   private async record(key) {
@@ -337,9 +337,9 @@ class DbSyncTelemetry {
 
   private recordInfo(info?) {
     if (info) {
-      const nbrDocs =
-        info.docs_read || // result of .replicate contains info for just one direction
-        (info.push?.docs_read + info.pull?.docs_read); // result of .sync contains info for push and pull
+      const nbrDocs = info.push ?
+        (info.push?.docs_read + info.pull?.docs_read) : // result of .sync contains info for push and pull
+        info.docs_read; // result of .replicate contains info for just one direction
       return this.telemetryService.record(this.getDocsKey(), nbrDocs);
     }
   }

--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -341,6 +341,7 @@ class DbSyncTelemetry {
         info.docs_read; // result of .replicate contains info for just one direction
       return this.telemetryService.record(this.getDocsKey(), nbrDocs);
     }
+    return Promise.resolve();
   }
 
   async recordSuccess(info?) {

--- a/webapp/tests/karma/test.ts
+++ b/webapp/tests/karma/test.ts
@@ -20,6 +20,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /db-sync.*\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/webapp/tests/karma/test.ts
+++ b/webapp/tests/karma/test.ts
@@ -20,6 +20,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /db-sync.*\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -180,11 +180,11 @@ describe('DBSync service', () => {
         expect(telemetryService.record.callCount).to.equal(6);
         expect(telemetryService.record.args).to.have.deep.members([
           ['replication:medic:from:success', 1000],
-          ['replication:medic:from:last-replicated-date', 400],
+          ['replication:medic:from:ms-since-last-replicated-date', 400],
           ['replication:medic:from:docs', 45],
 
           ['replication:medic:to:success', 1500],
-          ['replication:medic:to:last-replicated-date', 400],
+          ['replication:medic:to:ms-since-last-replicated-date', 400],
           ['replication:medic:to:docs', 63],
         ]);
       });
@@ -371,12 +371,12 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(7);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 2000],
-            ['replication:medic:from:last-replicated-date', 800],
+            ['replication:medic:from:ms-since-last-replicated-date', 800],
             ['replication:medic:from:docs', 22],
             ['replication:medic:from:failure:reason:offline:server'],
 
             ['replication:medic:to:success', 3000],
-            ['replication:medic:to:last-replicated-date', 800],
+            ['replication:medic:to:ms-since-last-replicated-date', 800],
             ['replication:medic:to:docs', 32],
           ]);
         });
@@ -413,12 +413,12 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(7);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 500],
-            ['replication:medic:from:last-replicated-date', 700],
+            ['replication:medic:from:ms-since-last-replicated-date', 700],
             ['replication:medic:from:docs', 12],
             ['replication:medic:from:failure:reason:offline:client'],
 
             ['replication:medic:to:success', 1000],
-            ['replication:medic:to:last-replicated-date', 700],
+            ['replication:medic:to:ms-since-last-replicated-date', 700],
             ['replication:medic:to:docs', 67],
           ]);
         });
@@ -454,12 +454,12 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(7);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 500],
-            ['replication:medic:from:last-replicated-date', 700],
+            ['replication:medic:from:ms-since-last-replicated-date', 700],
             ['replication:medic:from:docs', 12],
             ['replication:medic:from:failure:reason:error'],
 
             ['replication:medic:to:success', 1000],
-            ['replication:medic:to:last-replicated-date', 700],
+            ['replication:medic:to:ms-since-last-replicated-date', 700],
             ['replication:medic:to:docs', 67],
           ]);
         });
@@ -495,11 +495,11 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(7);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 3000],
-            ['replication:medic:from:last-replicated-date', 800],
+            ['replication:medic:from:ms-since-last-replicated-date', 800],
             ['replication:medic:from:docs', 32],
 
             ['replication:medic:to:failure', 2000],
-            ['replication:medic:to:last-replicated-date', 800],
+            ['replication:medic:to:ms-since-last-replicated-date', 800],
             ['replication:medic:to:docs', 22],
             ['replication:medic:to:failure:reason:offline:server'],
           ]);
@@ -537,11 +537,11 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(7);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 8000],
-            ['replication:medic:from:last-replicated-date', 100],
+            ['replication:medic:from:ms-since-last-replicated-date', 100],
             ['replication:medic:from:docs', 500],
 
             ['replication:medic:to:failure', 1000],
-            ['replication:medic:to:last-replicated-date', 100],
+            ['replication:medic:to:ms-since-last-replicated-date', 100],
             ['replication:medic:to:docs', 12],
             ['replication:medic:to:failure:reason:offline:client'],
           ]);
@@ -575,11 +575,11 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(7);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 700],
-            ['replication:medic:from:last-replicated-date', 100],
+            ['replication:medic:from:ms-since-last-replicated-date', 100],
             ['replication:medic:from:docs', 400],
 
             ['replication:medic:to:failure', 700],
-            ['replication:medic:to:last-replicated-date', 100],
+            ['replication:medic:to:ms-since-last-replicated-date', 100],
             ['replication:medic:to:docs', 6],
             ['replication:medic:to:failure:reason:error'],
           ]);
@@ -618,12 +618,12 @@ describe('DBSync service', () => {
           expect(telemetryService.record.callCount).to.equal(8);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:to:failure', 100],
-            ['replication:medic:to:last-replicated-date', 100],
+            ['replication:medic:to:ms-since-last-replicated-date', 100],
             ['replication:medic:to:docs', 6],
             ['replication:medic:to:failure:reason:error'],
 
             ['replication:medic:from:failure', 200],
-            ['replication:medic:from:last-replicated-date', 100],
+            ['replication:medic:from:ms-since-last-replicated-date', 100],
             ['replication:medic:from:docs', 12],
             ['replication:medic:from:failure:reason:error'],
           ]);
@@ -830,7 +830,7 @@ describe('DBSync service', () => {
         ]);
       });
 
-      it('should record telemetry when failed', async () => {
+      it('should record telemetry when failed because "server" was offline', async () => {
         let syncResolve;
         syncResult = new Promise(resolve => syncResolve = resolve);
 
@@ -839,14 +839,40 @@ describe('DBSync service', () => {
         await Promise.resolve();
         await Promise.resolve();
 
-        sync.events['error']({ message: 'Failed to fetch', result: { docs_read: 10 } });
+        sync.events['error']({ message: 'Failed to fetch', result: { docs_read: 0 } });
         syncResolve();
 
         await syncCall;
 
         expect(telemetryService.record.args).to.have.deep.members([
-          ['replication:meta:sync:success', 1000],
-          ['replication:meta:sync:docs', 100],
+          ['replication:meta:sync:failure', 1000],
+          ['replication:meta:sync:docs', 0],
+          ['replication:meta:sync:failure:reason:offline:server'],
+
+          ['replication:medic:to:success', 0],
+          ['replication:medic:from:success', 0],
+        ]);
+      });
+
+      it('should record telemetry when failed because "client" was offline', async () => {
+        let syncResolve;
+        syncResult = new Promise(resolve => syncResolve = resolve);
+        service.setOnlineStatus(false);
+
+        const syncCall = service.sync(true);
+        clock.tick(1312321);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        sync.events['error']({ message: 'Failed to fetch', result: { docs_read: 13 } });
+        syncResolve();
+
+        await syncCall;
+
+        expect(telemetryService.record.args).to.have.deep.members([
+          ['replication:meta:sync:failure', 1312321],
+          ['replication:meta:sync:docs', 13],
+          ['replication:meta:sync:failure:reason:offline:client'],
 
           ['replication:medic:to:success', 0],
           ['replication:medic:from:success', 0],

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -9,6 +9,7 @@ import { DBSyncService } from '@mm-services/db-sync.service';
 import { DbService } from '@mm-services/db.service';
 import { AuthService } from '@mm-services/auth.service';
 import { CheckDateService } from '@mm-services/check-date.service';
+import { TelemetryService } from '@mm-services/telemetry.service';
 
 describe('DBSync service', () => {
   let service:DBSyncService;
@@ -22,11 +23,13 @@ describe('DBSync service', () => {
   let hasAuth;
   let recursiveOnTo;
   let recursiveOnFrom;
-  let replicationResult;
+  let replicationResultTo;
+  let replicationResultFrom;
   let getItem;
   let dbSyncRetry;
   let rulesEngine;
   let checkDateService;
+  let telemetryService;
 
   let localMedicDb;
   let localMetaDb;
@@ -39,13 +42,15 @@ describe('DBSync service', () => {
   beforeEach(() => {
     clock = sinon.useFakeTimers();
 
-    replicationResult = () => Promise.resolve();
+    replicationResultTo = Promise.resolve();
+    replicationResultFrom = Promise.resolve();
+
     to = sinon.stub();
     to.events = {};
     recursiveOnTo = sinon.stub();
     recursiveOnTo.callsFake((event, fn) => {
       to.events[event] = fn;
-      const promise = replicationResult();
+      const promise = replicationResultTo;
       promise.on = recursiveOnTo;
       return promise;
     });
@@ -55,7 +60,7 @@ describe('DBSync service', () => {
     recursiveOnFrom = sinon.stub();
     recursiveOnFrom.callsFake((event, fn) => {
       from.events[event] = fn;
-      const promise = replicationResult();
+      const promise = replicationResultFrom;
       promise.on = recursiveOnFrom;
       return promise;
     });
@@ -64,10 +69,10 @@ describe('DBSync service', () => {
     userCtx = sinon.stub();
     sync = sinon.stub();
     sync.events = {};
-    syncResult = () => Promise.resolve();
+    syncResult = Promise.resolve();
     recursiveOnSync = sinon.stub().callsFake((event, fn) => {
       sync.events[event] = fn;
-      const promise = syncResult();
+      const promise = syncResult;
       promise.on = recursiveOnSync;
       return promise;
     });
@@ -75,6 +80,7 @@ describe('DBSync service', () => {
     hasAuth = sinon.stub();
     dbSyncRetry = sinon.stub();
     rulesEngine = { monitorExternalChanges: sinon.stub() };
+    telemetryService = { record: sinon.stub().resolves() };
 
     localMedicDb = {
       replicate: { to: to, from: from },
@@ -105,6 +111,7 @@ describe('DBSync service', () => {
         { provide: AuthService, useValue: { has: hasAuth } },
         { provide: DbSyncRetryService, useValue: { retryForbiddenFailure: dbSyncRetry } },
         { provide: RulesEngineService, useValue: rulesEngine },
+        { provide: TelemetryService, useValue: telemetryService },
         { provide: CheckDateService, useValue: checkDateService },
       ]
     });
@@ -141,6 +148,45 @@ describe('DBSync service', () => {
         expect(to.args[0][1]).to.have.keys('filter', 'checkpoint', 'batch_size');
         expect(checkDateService.check.callCount).to.equal(1);
         expect(checkDateService.check.args[0]).to.deep.equal([]);
+      });
+    });
+
+    it('should record telemetry for bi-directional replication', async () => {
+      isOnlineOnly.returns(false);
+      hasAuth.resolves(true);
+      getItem.withArgs('medic-last-replicated-date').returns(100);
+      clock.tick(500);
+
+
+      let fromResolve;
+      let toResolve;
+      replicationResultFrom = new Promise(resolve => fromResolve = resolve);
+      replicationResultTo = new Promise(resolve => toResolve = resolve);
+
+      const syncResult = service.sync();
+      await Promise.resolve();
+
+      clock.tick(1000);
+      fromResolve({ docs_read: 45 });
+      await Promise.resolve();
+
+      clock.tick(500);
+      toResolve({ docs_read: 63 });
+
+      return syncResult.then(() => {
+        expect(from.callCount).to.equal(1);
+        expect(to.callCount).to.equal(1);
+
+        expect(telemetryService.record.callCount).to.equal(6);
+        expect(telemetryService.record.args).to.have.deep.members([
+          ['replication:medic:from:success', 1000],
+          ['replication:medic:from:last-replicated-date', 400],
+          ['replication:medic:from:docs', 45],
+
+          ['replication:medic:to:success', 1500],
+          ['replication:medic:to:last-replicated-date', 400],
+          ['replication:medic:to:docs', 63],
+        ]);
       });
     });
 
@@ -192,7 +238,7 @@ describe('DBSync service', () => {
       isOnlineOnly.returns(false);
       hasAuth.resolves(true);
 
-      replicationResult = () => Promise.reject('error');
+      replicationResultTo = replicationResultFrom = Promise.reject('error');
       const onUpdate = sinon.stub();
       service.subscribe(onUpdate);
       localMedicDb.info.resolves({ update_seq: 100 });
@@ -213,7 +259,7 @@ describe('DBSync service', () => {
       isOnlineOnly.returns(false);
       hasAuth.resolves(true);
 
-      replicationResult = () => Promise.reject('error');
+      replicationResultTo = replicationResultFrom = Promise.reject('error');
       const onUpdate = sinon.stub();
       service.subscribe(onUpdate);
 
@@ -231,7 +277,7 @@ describe('DBSync service', () => {
       isOnlineOnly.returns(false);
       hasAuth.resolves(true);
 
-      replicationResult = () => Promise.resolve({ some: 'info' });
+      replicationResultFrom = Promise.resolve({ some: 'info' });
       const onUpdate = sinon.stub();
       service.subscribe(onUpdate);
 
@@ -291,6 +337,297 @@ describe('DBSync service', () => {
         expect(onUpdate.callCount).to.eq(2);
         expect(onUpdate.args[0][0]).to.deep.eq({ state: 'inProgress' });
         expect(onUpdate.args[1][0]).to.deep.eq({ to: 'success', from: 'success' });
+      });
+    });
+
+    describe('telemetry when replication fails', () => {
+      it('when from fails and maybe server is offline', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(200);
+        clock.tick(1000);
+
+        let fromReject;
+        let toResolve;
+        replicationResultFrom = new Promise((resolve, reject) => fromReject = reject);
+        replicationResultTo = new Promise(resolve => toResolve = resolve);
+
+        const syncResult = service.sync();
+        await Promise.resolve();
+
+        clock.tick(2000);
+        const error = { message: 'Failed to fetch', result: { docs_read: 22 } };
+        fromReject(error);
+        from.events['error'](error);
+        await Promise.resolve();
+
+        clock.tick(1000);
+        toResolve({ docs_read: 32 });
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(7);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:from:failure', 2000],
+            ['replication:medic:from:last-replicated-date', 800],
+            ['replication:medic:from:docs', 22],
+            ['replication:medic:from:failure:reason:offline:server'],
+
+            ['replication:medic:to:success', 3000],
+            ['replication:medic:to:last-replicated-date', 800],
+            ['replication:medic:to:docs', 32],
+          ]);
+        });
+      });
+
+      it('when from fails and client is offline', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(300);
+        clock.tick(1000);
+        service.setOnlineStatus(false);
+
+        let fromReject;
+        let toResolve;
+        replicationResultFrom = new Promise((resolve, reject) => fromReject = reject);
+        replicationResultTo = new Promise(resolve => toResolve = resolve);
+
+        const syncResult = service.sync(true);
+        await Promise.resolve();
+
+        clock.tick(500);
+        const error = { message: 'Failed to fetch', result: { docs_read: 12 } };
+        fromReject(error);
+        from.events['error'](error);
+        await Promise.resolve();
+
+        clock.tick(500);
+        toResolve({ docs_read: 67 });
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(7);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:from:failure', 500],
+            ['replication:medic:from:last-replicated-date', 700],
+            ['replication:medic:from:docs', 12],
+            ['replication:medic:from:failure:reason:offline:client'],
+
+            ['replication:medic:to:success', 1000],
+            ['replication:medic:to:last-replicated-date', 700],
+            ['replication:medic:to:docs', 67],
+          ]);
+        });
+      });
+
+      it('when from fails from another error', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(300);
+        clock.tick(1000);
+
+        let fromReject;
+        let toResolve;
+        replicationResultFrom = new Promise((resolve, reject) => fromReject = reject);
+        replicationResultTo = new Promise(resolve => toResolve = resolve);
+
+        const syncResult = service.sync();
+        await Promise.resolve();
+
+        clock.tick(500);
+        const error = { message: 'BOOM', result: { docs_read: 12 } };
+        fromReject(error);
+        from.events['error'](error);
+        await Promise.resolve();
+
+        clock.tick(500);
+        toResolve({ docs_read: 67 });
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(7);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:from:failure', 500],
+            ['replication:medic:from:last-replicated-date', 700],
+            ['replication:medic:from:docs', 12],
+            ['replication:medic:from:failure:reason:error'],
+
+            ['replication:medic:to:success', 1000],
+            ['replication:medic:to:last-replicated-date', 700],
+            ['replication:medic:to:docs', 67],
+          ]);
+        });
+      });
+
+      it('when to fails and maybe server is offline', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(200);
+        clock.tick(1000);
+
+        let fromResolve;
+        let toReject;
+        replicationResultFrom = new Promise(resolve => fromResolve = resolve);
+        replicationResultTo = new Promise((resolve, reject) => toReject = reject);
+
+        const syncResult = service.sync();
+        await Promise.resolve();
+
+        clock.tick(2000);
+        const error = { message: 'Failed to fetch', result: { docs_read: 22 } };
+        toReject(error);
+        to.events['error'](error);
+        await Promise.resolve();
+
+        clock.tick(1000);
+        fromResolve({ docs_read: 32 });
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(7);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:from:success', 3000],
+            ['replication:medic:from:last-replicated-date', 800],
+            ['replication:medic:from:docs', 32],
+
+            ['replication:medic:to:failure', 2000],
+            ['replication:medic:to:last-replicated-date', 800],
+            ['replication:medic:to:docs', 22],
+            ['replication:medic:to:failure:reason:offline:server'],
+          ]);
+        });
+      });
+
+      it('when to fails and client is offline', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(200);
+        service.setOnlineStatus(false);
+        clock.tick(300);
+
+        let fromResolve;
+        let toReject;
+        replicationResultFrom = new Promise(resolve => fromResolve = resolve);
+        replicationResultTo = new Promise((resolve, reject) => toReject = reject);
+
+        const syncResult = service.sync(true);
+        await Promise.resolve();
+
+        clock.tick(1000);
+        const error = { message: 'Failed to fetch', result: { docs_read: 12 } };
+        toReject(error);
+        to.events['error'](error);
+        await Promise.resolve();
+
+        clock.tick(7000);
+        fromResolve({ docs_read: 500 });
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(7);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:from:success', 8000],
+            ['replication:medic:from:last-replicated-date', 100],
+            ['replication:medic:from:docs', 500],
+
+            ['replication:medic:to:failure', 1000],
+            ['replication:medic:to:last-replicated-date', 100],
+            ['replication:medic:to:docs', 12],
+            ['replication:medic:to:failure:reason:offline:client'],
+          ]);
+        });
+      });
+
+      it('when to fails from other error', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(200);
+        clock.tick(300);
+
+        let fromResolve;
+        let toReject;
+        replicationResultFrom = new Promise(resolve => fromResolve = resolve);
+        replicationResultTo = new Promise((resolve, reject) => toReject = reject);
+
+        const syncResult = service.sync(true);
+        await Promise.resolve();
+
+        clock.tick(700);
+        const error = { message: 'Not failed to fetch', result: { docs_read: 6 } };
+        toReject(error);
+        to.events['error'](error);
+        fromResolve({ docs_read: 400 });
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(7);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:from:success', 700],
+            ['replication:medic:from:last-replicated-date', 100],
+            ['replication:medic:from:docs', 400],
+
+            ['replication:medic:to:failure', 700],
+            ['replication:medic:to:last-replicated-date', 100],
+            ['replication:medic:to:docs', 6],
+            ['replication:medic:to:failure:reason:error'],
+          ]);
+        });
+      });
+
+      it('when both fail', async () => {
+        isOnlineOnly.returns(false);
+        hasAuth.resolves(true);
+        getItem.withArgs('medic-last-replicated-date').returns(200);
+        clock.tick(300);
+
+        let fromReject;
+        let toReject;
+        replicationResultFrom = new Promise((resolve, reject) => fromReject = reject);
+        replicationResultTo = new Promise((resolve, reject) => toReject = reject);
+
+        const syncResult = service.sync(true);
+        await Promise.resolve();
+
+        clock.tick(100);
+        const errorTo = { message: 'Not failed to fetch', result: { docs_read: 6 } };
+        toReject(errorTo);
+        to.events['error'](errorTo);
+        await Promise.resolve();
+
+        clock.tick(100);
+        const errorFrom = { message: 'Not failed to fetch', result: { docs_read: 12 } };
+        fromReject(errorFrom);
+        from.events['error'](errorFrom);
+
+        return syncResult.then(() => {
+          expect(from.callCount).to.equal(1);
+          expect(to.callCount).to.equal(1);
+
+          expect(telemetryService.record.callCount).to.equal(8);
+          expect(telemetryService.record.args).to.have.deep.members([
+            ['replication:medic:to:failure', 100],
+            ['replication:medic:to:last-replicated-date', 100],
+            ['replication:medic:to:docs', 6],
+            ['replication:medic:to:failure:reason:error'],
+
+            ['replication:medic:from:failure', 200],
+            ['replication:medic:from:last-replicated-date', 100],
+            ['replication:medic:from:docs', 12],
+            ['replication:medic:from:failure:reason:error'],
+          ]);
+        });
       });
     });
 
@@ -386,6 +723,8 @@ describe('DBSync service', () => {
         expect(dbSyncRetry.callCount).to.equal(0);
         expect(consoleErrorMock.callCount).to.equal(1);
         expect(consoleErrorMock.args[0][0]).to.equal('Denied replicating from remote server');
+        expect(telemetryService.record.args).to.include.deep.members([['replication:medic:from:denied']]);
+        expect(telemetryService.record.args).to.not.include.deep.members([['replication:medic:to:denied']]);
       });
     });
 
@@ -401,6 +740,8 @@ describe('DBSync service', () => {
         expect(from.callCount).to.equal(1);
         expect(consoleErrorMock.callCount).to.equal(1);
         expect(consoleErrorMock.args[0][0]).to.equal('Denied replicating to remote server');
+        expect(telemetryService.record.args).to.not.include.deep.members([['replication:medic:from:denied']]);
+        expect(telemetryService.record.args).to.include.deep.members([['replication:medic:to:denied']]);
       });
     });
   });
@@ -464,6 +805,52 @@ describe('DBSync service', () => {
           expect(localMetaDb.put.callCount).to.equal(1);
           expect(localMetaDb.put.args[0]).to.deep.equal([{ _id: '_local/purgelog', synced_seq: 100, purged_seq: 10 }]);
         });
+      });
+
+      it('should record telemetry when successful', async () => {
+        let syncResolve;
+        syncResult = new Promise(resolve => syncResolve = resolve);
+
+        const syncCall = service.sync();
+        clock.tick(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        sync.events['complete']({ pull: { docs_read: 100 }, push: { docs_read: 32 } });
+        syncResolve();
+
+        await syncCall;
+
+        expect(telemetryService.record.args).to.have.deep.members([
+          ['replication:meta:sync:success', 1000],
+          ['replication:meta:sync:docs', 132],
+
+          ['replication:medic:to:success', 0],
+          ['replication:medic:from:success', 0],
+        ]);
+      });
+
+      it('should record telemetry when failed', async () => {
+        let syncResolve;
+        syncResult = new Promise(resolve => syncResolve = resolve);
+
+        const syncCall = service.sync();
+        clock.tick(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        sync.events['error']({ message: 'Failed to fetch', result: { docs_read: 10 } });
+        syncResolve();
+
+        await syncCall;
+
+        expect(telemetryService.record.args).to.have.deep.members([
+          ['replication:meta:sync:success', 1000],
+          ['replication:meta:sync:docs', 100],
+
+          ['replication:medic:to:success', 0],
+          ['replication:medic:from:success', 0],
+        ]);
       });
     });
   });


### PR DESCRIPTION
# Description

The following telemetry records are added: 

| key | value | recorded | 
| --- | ------- | -------- | 
| `replication:user-initiated`  | 1 | when the user clicks "Sync now" | 
| `replication:<database>:<direction>:success` | number representing how long in took to replicate, in ms | when replication is successful | 
| `replication:<database>:<direction>:failure` | number representing how long in took to replicate, in ms | when replication is failed | 
| `replication:<database>:<direction>:failure:reason:offline:client` | 1 | replication fails because of connection error and the app detects the client is offline | 
|  `replication:<database>:<direction>:failure:reason:offline:server` | 1 | replication fails because of connection error and the app detects the client is online | 
| `replication:<database>:<direction>:failure:reason:error` | 1 | replication fails because of other errors |
| `replication:<database>:<direction>:docs` | number of replicated docs | For one-directional, stores number of "read" docs, for sync, stores sum of read docs for every direction. | 
| `replication:medic:<direction>:ms-since-last-replicated-date` |  number in ms representing the difference between now and when the client last replicated successfully | only recorded for medic database, every time replication is attempted | 
| `replication:medic:<direction>:denied` | 1 | when replication is denied | 

Unless otherwise specified, <database> and <direction> placeholders stand for any combination of:
| database | direction | 
| --- | --- | 
| `medic` | `from` or `to`  | 
| `meta` | `sync` | 


medic/cht-core#6354

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
