### PR TITLE
Adds failed and delivered WO messages count to monitoring API

### DIFF
--- a/api/src/controllers/monitoring.js
+++ b/api/src/controllers/monitoring.js
@@ -3,12 +3,12 @@ const serverUtils = require('../server-utils');
 
 module.exports = {
   getV1: (req, res) => {
-    return service.v1()
+    return service.jsonV1()
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
   },
   getV2: (req, res) => {
-    return service.v2()
+    return service.jsonV2()
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
   },

--- a/api/src/controllers/monitoring.js
+++ b/api/src/controllers/monitoring.js
@@ -3,12 +3,14 @@ const serverUtils = require('../server-utils');
 
 module.exports = {
   getV1: (req, res) => {
-    return service.jsonV1()
+    return service
+      .jsonV1()
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
   },
   getV2: (req, res) => {
-    return service.jsonV2()
+    return service
+      .jsonV2()
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
   },

--- a/api/src/controllers/monitoring.js
+++ b/api/src/controllers/monitoring.js
@@ -2,9 +2,14 @@ const service = require('../services/monitoring');
 const serverUtils = require('../server-utils');
 
 module.exports = {
-  get: (req, res) => {
-    return service.json()
+  getV1: (req, res) => {
+    return service.v1()
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
-  }
+  },
+  getV2: (req, res) => {
+    return service.v2()
+      .then(body => res.json(body))
+      .catch(err => serverUtils.error(err, req, res));
+  },
 };

--- a/api/src/middleware/deprecation.js
+++ b/api/src/middleware/deprecation.js
@@ -1,0 +1,11 @@
+const logger = require('../logger');
+
+module.exports = {
+  deprecate: (replacement) => {
+    return (req, res, next) => {
+      const message = `${req.path} is deprecated.${replacement ? ` Please use ${replacement} instead.`: ''}`;
+      logger.warn(message);
+      next();
+    };
+  },
+};

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -337,7 +337,8 @@ app.get('/api/deploy-info', (req, res) => {
   res.json(environment.getDeployInfo());
 });
 
-app.get('/api/v1/monitoring', monitoring.get);
+app.get('/api/v1/monitoring', monitoring.getV1);
+app.get('/api/v2/monitoring', monitoring.getV2);
 
 app.get('/api/auth/:path', function(req, res) {
   auth.checkUrl(req)

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -35,6 +35,7 @@ const africasTalking = require('./controllers/africas-talking');
 const rapidPro = require('./controllers/rapidpro');
 const infodoc = require('./controllers/infodoc');
 const authorization = require('./middleware/authorization');
+const deprecation = require('./middleware/deprecation');
 const hydration = require('./controllers/hydration');
 const contactsByPhone = require('./controllers/contacts-by-phone');
 const createUserDb = require('./controllers/create-user-db');
@@ -337,7 +338,7 @@ app.get('/api/deploy-info', (req, res) => {
   res.json(environment.getDeployInfo());
 });
 
-app.get('/api/v1/monitoring', monitoring.getV1);
+app.get('/api/v1/monitoring', deprecation.deprecate('/api/v2/monitoring'), monitoring.getV1);
 app.get('/api/v2/monitoring', monitoring.getV2);
 
 app.get('/api/auth/:path', function(req, res) {

--- a/api/src/services/monitoring.js
+++ b/api/src/services/monitoring.js
@@ -196,6 +196,10 @@ const getWeeklyOutgoingMessageStatusCounter = () => {
     });
 };
 
+const getLastMessagesOutgoingStateCounter = () => {
+
+};
+
 const getReplicationLimitLog = () => {
   return db.medicLogs
     .query('logs/replication_limit')
@@ -248,10 +252,8 @@ const json = () => {
         },
         messaging: {
           outgoing: {
-            state: outgoingMessageStatus
-          },
-          outgoing_7_days: {
-            state: weeklyOutgoingMessageStatus,
+            total: outgoingMessageStatus,
+            seven_days: weeklyOutgoingMessageStatus,
           },
         },
         outbound_push: {

--- a/api/src/services/monitoring.js
+++ b/api/src/services/monitoring.js
@@ -196,10 +196,6 @@ const getWeeklyOutgoingMessageStatusCounter = () => {
     });
 };
 
-const getLastMessagesOutgoingStateCounter = () => {
-
-};
-
 const getReplicationLimitLog = () => {
   return db.medicLogs
     .query('logs/replication_limit')

--- a/api/tests/mocha/controllers/monitoring.spec.js
+++ b/api/tests/mocha/controllers/monitoring.spec.js
@@ -12,16 +12,16 @@ describe('Monitoring controller', () => {
 
   afterEach(() => sinon.restore());
 
-  describe('JSON', () => {
+  describe('v1', () => {
 
     beforeEach(() => {
       req = { query: {} };
       res = { json: sinon.stub() };
     });
-  
+
     it('returns successfully', () => {
-      sinon.stub(service, 'json').resolves({ version: { app: '1.2.3' } });
-      return controller.get(req, res).then(() => {
+      sinon.stub(service, 'v1').resolves({ version: { app: '1.2.3' } });
+      return controller.getV1(req, res).then(() => {
         chai.expect(res.json.callCount).to.equal(1);
         chai.expect(res.json.args[0][0]).to.deep.equal({
           version: {
@@ -32,9 +32,41 @@ describe('Monitoring controller', () => {
     });
 
     it('handles promise rejection gracefully', () => {
-      sinon.stub(service, 'json').rejects(new Error('something missing'));
+      sinon.stub(service, 'v1').rejects(new Error('something missing'));
       sinon.stub(serverUtils, 'error').returns();
-      return controller.get(req, res).then(() => {
+      return controller.getV1(req, res).then(() => {
+        chai.expect(serverUtils.error.callCount).to.equal(1);
+        chai.expect(res.json.callCount).to.equal(0);
+      });
+    });
+
+  });
+
+  describe('v2', () => {
+
+    beforeEach(() => {
+      req = { query: {} };
+      res = { json: sinon.stub() };
+    });
+
+    it('returns successfully', () => {
+      sinon.stub(service, 'v2').resolves({ version: { app: '4.5.6' } });
+      return controller.getV2(req, res).then(() => {
+        chai.expect(service.v2.callCount).to.equal(1);
+        chai.expect(res.json.callCount).to.equal(1);
+        chai.expect(res.json.args[0][0]).to.deep.equal({
+          version: {
+            app: '4.5.6',
+          }
+        });
+      });
+    });
+
+    it('handles promise rejection gracefully', () => {
+      sinon.stub(service, 'v2').rejects(new Error('something missing'));
+      sinon.stub(serverUtils, 'error').returns();
+      return controller.getV2(req, res).then(() => {
+        chai.expect(service.v2.callCount).to.equal(1);
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(res.json.callCount).to.equal(0);
       });

--- a/api/tests/mocha/controllers/monitoring.spec.js
+++ b/api/tests/mocha/controllers/monitoring.spec.js
@@ -20,7 +20,7 @@ describe('Monitoring controller', () => {
     });
 
     it('returns successfully', () => {
-      sinon.stub(service, 'v1').resolves({ version: { app: '1.2.3' } });
+      sinon.stub(service, 'jsonV1').resolves({ version: { app: '1.2.3' } });
       return controller.getV1(req, res).then(() => {
         chai.expect(res.json.callCount).to.equal(1);
         chai.expect(res.json.args[0][0]).to.deep.equal({
@@ -32,7 +32,7 @@ describe('Monitoring controller', () => {
     });
 
     it('handles promise rejection gracefully', () => {
-      sinon.stub(service, 'v1').rejects(new Error('something missing'));
+      sinon.stub(service, 'jsonV1').rejects(new Error('something missing'));
       sinon.stub(serverUtils, 'error').returns();
       return controller.getV1(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
@@ -50,9 +50,9 @@ describe('Monitoring controller', () => {
     });
 
     it('returns successfully', () => {
-      sinon.stub(service, 'v2').resolves({ version: { app: '4.5.6' } });
+      sinon.stub(service, 'jsonV2').resolves({ version: { app: '4.5.6' } });
       return controller.getV2(req, res).then(() => {
-        chai.expect(service.v2.callCount).to.equal(1);
+        chai.expect(service.jsonV2.callCount).to.equal(1);
         chai.expect(res.json.callCount).to.equal(1);
         chai.expect(res.json.args[0][0]).to.deep.equal({
           version: {
@@ -63,10 +63,10 @@ describe('Monitoring controller', () => {
     });
 
     it('handles promise rejection gracefully', () => {
-      sinon.stub(service, 'v2').rejects(new Error('something missing'));
+      sinon.stub(service, 'jsonV2').rejects(new Error('something missing'));
       sinon.stub(serverUtils, 'error').returns();
       return controller.getV2(req, res).then(() => {
-        chai.expect(service.v2.callCount).to.equal(1);
+        chai.expect(service.jsonV2.callCount).to.equal(1);
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(res.json.callCount).to.equal(0);
       });

--- a/api/tests/mocha/middleware/deprecation.spec.js
+++ b/api/tests/mocha/middleware/deprecation.spec.js
@@ -1,0 +1,58 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const deprecation = require('../../../src/middleware/deprecation');
+const logger = require('../../../src/logger');
+
+describe('deprecation middleware', () => {
+  let req;
+  let res;
+  let next;
+
+  beforeEach(() => {
+    next = sinon.stub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return a function', () => {
+    const middleware = deprecation.deprecate();
+    expect(middleware).to.be.a('function');
+  });
+
+  it('should log current req path and point to replacement', () => {
+    sinon.stub(logger, 'warn');
+    req = { path: '/old-endpoint' };
+
+    const middleware = deprecation.deprecate('/new-endpoint');
+
+    expect(logger.warn.callCount).to.equal(0);
+    expect(next.callCount).to.equal(0);
+
+    middleware(req, res, next);
+
+    expect(logger.warn.callCount).to.equal(1);
+    expect(logger.warn.args[0]).to.deep.equal(['/old-endpoint is deprecated. Please use /new-endpoint instead.']);
+    expect(next.callCount).to.equal(1);
+    expect(next.args[0]).to.deep.equal([]);
+  });
+
+  it('should work without replacement', () => {
+    sinon.stub(logger, 'warn');
+    req = { path: '/v1/something' };
+
+    const middleware = deprecation.deprecate();
+
+    expect(logger.warn.callCount).to.equal(0);
+    expect(next.callCount).to.equal(0);
+
+    middleware(req, res, next);
+
+    expect(logger.warn.callCount).to.equal(1);
+    expect(logger.warn.args[0]).to.deep.equal(['/v1/something is deprecated.']);
+    expect(next.callCount).to.equal(1);
+    expect(next.args[0]).to.deep.equal([]);
+  });
+});

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -149,23 +149,21 @@ describe('Monitoring service', () => {
       });
       chai.expect(actual.messaging).to.deep.equal({
         outgoing: {
-          state: {
+          total: {
             due: 3,
             scheduled: 15,
             muted: 0,
             failed: 20,
             delivered: 10,
-          }
-        },
-        outgoing_7_days: {
-          state: {
+          },
+          seven_days: {
             due: 20,
             scheduled: 0,
             muted: 0,
             failed: 5,
             delivered: 15,
           }
-        }
+        },
       });
       chai.expect(actual.sentinel).to.deep.equal({ backlog: 24 });
       chai.expect(actual.outbound_push).to.deep.equal({ backlog: 3 });
@@ -224,22 +222,20 @@ describe('Monitoring service', () => {
       });
       chai.expect(actual.messaging).to.deep.equal({
         outgoing: {
-          state: {
-            due: -1,
-            scheduled: -1,
-            muted: -1,
-            failed: -1,
-            delivered: -1,
-          }
-        },
-        outgoing_7_days: {
-          state: {
+          total: {
             due: -1,
             scheduled: -1,
             muted: -1,
             failed: -1,
             delivered: -1,
           },
+          seven_days: {
+            due: -1,
+            scheduled: -1,
+            muted: -1,
+            failed: -1,
+            delivered: -1,
+          }
         },
       });
       chai.expect(actual.sentinel).to.deep.equal({ backlog: -1 });

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const chai = require('chai');
 const request = require('request-promise-native');
+const _ = require('lodash');
 
 const db = require('../../../src/db');
 const environment = require('../../../src/environment');
@@ -96,6 +97,38 @@ const setUpMocks = () => {
     .resolves({ rows: [ { value: 1 } ] });
 };
 
+const generateRows = (statusCounters) => {
+  const rows = [];
+  Object.entries(statusCounters).forEach(([status, counter]) => {
+    rows.push(...Array.from({ length: counter }).map(() => ({ key: ['group', 100, status] })));
+  });
+  return _.shuffle(rows);
+};
+
+const setupV2Mocks = (statusCounters) => {
+  const view = 'medic-sms/messages_by_last_updated_state';
+  const finalRows = generateRows({
+    sent: statusCounters.sent,
+    delivered: statusCounters.delivered,
+    failed: statusCounters.failed,
+  });
+  const pendingRows = generateRows({
+    pending: statusCounters.pending,
+    'forwarded-to-gateway': statusCounters['forwarded-to-gateway'],
+  });
+  const mutedRows = generateRows({
+    denied: statusCounters.denied,
+    cleared: statusCounters.cleared,
+  });
+  db.medic.query
+    .withArgs(view, sinon.match({ start_key: sinon.match.array.startsWith(['final']) }))
+    .resolves({ rows: finalRows })
+    .withArgs(view, sinon.match({ start_key: sinon.match.array.startsWith(['pending']) }))
+    .resolves({ rows: pendingRows })
+    .withArgs(view, sinon.match({ start_key: sinon.match.array.startsWith(['muted']) }))
+    .resolves({ rows: mutedRows });
+};
+
 describe('Monitoring service', () => {
 
   beforeEach(() => {
@@ -107,10 +140,79 @@ describe('Monitoring service', () => {
     sinon.restore();
   });
 
-  it('json returns successfully', () => {
+  it('v1 returns successfully', () => {
     setUpMocks();
 
-    return service.json().then(actual => {
+    return service.v1().then(actual => {
+      chai.expect(request.post.callCount).to.equal(1);
+      chai.expect(actual.version).to.deep.equal({
+        app: '5.3.2',
+        node: process.version,
+        couchdb: 'v3.3.3'
+      });
+      chai.expect(actual.couchdb).to.deep.equal({
+        medic: {
+          doc_count: 20,
+          doc_del_count: 10,
+          fragmentation: 1.1666666666666667,
+          name: 'mydb',
+          update_sequence: 100
+        },
+        sentinel: {
+          doc_count: 30,
+          doc_del_count: 20,
+          fragmentation: 1,
+          name: 'mydb-sentinel',
+          update_sequence: 200
+        },
+        users: {
+          doc_count: 50,
+          doc_del_count: 40,
+          fragmentation: 1.002,
+          name: '_users',
+          update_sequence: 400
+        },
+        usersmeta: {
+          doc_count: 40,
+          doc_del_count: 30,
+          fragmentation: 10,
+          name: 'mydb-users-meta',
+          update_sequence: 300
+        }
+      });
+      chai.expect(actual.messaging).to.deep.equal({
+        outgoing: {
+          state: {
+            due: 3,
+            scheduled: 15,
+            muted: 0,
+            failed: 20,
+            delivered: 10,
+          },
+        },
+      });
+      chai.expect(actual.sentinel).to.deep.equal({ backlog: 24 });
+      chai.expect(actual.outbound_push).to.deep.equal({ backlog: 3 });
+      chai.expect(actual.feedback).to.deep.equal({ count: 2 });
+      chai.expect(actual.conflict).to.deep.equal({ count: 40 });
+      chai.expect(actual.date.current).to.equal(0);
+      chai.expect(actual.replication_limit.count).to.equal(1);
+    });
+  });
+
+  it('v2 returns successfully', () => {
+    setUpMocks();
+    setupV2Mocks({
+      pending: 30,
+      'forwarded-to-gateway': 70,
+      sent: 20,
+      delivered: 70,
+      failed: 10,
+      denied: 20,
+      cleared: 30,
+    });
+
+    return service.v2().then(actual => {
       chai.expect(request.post.callCount).to.equal(1);
       chai.expect(actual.version).to.deep.equal({
         app: '5.3.2',
@@ -162,7 +264,26 @@ describe('Monitoring service', () => {
             muted: 0,
             failed: 5,
             delivered: 15,
-          }
+          },
+          last_hundred: {
+            final: {
+              sent: 20,
+              delivered: 70,
+              failed: 10,
+            },
+            pending: {
+              pending: 30,
+              'forwarded-to-gateway': 70,
+              'forwarded-by-gateway': 0,
+              'received-by-gateway': 0,
+            },
+            muted: {
+              denied: 20,
+              cleared: 30,
+              duplicate: 0,
+              muted: 0,
+            },
+          },
         },
       });
       chai.expect(actual.sentinel).to.deep.equal({ backlog: 24 });
@@ -174,7 +295,7 @@ describe('Monitoring service', () => {
     });
   });
 
-  it('handles errors gracefully', () => {
+  it('v1 handles errors gracefully', () => {
     sinon.stub(db.medic, 'get').withArgs('_design/medic').rejects();
     sinon.stub(request, 'get').withArgs(sinon.match({ url: environment.serverUrl })).rejects();
     sinon.stub(request, 'post').withArgs(sinon.match({ url: `${environment.serverUrl}/_dbs_info` })).rejects();
@@ -184,7 +305,71 @@ describe('Monitoring service', () => {
     sinon.stub(db.medicUsersMeta, 'query').rejects();
     sinon.stub(db.medicLogs, 'query').rejects();
 
-    return service.json().then(actual => {
+    return service.v1().then(actual => {
+      chai.expect(actual.version).to.deep.equal({
+        app: '',
+        node: process.version,
+        couchdb: ''
+      });
+      chai.expect(actual.couchdb).to.deep.equal({
+        medic: {
+          doc_count: -1,
+          doc_del_count: -1,
+          fragmentation: -1,
+          name: '',
+          update_sequence: -1
+        },
+        sentinel: {
+          doc_count: -1,
+          doc_del_count: -1,
+          fragmentation: -1,
+          name: '',
+          update_sequence: -1
+        },
+        users: {
+          doc_count: -1,
+          doc_del_count: -1,
+          fragmentation: -1,
+          name: '',
+          update_sequence: -1
+        },
+        usersmeta: {
+          doc_count: -1,
+          doc_del_count: -1,
+          fragmentation: -1,
+          name: '',
+          update_sequence: -1
+        }
+      });
+      chai.expect(actual.messaging).to.deep.equal({
+        outgoing: {
+          state: {
+            due: -1,
+            scheduled: -1,
+            muted: -1,
+            failed: -1,
+            delivered: -1,
+          },
+        },
+      });
+      chai.expect(actual.sentinel).to.deep.equal({ backlog: -1 });
+      chai.expect(actual.outbound_push).to.deep.equal({ backlog: -1 });
+      chai.expect(actual.feedback).to.deep.equal({ count: -1 });
+      chai.expect(actual.replication_limit).to.deep.equal({ count: -1 });
+    });
+  });
+
+  it('v2 handles errors gracefully', () => {
+    sinon.stub(db.medic, 'get').withArgs('_design/medic').rejects();
+    sinon.stub(request, 'get').withArgs(sinon.match({ url: environment.serverUrl })).rejects();
+    sinon.stub(request, 'post').withArgs(sinon.match({ url: `${environment.serverUrl}/_dbs_info` })).rejects();
+    sinon.stub(db.sentinel, 'get').withArgs('_local/sentinel-meta-data').rejects();
+    sinon.stub(db.medic, 'query').rejects();
+    sinon.stub(db.sentinel, 'query').rejects();
+    sinon.stub(db.medicUsersMeta, 'query').rejects();
+    sinon.stub(db.medicLogs, 'query').rejects();
+
+    return service.v2().then(actual => {
       chai.expect(actual.version).to.deep.equal({
         app: '',
         node: process.version,
@@ -235,7 +420,26 @@ describe('Monitoring service', () => {
             muted: -1,
             failed: -1,
             delivered: -1,
-          }
+          },
+          last_hundred: {
+            final: {
+              sent: -1,
+              delivered: -1,
+              failed: -1,
+            },
+            pending: {
+              pending: -1,
+              'forwarded-to-gateway': -1,
+              'forwarded-by-gateway': -1,
+              'received-by-gateway': -1,
+            },
+            muted: {
+              denied: -1,
+              cleared: -1,
+              duplicate: -1,
+              muted: -1,
+            },
+          },
         },
       });
       chai.expect(actual.sentinel).to.deep.equal({ backlog: -1 });
@@ -245,7 +449,7 @@ describe('Monitoring service', () => {
     });
   });
 
-  it('handles empty reduce response correctly', () => {
+  it('v1 handles empty reduce response correctly', () => {
     sinon.stub(db.medic, 'get').withArgs('_design/medic')
       .resolves({ version: '5.3.2' });
     sinon.stub(request, 'get').withArgs(sinon.match({ url: environment.serverUrl }))
@@ -263,7 +467,7 @@ describe('Monitoring service', () => {
     sinon.stub(db.sentinel, 'query').resolves({ rows: [] });
     sinon.stub(db.medicUsersMeta, 'query').resolves({ rows: [] });
     sinon.stub(db.medicLogs, 'query').resolves({ rows: [] });
-    return service.json().then(actual => {
+    return service.v1().then(actual => {
       chai.expect(actual.outbound_push).to.deep.equal({ backlog: 0 });
       chai.expect(actual.feedback).to.deep.equal({ count: 0 });
     });

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -99,9 +99,11 @@ const setUpMocks = () => {
 
 const generateRows = (statusCounters) => {
   const rows = [];
-  Object.entries(statusCounters).forEach(([status, counter]) => {
-    rows.push(...Array.from({ length: counter }).map(() => ({ key: ['group', 100, status] })));
-  });
+  Object
+    .entries(statusCounters)
+    .forEach(([status, counter]) => {
+      rows.push(...Array.from({ length: counter }).map(() => ({ key: ['group', 100, status] })));
+    });
   return _.shuffle(rows);
 };
 

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -68,7 +68,7 @@ const setUpMocks = () => {
     .withArgs(sinon.match({ url: `${environment.couchUrl}/_changes` })).resolves({ pending: 24 });
   sinon.stub(request, 'post').withArgs(sinon.match({ url: `${environment.serverUrl}/_dbs_info` }))
     .resolves(dbInfos);
-  sinon.stub(db.sentinel, 'get').withArgs('_local/sentinel-meta-data')
+  sinon.stub(db.sentinel, 'get').withArgs('_local/transitions-seq')
     .resolves({ processed_seq: '50-xyz' });
   const medicQuery = sinon.stub(db.medic, 'query');
   medicQuery.withArgs('medic-admin/message_queue')
@@ -143,7 +143,7 @@ describe('Monitoring service', () => {
   it('v1 returns successfully', () => {
     setUpMocks();
 
-    return service.v1().then(actual => {
+    return service.jsonV1().then(actual => {
       chai.expect(request.post.callCount).to.equal(1);
       chai.expect(actual.version).to.deep.equal({
         app: '5.3.2',
@@ -212,7 +212,7 @@ describe('Monitoring service', () => {
       cleared: 30,
     });
 
-    return service.v2().then(actual => {
+    return service.jsonV2().then(actual => {
       chai.expect(request.post.callCount).to.equal(1);
       chai.expect(actual.version).to.deep.equal({
         app: '5.3.2',
@@ -299,13 +299,13 @@ describe('Monitoring service', () => {
     sinon.stub(db.medic, 'get').withArgs('_design/medic').rejects();
     sinon.stub(request, 'get').withArgs(sinon.match({ url: environment.serverUrl })).rejects();
     sinon.stub(request, 'post').withArgs(sinon.match({ url: `${environment.serverUrl}/_dbs_info` })).rejects();
-    sinon.stub(db.sentinel, 'get').withArgs('_local/sentinel-meta-data').rejects();
+    sinon.stub(db.sentinel, 'get').withArgs('_local/transitions-seq').rejects();
     sinon.stub(db.medic, 'query').rejects();
     sinon.stub(db.sentinel, 'query').rejects();
     sinon.stub(db.medicUsersMeta, 'query').rejects();
     sinon.stub(db.medicLogs, 'query').rejects();
 
-    return service.v1().then(actual => {
+    return service.jsonV1().then(actual => {
       chai.expect(actual.version).to.deep.equal({
         app: '',
         node: process.version,
@@ -363,13 +363,13 @@ describe('Monitoring service', () => {
     sinon.stub(db.medic, 'get').withArgs('_design/medic').rejects();
     sinon.stub(request, 'get').withArgs(sinon.match({ url: environment.serverUrl })).rejects();
     sinon.stub(request, 'post').withArgs(sinon.match({ url: `${environment.serverUrl}/_dbs_info` })).rejects();
-    sinon.stub(db.sentinel, 'get').withArgs('_local/sentinel-meta-data').rejects();
+    sinon.stub(db.sentinel, 'get').withArgs('_local/transitions-seq').rejects();
     sinon.stub(db.medic, 'query').rejects();
     sinon.stub(db.sentinel, 'query').rejects();
     sinon.stub(db.medicUsersMeta, 'query').rejects();
     sinon.stub(db.medicLogs, 'query').rejects();
 
-    return service.v2().then(actual => {
+    return service.jsonV2().then(actual => {
       chai.expect(actual.version).to.deep.equal({
         app: '',
         node: process.version,
@@ -456,7 +456,7 @@ describe('Monitoring service', () => {
       .resolves({ version: 'v3.3.3' });
     sinon.stub(request, 'post').withArgs(sinon.match({ url: `${environment.serverUrl}/_dbs_info` }))
       .resolves(dbInfos);
-    sinon.stub(db.sentinel, 'get').withArgs('_local/sentinel-meta-data')
+    sinon.stub(db.sentinel, 'get').withArgs('_local/transitions-seq')
       .resolves({ processed_seq: '50-xyz' });
     sinon.stub(db.medic, 'query')
       .resolves({ rows: [
@@ -467,7 +467,7 @@ describe('Monitoring service', () => {
     sinon.stub(db.sentinel, 'query').resolves({ rows: [] });
     sinon.stub(db.medicUsersMeta, 'query').resolves({ rows: [] });
     sinon.stub(db.medicLogs, 'query').resolves({ rows: [] });
-    return service.v1().then(actual => {
+    return service.jsonV1().then(actual => {
       chai.expect(actual.outbound_push).to.deep.equal({ backlog: 0 });
       chai.expect(actual.feedback).to.deep.equal({ count: 0 });
     });

--- a/ddocs/medic-db/medic-sms/views/messages_by_last_updated_state/map.js
+++ b/ddocs/medic-db/medic-sms/views/messages_by_last_updated_state/map.js
@@ -1,9 +1,23 @@
 function (doc) {
+  var finalStatuses = ['sent', 'delivered', 'failed'];
+  var mutedStatuses = ['muted', 'cleared', 'denied', 'duplicate'];
+  var scheduledStatus = 'scheduled';
+
   var _emit = function(tasks) {
     tasks.forEach(function(task) {
       var history = task.state_history && task.state_history[task.state_history.length - 1];
       var lastUpdated = new Date(history && history.timestamp || task.timestamp || doc.reported_date).getTime();
-      emit([lastUpdated, task.state]);
+
+      var statusGroup = 'pending';
+      if (task.state === scheduledStatus) {
+        statusGroup = scheduledStatus;
+      } else if (finalStatuses.indexOf(task.state) > -1) {
+        statusGroup = 'final';
+      } else if (mutedStatuses.indexOf(task.state) > -1) {
+        statusGroup = 'muted';
+      }
+
+      emit([statusGroup, lastUpdated, task.state]);
     });
   };
   _emit(doc.tasks || []);

--- a/ddocs/medic-db/medic-sms/views/messages_by_last_updated_state/map.js
+++ b/ddocs/medic-db/medic-sms/views/messages_by_last_updated_state/map.js
@@ -1,0 +1,11 @@
+function (doc) {
+  var _emit = function(tasks) {
+    tasks.forEach(function(task) {
+      var history = task.state_history && task.state_history[task.state_history.length - 1];
+      var lastUpdated = new Date(history && history.timestamp || task.timestamp || doc.reported_date).getTime();
+      emit([lastUpdated, task.state]);
+    });
+  };
+  _emit(doc.tasks || []);
+  _emit(doc.scheduled_tasks || []);
+}

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -8,6 +8,8 @@ const browserLogStream = fs.createWriteStream(
 );
 
 const chai = require('chai');
+chai.use(require('chai-exclude'));
+chai.use(require('chai-shallow-deep-equal'));
 // so the .to.have.members will display the array members when assertions fail instead of [ Array(6) ]
 chai.config.truncateThreshold = 0;
 
@@ -18,8 +20,15 @@ const baseConfig = {
   SELENIUM_PROMISE_MANAGER: false,
   seleniumAddress: 'http://localhost:4444/wd/hub',
   suites: {
-    web: [ 'e2e/!(cht)/**/*.js','e2e/*.js', 'mobile/**/*.js', 'medic-conf/**/*.js'],
-    cht: ['e2e/cht/*.spec.js'],
+    web: [
+      'e2e/!(cht)/**/*.js',
+      'e2e/*.js',
+      'mobile/**/*.js',
+      'medic-conf/**/*.js'
+    ],
+    cht: [
+      'e2e/cht/*.spec.js'
+    ],
     mobile: [],
     // performance: 'performance/**/*.js'
   },

--- a/tests/e2e/api/controllers/all-docs.spec.js
+++ b/tests/e2e/api/controllers/all-docs.spec.js
@@ -1,6 +1,4 @@
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const _ = require('lodash');
 const utils = require('../../../utils');
 const constants = require('../../../constants');

--- a/tests/e2e/api/controllers/bulk-docs.spec.js
+++ b/tests/e2e/api/controllers/bulk-docs.spec.js
@@ -1,6 +1,4 @@
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const _ = require('lodash');
 const utils = require('../../../utils');
 const sUtils = require('../../sentinel/utils');

--- a/tests/e2e/api/controllers/bulk-get.spec.js
+++ b/tests/e2e/api/controllers/bulk-get.spec.js
@@ -1,6 +1,4 @@
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const _ = require('lodash');
 const utils = require('../../../utils');
 const constants = require('../../../constants');

--- a/tests/e2e/api/controllers/contacts-by-phone.spec.js
+++ b/tests/e2e/api/controllers/contacts-by-phone.spec.js
@@ -1,6 +1,4 @@
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const utils = require('../../../utils');
 const _ = require('lodash');
 

--- a/tests/e2e/api/controllers/db-doc.spec.js
+++ b/tests/e2e/api/controllers/db-doc.spec.js
@@ -1,7 +1,5 @@
 const _ = require('lodash');
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const utils = require('../../../utils');
 const sUtils = require('../../sentinel/utils');
 const constants = require('../../../constants');

--- a/tests/e2e/api/controllers/hydration.spec.js
+++ b/tests/e2e/api/controllers/hydration.spec.js
@@ -1,6 +1,4 @@
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const utils = require('../../../utils');
 const _ = require('lodash');
 

--- a/tests/e2e/api/controllers/monitoring.spec.js
+++ b/tests/e2e/api/controllers/monitoring.spec.js
@@ -1,0 +1,188 @@
+const { expect } = require('chai');
+
+const utils = require('../../../utils');
+const sentinelUtils = require('../../sentinel/utils');
+
+const getAppVersion = async () => {
+  const deployInfo = await utils.request({ path: '/api/deploy-info' });
+  return deployInfo.version;
+};
+
+const getCouchDBVersion = async () => {
+  const serverInfo = await getInfo('');
+  return serverInfo.version;
+};
+
+const getInfo = (db) => utils.request({ path: `/${db}` });
+const getUpdateSeq = (info) => parseInt(info.update_seq.split('-')[0]);
+
+describe('monitoring', () => {
+  beforeEach(() => sentinelUtils.waitForSentinel());
+  afterEach(() => utils.afterEach());
+
+  describe('v1', () => {
+    it('should return empty values for empty db', async () => {
+      const medicInfo = await getInfo('medic');
+      const sentinelInfo = await getInfo('medic-test-sentinel');
+      const usersMetaInfo = await getInfo('medic-test-users-meta');
+      const usersInfo = await getInfo('_users');
+
+      const result = await utils.request({ path: '/api/v1/monitoring' });
+      expect(result).excludingEvery(['current', 'uptime', 'date', 'fragmentation']).to.deep.equal({
+        version: {
+          app: await getAppVersion(),
+          node: process.version,
+          couchdb: await getCouchDBVersion(),
+        },
+        couchdb: {
+          medic: {
+            name: 'medic-test',
+            update_sequence: getUpdateSeq(medicInfo),
+            doc_count: medicInfo.doc_count,
+            doc_del_count: medicInfo.doc_del_count,
+          },
+          sentinel: {
+            name: 'medic-test-sentinel',
+            update_sequence: getUpdateSeq(sentinelInfo),
+            doc_count: sentinelInfo.doc_count,
+            doc_del_count: sentinelInfo.doc_del_count,
+          },
+          usersmeta: {
+            name: 'medic-test-users-meta',
+            update_sequence: getUpdateSeq(usersMetaInfo),
+            doc_count: usersMetaInfo.doc_count,
+            doc_del_count: usersMetaInfo.doc_del_count,
+          },
+          users: {
+            name: '_users',
+            update_sequence: getUpdateSeq(usersInfo),
+            doc_count: usersInfo.doc_count,
+            doc_del_count: usersInfo.doc_del_count,
+          },
+        },
+        sentinel: {
+          backlog: await sentinelUtils.getBacklogCount(),
+        },
+        messaging: {
+          outgoing: {
+            state: {
+              due: 0,
+              scheduled: 0,
+              muted: 0,
+              failed: 0,
+              delivered: 0,
+            }
+          }
+        },
+        outbound_push: {
+          backlog: 0,
+        },
+        feedback: {
+          count: 0,
+        },
+        conflict: {
+          count: 0,
+        },
+        replication_limit: {
+          count: 0,
+        },
+      });
+    });
+  });
+
+  describe('v2', () => {
+    it('should return empty values for empty db', async () => {
+      const medicInfo = await getInfo('medic');
+      const sentinelInfo = await getInfo('medic-test-sentinel');
+      const usersMetaInfo = await getInfo('medic-test-users-meta');
+      const usersInfo = await getInfo('_users');
+
+      const result = await utils.request({ path: '/api/v2/monitoring' });
+      expect(result).excludingEvery(['current', 'uptime', 'date', 'fragmentation']).to.deep.equal({
+        version: {
+          app: await getAppVersion(),
+          node: process.version,
+          couchdb: await getCouchDBVersion(),
+        },
+        couchdb: {
+          medic: {
+            name: 'medic-test',
+            update_sequence: getUpdateSeq(medicInfo),
+            doc_count: medicInfo.doc_count,
+            doc_del_count: medicInfo.doc_del_count,
+          },
+          sentinel: {
+            name: 'medic-test-sentinel',
+            update_sequence: getUpdateSeq(sentinelInfo),
+            doc_count: sentinelInfo.doc_count,
+            doc_del_count: sentinelInfo.doc_del_count,
+          },
+          usersmeta: {
+            name: 'medic-test-users-meta',
+            update_sequence: getUpdateSeq(usersMetaInfo),
+            doc_count: usersMetaInfo.doc_count,
+            doc_del_count: usersMetaInfo.doc_del_count,
+          },
+          users: {
+            name: '_users',
+            update_sequence: getUpdateSeq(usersInfo),
+            doc_count: usersInfo.doc_count,
+            doc_del_count: usersInfo.doc_del_count,
+          },
+        },
+        sentinel: {
+          backlog: await sentinelUtils.getBacklogCount(),
+        },
+        messaging: {
+          outgoing: {
+            total: {
+              due: 0,
+              scheduled: 0,
+              muted: 0,
+              failed: 0,
+              delivered: 0,
+            },
+            seven_days: {
+              due: 0,
+              scheduled: 0,
+              muted: 0,
+              failed: 0,
+              delivered: 0,
+            },
+            last_hundred: {
+              pending: {
+                pending: 0,
+                'forwarded-to-gateway': 0,
+                'received-by-gateway': 0,
+                'forwarded-by-gateway': 0,
+              },
+              final: {
+                sent: 0,
+                delivered: 0,
+                failed: 0,
+              },
+              muted: {
+                denied: 0,
+                cleared: 0,
+                muted: 0,
+                duplicate: 0,
+              }
+            }
+          }
+        },
+        outbound_push: {
+          backlog: 0,
+        },
+        feedback: {
+          count: 0,
+        },
+        conflict: {
+          count: 0,
+        },
+        replication_limit: {
+          count: 0,
+        },
+      });
+    });
+  });
+});

--- a/tests/e2e/login/db-sync-filter.spec.js
+++ b/tests/e2e/login/db-sync-filter.spec.js
@@ -3,8 +3,6 @@ const commonElements = require('../../page-objects/common/common.po.js');
 const utils = require('../../utils');
 const loginPage = require('../../page-objects/login/login.po.js');
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
-chai.use(chaiExclude);
 const uuid = require('uuid/v4');
 
 /* global window */

--- a/tests/e2e/sentinel/utils.js
+++ b/tests/e2e/sentinel/utils.js
@@ -4,6 +4,8 @@ const constants = require('../../constants');
 const _ = require('lodash');
 
 const SKIPPED_BY_SENTINEL = /^_design\/|(-info|____tombstone)$/;
+const TRANSITION_SEQ = '/_local/transitions-seq';
+const BACKGROUND_SEQ = '/_local/background-seq';
 
 //
 // Waits for a procedure that logs its progress to a metadata document (such as sentinel
@@ -23,10 +25,7 @@ const waitForSeq = (metadataId, docIds) => {
     })
     .then(metaData => metaData.value)
     .then(seq => {
-      const opts = {
-        path: '/_changes',
-        headers: { 'Content-Type': 'application/json' },
-      };
+      const opts = { path: '/_changes' };
       if (docIds) {
         opts.path = `${opts.path}?${querystring.stringify({ since: seq, filter: '_doc_ids' })}`;
         opts.method = 'POST';
@@ -107,10 +106,15 @@ const waitForPurgeCompletion = seq => {
 };
 
 const getCurrentSeq = () => requestOnSentinelTestDb('').then(data => data.update_seq);
+const getBacklogCount = () => {
+  return requestOnSentinelTestDb(TRANSITION_SEQ)
+    .then(metadata => utils.request({ path: '/medic/_changes', qs: { limit: 0, since: metadata.value } }))
+    .then(result => result.pending);
+};
 
 module.exports = {
-  waitForSentinel: docIds => waitForSeq('/_local/transitions-seq', docIds),
-  waitForBackgroundCleanup: docIds => waitForSeq('/_local/background-seq', docIds),
+  waitForSentinel: docIds => waitForSeq(TRANSITION_SEQ, docIds),
+  waitForBackgroundCleanup: docIds => waitForSeq(BACKGROUND_SEQ, docIds),
   requestOnSentinelTestDb: requestOnSentinelTestDb,
   getInfoDoc: getInfoDoc,
   getInfoDocs: getInfoDocs,
@@ -118,4 +122,5 @@ module.exports = {
   waitForPurgeCompletion: waitForPurgeCompletion,
   getCurrentSeq: getCurrentSeq,
   getPurgeDbs: getPurgeDbs,
+  getBacklogCount: getBacklogCount,
 };

--- a/tests/e2e/transitions/sms_workflows.spec.js
+++ b/tests/e2e/transitions/sms_workflows.spec.js
@@ -2,9 +2,7 @@ const utils = require('../../utils');
 const sentinelUtils = require('../sentinel/utils');
 
 const chai = require('chai');
-const chaiExclude = require('chai-exclude');
 const commonPo = require('../../page-objects/common/common.po');
-chai.use(chaiExclude);
 
 const contacts = [
   {


### PR DESCRIPTION
# Description

Updates `medic-admin/message_queue` to separately index failed (`failed`) and delivered (`delivered` and `sent`) outgoing messages. 
Adds `monitoring.messaging.outgoing..state.delivered` and `monitoring.messaging.outgoing.state.failed` counters. 
Fixes `monitoring.sentinel.backlog` not using the new metadata doc. 
Adds `/api/v2/monitoring` endpoint with the following changes compared to `api/v1/monitoring`:
- Renames `monitoring.messaging.outgoing.state`. to `monitoring.messaging.outgoing.total`. 
- Adds a new section `monitoring.messaging.outgoing.seven_days` that includes the same metrics, but only covers the last 7 days. 
- Adds a new section `monitoring.messaging.outgoing.last_hundred` that groups messages by statuses (pending, final, muted) and displays counts statuses for last 100 updated messages per group. 


medic/cht-core#6572
medic/cht-core#7113

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
