### PR TITLE
Upgrade moment.js to latest version

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -229,9 +229,9 @@
       "optional": true
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -24,7 +24,7 @@
     "jquery": "^3.6.0",
     "lodash": "^4.17.19",
     "messageformat": "^2.3.0",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "mustache": "^4.2.0",
     "ng-redux": "^4.4.3",
     "object-path": "^0.11.5",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1079,9 +1079,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "morgan": {
       "version": "1.10.0",

--- a/api/package.json
+++ b/api/package.json
@@ -29,7 +29,7 @@
     "http-proxy": "^1.18.1",
     "locale": "^0.1.0",
     "lodash": "^4.17.19",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "morgan": "^1.10.0",
     "mustache": "^4.2.0",
     "node-cache": "^5.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13842,9 +13842,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
     "moment-locales-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "loose-envify": "^1.4.0",
     "medic-conf": "^3.2.1",
     "mocha": "^7.2.0",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "moment-locales-webpack-plugin": "^1.2.0",
     "node-sass": "^4.14.1",
     "nodemon": "^2.0.7",

--- a/sentinel/package-lock.json
+++ b/sentinel/package-lock.json
@@ -447,9 +447,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.3",

--- a/sentinel/package.json
+++ b/sentinel/package.json
@@ -16,7 +16,7 @@
     "gsm": "^0.1.4",
     "later": "^1.2.0",
     "lodash": "^4.17.19",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "mustache": "^4.2.0",
     "object-path": "^0.11.5",
     "pouchdb-adapter-http": "^7.2.2",

--- a/shared-libs/calendar-interval/package-lock.json
+++ b/shared-libs/calendar-interval/package-lock.json
@@ -741,9 +741,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.1",

--- a/shared-libs/calendar-interval/package.json
+++ b/shared-libs/calendar-interval/package.json
@@ -14,6 +14,6 @@
     "sinon": "^8.1.1"
   },
   "dependencies": {
-    "moment": "^2.26.0"
+    "moment": "^2.29.1"
   }
 }

--- a/shared-libs/message-utils/package-lock.json
+++ b/shared-libs/message-utils/package-lock.json
@@ -712,9 +712,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.1",

--- a/shared-libs/message-utils/package.json
+++ b/shared-libs/message-utils/package.json
@@ -17,7 +17,7 @@
     "google-libphonenumber": "^3.2.19",
     "gsm": "^0.1.4",
     "lodash": "^4.17.19",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "mustache": "^4.2.0",
     "object-path": "^0.11.5"
   }

--- a/shared-libs/rules-engine/package-lock.json
+++ b/shared-libs/rules-engine/package-lock.json
@@ -1368,9 +1368,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
     "ms": {

--- a/shared-libs/rules-engine/package.json
+++ b/shared-libs/rules-engine/package.json
@@ -30,7 +30,7 @@
     "chai": "^4.3.4",
     "chai-exclude": "^2.0.3",
     "mocha": "^7.2.0",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "pouchdb": "^7.2.2",
     "pouchdb-adapter-memory": "^7.2.2",
     "sinon": "^8.1.1"

--- a/shared-libs/search/package-lock.json
+++ b/shared-libs/search/package-lock.json
@@ -740,9 +740,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.1",

--- a/shared-libs/search/package.json
+++ b/shared-libs/search/package.json
@@ -15,6 +15,6 @@
   },
   "dependencies": {
     "lodash": "^4.17.19",
-    "moment": "^2.26.0"
+    "moment": "^2.29.1"
   }
 }

--- a/shared-libs/transitions/package-lock.json
+++ b/shared-libs/transitions/package-lock.json
@@ -1045,9 +1045,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.1",

--- a/shared-libs/transitions/package.json
+++ b/shared-libs/transitions/package.json
@@ -30,7 +30,7 @@
     "google-libphonenumber": "^3.2.19",
     "gsm": "^0.1.4",
     "lodash": "^4.17.19",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "mustache": "^4.2.0",
     "object-path": "^0.11.5",
     "request": "^2.88.2",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -286,9 +286,9 @@
       "optional": true
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "messageformat": "^2.3.0",
-    "moment": "^2.26.0",
+    "moment": "^2.29.1",
     "mustache": "^4.2.0",
     "ngrx-store-logger": "^0.2.4",
     "ngx-bootstrap": "^6.2.0",

--- a/webapp/patches/moment-hindi-use-euro-numerals.patch
+++ b/webapp/patches/moment-hindi-use-euro-numerals.patch
@@ -1,41 +1,48 @@
-*** /home/diana/projects/medic/webapp/node_modules/moment/locale/hi.js	1985-10-26 10:15:00.000000000 +0200
---- ./hi.js	2020-06-02 20:53:31.173865742 +0300
+*** node_modules/moment/locale/hi.js	Sat Oct 26 15:15:00 1985
+--- patches/hi.js	Fri May 21 16:56:36 2021
 ***************
 *** 11,41 ****
   
       //! moment.js locale configuration
   
--     var symbolMap = {
--             '1': '१',
--             '2': '२',
--             '3': '३',
--             '4': '४',
--             '5': '५',
--             '6': '६',
--             '7': '७',
--             '8': '८',
--             '9': '९',
--             '0': '०',
--         },
--         numberMap = {
--             '१': '1',
--             '२': '2',
--             '३': '3',
--             '४': '4',
--             '५': '5',
--             '६': '6',
--             '७': '7',
--             '८': '8',
--             '९': '9',
--             '०': '0',
--         };
-- 
-      var hi = moment.defineLocale('hi', {
-          months: 'जनवरी_फ़रवरी_मार्च_अप्रैल_मई_जून_जुलाई_अगस्त_सितम्बर_अक्टूबर_नवम्बर_दिसम्बर'.split(
-              '_'
---- 11,16 ----
+!     var symbolMap = {
+!             1: '१',
+!             2: '२',
+!             3: '३',
+!             4: '४',
+!             5: '५',
+!             6: '६',
+!             7: '७',
+!             8: '८',
+!             9: '९',
+!             0: '०',
+!         },
+!         numberMap = {
+!             '१': '1',
+!             '२': '2',
+!             '३': '3',
+!             '४': '4',
+!             '५': '5',
+!             '६': '6',
+!             '७': '7',
+!             '८': '8',
+!             '९': '9',
+!             '०': '0',
+!         },
+!         monthsParse = [
+              /^जन/i,
+              /^फ़र|फर/i,
+              /^मार्च/i,
+--- 11,17 ----
+  
+      //! moment.js locale configuration
+  
+!     var monthsParse = [
+              /^जन/i,
+              /^फ़र|फर/i,
+              /^मार्च/i,
 ***************
-*** 80,93 ****
+*** 125,138 ****
               yy: '%d वर्ष',
           },
           preparse: function (string) {
@@ -50,7 +57,7 @@
           },
           // Hindi notation for meridiems are quite fuzzy in practice. While there exists
           // a rigid notion of a 'Pahar' it is not used as rigidly in modern Hindi.
---- 55,64 ----
+--- 101,110 ----
               yy: '%d वर्ष',
           },
           preparse: function (string) {


### PR DESCRIPTION
# Description

This PR:
- Fixes the MomentJS patch
- Upgrades the MomentJS to 2.29.1 in CHT-Core's apps

https://github.com/medic/cht-core/issues/7084

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
