### PR TITLE
"Sync Now" also syncronize "meta" db

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -18,7 +18,7 @@ They live in the `tests` directories of each app. Run them with grunt: `grunt un
 ## Stack overview
 
 ### Requirements
-Follow the guide [DEVELOPMENT.md](DEVELOPMENT.MD)
+Follow the guide [DEVELOPMENT.md](DEVELOPMENT.md)
 JDK installed for Selenium.
 Docker to run couchdb.
 
@@ -97,7 +97,7 @@ Documented here are two ways to run individual tests and have your IDE break on 
 1. Optionally set the Protractor options to `--capabilities.chromeOptions.args=start-maximized --jasmine.DEFAULT_TIMEOUT_INTERVAL=120000`.
 1. Select the radio button for Test.
 1. Enter the path to the Test file Ex: `<cht-core-repo>/tests/e2e/login/login.specs.js`.
-1. Enter the test name. This is a bit of a chore. IntelliJ will automatically add the regex flags for begins(`^`) of line and end of line(`$`). Protractor presents the name for matching as the Describe description followed by the It description. To run the login test for should have a title you would need to put this as your matcher. `Login tests : should have a title`. An alternative would be to select Test File and run the entire file. You can add an `x` in front of `it` to disable the ones you do not need. EX: `xit('should login`)
+1. Enter the test name. This is a bit of a chore. IntelliJ will automatically add the regex flags for begins(`^`) of line and end of line(`$`). Protractor presents the name for matching as the Describe description followed by the It description. To run the login test for should have a title you would need to put this as your matcher. `Login tests : should have a title`. An alternative would be to select Test File and run the entire file. You can add an `x` in front of `it` to disable the ones you do not need. EX: `xit('should login')`.
 1. Click ok.
 1. Click the run configuration dropdown and select the protractor config. 
 1. In a terminal run `grunt e2e-deploy`   NOTE: This has to happen each time you run. 

--- a/tests/e2e/contacts/new-lineage-structure.wdio-spec.js
+++ b/tests/e2e/contacts/new-lineage-structure.wdio-spec.js
@@ -74,7 +74,7 @@ describe('Create new lineage structure', () => {
     chai.expect(await contactPage.editPerson(name, updatedName)).to.equal(updatedName);
   });
 
-  xit('should delete the primary contact of health facility', async () => {
+  it('should delete the primary contact of health facility', async () => {
     await contactPage.selectLHSRowByText(area);
     await contactPage.deletePerson(centerContact);
     chai.expect(await contactPage.getAllRHSPeopleNames()).to.not.have.members([centerContact]);

--- a/tests/e2e/contacts/new-lineage-structure.wdio-spec.js
+++ b/tests/e2e/contacts/new-lineage-structure.wdio-spec.js
@@ -74,7 +74,7 @@ describe('Create new lineage structure', () => {
     chai.expect(await contactPage.editPerson(name, updatedName)).to.equal(updatedName);
   });
 
-  it('should delete the primary contact of health facility', async () => {
+  xit('should delete the primary contact of health facility', async () => {
     await contactPage.selectLHSRowByText(area);
     await contactPage.deletePerson(centerContact);
     chai.expect(await contactPage.getAllRHSPeopleNames()).to.not.have.members([centerContact]);

--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -269,7 +269,7 @@ export class DBSyncService {
       return Promise.resolve();
     }
 
-    if (!this.intervalPromises.meta) {
+    if (!this.intervalPromises.meta || force) {
       this.intervalPromises.meta = setInterval(this.syncMeta.bind(this), META_SYNC_INTERVAL);
       this.syncMeta();
     }

--- a/webapp/tests/karma/ts/services/db-sync-retry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync-retry.service.spec.ts
@@ -26,7 +26,6 @@ describe('DBSyncRetry service', () => {
 
   afterEach(() => sinon.restore());
 
-
   describe('retryForbiddenFailure', () => {
     it('should do nothing when no error', () => {
       const result = service.retryForbiddenFailure();

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -44,11 +44,11 @@ describe('DBSync service', () => {
   const realSetTimeout = setTimeout;
   const nextTick = () => new Promise(resolve => realSetTimeout(() => resolve()));
 
-  const expectSyncCall = (numCalls = 1) => {
+  const expectSyncCall = (numCalls) => {
     expect(from.callCount).to.equal(numCalls);
     expect(to.callCount).to.equal(numCalls);
   };
-  const expectSyncMetaCall = (numCalls = 1) => {
+  const expectSyncMetaCall = (numCalls) => {
     expect(db.withArgs({ meta: true }).callCount).to.equal(numCalls);
     expect(db.withArgs({ meta: true, remote: true }).callCount).to.equal(numCalls);
   };
@@ -150,13 +150,13 @@ describe('DBSync service', () => {
       return service.sync().then(() => {
         expect(hasAuth.callCount).to.equal(1);
         expect(hasAuth.args[0][0]).to.equal('can_edit');
-        expectSyncCall();
+        expectSyncCall(1);
         expect(from.args[0][1]).to.have.keys('heartbeat', 'timeout', 'batch_size');
         expect(from.args[0][1]).to.not.have.keys('filter', 'checkpoint');
         expect(to.args[0][1]).to.have.keys('filter', 'checkpoint', 'batch_size');
         expect(checkDateService.check.callCount).to.equal(1);
         expect(checkDateService.check.args[0]).to.deep.equal([]);
-        expectSyncMetaCall();
+        expectSyncMetaCall(1);
       });
     });
 
@@ -185,7 +185,7 @@ describe('DBSync service', () => {
       toResolve({ docs_read: 63 });
 
       return syncResult.then(() => {
-        expectSyncCall();
+        expectSyncCall(1);
         expect(telemetryService.record.callCount).to.equal(8);
         expect(telemetryService.record.args).to.have.deep.members([
           ['replication:medic:from:success', 1000],
@@ -230,7 +230,7 @@ describe('DBSync service', () => {
 
       service.sync();
       return service.sync().then(() => {
-        expectSyncCall();
+        expectSyncCall(1);
       });
     });
 
@@ -240,7 +240,7 @@ describe('DBSync service', () => {
 
       service.setOnlineStatus(false);
       return service.sync(true).then(() => {
-        expectSyncCall();
+        expectSyncCall(1);
         expect(checkDateService.check.callCount).to.equal(1);
       });
     });
@@ -306,12 +306,12 @@ describe('DBSync service', () => {
 
       // sync with default online status
       await service.sync();
-      expectSyncCall();
+      expectSyncCall(1);
       // go offline, don't attempt to sync
       service.setOnlineStatus(false);
       clock.tick(25 * 60 * 1000 + 1);
       await nextTick();
-      expectSyncCall();
+      expectSyncCall(1);
 
       // when you come back online eventually, sync immediately
       service.setOnlineStatus(true);
@@ -379,7 +379,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 32 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 2000],
@@ -423,7 +423,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 32 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
 
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
@@ -469,7 +469,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 67 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 500],
@@ -511,7 +511,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 67 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 500],
@@ -553,7 +553,7 @@ describe('DBSync service', () => {
         fromResolve({ docs_read: 32 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 3000],
@@ -596,7 +596,7 @@ describe('DBSync service', () => {
         fromResolve({ docs_read: 500 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 8000],
@@ -635,7 +635,7 @@ describe('DBSync service', () => {
         fromResolve({ docs_read: 400 });
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 700],
@@ -679,7 +679,7 @@ describe('DBSync service', () => {
         from.events['error'](errorFrom);
 
         return syncResult.then(() => {
-          expectSyncCall();
+          expectSyncCall(1);
           expect(telemetryService.record.callCount).to.equal(10);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:to:failure', 100],
@@ -804,7 +804,7 @@ describe('DBSync service', () => {
         to.events.denied({ some: 'err' });
         expect(dbSyncRetry.callCount).to.equal(1);
         expect(dbSyncRetry.args[0]).to.deep.equal([{ some: 'err' }]);
-        expectSyncCall();
+        expectSyncCall(1);
         expect(consoleErrorMock.callCount).to.equal(1);
         expect(consoleErrorMock.args[0][0]).to.equal('Denied replicating to remote server');
         expect(telemetryService.record.args).to.not.include.deep.members([['replication:medic:from:denied']]);
@@ -840,7 +840,7 @@ describe('DBSync service', () => {
         from.events.change(replicationResult);
         expect(rulesEngine.monitorExternalChanges.callCount).to.equal(1);
         expect(rulesEngine.monitorExternalChanges.args[0]).to.deep.equal([replicationResult]);
-        expectSyncCall();
+        expectSyncCall(1);
       });
     });
 
@@ -852,7 +852,7 @@ describe('DBSync service', () => {
 
       it('should sync meta dbs with no filter', () => {
         return service.sync().then(() => {
-          expectSyncMetaCall();
+          expectSyncMetaCall(1);
           expect(localMetaDb.replicate.from.callCount).to.equal(1);
           expect(localMetaDb.replicate.from.args[0]).to.deep.equal([remoteMetaDb]);
           expect(localMetaDb.replicate.to.callCount).to.equal(1);

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -44,6 +44,15 @@ describe('DBSync service', () => {
   const realSetTimeout = setTimeout;
   const nextTick = () => new Promise(resolve => realSetTimeout(() => resolve()));
 
+  const expectSyncCall = (numCalls = 1) => {
+    expect(from.callCount).to.equal(numCalls);
+    expect(to.callCount).to.equal(numCalls);
+  };
+  const expectSyncMetaCall = (numCalls = 1) => {
+    expect(db.withArgs({ meta: true }).callCount).to.equal(numCalls);
+    expect(db.withArgs({ meta: true, remote: true }).callCount).to.equal(numCalls);
+  };
+
   beforeEach(() => {
     clock = sinon.useFakeTimers();
 
@@ -129,8 +138,7 @@ describe('DBSync service', () => {
     it('does nothing for admins', () => {
       isOnlineOnly.returns(true);
       return service.sync().then(() => {
-        expect(to.callCount).to.equal(0);
-        expect(from.callCount).to.equal(0);
+        expectSyncCall(0);
         expect(checkDateService.check.callCount).to.equal(0);
       });
     });
@@ -142,13 +150,13 @@ describe('DBSync service', () => {
       return service.sync().then(() => {
         expect(hasAuth.callCount).to.equal(1);
         expect(hasAuth.args[0][0]).to.equal('can_edit');
-        expect(from.callCount).to.equal(1);
+        expectSyncCall();
         expect(from.args[0][1]).to.have.keys('heartbeat', 'timeout', 'batch_size');
         expect(from.args[0][1]).to.not.have.keys('filter', 'checkpoint');
-        expect(to.callCount).to.equal(1);
         expect(to.args[0][1]).to.have.keys('filter', 'checkpoint', 'batch_size');
         expect(checkDateService.check.callCount).to.equal(1);
         expect(checkDateService.check.args[0]).to.deep.equal([]);
+        expectSyncMetaCall();
       });
     });
 
@@ -177,9 +185,7 @@ describe('DBSync service', () => {
       toResolve({ docs_read: 63 });
 
       return syncResult.then(() => {
-        expect(from.callCount).to.equal(1);
-        expect(to.callCount).to.equal(1);
-
+        expectSyncCall();
         expect(telemetryService.record.callCount).to.equal(8);
         expect(telemetryService.record.args).to.have.deep.members([
           ['replication:medic:from:success', 1000],
@@ -201,10 +207,10 @@ describe('DBSync service', () => {
       hasAuth.resolves(true);
 
       await service.sync();
-      expect(from.callCount).to.equal(1);
+      expectSyncCall(1);
       clock.tick(5 * 60 * 1000 + 1);
       await nextTick();
-      expect(from.callCount).to.equal(2);
+      expectSyncCall(2);
     });
 
     it('does not attempt sync while offline', () => {
@@ -213,7 +219,7 @@ describe('DBSync service', () => {
 
       service.setOnlineStatus(false);
       return service.sync().then(() => {
-        expect(from.callCount).to.equal(0);
+        expectSyncCall(0);
         expect(checkDateService.check.callCount).to.equal(0);
       });
     });
@@ -224,7 +230,7 @@ describe('DBSync service', () => {
 
       service.sync();
       return service.sync().then(() => {
-        expect(from.callCount).to.equal(1);
+        expectSyncCall();
       });
     });
 
@@ -234,7 +240,7 @@ describe('DBSync service', () => {
 
       service.setOnlineStatus(false);
       return service.sync(true).then(() => {
-        expect(from.callCount).to.equal(1);
+        expectSyncCall();
         expect(checkDateService.check.callCount).to.equal(1);
       });
     });
@@ -300,31 +306,31 @@ describe('DBSync service', () => {
 
       // sync with default online status
       await service.sync();
-      expect(from.callCount).to.equal(1);
+      expectSyncCall();
       // go offline, don't attempt to sync
       service.setOnlineStatus(false);
       clock.tick(25 * 60 * 1000 + 1);
       await nextTick();
-      expect(from.callCount).to.equal(1);
+      expectSyncCall();
 
       // when you come back online eventually, sync immediately
       service.setOnlineStatus(true);
-      expect(from.callCount).to.equal(1);
+      expectSyncCall(1);
 
       // wait for the inprogress sync to complete before continuing the test
       await service.sync();
-      expect(from.callCount).to.equal(2);
+      expectSyncCall(2);
 
       // don't sync if you quickly lose and regain connectivity
       service.setOnlineStatus(false);
       service.setOnlineStatus(true);
-      expect(from.callCount).to.equal(2);
+      expectSyncCall(2);
 
       // eventually, sync on the timer
       clock.tick(5 * 60 * 1000 + 1);
       await nextTick();
 
-      expect(from.callCount).to.equal(3);
+      expectSyncCall(3);
     });
 
     it('does not sync to remote if user lacks "can_edit" permission', () => {
@@ -373,9 +379,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 32 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 2000],
@@ -419,8 +423,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 32 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
+          expectSyncCall();
 
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
@@ -466,9 +469,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 67 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 500],
@@ -510,9 +511,7 @@ describe('DBSync service', () => {
         toResolve({ docs_read: 67 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:failure', 500],
@@ -554,9 +553,7 @@ describe('DBSync service', () => {
         fromResolve({ docs_read: 32 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 3000],
@@ -599,9 +596,7 @@ describe('DBSync service', () => {
         fromResolve({ docs_read: 500 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 8000],
@@ -640,9 +635,7 @@ describe('DBSync service', () => {
         fromResolve({ docs_read: 400 });
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(9);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:from:success', 700],
@@ -686,9 +679,7 @@ describe('DBSync service', () => {
         from.events['error'](errorFrom);
 
         return syncResult.then(() => {
-          expect(from.callCount).to.equal(1);
-          expect(to.callCount).to.equal(1);
-
+          expectSyncCall();
           expect(telemetryService.record.callCount).to.equal(10);
           expect(telemetryService.record.args).to.have.deep.members([
             ['replication:medic:to:failure', 100],
@@ -813,8 +804,7 @@ describe('DBSync service', () => {
         to.events.denied({ some: 'err' });
         expect(dbSyncRetry.callCount).to.equal(1);
         expect(dbSyncRetry.args[0]).to.deep.equal([{ some: 'err' }]);
-        expect(to.callCount).to.equal(1);
-        expect(from.callCount).to.equal(1);
+        expectSyncCall();
         expect(consoleErrorMock.callCount).to.equal(1);
         expect(consoleErrorMock.args[0][0]).to.equal('Denied replicating to remote server');
         expect(telemetryService.record.args).to.not.include.deep.members([['replication:medic:from:denied']]);
@@ -850,8 +840,7 @@ describe('DBSync service', () => {
         from.events.change(replicationResult);
         expect(rulesEngine.monitorExternalChanges.callCount).to.equal(1);
         expect(rulesEngine.monitorExternalChanges.args[0]).to.deep.equal([replicationResult]);
-        expect(to.callCount).to.equal(1);
-        expect(from.callCount).to.equal(1);
+        expectSyncCall();
       });
     });
 
@@ -863,13 +852,31 @@ describe('DBSync service', () => {
 
       it('should sync meta dbs with no filter', () => {
         return service.sync().then(() => {
-          expect(db.withArgs({ meta: true }).callCount).to.equal(1);
-          expect(db.withArgs({ meta: true, remote: true }).callCount).to.equal(1);
+          expectSyncMetaCall();
           expect(localMetaDb.replicate.from.callCount).to.equal(1);
           expect(localMetaDb.replicate.from.args[0]).to.deep.equal([remoteMetaDb]);
           expect(localMetaDb.replicate.to.callCount).to.equal(1);
           expect(localMetaDb.replicate.to.args[0]).to.deep.equal([remoteMetaDb]);
         });
+      });
+
+      it('should sync meta dbs only once if sync is called twice', async () => {
+        await service.sync();
+        expectSyncMetaCall(1);
+        expect(localMetaDb.sync.callCount).to.equal(1);
+        expect(localMetaDb.sync.args[0][0]).to.equal(remoteMetaDb);
+        expect(localMetaDb.sync.args[0][1]).to.equal(undefined);
+        await service.sync();
+        expectSyncMetaCall(1);
+        expect(localMetaDb.sync.callCount).to.equal(1);
+      });
+
+      it('should sync meta dbs twice if sync is called twice with force flag', async () => {
+        await service.sync();
+        expectSyncMetaCall(1);
+        await service.sync(true);
+        expectSyncMetaCall(2);
+        expect(localMetaDb.sync.callCount).to.equal(2);
       });
 
       it('should write purge log with the current seq after syncing', () => {

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -42,7 +42,7 @@ describe('DBSync service', () => {
   let clock;
 
   const realSetTimeout = setTimeout;
-  const nextTick = () => new Promise(resolve => realSetTimeout(() => resolve()));
+  const nextTick = () => new Promise(resolve => realSetTimeout(resolve));
 
   const expectSyncCall = (numCalls) => {
     expect(from.callCount).to.equal(numCalls);

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -863,12 +863,14 @@ describe('DBSync service', () => {
       it('should sync meta dbs only once if sync is called twice', async () => {
         await service.sync();
         expectSyncMetaCall(1);
-        expect(localMetaDb.sync.callCount).to.equal(1);
-        expect(localMetaDb.sync.args[0][0]).to.equal(remoteMetaDb);
-        expect(localMetaDb.sync.args[0][1]).to.equal(undefined);
+        expect(localMetaDb.replicate.from.callCount).to.equal(1);
+        expect(localMetaDb.replicate.from.args[0]).to.deep.equal([remoteMetaDb]);
+        expect(localMetaDb.replicate.to.callCount).to.equal(1);
+        expect(localMetaDb.replicate.to.args[0]).to.deep.equal([remoteMetaDb]);
+
         await service.sync();
         expectSyncMetaCall(1);
-        expect(localMetaDb.sync.callCount).to.equal(1);
+        expect(localMetaDb.replicate.from.callCount).to.equal(1);
       });
 
       it('should sync meta dbs twice if sync is called twice with force flag', async () => {
@@ -876,7 +878,7 @@ describe('DBSync service', () => {
         expectSyncMetaCall(1);
         await service.sync(true);
         expectSyncMetaCall(2);
-        expect(localMetaDb.sync.callCount).to.equal(2);
+        expect(localMetaDb.replicate.from.callCount).to.equal(2);
       });
 
       it('should write purge log with the current seq after syncing', () => {


### PR DESCRIPTION
# Description

Force the syncronization of the "meta" database along with the main db when user press _"Sync Now"_.

medic/cht-core#7121

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
