### PR TITLE
Search for "closest" db-doc-ref in repeats

### DIFF
--- a/tests/e2e/forms/submit-delivery-form.specs.js
+++ b/tests/e2e/forms/submit-delivery-form.specs.js
@@ -24,7 +24,7 @@ describe('Submit Delivery Report', () => {
     //select name
     await deliveryReport.selectPatientName('jack');
     await genericForm.nextPageNative();
-    await helper.waitElementToBeVisible(element(by.css('[value="healthy"]')));
+    await helper.waitElementToBeVisibleNative(element(by.css('[value="healthy"]')));
     //Delivery info
     await deliveryReport.selectLiveBirthButton();
     await deliveryReport.selectFacilityButton();

--- a/tests/page-objects/forms/add-family-form.po.js
+++ b/tests/page-objects/forms/add-family-form.po.js
@@ -114,7 +114,7 @@ module.exports = {
     hygeinicToilet,
     planningMethod
   ) => {
-    helper.waitUntilReadyNative(element.all(by.css('.details>ul>li')));
+    await helper.waitUntilReadyNative(element(by.css('.details>ul>li')));
     const savedParameters = element.all(by.css('.details>ul>li'));
 
     // Primary Caregiver

--- a/tests/page-objects/forms/delivery-report.po.js
+++ b/tests/page-objects/forms/delivery-report.po.js
@@ -40,7 +40,7 @@ module.exports = {
     const search = await element(by.css('.select2-search__field'));
     await search.click();
     await search.sendKeys(name);
-    await helper.waitElementToBeVisible(element(by.css('.name')));
+    await helper.waitElementToBeVisibleNative(element(by.css('.name')));
     await element(by.css('.name')).click();
   },
 
@@ -111,7 +111,7 @@ module.exports = {
 
   getFollowUpMessage: async () => {
     const css = '[lang="en"] [data-value=" /delivery/chw_sms "]';
-    await helper.waitElementToBeVisible(element(by.css(css)));
+    await helper.waitElementToBeVisibleNative(element(by.css(css)));
     return element(by.css(css)).getText();
   },
 };

--- a/tests/page-objects/reports/reports.po.js
+++ b/tests/page-objects/reports/reports.po.js
@@ -123,7 +123,7 @@ module.exports = {
 
   expandSelectionNative: async () => {
     await helper.clickElementNative(element(by.css(itemSummary)));
-    await helper.waitElementToBeVisible(element(by.css(reportBodyDetails)));
+    await helper.waitElementToBeVisibleNative(element(by.css(reportBodyDetails)));
   },
 
   selectAll: () => {

--- a/webapp/src/ts/services/enketo-translation.service.ts
+++ b/webapp/src/ts/services/enketo-translation.service.ts
@@ -129,6 +129,7 @@ export class EnketoTranslationService {
   }
 
   reportRecordToJs(record, formXml?) {
+    console.log('lalalalla', formXml);
     const root = $.parseXML(record).firstChild;
     if (!formXml) {
       return this.nodesToJs(root.childNodes);
@@ -139,6 +140,7 @@ export class EnketoTranslationService {
         return $(element).attr('nodeset');
       })
       .get();
+    console.log(repeatPaths);
     return this.nodesToJs(root.childNodes, repeatPaths, '/' + root.nodeName);
   }
 

--- a/webapp/src/ts/services/enketo-translation.service.ts
+++ b/webapp/src/ts/services/enketo-translation.service.ts
@@ -128,19 +128,21 @@ export class EnketoTranslationService {
     return fields;
   }
 
-  reportRecordToJs(record, formXml?) {
-    console.log('lalalalla', formXml);
-    const root = $.parseXML(record).firstChild;
-    if (!formXml) {
-      return this.nodesToJs(root.childNodes);
-    }
-    const repeatPaths = $(formXml)
+  getRepeatPaths(formXml) {
+    return $(formXml)
       .find('repeat[nodeset]')
       .map((idx, element) => {
         return $(element).attr('nodeset');
       })
       .get();
-    console.log(repeatPaths);
+  }
+
+  reportRecordToJs(record, formXml?) {
+    const root = $.parseXML(record).firstChild;
+    if (!formXml) {
+      return this.nodesToJs(root.childNodes);
+    }
+    const repeatPaths = this.getRepeatPaths(formXml);
     return this.nodesToJs(root.childNodes, repeatPaths, '/' + root.nodeName);
   }
 

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -3,7 +3,6 @@ import { v4 as uuid } from 'uuid';
 import * as pojo2xml from 'pojo2xml';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
-import { uniq as _uniq } from 'lodash-es';
 
 import { Xpath } from '@mm-providers/xpath-element-path.provider';
 import * as medicXpathExtensions from '../../js/enketo/medic-xpath-extensions';

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -3,6 +3,7 @@ import { v4 as uuid } from 'uuid';
 import * as pojo2xml from 'pojo2xml';
 import { Store } from '@ngrx/store';
 import { TranslateService } from '@ngx-translate/core';
+import { uniq as _uniq } from 'lodash-es';
 
 import { Xpath } from '@mm-providers/xpath-element-path.provider';
 import * as medicXpathExtensions from '../../js/enketo/medic-xpath-extensions';
@@ -454,6 +455,8 @@ export class EnketoService {
         ._couchId;
     };
 
+    //const getClosestId =
+
     // Chrome 30 doesn't support $xml.outerHTML: #3880
     const getOuterHTML = (xml) => {
       if (xml.outerHTML) {
@@ -479,7 +482,16 @@ export class EnketoService {
       .find('[db-doc-ref]')
       .each((idx, element) => {
         const $ref = $(element);
-        const refId = getId($ref.attr('db-doc-ref'));
+        const reference = $ref.attr('db-doc-ref');
+        let path = reference;
+        if (reference.startsWith('./')) {
+          element.id = uuid();
+          path = `//${element.nodeName}[@id="${element.id}"]/ancestor::${reference.replace(/^\.\//, '')}`;
+          console.log(path);
+          console.log($record);
+        }
+
+        const refId = getId(path);
         $ref.text(refId);
       });
 
@@ -535,6 +547,7 @@ export class EnketoService {
       .get(doc.form)
       .then((form) => this.getFormAttachment(form))
       .then((form) => {
+        console.log('form xml', form);
         doc.fields = this.enketoTranslationService.reportRecordToJs(record, form);
         return docsToStore;
       });

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -663,14 +663,14 @@ export class EnketoService {
   }
 
   private _save(formInternalId, form, geoHandle, docId?) {
-    const promise = docId ? this.update(docId) : this.create(formInternalId);
+    const getDocPromise = docId ? this.update(docId) : this.create(formInternalId);
 
-    return promise
-      .then((doc) => {
-        return this
-          .getFormXml(doc.form)
-          .then(formXml => this.xmlToDocs(doc, formXml, form.getDataStr({ irrelevant: false })));
-      })
+    return Promise
+      .all([
+        getDocPromise,
+        this.getFormXml(formInternalId),
+      ])
+      .then(([doc, formXml]) => this.xmlToDocs(doc, formXml, form.getDataStr({ irrelevant: false })))
       .then((docs) => this.saveGeo(geoHandle, docs))
       .then((docs) => this.saveDocs(docs))
       .then((docs) => {

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -464,21 +464,30 @@ export class EnketoService {
       }
     };
 
-    const getClosestPath = (element, $element, path) => {
-      path = path.trim();
-      const relativeReference = path.startsWith('./');
+    const getRelativePath = (path) => {
       const repeatReference = repeatPaths?.find(repeatPath => path.startsWith(repeatPath));
+      if (repeatReference) {
+        return path.replace(`${repeatReference}/`, '');
+      }
 
-      if (!relativeReference && !repeatReference) {
+      if (path.startsWith('./')) {
+        return path.replace('./', '');
+      }
+    };
+
+    const getClosestPath = (element, $element, path) => {
+      const relativePath = getRelativePath(path.trim());
+      if (!relativePath) {
         return;
       }
 
       // assign a unique id for xpath context, since the element can be inside a repeat
-      element.id = element.id || uuid();
+      if (!element.id) {
+        element.id = uuid();
+      }
       const uniqueElementSelector = `${element.nodeName}[@id="${element.id}"]`;
-      const localPath = path.replace(repeatReference ? `${repeatReference}/` : './', '');
 
-      return `//${uniqueElementSelector}/ancestor-or-self::*/descendant-or-self::${localPath}`;
+      return `//${uniqueElementSelector}/ancestor-or-self::*/descendant-or-self::${relativePath}`;
     };
 
     // Chrome 30 doesn't support $xml.outerHTML: #3880

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -465,6 +465,7 @@ export class EnketoService {
     };
 
     const getClosestPath = (element, $element, path) => {
+      path = path.trim();
       const relativeReference = path.startsWith('./');
       const repeatReference = repeatPaths?.find(repeatPath => path.startsWith(repeatPath));
 

--- a/webapp/tests/karma/karma-unit.conf.js
+++ b/webapp/tests/karma/karma-unit.conf.js
@@ -49,7 +49,7 @@ module.exports = function (config) {
 
   // allow to require xml files as strings
   config.buildWebpack.webpackConfig.module.rules.push({
-    test: /\.xml$/i,
+    test: /enketo-xml\/.*\.xml$/i,
     use: 'raw-loader',
   });
 };

--- a/webapp/tests/karma/karma-unit.conf.js
+++ b/webapp/tests/karma/karma-unit.conf.js
@@ -34,7 +34,6 @@ module.exports = function (config) {
         flags: ['--no-sandbox'],
       }
     },
-    files: [],
     browserConsoleLogOptions: {
       level: 'log',
       format: '%b %T: %m',
@@ -46,5 +45,11 @@ module.exports = function (config) {
       fixWebpackSourcePaths: true,
       skipFilesWithNoCoverage: true,
     },
+  });
+
+  // allow to require xml files as strings
+  config.buildWebpack.webpackConfig.module.rules.push({
+    test: /\.xml$/i,
+    use: 'raw-loader',
   });
 };

--- a/webapp/tests/karma/test.ts
+++ b/webapp/tests/karma/test.ts
@@ -20,6 +20,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /enketo.*\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/webapp/tests/karma/test.ts
+++ b/webapp/tests/karma/test.ts
@@ -20,6 +20,6 @@ getTestBed().initTestEnvironment(
   platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
-const context = require.context('./', true, /\.spec\.ts$/);
+const context = require.context('./', true, /enketo.*\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);

--- a/webapp/tests/karma/ts/services/enketo-xml/binary-field.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/binary-field.xml
@@ -1,0 +1,6 @@
+<my-form>
+  <name>Mary</name>
+  <age>10</age>
+  <gender>f</gender>
+  <my_file type="binary">some image data</my_file>
+</my-form>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-deep-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-deep-repeat.xml
@@ -1,0 +1,68 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section>
+    <extra>data1</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+  <repeat_section>
+    <extra>data2</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+  <repeat_section>
+    <extra>data3</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-deep-repeats-extra-repeats.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-deep-repeats-extra-repeats.xml
@@ -1,0 +1,80 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section>
+    <extra>data1</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc>
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+          </repeat_doc>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+  <repeat_section>
+    <extra>data2</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc>
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+          </repeat_doc>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+  <repeat_section>
+    <extra>data3</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc>
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+          </repeat_doc>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-deep-repeats-with-local-references.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-deep-repeats-with-local-references.xml
@@ -1,0 +1,80 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section>
+    <extra>data1</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc>
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+          </repeat_doc>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="./repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+  <repeat_section>
+    <extra>data2</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc>
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+          </repeat_doc>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="./repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+  <repeat_section>
+    <extra>data3</extra>
+    <other>
+      <deep>
+        <structure>
+          <repeat_doc>
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+          </repeat_doc>
+          <repeat_doc db-doc="true">
+            <type>repeater</type>
+            <some_property>some_value_1</some_property>
+            <my_parent db-doc-ref="/data"/>
+          </repeat_doc>
+        </structure>
+      </deep>
+    </other>
+    <some>
+      <deep>
+        <structure>
+          <repeat_doc_ref db-doc-ref="./repeat_doc"/>
+        </structure>
+      </deep>
+    </some>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-repeat.xml
@@ -1,0 +1,38 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section>
+    <extra>data1</extra>
+    <repeat_doc db-doc="true">
+      <type>repeater</type>
+      <some_property>some_value_1</some_property>
+      <my_parent db-doc-ref="/data"/>
+    </repeat_doc>
+    <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+  <repeat_section>
+    <extra>data2</extra>
+    <repeat_doc db-doc="true">
+      <type>repeater</type>
+      <some_property>some_value_2</some_property>
+      <my_parent db-doc-ref="/data"/>
+    </repeat_doc>
+    <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+  <repeat_section>
+    <extra>data3</extra>
+    <repeat_doc db-doc="true">
+      <type>repeater</type>
+      <some_property>some_value_3</some_property>
+      <my_parent db-doc-ref="/data"/>
+    </repeat_doc>
+    <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-repeats-with-local-references.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-in-repeats-with-local-references.xml
@@ -1,0 +1,38 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section>
+    <extra>data1</extra>
+    <repeat_doc db-doc="true">
+      <type>repeater</type>
+      <some_property>some_value_1</some_property>
+      <my_parent db-doc-ref="/data"/>
+    </repeat_doc>
+    <repeat_doc_ref db-doc-ref="./repeat_doc">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+  <repeat_section>
+    <extra>data2</extra>
+    <repeat_doc db-doc="true">
+      <type>repeater</type>
+      <some_property>some_value_2</some_property>
+      <my_parent db-doc-ref="/data"/>
+    </repeat_doc>
+    <repeat_doc_ref db-doc-ref="./repeat_doc">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+  <repeat_section>
+    <extra>data3</extra>
+    <repeat_doc db-doc="true">
+      <type>repeater</type>
+      <some_property>some_value_3</some_property>
+      <my_parent db-doc-ref="/data"/>
+    </repeat_doc>
+    <repeat_doc_ref db-doc-ref="./repeat_doc">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-outside-of-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-outside-of-repeat.xml
@@ -1,0 +1,23 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <separate_doc db-doc="true">
+    <type>separat5e</type>
+    <some_property>some_value_1</some_property>
+    <my_parent db-doc-ref="/data"/>
+  </separate_doc>
+
+  <repeat_section>
+    <extra>data1</extra>
+    <repeat_doc_ref db-doc-ref="data/separate_doc"/>
+  </repeat_section>
+  <repeat_section>
+    <extra>data2</extra>
+    <repeat_doc_ref db-doc-ref="data/separate_doc"/>
+  </repeat_section>
+  <repeat_section>
+    <extra>data3</extra>
+    <repeat_doc_ref db-doc-ref="data/separate_doc"/>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/deep-file-fields.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/deep-file-fields.xml
@@ -1,0 +1,11 @@
+<my-root-element>
+  <name>Mary</name>
+  <age>10</age>
+  <gender>f</gender>
+  <my_file type="file">some image name.png</my_file>
+  <sub_element>
+    <sub_sub_element>
+      <other_file type="file">some other name.png</other_file>
+    </sub_sub_element>
+  </sub_element>
+</my-root-element>

--- a/webapp/tests/karma/ts/services/enketo-xml/extra-docs-with-references.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/extra-docs-with-references.xml
@@ -1,0 +1,22 @@
+<data>
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <doc1 db-doc="true">
+    <type>thing_1</type>
+    <some_property_1>some_value_1</some_property_1>
+    <my_self_1 db-doc-ref="/data/doc1"/>
+    <my_parent_1 db-doc-ref="/data"/>
+    <my_sibling_1 db-doc-ref="/data/doc2"/>
+  </doc1>
+  <doc2 db-doc="true">
+    <type>thing_2</type>
+    <some_property_2>some_value_2</some_property_2>
+    <my_self_2 db-doc-ref="/data/doc2"/>
+    <my_parent_2 db-doc-ref="/data"/>
+    <my_sibling_2 db-doc-ref="/data/doc1"/>
+  </doc2>
+  <my_self_0 db-doc-ref="/data"/>
+  <my_child_01 db-doc-ref="/data/doc1"/>
+  <my_child_02 db-doc-ref="/data/doc2"/>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/extra-docs-with-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/extra-docs-with-repeat.xml
@@ -1,0 +1,20 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_doc db-doc="true" jr:template="">
+    <type>repeater</type>
+    <some_property>some_value_1</some_property>
+    <my_parent db-doc-ref="/data"/>
+  </repeat_doc>
+  <repeat_doc db-doc="true">
+    <type>repeater</type>
+    <some_property>some_value_2</some_property>
+    <my_parent db-doc-ref="/data"/>
+  </repeat_doc>
+  <repeat_doc db-doc="true">
+    <type>repeater</type>
+    <some_property>some_value_3</some_property>
+    <my_parent db-doc-ref="/data"/>
+  </repeat_doc>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/extra-docs.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/extra-docs.xml
@@ -1,0 +1,13 @@
+<model>
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <doc1 db-doc="true">
+    <type>thing_1</type>
+    <some_property_1>some_value_1</some_property_1>
+  </doc1>
+  <doc2 db-doc="true">
+    <type>thing_2</type>
+    <some_property_2>some_value_2</some_property_2>
+  </doc2>
+</model>

--- a/webapp/tests/karma/ts/services/enketo-xml/file-field.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/file-field.xml
@@ -1,0 +1,6 @@
+<my-form>
+  <name>Mary</name>
+  <age>10</age>
+  <gender>f</gender>
+  <my_file type="file">some image name.png</my_file>
+</my-form>

--- a/webapp/tests/karma/ts/services/enketo-xml/hidden-field.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/hidden-field.xml
@@ -1,0 +1,5 @@
+<model>
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+</model>

--- a/webapp/tests/karma/ts/services/enketo-xml/sally-lmp.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/sally-lmp.xml
@@ -1,0 +1,4 @@
+<model>
+  <name>Sally</name>
+  <lmp>10</lmp>
+</model>

--- a/webapp/tests/karma/ts/services/enketo-xml/visit-contact-summary.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/visit-contact-summary.xml
@@ -1,0 +1,25 @@
+<model>
+  <instance>
+    <data id="V" version="2015-06-05">
+      <patient_id tag="id"/>
+      <name tag="name"/>
+      <inputs>
+        <patient_id tag="n"/>
+        <user>
+          <_id tag="ui"/>
+          <facility_id tag="ufi"/>
+        </user>
+      </inputs>
+    </data>
+  </instance>
+  <instance id="contact-summary" />
+  <itext>
+    <translation lang="eng">
+      <text id="patient_id:label">
+        <value>Patient ID</value>
+      </text>
+    </translation>
+  </itext>
+  <bind nodeset="/data/patient_id" type="medicPatientSelect" required="true()" />
+  <bind nodeset="/data/name" type="string" required="true()" />
+</model>

--- a/webapp/tests/karma/ts/services/enketo-xml/visit.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/visit.xml
@@ -1,0 +1,24 @@
+<model>
+  <instance>
+    <data id="V" version="2015-06-05">
+      <patient_id tag="id"/>
+      <name tag="name"/>
+      <inputs>
+        <patient_id tag="n"/>
+        <user>
+          <_id tag="ui"/>
+          <facility_id tag="ufi"/>
+        </user>
+      </inputs>
+    </data>
+  </instance>
+  <itext>
+    <translation lang="eng">
+      <text id="patient_id:label">
+        <value>Patient ID</value>
+      </text>
+    </translation>
+  </itext>
+  <bind nodeset="/data/patient_id" type="medicPatientSelect" required="true()" />
+  <bind nodeset="/data/name" type="string" required="true()" />
+</model>

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -33,58 +33,10 @@ describe('Enketo service', () => {
     };
   };
 
-  const VISIT_MODEL = `
-    <model>
-      <instance>
-        <data id="V" version="2015-06-05">
-          <patient_id tag="id"/>
-          <name tag="name"/>
-          <inputs>
-            <patient_id tag="n"/>
-            <user>
-              <_id tag="ui"/>
-              <facility_id tag="ufi"/>
-            </user>
-          </inputs>
-        </data>
-      </instance>
-      <itext>
-        <translation lang="eng">
-          <text id="patient_id:label">
-            <value>Patient ID</value>
-          </text>
-        </translation>
-      </itext>
-      <bind nodeset="/data/patient_id" type="medicPatientSelect" required="true()" />
-      <bind nodeset="/data/name" type="string" required="true()" />
-    </model>`;
+  const loadXML = (name) => require(`./enketo-xml/${name}.xml`).default;
 
-  const VISIT_MODEL_WITH_CONTACT_SUMMARY = `
-    <model>
-      <instance>
-        <data id="V" version="2015-06-05">
-          <patient_id tag="id"/>
-          <name tag="name"/>
-          <inputs>
-            <patient_id tag="n"/>
-            <user>
-              <_id tag="ui"/>
-              <facility_id tag="ufi"/>
-            </user>
-          </inputs>
-        </data>
-      </instance>
-      <instance id="contact-summary" />
-      <itext>
-        <translation lang="eng">
-          <text id="patient_id:label">
-            <value>Patient ID</value>
-          </text>
-        </translation>
-      </itext>
-      <bind nodeset="/data/patient_id" type="medicPatientSelect" required="true()" />
-      <bind nodeset="/data/name" type="string" required="true()" />
-    </model>`;
+  const VISIT_MODEL = loadXML('visit');
+  const VISIT_MODEL_WITH_CONTACT_SUMMARY = loadXML('visit-contact-summary');
 
   let service;
   let setLastChangedDoc;
@@ -513,7 +465,7 @@ describe('Enketo service', () => {
 
     it('creates report', () => {
       form.validate.resolves(true);
-      const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+      const content = loadXML('sally-lmp');
       form.getDataStr.returns(content);
       dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
       dbGetAttachment.resolves('<form/>');
@@ -540,7 +492,7 @@ describe('Enketo service', () => {
         expect(AddAttachment.callCount).to.equal(1);
         expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
         expect(AddAttachment.args[0][1]).to.equal('content');
-        expect(AddAttachment.args[0][2]).to.equal(content);
+        expect(AddAttachment.args[0][2]).to.equal(content.replace(/\n$/, ''));
         expect(AddAttachment.args[0][3]).to.equal('application/xml');
       });
     });
@@ -548,7 +500,7 @@ describe('Enketo service', () => {
     describe('Geolocation recording', () => {
       it('saves geolocation data into a new report', () => {
         form.validate.resolves(true);
-        const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+        const content = loadXML('sally-lmp');
         form.getDataStr.returns(content);
         dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
         dbGetAttachment.resolves('<form/>');
@@ -588,14 +540,14 @@ describe('Enketo service', () => {
           expect(AddAttachment.callCount).to.equal(1);
           expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
           expect(AddAttachment.args[0][1]).to.equal('content');
-          expect(AddAttachment.args[0][2]).to.equal(content);
+          expect(AddAttachment.args[0][2]).to.equal(content.replace(/\n$/, ''));
           expect(AddAttachment.args[0][3]).to.equal('application/xml');
         });
       });
 
       it('saves a geolocation error into a new report', () => {
         form.validate.resolves(true);
-        const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+        const content = loadXML('sally-lmp');
         form.getDataStr.returns(content);
         dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
         dbGetAttachment.resolves('<form/>');
@@ -630,14 +582,14 @@ describe('Enketo service', () => {
           expect(AddAttachment.callCount).to.equal(1);
           expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
           expect(AddAttachment.args[0][1]).to.equal('content');
-          expect(AddAttachment.args[0][2]).to.equal(content);
+          expect(AddAttachment.args[0][2]).to.equal(content.replace(/\n$/, ''));
           expect(AddAttachment.args[0][3]).to.equal('application/xml');
         });
       });
 
-      it('overwrites exising geolocation info on edit with new info and appends to the log', () => {
+      it('overwrites existing geolocation info on edit with new info and appends to the log', () => {
         form.validate.resolves(true);
-        const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+        const content = loadXML('sally-lmp');
         form.getDataStr.returns(content);
         const originalGeoData = {
           latitude: 1,
@@ -699,7 +651,7 @@ describe('Enketo service', () => {
           expect(AddAttachment.callCount).to.equal(1);
           expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
           expect(AddAttachment.args[0][1]).to.equal('content');
-          expect(AddAttachment.args[0][2]).to.equal(content);
+          expect(AddAttachment.args[0][2]).to.equal(content.replace(/\n$/, ''));
           expect(AddAttachment.args[0][3]).to.equal('application/xml');
           expect(setLastChangedDoc.callCount).to.equal(1);
           expect(setLastChangedDoc.args[0]).to.deep.equal([actual]);
@@ -709,7 +661,7 @@ describe('Enketo service', () => {
 
     it('creates report with erroring geolocation', () => {
       form.validate.resolves(true);
-      const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+      const content = loadXML('sally-lmp');
       form.getDataStr.returns(content);
       dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
       dbGetAttachment.resolves('<form/>');
@@ -741,19 +693,14 @@ describe('Enketo service', () => {
         expect(AddAttachment.callCount).to.equal(1);
         expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
         expect(AddAttachment.args[0][1]).to.equal('content');
-        expect(AddAttachment.args[0][2]).to.equal(content);
+        expect(AddAttachment.args[0][2]).to.equal(content.replace(/\n$/, ''));
         expect(AddAttachment.args[0][3]).to.equal('application/xml');
       });
     });
 
     it('creates report with hidden fields', () => {
       form.validate.resolves(true);
-      const content =
-        `<doc>
-          <name>Sally</name>
-          <lmp>10</lmp>
-          <secret_code_name tag="hidden">S4L</secret_code_name>
-        </doc>`;
+      const content = loadXML('hidden-field');
       form.getDataStr.returns(content);
       dbBulkDocs.resolves([ { ok: true, id: '(generated-in-service)', rev: '1-abc' } ]);
       dbGetAttachment.resolves('<form/>');
@@ -782,7 +729,7 @@ describe('Enketo service', () => {
 
     it('updates report', () => {
       form.validate.resolves(true);
-      const content = '<doc><name>Sally</name><lmp>10</lmp></doc>';
+      const content = loadXML('sally-lmp');
       form.getDataStr.returns(content);
       dbGet.resolves({
         _id: '6',
@@ -815,7 +762,7 @@ describe('Enketo service', () => {
         expect(AddAttachment.callCount).to.equal(1);
         expect(AddAttachment.args[0][0]._id).to.equal(actual._id);
         expect(AddAttachment.args[0][1]).to.equal('content');
-        expect(AddAttachment.args[0][2]).to.equal(content);
+        expect(AddAttachment.args[0][2]).to.equal(content.replace(/\n$/, ''));
         expect(AddAttachment.args[0][3]).to.equal('application/xml');
         expect(setLastChangedDoc.callCount).to.equal(1);
         expect(setLastChangedDoc.args[0]).to.deep.equal([actual]);
@@ -827,20 +774,7 @@ describe('Enketo service', () => {
       const startTime = Date.now() - 1;
 
       form.validate.resolves(true);
-      const content =
-        `<data>
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <doc1 db-doc="true">
-              <type>thing_1</type>
-              <some_property_1>some_value_1</some_property_1>
-            </doc1>
-            <doc2 db-doc="true">
-              <type>thing_2</type>
-              <some_property_2>some_value_2</some_property_2>
-            </doc2>
-          </data>`;
+      const content = loadXML('extra-docs');
       form.getDataStr.returns(content);
       dbBulkDocs.callsFake(docs => {
         return Promise.resolve(docs.map(doc => {
@@ -900,20 +834,7 @@ describe('Enketo service', () => {
       const startTime = Date.now() - 1;
 
       form.validate.resolves(true);
-      const content =
-        `<data>
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <doc1 db-doc="true">
-              <type>thing_1</type>
-              <some_property_1>some_value_1</some_property_1>
-            </doc1>
-            <doc2 db-doc="true">
-              <type>thing_2</type>
-              <some_property_2>some_value_2</some_property_2>
-            </doc2>
-          </data>`;
+      const content = loadXML('extra-docs');
       form.getDataStr.returns(content);
       dbBulkDocs.resolves([
         { ok: true, id: '6', rev: '1-abc' },
@@ -979,29 +900,7 @@ describe('Enketo service', () => {
 
     it('creates extra docs with references', () => {
       form.validate.resolves(true);
-      const content =
-        `<data>
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <doc1 db-doc="true">
-              <type>thing_1</type>
-              <some_property_1>some_value_1</some_property_1>
-              <my_self_1 db-doc-ref="/data/doc1"/>
-              <my_parent_1 db-doc-ref="/data"/>
-              <my_sibling_1 db-doc-ref="/data/doc2"/>
-            </doc1>
-            <doc2 db-doc="true">
-              <type>thing_2</type>
-              <some_property_2>some_value_2</some_property_2>
-              <my_self_2 db-doc-ref="/data/doc2"/>
-              <my_parent_2 db-doc-ref="/data"/>
-              <my_sibling_2 db-doc-ref="/data/doc1"/>
-            </doc2>
-            <my_self_0 db-doc-ref="/data"/>
-            <my_child_01 db-doc-ref="/data/doc1"/>
-            <my_child_02 db-doc-ref="/data/doc2"/>
-          </data>`;
+      const content = loadXML('extra-docs-with-references');
       form.getDataStr.returns(content);
       dbBulkDocs.resolves([
         { ok: true, id: '6', rev: '1-abc' },
@@ -1061,27 +960,7 @@ describe('Enketo service', () => {
 
     it('creates extra docs with repeats', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <repeat_doc db-doc="true" jr:template="">
-              <type>repeater</type>
-              <some_property>some_value_1</some_property>
-              <my_parent db-doc-ref="/data"/>
-            </repeat_doc>
-            <repeat_doc db-doc="true">
-              <type>repeater</type>
-              <some_property>some_value_2</some_property>
-              <my_parent db-doc-ref="/data"/>
-            </repeat_doc>
-            <repeat_doc db-doc="true">
-              <type>repeater</type>
-              <some_property>some_value_3</some_property>
-              <my_parent db-doc-ref="/data"/>
-            </repeat_doc>
-          </data>`;
+      const content = loadXML('extra-docs-with-repeat');
       form.getDataStr.returns(content);
       dbBulkDocs.resolves([
         { ok: true, id: '6', rev: '1-abc' },
@@ -1126,45 +1005,7 @@ describe('Enketo service', () => {
 
     it('db-doc-ref with repeats', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <repeat_section>
-              <extra>data1</extra>
-              <repeat_doc db-doc="true">
-                <type>repeater</type>
-                <some_property>some_value_1</some_property>
-                <my_parent db-doc-ref="/data"/>
-              </repeat_doc>
-              <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
-                value value
-              </repeat_doc_ref>             
-            </repeat_section>
-            <repeat_section>
-              <extra>data2</extra>
-              <repeat_doc db-doc="true">
-                <type>repeater</type>
-                <some_property>some_value_2</some_property>
-                <my_parent db-doc-ref="/data"/>
-              </repeat_doc>
-              <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
-                value value
-              </repeat_doc_ref> 
-            </repeat_section>
-            <repeat_section>
-              <extra>data3</extra>
-              <repeat_doc db-doc="true">
-                <type>repeater</type>
-                <some_property>some_value_3</some_property>
-                <my_parent db-doc-ref="/data"/>
-              </repeat_doc>
-              <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
-                value value
-              </repeat_doc_ref>         
-            </repeat_section>
-          </data>`;
+      const content = loadXML('db-doc-ref-in-repeat');
       form.getDataStr.returns(content);
 
       dbBulkDocs.resolves([
@@ -1206,75 +1047,7 @@ describe('Enketo service', () => {
 
     it('db-doc-ref with deep repeats', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <repeat_section>
-              <extra>data1</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-            <repeat_section>
-              <extra>data2</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-            <repeat_section>
-              <extra>data3</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-          </data>`;
+      const content = loadXML('db-doc-ref-in-deep-repeat');
       form.getDataStr.returns(content);
 
       dbBulkDocs.resolves([
@@ -1316,87 +1089,7 @@ describe('Enketo service', () => {
 
     it('db-doc-ref with deep repeats and non-db-doc repeats', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <repeat_section>
-              <extra>data1</extra>              
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc>
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>                     
-                    </repeat_doc>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-            <repeat_section>
-              <extra>data2</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc>
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>                     
-                    </repeat_doc>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-            <repeat_section>
-              <extra>data3</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc>
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>                     
-                    </repeat_doc>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="/data/repeat_section/other/deep/structure/repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-          </data>`;
+      const content = loadXML('db-doc-ref-in-deep-repeats-extra-repeats');
       form.getDataStr.returns(content);
 
       dbBulkDocs.resolves([
@@ -1438,45 +1131,7 @@ describe('Enketo service', () => {
 
     it('db-doc-ref with repeats and local references', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <repeat_section>
-              <extra>data1</extra>
-              <repeat_doc db-doc="true">
-                <type>repeater</type>
-                <some_property>some_value_1</some_property>
-                <my_parent db-doc-ref="/data"/>
-              </repeat_doc>
-              <repeat_doc_ref db-doc-ref="./repeat_doc">
-                value value
-              </repeat_doc_ref>             
-            </repeat_section>
-            <repeat_section>
-              <extra>data2</extra>
-              <repeat_doc db-doc="true">
-                <type>repeater</type>
-                <some_property>some_value_2</some_property>
-                <my_parent db-doc-ref="/data"/>
-              </repeat_doc>
-              <repeat_doc_ref db-doc-ref="./repeat_doc">
-                value value
-              </repeat_doc_ref> 
-            </repeat_section>
-            <repeat_section>
-              <extra>data3</extra>
-              <repeat_doc db-doc="true">
-                <type>repeater</type>
-                <some_property>some_value_3</some_property>
-                <my_parent db-doc-ref="/data"/>
-              </repeat_doc>
-              <repeat_doc_ref db-doc-ref="./repeat_doc">
-                value value
-              </repeat_doc_ref>         
-            </repeat_section>
-          </data>`;
+      const content = loadXML('db-doc-ref-in-repeats-with-local-references');
       form.getDataStr.returns(content);
 
       dbBulkDocs.resolves([
@@ -1518,87 +1173,7 @@ describe('Enketo service', () => {
 
     it('db-doc-ref with deep repeats and local references', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <repeat_section>
-              <extra>data1</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc>
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>                     
-                    </repeat_doc>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="./repeat_doc"/>                                     
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-            <repeat_section>
-              <extra>data2</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc>
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>                     
-                    </repeat_doc>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="./repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-            <repeat_section>
-              <extra>data3</extra>
-              <other>
-                <deep>
-                  <structure>
-                    <repeat_doc>
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>                     
-                    </repeat_doc>
-                    <repeat_doc db-doc="true">
-                      <type>repeater</type>
-                      <some_property>some_value_1</some_property>
-                      <my_parent db-doc-ref="/data"/>
-                    </repeat_doc>
-                  </structure>
-                </deep>
-              </other>             
-              <some>
-                <deep>
-                  <structure>
-                    <repeat_doc_ref db-doc-ref="./repeat_doc"/>                 
-                  </structure>
-                </deep>
-              </some>                          
-            </repeat_section>
-          </data>`;
+      const content = loadXML('db-doc-ref-in-deep-repeats-with-local-references');
       form.getDataStr.returns(content);
 
       dbBulkDocs.resolves([
@@ -1640,30 +1215,7 @@ describe('Enketo service', () => {
 
     it('db-doc-ref with repeats with refs outside of repeat', () => {
       form.validate.resolves(true);
-      const content =
-        `<data xmlns:jr="http://openrosa.org/javarosa">
-            <name>Sally</name>
-            <lmp>10</lmp>
-            <secret_code_name tag="hidden">S4L</secret_code_name>
-            <separate_doc db-doc="true">
-                <type>separat5e</type>
-                <some_property>some_value_1</some_property>
-                <my_parent db-doc-ref="/data"/>
-            </separate_doc>
-              
-            <repeat_section>
-              <extra>data1</extra>             
-              <repeat_doc_ref db-doc-ref="data/separate_doc"/>             
-            </repeat_section>
-            <repeat_section>
-              <extra>data2</extra>             
-              <repeat_doc_ref db-doc-ref="data/separate_doc"/>             
-            </repeat_section>
-            <repeat_section>
-              <extra>data3</extra>             
-              <repeat_doc_ref db-doc-ref="data/separate_doc"/>             
-            </repeat_section>
-          </data>`;
+      const content = loadXML('db-doc-ref-outside-of-repeat');
       form.getDataStr.returns(content);
 
       dbBulkDocs.resolves([
@@ -1713,14 +1265,7 @@ describe('Enketo service', () => {
         .returns([{ files: [{ type: 'image', foo: 'bar' }] }]);
 
       form.validate.resolves(true);
-      const content = `
-        <my-form>
-          <name>Mary</name>
-          <age>10</age>
-          <gender>f</gender>
-          <my_file type="file">some image name.png</my_file>
-        </my-form>
-      `;
+      const content = loadXML('file-field');
 
       form.getDataStr.returns(content);
       dbGetAttachment.resolves('<form/>');
@@ -1739,13 +1284,7 @@ describe('Enketo service', () => {
 
     it('removes binary data from content', () => {
       form.validate.resolves(true);
-      const content =
-        `<my-form>
-  <name>Mary</name>
-  <age>10</age>
-  <gender>f</gender>
-  <my_file type="binary">some image data</my_file>
-</my-form>`;
+      const content = loadXML('binary-field');
 
       const expected =
         `<my-form>
@@ -1785,19 +1324,7 @@ describe('Enketo service', () => {
         .withArgs('input[type=file][name="/my-root-element/sub_element/sub_sub_element/other_file"]')
         .returns([{ files: [{ type: 'mytype', foo: 'baz' }] }]);
       form.validate.resolves(true);
-      const content = `
-        <my-root-element>
-          <name>Mary</name>
-          <age>10</age>
-          <gender>f</gender>
-          <my_file type="file">some image name.png</my_file>
-          <sub_element>
-            <sub_sub_element>
-              <other_file type="file">some other name.png</other_file>
-            </sub_sub_element>
-          </sub_element>
-        </my-root-element>
-      `;
+      const content = loadXML('deep-file-fields');
 
       form.getDataStr.returns(content);
       dbGetAttachment.resolves('<form/>');

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1102,8 +1102,6 @@ describe('Enketo service', () => {
 
         const actualReport = actual[0];
 
-        console.log(JSON.stringify(actualReport, null, 2));
-
         expect(actualReport._id).to.match(/(\w+-)\w+/);
         expect(actualReport.fields.name).to.equal('Sally');
         expect(actualReport.fields.lmp).to.equal('10');
@@ -1134,35 +1132,35 @@ describe('Enketo service', () => {
             <lmp>10</lmp>
             <secret_code_name tag="hidden">S4L</secret_code_name>
             <repeat_section>
-              <extra>data</extra>
+              <extra>data1</extra>
               <repeat_doc db-doc="true">
                 <type>repeater</type>
                 <some_property>some_value_1</some_property>
                 <my_parent db-doc-ref="/data"/>
               </repeat_doc>
-              <repeat_doc_ref db-doc-ref="data/repeat_section[0]/repeat_doc">
+              <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
                 value value
               </repeat_doc_ref>             
             </repeat_section>
             <repeat_section>
-              <extra>data</extra>
+              <extra>data2</extra>
               <repeat_doc db-doc="true">
                 <type>repeater</type>
                 <some_property>some_value_2</some_property>
                 <my_parent db-doc-ref="/data"/>
               </repeat_doc>
-              <repeat_doc_ref db-doc-ref="data/repeat_section[1]/repeat_doc">
+              <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
                 value value
               </repeat_doc_ref> 
             </repeat_section>
             <repeat_section>
-              <extra>data</extra>
+              <extra>data3</extra>
               <repeat_doc db-doc="true">
                 <type>repeater</type>
                 <some_property>some_value_3</some_property>
                 <my_parent db-doc-ref="/data"/>
               </repeat_doc>
-              <repeat_doc_ref db-doc-ref="data/repeat_section[2]/repeat_doc">
+              <repeat_doc_ref db-doc-ref="/data/repeat_section/repeat_doc">
                 value value
               </repeat_doc_ref>         
             </repeat_section>
@@ -1188,7 +1186,21 @@ describe('Enketo service', () => {
         expect(dbBulkDocs.callCount).to.equal(1);
         expect(UserContact.callCount).to.equal(1);
 
-        console.log(JSON.stringify(actual, null, 2));
+        expect(actual.length).to.equal(4);
+        const doc = actual[0];
+
+        expect(doc).to.deep.nested.include({
+          form: 'V',
+          'fields.name': 'Sally',
+          'fields.lmp': '10',
+          'fields.secret_code_name': 'S4L',
+          'fields.repeat_section[0].extra': 'data1',
+          'fields.repeat_section[0].repeat_doc_ref': actual[1]._id,
+          'fields.repeat_section[1].extra': 'data2',
+          'fields.repeat_section[1].repeat_doc_ref': actual[2]._id,
+          'fields.repeat_section[2].extra': 'data3',
+          'fields.repeat_section[2].repeat_doc_ref': actual[3]._id,
+        });
       });
     });
 
@@ -1200,35 +1212,35 @@ describe('Enketo service', () => {
             <lmp>10</lmp>
             <secret_code_name tag="hidden">S4L</secret_code_name>
             <repeat_section>
-              <extra>data</extra>
+              <extra>data1</extra>
               <repeat_doc db-doc="true">
                 <type>repeater</type>
                 <some_property>some_value_1</some_property>
                 <my_parent db-doc-ref="/data"/>
               </repeat_doc>
-              <repeat_doc_ref db-doc-ref="./repeat_section/repeat_doc">
+              <repeat_doc_ref db-doc-ref="./repeat_doc">
                 value value
               </repeat_doc_ref>             
             </repeat_section>
             <repeat_section>
-              <extra>data</extra>
+              <extra>data2</extra>
               <repeat_doc db-doc="true">
                 <type>repeater</type>
                 <some_property>some_value_2</some_property>
                 <my_parent db-doc-ref="/data"/>
               </repeat_doc>
-              <repeat_doc_ref db-doc-ref="./repeat_section/repeat_doc">
+              <repeat_doc_ref db-doc-ref="./repeat_doc">
                 value value
               </repeat_doc_ref> 
             </repeat_section>
             <repeat_section>
-              <extra>data</extra>
+              <extra>data3</extra>
               <repeat_doc db-doc="true">
                 <type>repeater</type>
                 <some_property>some_value_3</some_property>
                 <my_parent db-doc-ref="/data"/>
               </repeat_doc>
-              <repeat_doc_ref db-doc-ref="./repeat_section/repeat_doc">
+              <repeat_doc_ref db-doc-ref="./repeat_doc">
                 value value
               </repeat_doc_ref>         
             </repeat_section>
@@ -1254,7 +1266,21 @@ describe('Enketo service', () => {
         expect(dbBulkDocs.callCount).to.equal(1);
         expect(UserContact.callCount).to.equal(1);
 
-        console.log(JSON.stringify(actual, null, 2));
+        expect(actual.length).to.equal(4);
+        const doc = actual[0];
+
+        expect(doc).to.deep.nested.include({
+          form: 'V',
+          'fields.name': 'Sally',
+          'fields.lmp': '10',
+          'fields.secret_code_name': 'S4L',
+          'fields.repeat_section[0].extra': 'data1',
+          'fields.repeat_section[0].repeat_doc_ref': actual[1]._id,
+          'fields.repeat_section[1].extra': 'data2',
+          'fields.repeat_section[1].repeat_doc_ref': actual[2]._id,
+          'fields.repeat_section[2].extra': 'data3',
+          'fields.repeat_section[2].repeat_doc_ref': actual[3]._id,
+        });
       });
     });
 


### PR DESCRIPTION
# Description

Updates the way the EnketoService finds `db-doc-refs` to support "closest" searches when the reference is relative or inside a repeat. 

medic/cht-core#6718

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
