### PR TITLE
Hardcode chromedriver to 90

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -934,7 +934,6 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('start-webdriver', 'Starts Protractor Webdriver', [
-    'replace:webdriver-version',
     CI ? 'exec:start-webdriver-ci' : 'exec:start-webdriver',
   ]);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,6 @@ const {
   BUILDS_SERVER,
   TRAVIS_BUILD_NUMBER,
   CI,
-  WEBDRIVER_VERSION=88
 } = process.env;
 
 const releaseName = TRAVIS_TAG || TRAVIS_BRANCH || 'local-development';
@@ -88,16 +87,6 @@ module.exports = function(grunt) {
             to: `"_id": "medic:medic:test-${TRAVIS_BUILD_NUMBER}"`,
           },
         ],
-      },
-      'webdriver-version': {
-        src: ['node_modules/protractor/node_modules/webdriver-manager/built/config.json'],
-        overwrite: true,
-        replacements: [
-          {
-            from: /"maxChromedriver": ".*",/g,
-            to: `"maxChromedriver": "${WEBDRIVER_VERSION}",`,
-          },
-        ]
       },
     },
     'couch-compile': {
@@ -477,8 +466,8 @@ module.exports = function(grunt) {
       'start-webdriver': {
         cmd:
           'mkdir -p tests/logs && ' +
-          './node_modules/.bin/webdriver-manager update && ' +
-          './node_modules/.bin/webdriver-manager start > tests/logs/webdriver.log & ' +
+          './node_modules/.bin/webdriver-manager update --versions.chrome 90.0.4430.24 && ' +
+          './node_modules/.bin/webdriver-manager start --versions.chrome 90.0.4430.24 > tests/logs/webdriver.log & ' +
           'until nc -z localhost 4444; do sleep 1; done',
       },
       'start-webdriver-ci': {

--- a/scripts/e2e/start_webdriver.sh
+++ b/scripts/e2e/start_webdriver.sh
@@ -1,7 +1,8 @@
 mkdir -p tests/logs &&
-CHROME_VERSION=`google-chrome-stable --version | grep -Po '(\d+)(?=\.\d+\.\d+\.\d+)'` &&  
+CHROME_VERSION=`google-chrome-stable --version | grep -Po '(\d+)(?=\.\d+\.\d+\.\d+)'` &&
 echo 'Detected chrome version ' $CHROME_VERSION &&
 CHROMEDRIVER_VERSION=$(curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION) &&
+CHROMEDRIVER_VERSION="90.0.4430.24" # temporary fix because of regression in driver v91
 echo 'Getting Chrome driver version ' $CHROMEDRIVER_VERSION &&
 ./node_modules/.bin/webdriver-manager update --versions.chrome $CHROMEDRIVER_VERSION &&
 ./node_modules/.bin/webdriver-manager start --versions.chrome $CHROMEDRIVER_VERSION > tests/logs/webdriver.log &

--- a/tests/e2e/api/controllers/export-data-2.js
+++ b/tests/e2e/api/controllers/export-data-2.js
@@ -2,7 +2,7 @@ const utils = require('../../../utils');
 
 describe('Export Data V2.0', () => {
 
-  afterAll(utils.deleteAllDocs);
+  afterAll(() => utils.afterEach());
 
   describe('GET|POST /api/v2/export/reports', () => {
     const docs = [{
@@ -41,10 +41,11 @@ describe('Export Data V2.0', () => {
         baz: 'bazVal',
       }
     }];
+
     beforeAll(() => utils.saveDocs(docs));
 
-    it('Returns all reports that exist in the system', () =>
-      utils.request({ path: '/api/v2/export/reports' }).then(result => {
+    it('Returns all reports that exist in the system', () => {
+      return utils.request({ path: '/api/v2/export/reports' }).then(result => {
         const rows = result.split('\n');
         rows.pop(); // Last row is empty string, discard
         const expected = [
@@ -58,9 +59,10 @@ describe('Export Data V2.0', () => {
         rows.splice(1).forEach(row => {
           expect(expected).toContain(row);
         });
-      }));
-    it('POST Filters by form', () =>
-      utils.request({
+      });
+    });
+    it('POST Filters by form', () => {
+      return utils.request({
         method: 'POST',
         path: '/api/v2/export/reports',
         body: {
@@ -78,24 +80,26 @@ describe('Export Data V2.0', () => {
         ];
         expect(rows.length).toBe(2);
         expect(rows).toEqual(expected);
-      }));
+      });
+    });
     it('GET Filters by date', () => {
       const from = Date.UTC(2018,1,2,12);
       const to = Date.UTC(2018,1,3,12);
-      return utils.request(`/api/v2/export/reports?` +
-        `filters%5Bsearch%5D=&filters%5Bdate%5D%5Bfrom%5D=${from}&filters%5Bdate%5D%5Bto%5D=${to}`,
-      {notJson: true}
-      ).then(result => {
-        const rows = result.split('\n');
-        rows.pop(); // Last row is empty string, discard
+      return utils
+        .request(`/api/v2/export/reports?` +
+          `filters%5Bsearch%5D=&filters%5Bdate%5D%5Bfrom%5D=${from}&filters%5Bdate%5D%5Bto%5D=${to}`,
+        )
+        .then(result => {
+          const rows = result.split('\n');
+          rows.pop(); // Last row is empty string, discard
 
-        const expected = [
-          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong', // eslint-disable-line max-len
-          '"export-data-2-test-doc-3","b","abc125",1517616000000,,,,,,,"bazVal",,'
-        ];
-        expect(rows.length).toBe(2);
-        expect(rows).toEqual(expected);
-      });
+          const expected = [
+            '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong', // eslint-disable-line max-len
+            '"export-data-2-test-doc-3","b","abc125",1517616000000,,,,,,,"bazVal",,'
+          ];
+          expect(rows.length).toBe(2);
+          expect(rows).toEqual(expected);
+        });
     });
   });
   describe('Weird data', () => {
@@ -114,30 +118,33 @@ describe('Export Data V2.0', () => {
       }
     }));
 
-    it('Outputs weird data types correctly', () =>
-      utils.request({
-        method: 'POST',
-        path: '/api/v2/export/reports',
-        body: {
-          filters: {
-            forms: {
-              selected: [{code: 'weird-data-types'}]
+    it('Outputs weird data types correctly', () => {
+      return utils
+        .request({
+          method: 'POST',
+          path: '/api/v2/export/reports',
+          body: {
+            filters: {
+              forms: {
+                selected: [{code: 'weird-data-types'}]
+              }
             }
-          }
-        }}).then(result => {
-        const rows = result.split('\n');
-        rows.pop(); // Last row is empty string, discard
-        //
-        // NB: if you have to debug this test failing, note that the test
-        // runner will not output the escaped string values correctly to the
-        // console. You can rely on its output to debug the problem.
-        //
-        const expected = [
-          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,wd_array,wd_emptyString,wd_false,wd_naughtyArray,wd_naughtyString,wd_null,wd_zero', // eslint-disable-line max-len
-          '"export-data-2-test-doc-4","weird-data-types",,"",,,,,,"[0,1,2]","",false,"[0,{\\"foo\\":false,\\"bar\\":null},\\"Hello, \\\\"world\\\\"\\"]","Woah there, \\"Jimmy O\'Tool\\"",,0', // eslint-disable-line max-len
-        ];
-        expect(rows.length).toBe(2);
-        expect(rows).toEqual(expected);
-      }));
+          }})
+        .then(result => {
+          const rows = result.split('\n');
+          rows.pop(); // Last row is empty string, discard
+          //
+          // NB: if you have to debug this test failing, note that the test
+          // runner will not output the escaped string values correctly to the
+          // console. You can rely on its output to debug the problem.
+          //
+          const expected = [
+            '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,wd_array,wd_emptyString,wd_false,wd_naughtyArray,wd_naughtyString,wd_null,wd_zero', // eslint-disable-line max-len
+            '"export-data-2-test-doc-4","weird-data-types",,"",,,,,,"[0,1,2]","",false,"[0,{\\"foo\\":false,\\"bar\\":null},\\"Hello, \\\\"world\\\\"\\"]","Woah there, \\"Jimmy O\'Tool\\"",,0', // eslint-disable-line max-len
+          ];
+          expect(rows.length).toBe(2);
+          expect(rows).toEqual(expected);
+        });
+    });
   });
 });

--- a/tests/e2e/api/controllers/export-data-2.js
+++ b/tests/e2e/api/controllers/export-data-2.js
@@ -41,11 +41,10 @@ describe('Export Data V2.0', () => {
         baz: 'bazVal',
       }
     }];
-
     beforeAll(() => utils.saveDocs(docs));
 
-    it('Returns all reports that exist in the system', () => {
-      return utils.request({ path: '/api/v2/export/reports' }).then(result => {
+    it('Returns all reports that exist in the system', () =>
+      utils.request({ path: '/api/v2/export/reports' }).then(result => {
         const rows = result.split('\n');
         rows.pop(); // Last row is empty string, discard
         const expected = [
@@ -59,10 +58,9 @@ describe('Export Data V2.0', () => {
         rows.splice(1).forEach(row => {
           expect(expected).toContain(row);
         });
-      });
-    });
-    it('POST Filters by form', () => {
-      return utils.request({
+      }));
+    it('POST Filters by form', () =>
+      utils.request({
         method: 'POST',
         path: '/api/v2/export/reports',
         body: {
@@ -80,26 +78,24 @@ describe('Export Data V2.0', () => {
         ];
         expect(rows.length).toBe(2);
         expect(rows).toEqual(expected);
-      });
-    });
+      }));
     it('GET Filters by date', () => {
       const from = Date.UTC(2018,1,2,12);
       const to = Date.UTC(2018,1,3,12);
-      return utils
-        .request(`/api/v2/export/reports?` +
-          `filters%5Bsearch%5D=&filters%5Bdate%5D%5Bfrom%5D=${from}&filters%5Bdate%5D%5Bto%5D=${to}`,
-        )
-        .then(result => {
-          const rows = result.split('\n');
-          rows.pop(); // Last row is empty string, discard
+      return utils.request(`/api/v2/export/reports?` +
+        `filters%5Bsearch%5D=&filters%5Bdate%5D%5Bfrom%5D=${from}&filters%5Bdate%5D%5Bto%5D=${to}`,
+      {notJson: true}
+      ).then(result => {
+        const rows = result.split('\n');
+        rows.pop(); // Last row is empty string, discard
 
-          const expected = [
-            '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong', // eslint-disable-line max-len
-            '"export-data-2-test-doc-3","b","abc125",1517616000000,,,,,,,"bazVal",,'
-          ];
-          expect(rows.length).toBe(2);
-          expect(rows).toEqual(expected);
-        });
+        const expected = [
+          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,bar,baz,foo,smang.smong', // eslint-disable-line max-len
+          '"export-data-2-test-doc-3","b","abc125",1517616000000,,,,,,,"bazVal",,'
+        ];
+        expect(rows.length).toBe(2);
+        expect(rows).toEqual(expected);
+      });
     });
   });
   describe('Weird data', () => {
@@ -118,33 +114,30 @@ describe('Export Data V2.0', () => {
       }
     }));
 
-    it('Outputs weird data types correctly', () => {
-      return utils
-        .request({
-          method: 'POST',
-          path: '/api/v2/export/reports',
-          body: {
-            filters: {
-              forms: {
-                selected: [{code: 'weird-data-types'}]
-              }
+    it('Outputs weird data types correctly', () =>
+      utils.request({
+        method: 'POST',
+        path: '/api/v2/export/reports',
+        body: {
+          filters: {
+            forms: {
+              selected: [{code: 'weird-data-types'}]
             }
-          }})
-        .then(result => {
-          const rows = result.split('\n');
-          rows.pop(); // Last row is empty string, discard
-          //
-          // NB: if you have to debug this test failing, note that the test
-          // runner will not output the escaped string values correctly to the
-          // console. You can rely on its output to debug the problem.
-          //
-          const expected = [
-            '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,wd_array,wd_emptyString,wd_false,wd_naughtyArray,wd_naughtyString,wd_null,wd_zero', // eslint-disable-line max-len
-            '"export-data-2-test-doc-4","weird-data-types",,"",,,,,,"[0,1,2]","",false,"[0,{\\"foo\\":false,\\"bar\\":null},\\"Hello, \\\\"world\\\\"\\"]","Woah there, \\"Jimmy O\'Tool\\"",,0', // eslint-disable-line max-len
-          ];
-          expect(rows.length).toBe(2);
-          expect(rows).toEqual(expected);
-        });
-    });
+          }
+        }}).then(result => {
+        const rows = result.split('\n');
+        rows.pop(); // Last row is empty string, discard
+        //
+        // NB: if you have to debug this test failing, note that the test
+        // runner will not output the escaped string values correctly to the
+        // console. You can rely on its output to debug the problem.
+        //
+        const expected = [
+          '_id,form,patient_id,reported_date,from,contact.name,contact.parent.name,contact.parent.parent.name,contact.parent.parent.parent.name,wd_array,wd_emptyString,wd_false,wd_naughtyArray,wd_naughtyString,wd_null,wd_zero', // eslint-disable-line max-len
+          '"export-data-2-test-doc-4","weird-data-types",,"",,,,,,"[0,1,2]","",false,"[0,{\\"foo\\":false,\\"bar\\":null},\\"Hello, \\\\"world\\\\"\\"]","Woah there, \\"Jimmy O\'Tool\\"",,0', // eslint-disable-line max-len
+        ];
+        expect(rows.length).toBe(2);
+        expect(rows).toEqual(expected);
+      }));
   });
 });


### PR DESCRIPTION
# Description

Fixes bug in export data afterAll.
Removes `webdriver-version`  replace, which no longer applies to current version of protractor. 

medic/cht-core#7124
medic/cht-core#7118

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
