### PR TITLE
Use translate wrapper to avoid errors for empty translation keys

### DIFF
--- a/webapp/src/js/enketo/widgets/mrdt.js
+++ b/webapp/src/js/enketo/widgets/mrdt.js
@@ -39,7 +39,7 @@
     const MRDT = window.CHTCore.MRDT;
 
     if ( !MRDT.enabled() ) {
-      $translate.get( 'mrdt.disabled' ).toPromise().then((label) => {
+      $translate.get( 'mrdt.disabled' ).then((label) => {
         $el.append( '<p>' + label + '</p>' );
       });
       return;
@@ -66,7 +66,7 @@
       } );
     } );
 
-    $translate.get( 'mrdt.verify' ).toPromise().then((label) => {
+    $translate.get( 'mrdt.verify' ).then((label) => {
       $el.append(
         '<div><a class="btn btn-default mrdt-verify">' + label + '</a></div>' +
                 '<div><img class="mrdt-preview"/></div>'

--- a/webapp/src/js/enketo/widgets/simprints.js
+++ b/webapp/src/js/enketo/widgets/simprints.js
@@ -37,7 +37,7 @@
     };
 
     if ( !service.enabled() ) {
-      $translate.get( 'simprints.disabled' ).toPromise().then(function( label ) {
+      $translate.get( 'simprints.disabled' ).then(function( label ) {
         $el.append( '<p>' + label + '</p>' );
       });
       return;
@@ -49,7 +49,7 @@
       } );
     } );
 
-    $translate.get( 'simprints.register' ).toPromise().then( function( label ) {
+    $translate.get( 'simprints.register' ).then( function( label ) {
       $el.append( '<div><a class="btn btn-default simprints-register">' +
         '<img src="/img/simprints.png" width="20" height="20"/> ' + label + '</a>' +
       '</div>' );

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -2,7 +2,6 @@ import { ActivationEnd, ActivationStart, Router, RouterEvent } from '@angular/ro
 import * as moment from 'moment';
 import { Component, NgZone, OnInit, HostListener } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { TranslateService } from '@ngx-translate/core';
 import { setTheme as setBootstrapTheme} from 'ngx-bootstrap/utils';
 import { combineLatest } from 'rxjs';
 
@@ -42,6 +41,7 @@ import { TranslateLocaleService } from '@mm-services/translate-locale.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TransitionsService } from '@mm-services/transitions.service';
 import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 const SYNC_STATUS = {
   inProgress: {

--- a/webapp/src/ts/components/filters/facility-filter/facility-filter.component.ts
+++ b/webapp/src/ts/components/filters/facility-filter/facility-filter.component.ts
@@ -19,7 +19,7 @@ import {
 import { PlaceHierarchyService } from '@mm-services/place-hierarchy.service';
 import { AbstractFilter } from '@mm-components/filters/abstract-filter';
 import { SessionService } from '@mm-services/session.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   selector: 'mm-facility-filter',
@@ -47,7 +47,7 @@ export class FacilityFilterComponent implements OnInit, AbstractFilter, AfterVie
   constructor(
     private store:Store,
     private placeHierarchyService:PlaceHierarchyService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private ngZone:NgZone,
     private sessionService:SessionService,
   ) {
@@ -175,7 +175,7 @@ export class FacilityFilterComponent implements OnInit, AbstractFilter, AfterVie
       return Promise.resolve(facility.doc.name);
     }
 
-    return this.translateHelperService.get(this.isOnlineOnly ? 'place.deleted' : 'place.unavailable');
+    return this.translateService.get(this.isOnlineOnly ? 'place.deleted' : 'place.unavailable');
   }
 
   clear() {

--- a/webapp/src/ts/components/filters/facility-filter/facility-filter.component.ts
+++ b/webapp/src/ts/components/filters/facility-filter/facility-filter.component.ts
@@ -9,9 +9,7 @@ import {
   AfterViewChecked
 } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { from } from 'rxjs';
 import { flatten as _flatten, sortBy as _sortBy } from 'lodash-es';
-import { TranslateService } from '@ngx-translate/core';
 
 import { GlobalActions } from '@mm-actions/global';
 import {
@@ -21,6 +19,7 @@ import {
 import { PlaceHierarchyService } from '@mm-services/place-hierarchy.service';
 import { AbstractFilter } from '@mm-components/filters/abstract-filter';
 import { SessionService } from '@mm-services/session.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   selector: 'mm-facility-filter',
@@ -48,7 +47,7 @@ export class FacilityFilterComponent implements OnInit, AbstractFilter, AfterVie
   constructor(
     private store:Store,
     private placeHierarchyService:PlaceHierarchyService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private ngZone:NgZone,
     private sessionService:SessionService,
   ) {
@@ -173,10 +172,10 @@ export class FacilityFilterComponent implements OnInit, AbstractFilter, AfterVie
 
   itemLabel(facility) {
     if (facility.doc && facility.doc.name) {
-      return from([facility.doc.name]);
+      return Promise.resolve(facility.doc.name);
     }
 
-    return this.translateService.get(this.isOnlineOnly ? 'place.deleted' : 'place.unavailable');
+    return this.translateHelperService.get(this.isOnlineOnly ? 'place.deleted' : 'place.unavailable');
   }
 
   clear() {

--- a/webapp/src/ts/components/filters/multi-dropdown-filter/multi-dropdown-filter.component.ts
+++ b/webapp/src/ts/components/filters/multi-dropdown-filter/multi-dropdown-filter.component.ts
@@ -1,9 +1,9 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 import { from, Observable } from 'rxjs';
 import { debounce as _debounce } from 'lodash-es';
 
 import { AbstractFilter } from '@mm-components/filters/abstract-filter';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   selector: 'multi-dropdown-filter',
@@ -25,7 +25,7 @@ export class MultiDropdownFilterComponent implements AbstractFilter, OnInit {
   selected = new Set();
   filterLabel;
 
-  constructor(private translateService:TranslateService) {
+  constructor(private translateHelperService:TranslateHelperService) {
     this.apply = _debounce(this.apply, 200);
   }
 
@@ -45,11 +45,11 @@ export class MultiDropdownFilterComponent implements AbstractFilter, OnInit {
         total: this.items,
         selected: this.selected,
       };
-      return this.translateService.get(this.label(state));
+      return this.translateHelperService.get(this.label(state));
     }
 
     if (this.selected.size === 0 || this.selected.size === this.items.length) {
-      return this.translateService.get(this.labelNoFilter);
+      return this.translateHelperService.get(this.labelNoFilter);
     }
 
     if (this.selected.size === 1) {
@@ -60,7 +60,7 @@ export class MultiDropdownFilterComponent implements AbstractFilter, OnInit {
       }
     }
 
-    return this.translateService.get(this.labelFilter, { number: this.selected.size });
+    return this.translateHelperService.get(this.labelFilter, { number: this.selected.size });
   }
 
   private apply() {

--- a/webapp/src/ts/components/filters/multi-dropdown-filter/multi-dropdown-filter.component.ts
+++ b/webapp/src/ts/components/filters/multi-dropdown-filter/multi-dropdown-filter.component.ts
@@ -3,7 +3,7 @@ import { from, Observable } from 'rxjs';
 import { debounce as _debounce } from 'lodash-es';
 
 import { AbstractFilter } from '@mm-components/filters/abstract-filter';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   selector: 'multi-dropdown-filter',
@@ -25,7 +25,7 @@ export class MultiDropdownFilterComponent implements AbstractFilter, OnInit {
   selected = new Set();
   filterLabel;
 
-  constructor(private translateHelperService:TranslateHelperService) {
+  constructor(private translateService:TranslateService) {
     this.apply = _debounce(this.apply, 200);
   }
 
@@ -45,11 +45,11 @@ export class MultiDropdownFilterComponent implements AbstractFilter, OnInit {
         total: this.items,
         selected: this.selected,
       };
-      return this.translateHelperService.get(this.label(state));
+      return this.translateService.get(this.label(state));
     }
 
     if (this.selected.size === 0 || this.selected.size === this.items.length) {
-      return this.translateHelperService.get(this.labelNoFilter);
+      return this.translateService.get(this.labelNoFilter);
     }
 
     if (this.selected.size === 1) {
@@ -60,7 +60,7 @@ export class MultiDropdownFilterComponent implements AbstractFilter, OnInit {
       }
     }
 
-    return this.translateHelperService.get(this.labelFilter, { number: this.selected.size });
+    return this.translateService.get(this.labelFilter, { number: this.selected.size });
   }
 
   private apply() {

--- a/webapp/src/ts/effects/contacts.effects.ts
+++ b/webapp/src/ts/effects/contacts.effects.ts
@@ -12,7 +12,7 @@ import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TasksForContactService } from '@mm-services/tasks-for-contact.service';
 import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 import { RouteSnapshotService } from '@mm-services/route-snapshot.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable()
 export class ContactsEffects {
@@ -28,7 +28,7 @@ export class ContactsEffects {
     private contactSummaryService: ContactSummaryService,
     private tasksForContactService: TasksForContactService,
     private targetAggregateService: TargetAggregatesService,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     private routeSnapshotService: RouteSnapshotService,
   ) {
     this.contactsActions = new ContactsActions(store);
@@ -66,7 +66,7 @@ export class ContactsEffects {
           .then(() => this.loadTasks())
           .catch(err => {
             if (err.code === 404 && !silent) {
-              this.globalActions.setSnackbarContent(this.translateHelperService.instant('error.404.title'));
+              this.globalActions.setSnackbarContent(this.translateService.instant('error.404.title'));
             }
             console.error('Error selecting contact', err);
             this.globalActions.unsetSelected();
@@ -81,9 +81,9 @@ export class ContactsEffects {
   private setTitle(selected) {
     const routeSnapshot = this.routeSnapshotService.get();
     const deceasedTitle = routeSnapshot?.data?.name === 'contacts.deceased'
-      ? this.translateHelperService.instant('contact.deceased.title') : null;
+      ? this.translateService.instant('contact.deceased.title') : null;
     const title = deceasedTitle || selected.type?.name_key || 'contact.profile';
-    this.globalActions.setTitle(this.translateHelperService.instant(title));
+    this.globalActions.setTitle(this.translateService.instant(title));
   }
 
   private loadContact(id) {

--- a/webapp/src/ts/effects/contacts.effects.ts
+++ b/webapp/src/ts/effects/contacts.effects.ts
@@ -3,7 +3,6 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store, select } from '@ngrx/store';
 import { of } from 'rxjs';
 import { exhaustMap, withLatestFrom } from 'rxjs/operators';
-import { TranslateService } from '@ngx-translate/core';
 
 import { Actions as ContactActionList, ContactsActions } from '@mm-actions/contacts';
 import { ContactViewModelGeneratorService } from '@mm-services/contact-view-model-generator.service';
@@ -13,6 +12,7 @@ import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TasksForContactService } from '@mm-services/tasks-for-contact.service';
 import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 import { RouteSnapshotService } from '@mm-services/route-snapshot.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable()
 export class ContactsEffects {
@@ -28,7 +28,7 @@ export class ContactsEffects {
     private contactSummaryService: ContactSummaryService,
     private tasksForContactService: TasksForContactService,
     private targetAggregateService: TargetAggregatesService,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     private routeSnapshotService: RouteSnapshotService,
   ) {
     this.contactsActions = new ContactsActions(store);
@@ -66,7 +66,7 @@ export class ContactsEffects {
           .then(() => this.loadTasks())
           .catch(err => {
             if (err.code === 404 && !silent) {
-              this.globalActions.setSnackbarContent(this.translateService.instant('error.404.title'));
+              this.globalActions.setSnackbarContent(this.translateHelperService.instant('error.404.title'));
             }
             console.error('Error selecting contact', err);
             this.globalActions.unsetSelected();
@@ -81,9 +81,9 @@ export class ContactsEffects {
   private setTitle(selected) {
     const routeSnapshot = this.routeSnapshotService.get();
     const deceasedTitle = routeSnapshot?.data?.name === 'contacts.deceased'
-      ? this.translateService.instant('contact.deceased.title') : null;
+      ? this.translateHelperService.instant('contact.deceased.title') : null;
     const title = deceasedTitle || selected.type?.name_key || 'contact.profile';
-    this.globalActions.setTitle(this.translateService.instant(title));
+    this.globalActions.setTitle(this.translateHelperService.instant(title));
   }
 
   private loadContact(id) {

--- a/webapp/src/ts/effects/reports.effects.ts
+++ b/webapp/src/ts/effects/reports.effects.ts
@@ -19,7 +19,7 @@ import { EditReportComponent } from '@mm-modals/edit-report/edit-report.componen
 import { VerifyReportComponent } from '@mm-modals/verify-report/verify-report.component';
 import { ServicesActions } from '@mm-actions/services';
 import { AuthService } from '@mm-services/auth.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 
 @Injectable()
@@ -39,7 +39,7 @@ export class ReportsEffects {
     private router:Router,
     private searchService:SearchService,
     private modalService:ModalService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private authService:AuthService,
   ) {
     this.reportActions = new ReportsActions(store);
@@ -281,7 +281,7 @@ export class ReportsEffects {
 
         const promptUserToConfirmVerification = () => {
           const verificationTranslationKey = verified ? 'reports.verify.valid' : 'reports.verify.invalid';
-          const proposedVerificationState = this.translateHelperService.instant(verificationTranslationKey);
+          const proposedVerificationState = this.translateService.instant(verificationTranslationKey);
           return this.modalService
             .show(VerifyReportComponent, { initialState: { model: { proposedVerificationState } } })
             .then(() => true)

--- a/webapp/src/ts/effects/reports.effects.ts
+++ b/webapp/src/ts/effects/reports.effects.ts
@@ -4,9 +4,8 @@ import { Actions, ofType, createEffect } from '@ngrx/effects';
 import { from, of } from 'rxjs';
 import { map, exhaustMap, filter, catchError, withLatestFrom, concatMap, tap } from 'rxjs/operators';
 import { Router } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
-import * as lineageFactory from '@medic/lineage';
 
+import * as lineageFactory from '@medic/lineage';
 import { Actions as ReportActionList, ReportsActions } from '@mm-actions/reports';
 import { GlobalActions } from '@mm-actions/global';
 import { ReportViewModelGeneratorService } from '@mm-services/report-view-model-generator.service';
@@ -20,6 +19,7 @@ import { EditReportComponent } from '@mm-modals/edit-report/edit-report.componen
 import { VerifyReportComponent } from '@mm-modals/verify-report/verify-report.component';
 import { ServicesActions } from '@mm-actions/services';
 import { AuthService } from '@mm-services/auth.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 
 @Injectable()
@@ -39,7 +39,7 @@ export class ReportsEffects {
     private router:Router,
     private searchService:SearchService,
     private modalService:ModalService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private authService:AuthService,
   ) {
     this.reportActions = new ReportsActions(store);
@@ -281,7 +281,7 @@ export class ReportsEffects {
 
         const promptUserToConfirmVerification = () => {
           const verificationTranslationKey = verified ? 'reports.verify.valid' : 'reports.verify.invalid';
-          const proposedVerificationState = this.translateService.instant(verificationTranslationKey);
+          const proposedVerificationState = this.translateHelperService.instant(verificationTranslationKey);
           return this.modalService
             .show(VerifyReportComponent, { initialState: { model: { proposedVerificationState } } })
             .then(() => true)

--- a/webapp/src/ts/modals/delete-doc-confirm/delete-doc-confirm.component.ts
+++ b/webapp/src/ts/modals/delete-doc-confirm/delete-doc-confirm.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import * as LineageFactory from '@medic/lineage';
-import { TranslateService } from '@ngx-translate/core';
 import { Store } from '@ngrx/store';
 import { combineLatest, Subscription } from 'rxjs';
 
@@ -10,6 +9,7 @@ import { DbService } from '@mm-services/db.service';
 import { MmModalAbstract } from '@mm-modals/mm-modal/mm-modal';
 import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   selector: 'delete-doc-confirm',
@@ -26,7 +26,7 @@ export class DeleteDocConfirmComponent extends MmModalAbstract implements OnInit
 
   constructor(
     private store: Store,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     bsModalRef: BsModalRef,
     private dbService: DbService,
     private router: Router
@@ -75,7 +75,7 @@ export class DeleteDocConfirmComponent extends MmModalAbstract implements OnInit
       .get()
       .put(doc)
       .then(() => {
-        const text = this.translateService.instant('document.deleted');
+        const text = this.translateHelperService.instant('document.deleted');
         const route = this.getRoute(this.router.url, doc);
         this.globalActions.setSnackbarContent(text);
         this.close();

--- a/webapp/src/ts/modals/delete-doc-confirm/delete-doc-confirm.component.ts
+++ b/webapp/src/ts/modals/delete-doc-confirm/delete-doc-confirm.component.ts
@@ -9,7 +9,7 @@ import { DbService } from '@mm-services/db.service';
 import { MmModalAbstract } from '@mm-modals/mm-modal/mm-modal';
 import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   selector: 'delete-doc-confirm',
@@ -26,7 +26,7 @@ export class DeleteDocConfirmComponent extends MmModalAbstract implements OnInit
 
   constructor(
     private store: Store,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     bsModalRef: BsModalRef,
     private dbService: DbService,
     private router: Router
@@ -75,7 +75,7 @@ export class DeleteDocConfirmComponent extends MmModalAbstract implements OnInit
       .get()
       .put(doc)
       .then(() => {
-        const text = this.translateHelperService.instant('document.deleted');
+        const text = this.translateService.instant('document.deleted');
         const route = this.getRoute(this.router.url, doc);
         this.globalActions.setSnackbarContent(text);
         this.close();

--- a/webapp/src/ts/modals/edit-user/update-password.component.ts
+++ b/webapp/src/ts/modals/edit-user/update-password.component.ts
@@ -7,7 +7,7 @@ import { UserSettingsService } from '@mm-services/user-settings.service';
 import { UpdateUserService } from '@mm-services/update-user.service';
 import { UserLoginService } from '@mm-services/user-login.service';
 import { EditUserAbstract } from '@mm-modals/edit-user/edit-user.component';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 import { ConfirmPasswordUpdatedComponent } from '@mm-modals/edit-user/confirm-password-updated.component';
 
 const PASSWORD_MINIMUM_LENGTH = 8;
@@ -39,7 +39,7 @@ export class UpdatePasswordComponent extends EditUserAbstract implements OnInit 
     userSettingsService: UserSettingsService,
     private updateUserService: UpdateUserService,
     private userLoginService: UserLoginService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private modalService: ModalService,
   ) {
     super(bsModalRef, userSettingsService);
@@ -77,12 +77,12 @@ export class UpdatePasswordComponent extends EditUserAbstract implements OnInit 
         })
         .catch(err => {
           if (err.status === 0) { //Offline Status
-            this.translateHelperService.get('online.action.message').then(value => {
+            this.translateService.get('online.action.message').then(value => {
               this.errors.currentPassword = value;
               this.setError(err, value);
             });
           } else if (err.status === 401) {
-            this.translateHelperService.get('password.incorrect').then(value => {
+            this.translateService.get('password.incorrect').then(value => {
               this.errors.currentPassword = value;
               this.setError(err, value);
             });
@@ -108,7 +108,7 @@ export class UpdatePasswordComponent extends EditUserAbstract implements OnInit 
 
   private validateRequired(fieldName, fieldDisplayName) {
     if (!this.editUserModel[fieldName]) {
-      this.translateHelperService
+      this.translateService
         .fieldIsRequired(fieldDisplayName)
         .then(value => {
           this.errors[fieldName] = value;
@@ -124,7 +124,7 @@ export class UpdatePasswordComponent extends EditUserAbstract implements OnInit 
   private validatePasswordStrength() {
     const password = this.editUserModel.password || '';
     if (password.length < PASSWORD_MINIMUM_LENGTH) {
-      this.translateHelperService
+      this.translateService
         .get('password.length.minimum', { minimum: PASSWORD_MINIMUM_LENGTH })
         .then((value) => {
           this.errors.password = value;
@@ -132,7 +132,7 @@ export class UpdatePasswordComponent extends EditUserAbstract implements OnInit 
       return false;
     }
     if (passwordTester(password) < PASSWORD_MINIMUM_SCORE) {
-      this.translateHelperService
+      this.translateService
         .get('password.weak')
         .then(value => {
           this.errors.password = value;
@@ -144,7 +144,7 @@ export class UpdatePasswordComponent extends EditUserAbstract implements OnInit 
 
   private validateConfirmPasswordMatches() {
     if (this.editUserModel.password !== this.editUserModel.passwordConfirm) {
-      this.translateHelperService.get('Passwords must match').then(value => {
+      this.translateService.get('Passwords must match').then(value => {
         this.errors.password = value;
       });
       return false;

--- a/webapp/src/ts/modals/feedback/feedback.component.ts
+++ b/webapp/src/ts/modals/feedback/feedback.component.ts
@@ -5,7 +5,7 @@ import { Store } from '@ngrx/store';
 import { FeedbackService } from '@mm-services/feedback.service';
 import { MmModalAbstract } from '../mm-modal/mm-modal';
 import { GlobalActions } from '@mm-actions/global';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   selector: 'feedback-modal',
@@ -22,7 +22,7 @@ export class FeedbackComponent extends MmModalAbstract {
     bsModalRef: BsModalRef,
     private feedbackService: FeedbackService,
     private store: Store,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
   ) {
     super(bsModalRef);
     this.globalActions = new GlobalActions(store);
@@ -33,7 +33,7 @@ export class FeedbackComponent extends MmModalAbstract {
       this.error.message = false;
       return Promise.resolve();
     } else {
-      return this.translateHelperService
+      return this.translateService
         .fieldIsRequired('Bug description')
         .then(value => this.error.message = value);
     }
@@ -56,7 +56,7 @@ export class FeedbackComponent extends MmModalAbstract {
           .then(() => {
             this.setFinished();
             this.close();
-            this.translateHelperService
+            this.translateService
               .get('feedback.submitted')
               .then(value => this.globalActions.setSnackbarContent(value));
           })

--- a/webapp/src/ts/modals/feedback/feedback.component.ts
+++ b/webapp/src/ts/modals/feedback/feedback.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { Store } from '@ngrx/store';
-import { TranslateService } from '@ngx-translate/core';
 
 import { FeedbackService } from '@mm-services/feedback.service';
 import { MmModalAbstract } from '../mm-modal/mm-modal';
@@ -22,7 +21,6 @@ export class FeedbackComponent extends MmModalAbstract {
   constructor(
     bsModalRef: BsModalRef,
     private feedbackService: FeedbackService,
-    private translateService: TranslateService,
     private store: Store,
     private translateHelperService:TranslateHelperService,
   ) {
@@ -58,9 +56,9 @@ export class FeedbackComponent extends MmModalAbstract {
           .then(() => {
             this.setFinished();
             this.close();
-            this.translateService
+            this.translateHelperService
               .get('feedback.submitted')
-              .subscribe(value => this.globalActions.setSnackbarContent(value));
+              .then(value => this.globalActions.setSnackbarContent(value));
           })
           .catch(err => {
             this.setError(err, 'Error saving feedback');

--- a/webapp/src/ts/modals/send-message/send-message.component.ts
+++ b/webapp/src/ts/modals/send-message/send-message.component.ts
@@ -9,7 +9,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { SendMessageService } from '@mm-services/send-message.service';
 import { MmModalAbstract } from '@mm-modals/mm-modal/mm-modal';
 import { Select2SearchService } from '@mm-services/select2-search.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   selector: 'send-message',
@@ -35,7 +35,7 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
     bsModalRef: BsModalRef,
     private sendMessageService: SendMessageService,
     private select2SearchService: Select2SearchService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
   ) {
     super(bsModalRef);
   }
@@ -53,7 +53,7 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
       return;
     }
 
-    return this.translateHelperService
+    return this.translateService
       .fieldIsRequired('tasks.0.messages.0.message')
       .then(value => {
         this.errors.message = value;
@@ -76,7 +76,7 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
   private validatePhoneNumbers(settings, recipients) {
     // Recipients is mandatory
     if (!recipients || !recipients.length) {
-      return this.translateHelperService
+      return this.translateService
         .fieldIsRequired('tasks.0.messages.0.to')
         .then(value => {
           this.errors.phone = value;
@@ -88,7 +88,7 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
 
     if (errors.length) {
       const errorRecipients = _map(errors, (error) => this.templateSelection(error)).join(', ');
-      return this.translateHelperService
+      return this.translateService
         .get('Invalid contact numbers', { recipients: errorRecipients })
         .then(value => {
           this.errors.phone = value;
@@ -99,7 +99,7 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
   }
 
   private formatPlace(row) {
-    return this.translateHelperService.instant('Everyone at', {
+    return this.translateService.instant('Everyone at', {
       facility: row.doc && row.doc.name,
       count: row.descendants ? row.descendants.length : ''
     });

--- a/webapp/src/ts/modals/send-message/send-message.component.ts
+++ b/webapp/src/ts/modals/send-message/send-message.component.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Component } from '@angular/core';
 import * as phoneNumber from '@medic/phone-number';
-import { TranslateService } from '@ngx-translate/core';
 import { filter as _filter, map as _map, partial as _partial } from 'lodash-es';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
@@ -30,7 +29,6 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
   };
 
   constructor(
-    private translateService: TranslateService,
     private formatProvider: FormatProvider,
     private settingsService: SettingsService,
     private contactTypesService: ContactTypesService,
@@ -90,9 +88,8 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
 
     if (errors.length) {
       const errorRecipients = _map(errors, (error) => this.templateSelection(error)).join(', ');
-      return this.translateService
+      return this.translateHelperService
         .get('Invalid contact numbers', { recipients: errorRecipients })
-        .toPromise()
         .then(value => {
           this.errors.phone = value;
         });
@@ -102,7 +99,7 @@ export class SendMessageComponent extends MmModalAbstract implements AfterViewIn
   }
 
   private formatPlace(row) {
-    return this.translateService.instant('Everyone at', {
+    return this.translateHelperService.instant('Everyone at', {
       facility: row.doc && row.doc.name,
       count: row.descendants ? row.descendants.length : ''
     });

--- a/webapp/src/ts/modules/about/about.component.ts
+++ b/webapp/src/ts/modules/about/about.component.ts
@@ -8,7 +8,7 @@ import { ResourceIconsService } from '@mm-services/resource-icons.service';
 import { Selectors } from '@mm-selectors/index';
 import { SessionService } from '@mm-services/session.service';
 import { VersionService } from '@mm-services/version.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   templateUrl: './about.component.html'
@@ -36,7 +36,7 @@ export class AboutComponent implements OnInit, OnDestroy {
     private resourceIconsService: ResourceIconsService,
     private sessionService: SessionService,
     private versionService: VersionService,
-    private translateService: TranslateHelperService,
+    private translateService: TranslateService,
     private router: Router
   ) { }
 

--- a/webapp/src/ts/modules/about/about.component.ts
+++ b/webapp/src/ts/modules/about/about.component.ts
@@ -2,13 +2,13 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subscription } from 'rxjs';
-import { TranslateService } from '@ngx-translate/core';
 
 import { DbService } from '@mm-services/db.service';
 import { ResourceIconsService } from '@mm-services/resource-icons.service';
 import { Selectors } from '@mm-selectors/index';
 import { SessionService } from '@mm-services/session.service';
 import { VersionService } from '@mm-services/version.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   templateUrl: './about.component.html'
@@ -36,7 +36,7 @@ export class AboutComponent implements OnInit, OnDestroy {
     private resourceIconsService: ResourceIconsService,
     private sessionService: SessionService,
     private versionService: VersionService,
-    private translateService: TranslateService,
+    private translateService: TranslateHelperService,
     private router: Router
   ) { }
 
@@ -93,7 +93,7 @@ export class AboutComponent implements OnInit, OnDestroy {
       .getRemoteRev()
       .catch(error => {
         console.debug('Could not access remote ddoc rev', error);
-        return this.translateService.get('app.version.unknown').toPromise();
+        return this.translateService.get('app.version.unknown');
       })
       .then(rev => this.remoteRev = rev);
   }

--- a/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
+++ b/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
@@ -2,12 +2,12 @@ import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { combineLatest, Subscription, Subject } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { TranslateService } from '@ngx-translate/core';
 
 import { Selectors } from '@mm-selectors/index';
 import { TargetAggregatesActions } from '@mm-actions/target-aggregates';
 import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 import { GlobalActions } from '@mm-actions/global';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   selector: 'analytics-target-aggregates-detail',
@@ -26,7 +26,7 @@ export class AnalyticsTargetAggregatesDetailComponent implements OnInit, OnDestr
     private store: Store,
     private route: ActivatedRoute,
     private targetAggregatesService: TargetAggregatesService,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
   ) {
     this.targetAggregatesActions = new TargetAggregatesActions(store);
     this.globalActions = new GlobalActions(store);
@@ -96,7 +96,7 @@ export class AnalyticsTargetAggregatesDetailComponent implements OnInit, OnDestr
       return;
     }
 
-    const title = this.translateService.instant('analytics.target.aggregates');
+    const title = this.translateHelperService.instant('analytics.target.aggregates');
     this.globalActions.setTitle(title);
     this.targetAggregatesActions.setSelectedTargetAggregate(aggregateDetails);
   }

--- a/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
+++ b/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
@@ -7,7 +7,7 @@ import { Selectors } from '@mm-selectors/index';
 import { TargetAggregatesActions } from '@mm-actions/target-aggregates';
 import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 import { GlobalActions } from '@mm-actions/global';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   selector: 'analytics-target-aggregates-detail',
@@ -26,7 +26,7 @@ export class AnalyticsTargetAggregatesDetailComponent implements OnInit, OnDestr
     private store: Store,
     private route: ActivatedRoute,
     private targetAggregatesService: TargetAggregatesService,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
   ) {
     this.targetAggregatesActions = new TargetAggregatesActions(store);
     this.globalActions = new GlobalActions(store);
@@ -96,7 +96,7 @@ export class AnalyticsTargetAggregatesDetailComponent implements OnInit, OnDestr
       return;
     }
 
-    const title = this.translateHelperService.instant('analytics.target.aggregates');
+    const title = this.translateService.instant('analytics.target.aggregates');
     this.globalActions.setTitle(title);
     this.targetAggregatesActions.setSelectedTargetAggregate(aggregateDetails);
   }

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -12,7 +12,6 @@ import { ContactsActions } from '@mm-actions/contacts';
 import { ChangesService } from '@mm-services/changes.service';
 import { ContactChangeFilterService } from '@mm-services/contact-change-filter.service';
 import { ResponsiveService } from '@mm-services/responsive.service';
-import { TranslateService } from '@ngx-translate/core';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
 import { ContactsMutedComponent } from '@mm-modals/contacts-muted/contacts-muted.component';
@@ -22,6 +21,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { SessionService } from '@mm-services/session.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 import { MutingTransition } from '@mm-services/transitions/muting.transition';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
 
@@ -58,7 +58,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
     private router: Router,
     private changesService: ChangesService,
     private contactChangeFilterService: ContactChangeFilterService,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     private translateFromService: TranslateFromService,
     private xmlFormsService: XmlFormsService,
     private modalService: ModalService,
@@ -343,7 +343,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
         const formSummaries = forms
           .map(xForm => {
             const title = xForm.translation_key ?
-              this.translateService.instant(xForm.translation_key) : this.translateFromService.get(xForm.title);
+              this.translateHelperService.instant(xForm.translation_key) : this.translateFromService.get(xForm.title);
 
             const isUnmuteForm = this.mutingTransition.isUnmuteForm(xForm.internalId, this.settings);
             const isMuted = this.contactMutedService.getMuted(this.selectedContact.doc);

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -21,7 +21,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { SessionService } from '@mm-services/session.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 import { MutingTransition } from '@mm-services/transitions/muting.transition';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
 
@@ -58,7 +58,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
     private router: Router,
     private changesService: ChangesService,
     private contactChangeFilterService: ContactChangeFilterService,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     private translateFromService: TranslateFromService,
     private xmlFormsService: XmlFormsService,
     private modalService: ModalService,
@@ -343,7 +343,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
         const formSummaries = forms
           .map(xForm => {
             const title = xForm.translation_key ?
-              this.translateHelperService.instant(xForm.translation_key) : this.translateFromService.get(xForm.title);
+              this.translateService.instant(xForm.translation_key) : this.translateFromService.get(xForm.title);
 
             const isUnmuteForm = this.mutingTransition.isUnmuteForm(xForm.internalId, this.settings);
             const isMuted = this.contactMutedService.getMuted(this.selectedContact.doc);

--- a/webapp/src/ts/modules/contacts/contacts-deceased.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-deceased.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { combineLatest, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { Router, ActivatedRoute } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 
 import { Selectors } from '@mm-selectors/index';
 import { ContactsActions } from '@mm-actions/contacts';
@@ -21,10 +20,9 @@ export class ContactsDeceasedComponent implements OnInit, OnDestroy {
   constructor(
     private store: Store,
     private changesService: ChangesService,
-    private translateService:TranslateService,
     private router: Router,
     private route: ActivatedRoute,
-  ){
+  ) {
     this.contactsActions = new ContactsActions(store);
   }
 

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -12,7 +12,7 @@ import { ContactSaveService } from '@mm-services/contact-save.service';
 import { Selectors } from '@mm-selectors/index';
 import { GlobalActions } from '@mm-actions/global';
 import { ContactsActions } from '@mm-actions/contacts';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 
 @Component({
@@ -28,7 +28,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     private contactTypesService:ContactTypesService,
     private dbService:DbService,
     private contactSaveService:ContactSaveService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
   ) {
     this.globalActions = new GlobalActions(store);
     this.contactsActions = new ContactsActions(store);
@@ -217,7 +217,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
           .select(Selectors.getTranslationsLoaded)
           .subscribe((loaded) => {
             if (loaded) {
-              this.translateHelperService
+              this.translateService
                 .get(titleKey)
                 .then((title) => this.globalActions.setTitle(title));
             }
@@ -293,7 +293,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
             this.globalActions.setEnketoSavingStatus(false);
             this.globalActions.setEnketoEditedStatus(false);
 
-            this.translateHelperService
+            this.translateService
               .get(docId ? 'contact.updated' : 'contact.created')
               .then(snackBarContent => this.globalActions.setSnackbarContent(snackBarContent));
 
@@ -303,7 +303,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
             console.error('Error submitting form data', err);
 
             this.globalActions.setEnketoSavingStatus(false);
-            return this.translateHelperService
+            return this.translateService
               .get('Error updating contact')
               .then(error => this.globalActions.setEnketoError(error));
           });

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -12,7 +12,7 @@ import { Selectors } from '@mm-selectors/index';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   templateUrl: './contacts-report.component.html'
@@ -45,7 +45,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
     private translateFromService: TranslateFromService,
     private router: Router,
     private route: ActivatedRoute,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     private contactViewModelGeneratorService: ContactViewModelGeneratorService,
     private ngZone: NgZone,
   ) {
@@ -230,7 +230,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
       .then((docs) => {
         console.debug('saved report and associated docs', docs);
         this.globalActions.setEnketoSavingStatus(false);
-        this.globalActions.setSnackbarContent(this.translateHelperService.instant('report.created'));
+        this.globalActions.setSnackbarContent(this.translateService.instant('report.created'));
         this.globalActions.setEnketoEditedStatus(false);
 
         this.telemetryData.postSave = Date.now();
@@ -244,7 +244,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
       .catch((err) => {
         this.globalActions.setEnketoSavingStatus(false);
         console.error('Error submitting form data: ', err);
-        this.globalActions.setEnketoError(this.translateHelperService.instant('error.report.save'));
+        this.globalActions.setEnketoError(this.translateService.instant('error.report.save'));
       });
   }
 }

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy, AfterViewInit, NgZone } from '@angular/co
 import { Store } from '@ngrx/store';
 import { combineLatest, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 import { isEqual as _isEqual } from 'lodash-es';
 
 import { ContactViewModelGeneratorService } from '@mm-services/contact-view-model-generator.service';
@@ -13,6 +12,7 @@ import { Selectors } from '@mm-selectors/index';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   templateUrl: './contacts-report.component.html'
@@ -45,7 +45,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
     private translateFromService: TranslateFromService,
     private router: Router,
     private route: ActivatedRoute,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     private contactViewModelGeneratorService: ContactViewModelGeneratorService,
     private ngZone: NgZone,
   ) {
@@ -230,7 +230,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
       .then((docs) => {
         console.debug('saved report and associated docs', docs);
         this.globalActions.setEnketoSavingStatus(false);
-        this.globalActions.setSnackbarContent(this.translateService.instant('report.created'));
+        this.globalActions.setSnackbarContent(this.translateHelperService.instant('report.created'));
         this.globalActions.setEnketoEditedStatus(false);
 
         this.telemetryData.postSave = Date.now();
@@ -244,7 +244,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
       .catch((err) => {
         this.globalActions.setEnketoSavingStatus(false);
         console.error('Error submitting form data: ', err);
-        this.globalActions.setEnketoError(this.translateService.instant('error.report.save'));
+        this.globalActions.setEnketoError(this.translateHelperService.instant('error.report.save'));
       });
   }
 }

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { combineLatest, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 import { findIndex as _findIndex } from 'lodash-es';
 
 import { GlobalActions } from '@mm-actions/global';
@@ -24,6 +23,7 @@ import { ScrollLoaderProvider } from '@mm-providers/scroll-loader.provider';
 import { TourService } from '@mm-services/tour.service';
 import { ExportService } from '@mm-services/export.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   templateUrl: './contacts.component.html'
@@ -63,7 +63,7 @@ export class ContactsComponent implements OnInit, OnDestroy{
     private store: Store,
     private route: ActivatedRoute,
     private changesService: ChangesService,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     private searchService: SearchService,
     private contactTypesService: ContactTypesService,
     private userSettingsService: UserSettingsService,
@@ -236,12 +236,12 @@ export class ContactsComponent implements OnInit, OnDestroy{
       if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
         if (contact.lastVisitedDate === 0) {
           contact.overdue = true;
-          contact.summary = this.translateService.instant('contact.last.visited.unknown');
+          contact.summary = this.translateHelperService.instant('contact.last.visited.unknown');
         } else {
           const now = new Date().getTime();
           const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
           contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
-          contact.summary = this.translateService.instant(
+          contact.summary = this.translateHelperService.instant(
             'contact.last.visited.date',
             { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
           );
@@ -249,8 +249,8 @@ export class ContactsComponent implements OnInit, OnDestroy{
 
         const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
         contact.visits = {
-          count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
-          summary: this.translateService.instant(
+          count: this.translateHelperService.instant('contacts.visits.count', { count: visitCount }),
+          summary: this.translateHelperService.instant(
             'contacts.visits.visits',
             { VISITS: contact.visitCount }
           )

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -23,7 +23,7 @@ import { ScrollLoaderProvider } from '@mm-providers/scroll-loader.provider';
 import { TourService } from '@mm-services/tour.service';
 import { ExportService } from '@mm-services/export.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   templateUrl: './contacts.component.html'
@@ -63,7 +63,7 @@ export class ContactsComponent implements OnInit, OnDestroy{
     private store: Store,
     private route: ActivatedRoute,
     private changesService: ChangesService,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     private searchService: SearchService,
     private contactTypesService: ContactTypesService,
     private userSettingsService: UserSettingsService,
@@ -236,12 +236,12 @@ export class ContactsComponent implements OnInit, OnDestroy{
       if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
         if (contact.lastVisitedDate === 0) {
           contact.overdue = true;
-          contact.summary = this.translateHelperService.instant('contact.last.visited.unknown');
+          contact.summary = this.translateService.instant('contact.last.visited.unknown');
         } else {
           const now = new Date().getTime();
           const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
           contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
-          contact.summary = this.translateHelperService.instant(
+          contact.summary = this.translateService.instant(
             'contact.last.visited.date',
             { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
           );
@@ -249,8 +249,8 @@ export class ContactsComponent implements OnInit, OnDestroy{
 
         const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
         contact.visits = {
-          count: this.translateHelperService.instant('contacts.visits.count', { count: visitCount }),
-          summary: this.translateHelperService.instant(
+          count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
+          summary: this.translateService.instant(
             'contacts.visits.visits',
             { VISITS: contact.visitCount }
           )

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Component, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { isEqual as _isEqual } from 'lodash-es';
 
@@ -16,6 +15,7 @@ import { GlobalActions } from '@mm-actions/global';
 import { ReportsActions } from '@mm-actions/reports';
 import { EnketoService } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 
 @Component({
@@ -32,7 +32,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
     private lineageModelGeneratorService:LineageModelGeneratorService,
     private xmlFormsService:XmlFormsService,
     private enketoService:EnketoService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private router:Router,
     private route:ActivatedRoute,
     private telemetryService:TelemetryService,
@@ -302,7 +302,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
         console.debug('saved report and associated docs', docs);
         this.globalActions.setEnketoSavingStatus(false);
         const snackBarTranslationKey = this.routeSnapshot.params.reportId ? 'report.updated' : 'report.created';
-        this.globalActions.setSnackbarContent(this.translateService.instant(snackBarTranslationKey));
+        this.globalActions.setSnackbarContent(this.translateHelperService.instant(snackBarTranslationKey));
         this.globalActions.setEnketoEditedStatus(false);
         this.router.navigate(['/reports', docs[0]._id]);
 
@@ -314,9 +314,8 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
       .catch((err) => {
         this.globalActions.setEnketoSavingStatus(false);
         console.error('Error submitting form data: ', err);
-        this.translateService
+        this.translateHelperService
           .get('error.report.save')
-          .toPromise()
           .then(msg => {
             this.globalActions.setEnketoError(msg);
           });

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -15,7 +15,7 @@ import { GlobalActions } from '@mm-actions/global';
 import { ReportsActions } from '@mm-actions/reports';
 import { EnketoService } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 
 @Component({
@@ -32,7 +32,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
     private lineageModelGeneratorService:LineageModelGeneratorService,
     private xmlFormsService:XmlFormsService,
     private enketoService:EnketoService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private router:Router,
     private route:ActivatedRoute,
     private telemetryService:TelemetryService,
@@ -302,7 +302,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
         console.debug('saved report and associated docs', docs);
         this.globalActions.setEnketoSavingStatus(false);
         const snackBarTranslationKey = this.routeSnapshot.params.reportId ? 'report.updated' : 'report.created';
-        this.globalActions.setSnackbarContent(this.translateHelperService.instant(snackBarTranslationKey));
+        this.globalActions.setSnackbarContent(this.translateService.instant(snackBarTranslationKey));
         this.globalActions.setEnketoEditedStatus(false);
         this.router.navigate(['/reports', docs[0]._id]);
 
@@ -314,7 +314,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
       .catch((err) => {
         this.globalActions.setEnketoSavingStatus(false);
         console.error('Error submitting form data: ', err);
-        this.translateHelperService
+        this.translateService
           .get('error.report.save')
           .then(msg => {
             this.globalActions.setEnketoError(msg);

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -20,7 +20,7 @@ import { Selectors } from '@mm-selectors/index';
 import { AddReadStatusService } from '@mm-services/add-read-status.service';
 import { ExportService } from '@mm-services/export.service';
 import { ResponsiveService } from '@mm-services/responsive.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 const PAGE_SIZE = 50;
 
@@ -57,7 +57,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
     private router:Router,
     private changesService:ChangesService,
     private searchService:SearchService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private tourService: TourService,
     private addReadStatusService:AddReadStatusService,
     private exportService:ExportService,
@@ -149,7 +149,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
 
   private getReportHeading(form, report) {
     if (form && form.subjectKey) {
-      return this.translateHelperService.instant(form.subjectKey, report);
+      return this.translateService.instant(form.subjectKey, report);
     }
     if (report.validSubject) {
       return report.subject.value;
@@ -157,7 +157,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
     if (report.subject.name) {
       return report.subject.name;
     }
-    return this.translateHelperService.instant('report.subject.unknown');
+    return this.translateService.instant('report.subject.unknown');
   }
 
   private prepareReports(reports) {

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest, Subscription } from 'rxjs';
-import { TranslateService } from '@ngx-translate/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { ScrollLoaderProvider } from '@mm-providers/scroll-loader.provider';
@@ -21,6 +20,7 @@ import { Selectors } from '@mm-selectors/index';
 import { AddReadStatusService } from '@mm-services/add-read-status.service';
 import { ExportService } from '@mm-services/export.service';
 import { ResponsiveService } from '@mm-services/responsive.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 const PAGE_SIZE = 50;
 
@@ -57,7 +57,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
     private router:Router,
     private changesService:ChangesService,
     private searchService:SearchService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private tourService: TourService,
     private addReadStatusService:AddReadStatusService,
     private exportService:ExportService,
@@ -149,7 +149,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
 
   private getReportHeading(form, report) {
     if (form && form.subjectKey) {
-      return this.translateService.instant(form.subjectKey, report);
+      return this.translateHelperService.instant(form.subjectKey, report);
     }
     if (report.validSubject) {
       return report.subject.value;
@@ -157,7 +157,7 @@ export class ReportsComponent implements OnInit, OnDestroy {
     if (report.subject.name) {
       return report.subject.name;
     }
-    return this.translateService.instant('report.subject.unknown');
+    return this.translateHelperService.instant('report.subject.unknown');
   }
 
   private prepareReports(reports) {

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -2,7 +2,6 @@ import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest, Subject, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 
 import { EnketoService } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
@@ -13,13 +12,14 @@ import { TasksActions } from '@mm-actions/tasks';
 import { Selectors } from '@mm-selectors/index';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { DbService } from '@mm-services/db.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Component({
   templateUrl: './tasks-content.component.html'
 })
 export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private route:ActivatedRoute,
     private store:Store,
     private enketoService:EnketoService,
@@ -221,7 +221,7 @@ export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
         this.form = formInstance;
         this.loadingForm = false;
         if (formDoc?.translation_key) {
-          this.globalActions.setTitle(this.translateService.instant(formDoc.translation_key));
+          this.globalActions.setTitle(this.translateHelperService.instant(formDoc.translation_key));
         } else {
           this.globalActions.setTitle(this.translateFromService.get(formDoc?.title));
         }
@@ -306,7 +306,7 @@ export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
       .save(this.formId, this.form, this.geoHandle)
       .then((docs) => {
         console.debug('saved report and associated docs', docs);
-        this.globalActions.setSnackbarContent(this.translateService.instant('report.created'));
+        this.globalActions.setSnackbarContent(this.translateHelperService.instant('report.created'));
 
         this.globalActions.setEnketoSavingStatus(false);
         this.globalActions.setEnketoEditedStatus(false);
@@ -326,7 +326,7 @@ export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
       .catch((err) => {
         this.globalActions.setEnketoSavingStatus(false);
         console.error('Error submitting form data: ', err);
-        this.globalActions.setEnketoError(this.translateService.instant('error.report.save'));
+        this.globalActions.setEnketoError(this.translateHelperService.instant('error.report.save'));
       });
   }
 

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -12,14 +12,14 @@ import { TasksActions } from '@mm-actions/tasks';
 import { Selectors } from '@mm-selectors/index';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { DbService } from '@mm-services/db.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Component({
   templateUrl: './tasks-content.component.html'
 })
 export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private route:ActivatedRoute,
     private store:Store,
     private enketoService:EnketoService,
@@ -221,7 +221,7 @@ export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
         this.form = formInstance;
         this.loadingForm = false;
         if (formDoc?.translation_key) {
-          this.globalActions.setTitle(this.translateHelperService.instant(formDoc.translation_key));
+          this.globalActions.setTitle(this.translateService.instant(formDoc.translation_key));
         } else {
           this.globalActions.setTitle(this.translateFromService.get(formDoc?.title));
         }
@@ -306,7 +306,7 @@ export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
       .save(this.formId, this.form, this.geoHandle)
       .then((docs) => {
         console.debug('saved report and associated docs', docs);
-        this.globalActions.setSnackbarContent(this.translateHelperService.instant('report.created'));
+        this.globalActions.setSnackbarContent(this.translateService.instant('report.created'));
 
         this.globalActions.setEnketoSavingStatus(false);
         this.globalActions.setEnketoEditedStatus(false);
@@ -326,7 +326,7 @@ export class TasksContentComponent implements OnInit, OnDestroy, AfterViewInit {
       .catch((err) => {
         this.globalActions.setEnketoSavingStatus(false);
         console.error('Error submitting form data: ', err);
-        this.globalActions.setEnketoError(this.translateHelperService.instant('error.report.save'));
+        this.globalActions.setEnketoError(this.translateService.instant('error.report.save'));
       });
   }
 

--- a/webapp/src/ts/pipes/date.pipe.ts
+++ b/webapp/src/ts/pipes/date.pipe.ts
@@ -4,7 +4,7 @@ import * as moment from 'moment';
 
 import { FormatDateService } from '@mm-services/format-date.service';
 import { RelativeDateService } from '@mm-services/relative-date.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 const getState = (state, translateService) => {
   return translateService
@@ -97,7 +97,7 @@ const getRecipient = (task, translateService) => {
 })
 export class AutoreplyPipe implements PipeTransform {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private formatDateService:FormatDateService,
     private relativeDateService:RelativeDateService,
     private sanitizer: DomSanitizer,
@@ -108,10 +108,10 @@ export class AutoreplyPipe implements PipeTransform {
       return Promise.resolve('');
     }
 
-    return getState(task.state, this.translateHelperService).then(state => {
+    return getState(task.state, this.translateService).then(state => {
       const content = state + '&nbsp;' +
         '<span class="autoreply" title="' + task.messages[0].message + '">' +
-        '<span class="autoreply-content">' + this.translateHelperService.instant('autoreply') + '</span>' +
+        '<span class="autoreply-content">' + this.translateService.instant('autoreply') + '</span>' +
         '</span>&nbsp';
 
       const transformedContent = getRelativeDate(getTaskDate(task), {
@@ -133,7 +133,7 @@ export class AutoreplyPipe implements PipeTransform {
 })
 export class StatePipe implements PipeTransform {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private formatDateService:FormatDateService,
     private relativeDateService:RelativeDateService,
     private sanitizer: DomSanitizer,
@@ -146,8 +146,8 @@ export class StatePipe implements PipeTransform {
 
     return Promise
       .all([
-        getState(task.state || 'received', this.translateHelperService),
-        getRecipient(task, this.translateHelperService),
+        getState(task.state || 'received', this.translateService),
+        getRecipient(task, this.translateService),
       ])
       .then(([ state, recipient ]) => {
         const relativeDate = getRelativeDate(getTaskDate(task), {
@@ -170,7 +170,7 @@ export class StatePipe implements PipeTransform {
 })
 export class DateOfDeathPipe implements PipeTransform {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private formatDateService:FormatDateService,
     private relativeDateService:RelativeDateService,
     private sanitizer: DomSanitizer,
@@ -186,7 +186,7 @@ export class DateOfDeathPipe implements PipeTransform {
       FormatDate: this.formatDateService,
       RelativeDate: this.relativeDateService,
       withoutTime: true,
-      prefix: this.translateHelperService.instant('contact.deceased.date.prefix') + '&nbsp;'
+      prefix: this.translateService.instant('contact.deceased.date.prefix') + '&nbsp;'
     }));
   }
 }

--- a/webapp/src/ts/pipes/date.pipe.ts
+++ b/webapp/src/ts/pipes/date.pipe.ts
@@ -1,15 +1,14 @@
 import { Pipe, PipeTransform, Injectable } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
-import { TranslateService } from '@ngx-translate/core';
 import * as moment from 'moment';
 
 import { FormatDateService } from '@mm-services/format-date.service';
 import { RelativeDateService } from '@mm-services/relative-date.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 const getState = (state, translateService) => {
   return translateService
     .get('state.' + state)
-    .toPromise()
     .then(label => '<span class="state ' + state + '">' + label + '</span>');
 };
 
@@ -85,7 +84,6 @@ const getRecipient = (task, translateService) => {
 
   return translateService
     .get('to recipient', { recipient: recipient })
-    .toPromise()
     .then(label => {
       return '<span class="recipient">&nbsp;' + label + '</span>';
     });
@@ -99,7 +97,7 @@ const getRecipient = (task, translateService) => {
 })
 export class AutoreplyPipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private formatDateService:FormatDateService,
     private relativeDateService:RelativeDateService,
     private sanitizer: DomSanitizer,
@@ -110,10 +108,10 @@ export class AutoreplyPipe implements PipeTransform {
       return Promise.resolve('');
     }
 
-    return getState(task.state, this.translateService).then(state => {
+    return getState(task.state, this.translateHelperService).then(state => {
       const content = state + '&nbsp;' +
         '<span class="autoreply" title="' + task.messages[0].message + '">' +
-        '<span class="autoreply-content">' + this.translateService.instant('autoreply') + '</span>' +
+        '<span class="autoreply-content">' + this.translateHelperService.instant('autoreply') + '</span>' +
         '</span>&nbsp';
 
       const transformedContent = getRelativeDate(getTaskDate(task), {
@@ -135,7 +133,7 @@ export class AutoreplyPipe implements PipeTransform {
 })
 export class StatePipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private formatDateService:FormatDateService,
     private relativeDateService:RelativeDateService,
     private sanitizer: DomSanitizer,
@@ -148,8 +146,8 @@ export class StatePipe implements PipeTransform {
 
     return Promise
       .all([
-        getState(task.state || 'received', this.translateService),
-        getRecipient(task, this.translateService),
+        getState(task.state || 'received', this.translateHelperService),
+        getRecipient(task, this.translateHelperService),
       ])
       .then(([ state, recipient ]) => {
         const relativeDate = getRelativeDate(getTaskDate(task), {
@@ -172,7 +170,7 @@ export class StatePipe implements PipeTransform {
 })
 export class DateOfDeathPipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private formatDateService:FormatDateService,
     private relativeDateService:RelativeDateService,
     private sanitizer: DomSanitizer,
@@ -188,7 +186,7 @@ export class DateOfDeathPipe implements PipeTransform {
       FormatDate: this.formatDateService,
       RelativeDate: this.relativeDateService,
       withoutTime: true,
-      prefix: this.translateService.instant('contact.deceased.date.prefix') + '&nbsp;'
+      prefix: this.translateHelperService.instant('contact.deceased.date.prefix') + '&nbsp;'
     }));
   }
 }

--- a/webapp/src/ts/pipes/message.pipe.ts
+++ b/webapp/src/ts/pipes/message.pipe.ts
@@ -1,9 +1,9 @@
 import { Injectable, Pipe, PipeTransform } from '@angular/core';
 import * as _ from 'lodash-es';
-import { TranslateService } from '@ngx-translate/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { FormatProvider } from '@mm-providers/format.provider';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 const getFormName = (record, forms) => {
   const form = _.find(forms, { code: record.form });
@@ -21,7 +21,7 @@ const getFormName = (record, forms) => {
 })
 export class SummaryPipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
   ) {}
 
   transform(record, forms) {
@@ -40,7 +40,7 @@ export class SummaryPipe implements PipeTransform {
       record.tasks[0].messages[0]) {
       return record.tasks[0].messages[0].message;
     }
-    return this.translateService.instant('tasks.0.messages.0.message');
+    return this.translateHelperService.instant('tasks.0.messages.0.message');
   }
 }
 
@@ -52,7 +52,7 @@ export class SummaryPipe implements PipeTransform {
 })
 export class TitlePipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
   ) {}
 
   transform(record, forms) {
@@ -63,9 +63,9 @@ export class TitlePipe implements PipeTransform {
       return getFormName(record, forms);
     }
     if (record.kujua_message) {
-      return this.translateService.instant('Outgoing Message');
+      return this.translateHelperService.instant('Outgoing Message');
     }
-    return this.translateService.instant('sms_message.message');
+    return this.translateHelperService.instant('sms_message.message');
   }
 }
 
@@ -78,7 +78,6 @@ export class TitlePipe implements PipeTransform {
 })
 export class ClinicPipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
     private formatProvider:FormatProvider,
   ) {}
 
@@ -96,7 +95,6 @@ export class ClinicPipe implements PipeTransform {
 })
 export class LineagePipe implements PipeTransform {
   constructor(
-    private translateService:TranslateService,
     private formatProvider:FormatProvider,
     private sanitizer:DomSanitizer,
   ) {}

--- a/webapp/src/ts/pipes/message.pipe.ts
+++ b/webapp/src/ts/pipes/message.pipe.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash-es';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { FormatProvider } from '@mm-providers/format.provider';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 const getFormName = (record, forms) => {
   const form = _.find(forms, { code: record.form });
@@ -21,7 +21,7 @@ const getFormName = (record, forms) => {
 })
 export class SummaryPipe implements PipeTransform {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
   ) {}
 
   transform(record, forms) {
@@ -40,7 +40,7 @@ export class SummaryPipe implements PipeTransform {
       record.tasks[0].messages[0]) {
       return record.tasks[0].messages[0].message;
     }
-    return this.translateHelperService.instant('tasks.0.messages.0.message');
+    return this.translateService.instant('tasks.0.messages.0.message');
   }
 }
 
@@ -52,7 +52,7 @@ export class SummaryPipe implements PipeTransform {
 })
 export class TitlePipe implements PipeTransform {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
   ) {}
 
   transform(record, forms) {
@@ -63,9 +63,9 @@ export class TitlePipe implements PipeTransform {
       return getFormName(record, forms);
     }
     if (record.kujua_message) {
-      return this.translateHelperService.instant('Outgoing Message');
+      return this.translateService.instant('Outgoing Message');
     }
-    return this.translateHelperService.instant('sms_message.message');
+    return this.translateService.instant('sms_message.message');
   }
 }
 

--- a/webapp/src/ts/providers/format.provider.ts
+++ b/webapp/src/ts/providers/format.provider.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import * as _ from 'lodash-es';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FormatProvider {
   constructor(
-    private translateService:TranslateService
+    private translateHelperService:TranslateHelperService
   ) {}
 
   private formatEntity(entity) {
@@ -59,7 +59,7 @@ export class FormatProvider {
       parts.push('<span class="name">' + _.escape(options.name) + '</span>');
     }
     if (options.muted) {
-      parts.push('<span class="muted">' + _.escape(this.translateService.instant('contact.muted')) + '</span>');
+      parts.push('<span class="muted">' + _.escape(this.translateHelperService.instant('contact.muted')) + '</span>');
     }
     if (options.phone) {
       parts.push('<span>' + _.escape(options.phone) + '</span>');

--- a/webapp/src/ts/providers/format.provider.ts
+++ b/webapp/src/ts/providers/format.provider.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import * as _ from 'lodash-es';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FormatProvider {
   constructor(
-    private translateHelperService:TranslateHelperService
+    private translateService:TranslateService
   ) {}
 
   private formatEntity(entity) {
@@ -59,7 +59,7 @@ export class FormatProvider {
       parts.push('<span class="name">' + _.escape(options.name) + '</span>');
     }
     if (options.muted) {
-      parts.push('<span class="muted">' + _.escape(this.translateHelperService.instant('contact.muted')) + '</span>');
+      parts.push('<span class="muted">' + _.escape(this.translateService.instant('contact.muted')) + '</span>');
     }
     if (options.phone) {
       parts.push('<span>' + _.escape(options.phone) + '</span>');

--- a/webapp/src/ts/services/contact-view-model-generator.service.ts
+++ b/webapp/src/ts/services/contact-view-model-generator.service.ts
@@ -15,7 +15,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { SearchService } from '@mm-services/search.service';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
 import { GetDataRecordsService } from '@mm-services/get-data-records.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 /**
  * Hydrates the given contact by uuid and creates a model which
@@ -40,7 +40,7 @@ export class ContactViewModelGeneratorService {
     private lineageModelGeneratorService:LineageModelGeneratorService,
     private dbService:DbService,
     private contactTypesService:ContactTypesService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private searchService:SearchService,
     private contactMutedService:ContactMutedService,
     private getDataRecordsService:GetDataRecordsService,
@@ -276,7 +276,7 @@ export class ContactViewModelGeneratorService {
   private getHeading(report, forms) {
     const form = _find(forms, { code: report.form });
     if (form && form.subjectKey) {
-      return this.translateHelperService.instant(form.subjectKey, report);
+      return this.translateService.instant(form.subjectKey, report);
     }
     if (report.validSubject && report.subject && report.subject.value) {
       return report.subject.value;
@@ -284,7 +284,7 @@ export class ContactViewModelGeneratorService {
     if (report.subject && report.subject.name) {
       return report.subject.name;
     }
-    return this.translateHelperService.instant('report.subject.unknown');
+    return this.translateService.instant('report.subject.unknown');
   }
 
   private addHeading(reports, forms) {

--- a/webapp/src/ts/services/contact-view-model-generator.service.ts
+++ b/webapp/src/ts/services/contact-view-model-generator.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, NgZone } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 import {
   groupBy as _groupBy,
   partial as _partial,
@@ -16,6 +15,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { SearchService } from '@mm-services/search.service';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
 import { GetDataRecordsService } from '@mm-services/get-data-records.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 /**
  * Hydrates the given contact by uuid and creates a model which
@@ -40,7 +40,7 @@ export class ContactViewModelGeneratorService {
     private lineageModelGeneratorService:LineageModelGeneratorService,
     private dbService:DbService,
     private contactTypesService:ContactTypesService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private searchService:SearchService,
     private contactMutedService:ContactMutedService,
     private getDataRecordsService:GetDataRecordsService,
@@ -276,7 +276,7 @@ export class ContactViewModelGeneratorService {
   private getHeading(report, forms) {
     const form = _find(forms, { code: report.form });
     if (form && form.subjectKey) {
-      return this.translateService.instant(form.subjectKey, report);
+      return this.translateHelperService.instant(form.subjectKey, report);
     }
     if (report.validSubject && report.subject && report.subject.value) {
       return report.subject.value;
@@ -284,7 +284,7 @@ export class ContactViewModelGeneratorService {
     if (report.subject && report.subject.name) {
       return report.subject.name;
     }
-    return this.translateService.instant('report.subject.unknown');
+    return this.translateHelperService.instant('report.subject.unknown');
   }
 
   private addHeading(reports, forms) {

--- a/webapp/src/ts/services/count-message.service.ts
+++ b/webapp/src/ts/services/count-message.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NgZone } from '@angular/core';
 
-import { TranslateService } from '@ngx-translate/core';
 import { SettingsService } from '@mm-services/settings.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +11,7 @@ export class CountMessageService {
   private gsmChars = new RegExp('^[A-Za-z0-9 \\r\\n@£$¥èéùìòÇØøÅå\u0394_\u03A6\u0393\u039B\u03A9\u03A0\u03A8\u03A3\u0398\u039EÆæßÉ!"#$%&\'()*+,\\-./:;<=>?¡ÄÖÑÜ§¿äöñüà^{}\\\\\\[~\\]|\u20AC]*$'); // eslint-disable-line
 
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private settingsService:SettingsService,
     private ngZone:NgZone,
   ) { }
@@ -36,7 +36,7 @@ export class CountMessageService {
       key = many ? 'message.characters.left.multiple.many' : 'message.characters.left.multiple';
     }
 
-    return this.translateService.instant(key, count);
+    return this.translateHelperService.instant(key, count);
   }
 
   init() {

--- a/webapp/src/ts/services/count-message.service.ts
+++ b/webapp/src/ts/services/count-message.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, NgZone } from '@angular/core';
 
 import { SettingsService } from '@mm-services/settings.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +11,7 @@ export class CountMessageService {
   private gsmChars = new RegExp('^[A-Za-z0-9 \\r\\n@£$¥èéùìòÇØøÅå\u0394_\u03A6\u0393\u039B\u03A9\u03A0\u03A8\u03A3\u0398\u039EÆæßÉ!"#$%&\'()*+,\\-./:;<=>?¡ÄÖÑÜ§¿äöñüà^{}\\\\\\[~\\]|\u20AC]*$'); // eslint-disable-line
 
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private settingsService:SettingsService,
     private ngZone:NgZone,
   ) { }
@@ -36,7 +36,7 @@ export class CountMessageService {
       key = many ? 'message.characters.left.multiple.many' : 'message.characters.left.multiple';
     }
 
-    return this.translateHelperService.instant(key, count);
+    return this.translateService.instant(key, count);
   }
 
   init() {

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -2,7 +2,6 @@ import { Injectable, NgZone } from '@angular/core';
 import { v4 as uuid } from 'uuid';
 import * as pojo2xml from 'pojo2xml';
 import { Store } from '@ngrx/store';
-import { TranslateService } from '@ngx-translate/core';
 
 import { Xpath } from '@mm-providers/xpath-element-path.provider';
 import * as medicXpathExtensions from '../../js/enketo/medic-xpath-extensions';
@@ -23,6 +22,7 @@ import { XmlFormsService } from '@mm-services/xml-forms.service';
 import { ZScoreService } from '@mm-services/z-score.service';
 import { ServicesActions } from '@mm-actions/services';
 import { ContactSummaryService } from '@mm-services/contact-summary.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 import { TransitionsService } from '@mm-services/transitions.service';
 
 @Injectable({
@@ -47,8 +47,8 @@ export class EnketoService {
     private userContactService:UserContactService,
     private xmlFormsService:XmlFormsService,
     private zScoreService:ZScoreService,
-    private translateService:TranslateService,
     private transitionsService:TransitionsService,
+    private translateHelperService:TranslateHelperService,
     private ngZone:NgZone,
   ) {
     this.inited = this.init();
@@ -131,7 +131,7 @@ export class EnketoService {
         const $html = $(html);
         $html.find('[data-i18n]').each((idx, element) => {
           const $element = $(element);
-          $element.text(this.translateService.instant('enketo.' + $element.attr('data-i18n')));
+          $element.text(this.translateHelperService.instant('enketo.' + $element.attr('data-i18n')));
         });
 
         // TODO remove this when our enketo-core dependency is updated as the latest

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -22,7 +22,7 @@ import { XmlFormsService } from '@mm-services/xml-forms.service';
 import { ZScoreService } from '@mm-services/z-score.service';
 import { ServicesActions } from '@mm-actions/services';
 import { ContactSummaryService } from '@mm-services/contact-summary.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 import { TransitionsService } from '@mm-services/transitions.service';
 
 @Injectable({
@@ -48,7 +48,7 @@ export class EnketoService {
     private xmlFormsService:XmlFormsService,
     private zScoreService:ZScoreService,
     private transitionsService:TransitionsService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private ngZone:NgZone,
   ) {
     this.inited = this.init();
@@ -131,7 +131,7 @@ export class EnketoService {
         const $html = $(html);
         $html.find('[data-i18n]').each((idx, element) => {
           const $element = $(element);
-          $element.text(this.translateHelperService.instant('enketo.' + $element.attr('data-i18n')));
+          $element.text(this.translateService.instant('enketo.' + $element.attr('data-i18n')));
         });
 
         // TODO remove this when our enketo-core dependency is updated as the latest

--- a/webapp/src/ts/services/format-date.service.ts
+++ b/webapp/src/ts/services/format-date.service.ts
@@ -1,16 +1,16 @@
 import * as moment from 'moment';
 import { Injectable } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 import { RelativeTimeKey } from 'moment';
 
 import { SettingsService } from '@mm-services/settings.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FormatDateService {
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private settingsService:SettingsService,
   ) {
   }
@@ -63,10 +63,10 @@ export class FormatDateService {
     const today = moment().startOf('day');
     const diff = date.diff(today, 'days');
     if (diff <= 0) {
-      return this.translateService.instant('task.overdue');
+      return this.translateHelperService.instant('task.overdue');
     }
     if (diff <= this.config.taskDayLimit) {
-      return this.translateService.instant('task.days.left', { DAYS: diff });
+      return this.translateHelperService.instant('task.days.left', { DAYS: diff });
     }
     return '';
   }
@@ -75,13 +75,13 @@ export class FormatDateService {
     const diff = this.getDateDiff(moment(date).startOf('day'), options);
     if (options.humanize) {
       if (diff.quantity === 0) {
-        return this.translateService.instant('today');
+        return this.translateHelperService.instant('today');
       }
       if (diff.quantity === 1) {
-        return this.translateService.instant('tomorrow');
+        return this.translateHelperService.instant('tomorrow');
       }
       if (diff.quantity === -1) {
-        return this.translateService.instant('yesterday');
+        return this.translateHelperService.instant('yesterday');
       }
     }
     const quantity = Math.abs(diff.quantity);

--- a/webapp/src/ts/services/format-date.service.ts
+++ b/webapp/src/ts/services/format-date.service.ts
@@ -3,20 +3,21 @@ import { Injectable } from '@angular/core';
 import { RelativeTimeKey } from 'moment';
 
 import { SettingsService } from '@mm-services/settings.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FormatDateService {
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private settingsService:SettingsService,
   ) {
   }
 
   init() {
-    this.settingsService.get()
+    this.settingsService
+      .get()
       .then((res:any) => {
         this.config.date = res.date_format;
         this.config.datetime = res.reported_date_format;
@@ -63,10 +64,10 @@ export class FormatDateService {
     const today = moment().startOf('day');
     const diff = date.diff(today, 'days');
     if (diff <= 0) {
-      return this.translateHelperService.instant('task.overdue');
+      return this.translateService.instant('task.overdue');
     }
     if (diff <= this.config.taskDayLimit) {
-      return this.translateHelperService.instant('task.days.left', { DAYS: diff });
+      return this.translateService.instant('task.days.left', { DAYS: diff });
     }
     return '';
   }
@@ -75,13 +76,13 @@ export class FormatDateService {
     const diff = this.getDateDiff(moment(date).startOf('day'), options);
     if (options.humanize) {
       if (diff.quantity === 0) {
-        return this.translateHelperService.instant('today');
+        return this.translateService.instant('today');
       }
       if (diff.quantity === 1) {
-        return this.translateHelperService.instant('tomorrow');
+        return this.translateService.instant('tomorrow');
       }
       if (diff.quantity === -1) {
-        return this.translateHelperService.instant('yesterday');
+        return this.translateService.instant('yesterday');
       }
     }
     const quantity = Math.abs(diff.quantity);

--- a/webapp/src/ts/services/integration-api.service.ts
+++ b/webapp/src/ts/services/integration-api.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 
 import { LanguageService } from '@mm-services/language.service';
 import { Select2SearchService } from '@mm-services/select2-search.service';
@@ -9,6 +8,7 @@ import { SettingsService } from '@mm-services/settings.service';
 import { AndroidApiService } from '@mm-services/android-api.service';
 import { DbService } from '@mm-services/db.service';
 import { EnketoService } from '@mm-services/enketo.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
@@ -29,7 +29,7 @@ export class IntegrationApiService {
     private languageService:LanguageService,
     private select2SearchService:Select2SearchService,
     private enketoService:EnketoService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private mrdtService:MRDTService,
     private markdownService:MarkdownService,
     private settingsService:SettingsService,
@@ -44,7 +44,7 @@ export class IntegrationApiService {
     this.Markdown = markdownService;
     this.Settings = settingsService;
     this.AndroidApi = androidApiService;
-    this.Translate = translateService;
+    this.Translate = translateHelperService;
   }
 
   get(service) {

--- a/webapp/src/ts/services/integration-api.service.ts
+++ b/webapp/src/ts/services/integration-api.service.ts
@@ -8,7 +8,7 @@ import { SettingsService } from '@mm-services/settings.service';
 import { AndroidApiService } from '@mm-services/android-api.service';
 import { DbService } from '@mm-services/db.service';
 import { EnketoService } from '@mm-services/enketo.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root'
@@ -29,7 +29,7 @@ export class IntegrationApiService {
     private languageService:LanguageService,
     private select2SearchService:Select2SearchService,
     private enketoService:EnketoService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private mrdtService:MRDTService,
     private markdownService:MarkdownService,
     private settingsService:SettingsService,
@@ -44,7 +44,7 @@ export class IntegrationApiService {
     this.Markdown = markdownService;
     this.Settings = settingsService;
     this.AndroidApi = androidApiService;
-    this.Translate = translateHelperService;
+    this.Translate = translateService;
   }
 
   get(service) {

--- a/webapp/src/ts/services/language.service.ts
+++ b/webapp/src/ts/services/language.service.ts
@@ -1,7 +1,7 @@
 import * as moment from 'moment';
 import { Injectable } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
 
 import { SettingsService } from '@mm-services/settings.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
@@ -32,7 +32,7 @@ export class SetLanguageCookieService {
 })
 export class SetLanguageService {
   constructor(
-    private translateService:TranslateService,
+    private ngxTranslateService:NgxTranslateService,
     private setLanguageCookieService:SetLanguageCookieService,
   ) {
   }
@@ -46,7 +46,7 @@ export class SetLanguageService {
   async set(code, setLanguageCookie?) {
     moment.locale([ code, 'en' ]);
     this.setDatepickerLanguage(code);
-    await this.translateService.use(code).toPromise();
+    await this.ngxTranslateService.use(code).toPromise();
 
     if (setLanguageCookie !== false) {
       this.setLanguageCookieService.set(code);

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NgZone, OnDestroy } from '@angular/core';
 import * as RegistrationUtils from '@medic/registration-utils';
 import * as RulesEngineCore from '@medic/rules-engine';
-import { TranslateService } from '@ngx-translate/core';
 import { Subject, Subscription } from 'rxjs';
 import { debounce as _debounce, uniq as _uniq } from 'lodash-es';
 
@@ -19,6 +18,7 @@ import { TranslateFromService } from '@mm-services/translate-from.service';
 import { DbService } from '@mm-services/db.service';
 import { CalendarIntervalService } from '@mm-services/calendar-interval.service';
 import { FeedbackService } from '@mm-services/feedback.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
 
 interface DebounceActive {
@@ -57,7 +57,7 @@ export class RulesEngineService implements OnDestroy {
   private observable = new Subject();
 
   constructor(
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private authService:AuthService,
     private sessionService:SessionService,
     private settingsService:SettingsService,
@@ -292,7 +292,7 @@ export class RulesEngineService implements OnDestroy {
   private translateProperty(property, task) {
     if (typeof property === 'string') {
       // new translation key style
-      return this.translateService.instant(property, task);
+      return this.translateHelperService.instant(property, task);
     }
     // old message array style
     return this.translateFromService.get(property, task);

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -18,8 +18,8 @@ import { TranslateFromService } from '@mm-services/translate-from.service';
 import { DbService } from '@mm-services/db.service';
 import { CalendarIntervalService } from '@mm-services/calendar-interval.service';
 import { FeedbackService } from '@mm-services/feedback.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
 import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 interface DebounceActive {
   [key: string]: {
@@ -57,7 +57,7 @@ export class RulesEngineService implements OnDestroy {
   private observable = new Subject();
 
   constructor(
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private authService:AuthService,
     private sessionService:SessionService,
     private settingsService:SettingsService,
@@ -292,7 +292,7 @@ export class RulesEngineService implements OnDestroy {
   private translateProperty(property, task) {
     if (typeof property === 'string') {
       // new translation key style
-      return this.translateHelperService.instant(property, task);
+      return this.translateService.instant(property, task);
     }
     // old message array style
     return this.translateFromService.get(property, task);

--- a/webapp/src/ts/services/select2-search.service.ts
+++ b/webapp/src/ts/services/select2-search.service.ts
@@ -8,7 +8,7 @@ import { SearchService } from '@mm-services/search.service';
 import { SessionService } from '@mm-services/session.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root'
@@ -17,7 +17,7 @@ export class Select2SearchService {
 
   constructor(
     private formatProvider: FormatProvider,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     private lineageModelGeneratorService: LineageModelGeneratorService,
     private searchService: SearchService,
     private sessionService: SessionService,
@@ -36,7 +36,7 @@ export class Select2SearchService {
 
   private defaultTemplateSelection(row) {
     if (row.doc) {
-      return row.doc.name + (row.doc.muted ? ' (' + this.translateHelperService.instant('contact.muted') + ')' : '');
+      return row.doc.name + (row.doc.muted ? ' (' + this.translateService.instant('contact.muted') + ')' : '');
     }
 
     return row.text;
@@ -155,7 +155,7 @@ export class Select2SearchService {
     });
 
     if (options.allowNew) {
-      const addNewText = this.translateHelperService.instant('contact.type.' + types[0] + '.new');
+      const addNewText = this.translateService.instant('contact.type.' + types[0] + '.new');
       const button = $('<a class="btn btn-link add-new"><i class="fa fa-plus"></i> ' + addNewText + '</a>')
         .on('click', () => {
           selectEl.append($('<option value="NEW" selected="selected">' + addNewText + '</option>'));

--- a/webapp/src/ts/services/select2-search.service.ts
+++ b/webapp/src/ts/services/select2-search.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 import { sortBy as _sortBy } from 'lodash-es';
 import * as phoneNumber from '@medic/phone-number';
 
@@ -9,6 +8,7 @@ import { SearchService } from '@mm-services/search.service';
 import { SessionService } from '@mm-services/session.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
@@ -17,7 +17,7 @@ export class Select2SearchService {
 
   constructor(
     private formatProvider: FormatProvider,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     private lineageModelGeneratorService: LineageModelGeneratorService,
     private searchService: SearchService,
     private sessionService: SessionService,
@@ -36,7 +36,7 @@ export class Select2SearchService {
 
   private defaultTemplateSelection(row) {
     if (row.doc) {
-      return row.doc.name + (row.doc.muted ? ' (' + this.translateService.instant('contact.muted') + ')' : '');
+      return row.doc.name + (row.doc.muted ? ' (' + this.translateHelperService.instant('contact.muted') + ')' : '');
     }
 
     return row.text;
@@ -155,7 +155,7 @@ export class Select2SearchService {
     });
 
     if (options.allowNew) {
-      const addNewText = this.translateService.instant('contact.type.' + types[0] + '.new');
+      const addNewText = this.translateHelperService.instant('contact.type.' + types[0] + '.new');
       const button = $('<a class="btn btn-link add-new"><i class="fa fa-plus"></i> ' + addNewText + '</a>')
         .on('click', () => {
           selectEl.append($('<option value="NEW" selected="selected">' + addNewText + '</option>'));

--- a/webapp/src/ts/services/target-aggregates.service.ts
+++ b/webapp/src/ts/services/target-aggregates.service.ts
@@ -12,7 +12,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { AuthService } from '@mm-services/auth.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { CalendarIntervalService } from '@mm-services/calendar-interval.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +22,7 @@ export class TargetAggregatesService {
   constructor(
     private uhcSettingsService:UHCSettingsService,
     private dbService:DbService,
-    private translateHelperService:TranslateHelperService,
+    private translateService:TranslateService,
     private translateFromService:TranslateFromService,
     private searchService:SearchService,
     private getDataRecordsService:GetDataRecordsService,
@@ -95,7 +95,7 @@ export class TargetAggregatesService {
 
   private getTranslatedTitle(target) {
     if (target.translation_key) {
-      return this.translateHelperService.instant(target.translation_key);
+      return this.translateService.instant(target.translation_key);
     }
 
     return this.translateFromService.get(target.title);
@@ -168,7 +168,7 @@ export class TargetAggregatesService {
 
     if (aggregate.hasGoal) {
       const translationKey = 'analytics.target.aggregates.ratio';
-      aggregate.aggregateValue.summary = this.translateHelperService.instant(translationKey, aggregate.aggregateValue);
+      aggregate.aggregateValue.summary = this.translateService.instant(translationKey, aggregate.aggregateValue);
     } else {
       aggregate.aggregateValue.summary = aggregate.isPercent ?
         `${aggregate.aggregateValue.percent}%` : aggregate.aggregateValue.pass;

--- a/webapp/src/ts/services/target-aggregates.service.ts
+++ b/webapp/src/ts/services/target-aggregates.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NgZone } from '@angular/core';
 import * as moment from 'moment';
 import { isString as _isString } from 'lodash-es';
-import { TranslateService } from '@ngx-translate/core';
 
 import { UHCSettingsService } from '@mm-services/uhc-settings.service';
 import { DbService } from '@mm-services/db.service';
@@ -13,6 +12,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { AuthService } from '@mm-services/auth.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { CalendarIntervalService } from '@mm-services/calendar-interval.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +22,7 @@ export class TargetAggregatesService {
   constructor(
     private uhcSettingsService:UHCSettingsService,
     private dbService:DbService,
-    private translateService:TranslateService,
+    private translateHelperService:TranslateHelperService,
     private translateFromService:TranslateFromService,
     private searchService:SearchService,
     private getDataRecordsService:GetDataRecordsService,
@@ -95,7 +95,7 @@ export class TargetAggregatesService {
 
   private getTranslatedTitle(target) {
     if (target.translation_key) {
-      return this.translateService.instant(target.translation_key);
+      return this.translateHelperService.instant(target.translation_key);
     }
 
     return this.translateFromService.get(target.title);
@@ -167,8 +167,8 @@ export class TargetAggregatesService {
     aggregate.aggregateValue.hasGoal = aggregate.hasGoal;
 
     if (aggregate.hasGoal) {
-      const summary = this.translateService.instant('analytics.target.aggregates.ratio', aggregate.aggregateValue);
-      aggregate.aggregateValue.summary = summary;
+      const translationKey = 'analytics.target.aggregates.ratio';
+      aggregate.aggregateValue.summary = this.translateHelperService.instant(translationKey, aggregate.aggregateValue);
     } else {
       aggregate.aggregateValue.summary = aggregate.isPercent ?
         `${aggregate.aggregateValue.percent}%` : aggregate.aggregateValue.pass;

--- a/webapp/src/ts/services/tour.service.ts
+++ b/webapp/src/ts/services/tour.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
 import { compact  as _compact } from 'lodash-es';
 
 import { AuthService } from '@mm-services/auth.service';
@@ -8,6 +7,7 @@ import { FeedbackService } from '@mm-services/feedback.service';
 import { AnalyticsModulesService } from '@mm-services/analytics-modules.service';
 import { SessionService } from '@mm-services/session.service';
 import { ResponsiveService } from '@mm-services/responsive.service';
+import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
@@ -24,7 +24,7 @@ export class TourService {
     private authService: AuthService,
     private feedbackService: FeedbackService,
     private sessionService: SessionService,
-    private translateService: TranslateService,
+    private translateHelperService: TranslateHelperService,
     private router: Router,
     private responsiveService:ResponsiveService,
   ) { }
@@ -413,14 +413,14 @@ export class TourService {
               <div class="popover-navigation">
                 <div class="btn-group">
                   <button class="btn btn-sm btn-default" data-role="prev">
-                    &laquo;  ${this.translateService.instant('Previous')}
+                    &laquo;  ${this.translateHelperService.instant('Previous')}
                   </button>
                   <button class="btn btn-sm btn-default" data-role="next">
-                    ${this.translateService.instant('Next')} &raquo;
+                    ${this.translateHelperService.instant('Next')} &raquo;
                   </button>
                 </div>
                 <button class="btn btn-sm btn-link" data-role="end">
-                  ${this.translateService.instant('End tour')}
+                  ${this.translateHelperService.instant('End tour')}
                 </button>
               </div>
             </div>`;
@@ -520,8 +520,8 @@ export class TourService {
 
       const mobile = this.responsiveService.isMobile();
       settings.steps.forEach(step => {
-        step.title = this.translateService.instant(step.title);
-        step.content = this.translateService.instant(step.content);
+        step.title = this.translateHelperService.instant(step.title);
+        step.content = this.translateHelperService.instant(step.content);
         if (mobile) {
           // there's no room to show steps to the left or right on a mobile device
           if (step.mobileElement) {

--- a/webapp/src/ts/services/tour.service.ts
+++ b/webapp/src/ts/services/tour.service.ts
@@ -7,7 +7,7 @@ import { FeedbackService } from '@mm-services/feedback.service';
 import { AnalyticsModulesService } from '@mm-services/analytics-modules.service';
 import { SessionService } from '@mm-services/session.service';
 import { ResponsiveService } from '@mm-services/responsive.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 @Injectable({
   providedIn: 'root'
@@ -24,7 +24,7 @@ export class TourService {
     private authService: AuthService,
     private feedbackService: FeedbackService,
     private sessionService: SessionService,
-    private translateHelperService: TranslateHelperService,
+    private translateService: TranslateService,
     private router: Router,
     private responsiveService:ResponsiveService,
   ) { }
@@ -413,14 +413,14 @@ export class TourService {
               <div class="popover-navigation">
                 <div class="btn-group">
                   <button class="btn btn-sm btn-default" data-role="prev">
-                    &laquo;  ${this.translateHelperService.instant('Previous')}
+                    &laquo;  ${this.translateService.instant('Previous')}
                   </button>
                   <button class="btn btn-sm btn-default" data-role="next">
-                    ${this.translateHelperService.instant('Next')} &raquo;
+                    ${this.translateService.instant('Next')} &raquo;
                   </button>
                 </div>
                 <button class="btn btn-sm btn-link" data-role="end">
-                  ${this.translateHelperService.instant('End tour')}
+                  ${this.translateService.instant('End tour')}
                 </button>
               </div>
             </div>`;
@@ -520,8 +520,8 @@ export class TourService {
 
       const mobile = this.responsiveService.isMobile();
       settings.steps.forEach(step => {
-        step.title = this.translateHelperService.instant(step.title);
-        step.content = this.translateHelperService.instant(step.content);
+        step.title = this.translateService.instant(step.title);
+        step.content = this.translateService.instant(step.content);
         if (mobile) {
           // there's no room to show steps to the left or right on a mobile device
           if (step.mobileElement) {

--- a/webapp/src/ts/services/translate-from.service.ts
+++ b/webapp/src/ts/services/translate-from.service.ts
@@ -18,13 +18,13 @@
  */
 import * as _ from 'lodash-es';
 import { Injectable } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TranslateFromService {
-  constructor(private translateService:TranslateService) {
+  constructor(private ngxTranslateService:NgxTranslateService) {
   }
 
   private getLabel(labels, locale) {
@@ -55,7 +55,7 @@ export class TranslateFromService {
     if (!labels) {
       return;
     }
-    const label = this.getLabel(labels, this.translateService.currentLang);
+    const label = this.getLabel(labels, this.ngxTranslateService.currentLang);
     if (!scope || !label || label.indexOf('{{') === -1) {
       return label;
     }

--- a/webapp/src/ts/services/translate-helper.service.ts
+++ b/webapp/src/ts/services/translate-helper.service.ts
@@ -20,7 +20,23 @@ export class TranslateHelperService {
       .then(field => this.get('field is required', { field: field }));
   }
 
+  private invalidKey(key) {
+    return !key || !key.length;
+  }
+
   get(key, interpolateParams?) {
+    if (this.invalidKey(key)) {
+      return Promise.resolve(key);
+    }
+
     return this.translateService.get(key, interpolateParams).toPromise();
+  }
+
+  instant(key, interpolateParams?) {
+    if (this.invalidKey(key)) {
+      return key;
+    }
+
+    return this.translateService.instant(key, interpolateParams);
   }
 }

--- a/webapp/src/ts/services/translate-helper.service.ts
+++ b/webapp/src/ts/services/translate-helper.service.ts
@@ -1,5 +1,5 @@
 /**
- * Service to encapsulate repeatedly used translation logic
+ * Service to act as a wrapper for ngx-translate's TranslateService and encapsulate repeatedly used translation logic
  */
 
 import { TranslateService } from '@ngx-translate/core';
@@ -20,6 +20,7 @@ export class TranslateHelperService {
       .then(field => this.get('field is required', { field: field }));
   }
 
+  // ngx-translate's TranslateService throws an error if the key is not defined or is an empty string
   private invalidKey(key) {
     return !key || !key.length;
   }

--- a/webapp/src/ts/services/translate-locale.service.ts
+++ b/webapp/src/ts/services/translate-locale.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
 import { map, take, shareReplay } from 'rxjs/operators';
 
 @Injectable({
@@ -7,14 +7,14 @@ import { map, take, shareReplay } from 'rxjs/operators';
 })
 export class TranslateLocaleService {
   constructor(
-    private translateService:TranslateService,
+    private ngxTranslateService:NgxTranslateService,
   ) {
   }
 
   private loadingTranslations = {};
 
   private loadTranslations(locale) {
-    return this.translateService
+    return this.ngxTranslateService
       .currentLoader
       .getTranslation(locale)
       .pipe(
@@ -24,7 +24,7 @@ export class TranslateLocaleService {
   }
 
   private getTranslation(locale) {
-    if (this.translateService.translations[locale]) {
+    if (this.ngxTranslateService.translations[locale]) {
       return;
     }
 
@@ -35,13 +35,13 @@ export class TranslateLocaleService {
     const loadingTranslations = this.loadTranslations(locale);
     const translationsCompiled = loadingTranslations
       .pipe(
-        map((res) => this.translateService.compiler.compileTranslations(res, locale)),
+        map((res) => this.ngxTranslateService.compiler.compileTranslations(res, locale)),
         shareReplay(1),
         take(1),
       );
     translationsCompiled.subscribe((res) => {
-      this.translateService.translations[locale] = res;
-      this.translateService.addLangs(Object.keys(this.translateService.translations));
+      this.ngxTranslateService.translations[locale] = res;
+      this.ngxTranslateService.addLangs(Object.keys(this.ngxTranslateService.translations));
       delete this.loadingTranslations[locale];
     });
     this.loadingTranslations[locale] = translationsCompiled;
@@ -53,21 +53,21 @@ export class TranslateLocaleService {
     this.getTranslation(locale);
 
     if (skipInterpolation) {
-      return this.translateService.translations[locale] && this.translateService.translations[locale][key];
+      return this.ngxTranslateService.translations[locale] && this.ngxTranslateService.translations[locale][key];
     }
 
-    return this.translateService.getParsedResult(this.translateService.translations[locale], key, params);
+    return this.ngxTranslateService.getParsedResult(this.ngxTranslateService.translations[locale], key, params);
   }
 
   reloadLang(locale, hotReload = false) {
-    if (!this.translateService.translations[locale]) {
+    if (!this.ngxTranslateService.translations[locale]) {
       // don't "reload" languages we haven't already loaded
       return;
     }
 
     if (!hotReload) {
       // reloading "secondary" languages
-      this.translateService.resetLang(locale);
+      this.ngxTranslateService.resetLang(locale);
       this.getTranslation(locale);
       return;
     }
@@ -77,7 +77,7 @@ export class TranslateLocaleService {
     // the 2nd method (set) is a poorer choice, as it requires setting a translation key + value
     // https://github.com/ngx-translate/core/issues/874
     this.loadTranslations(locale).subscribe(rawTranslations => {
-      this.translateService.setTranslation(locale, rawTranslations);
+      this.ngxTranslateService.setTranslation(locale, rawTranslations);
     });
   }
 }

--- a/webapp/src/ts/services/translate.service.ts
+++ b/webapp/src/ts/services/translate.service.ts
@@ -2,15 +2,15 @@
  * Service to act as a wrapper for ngx-translate's TranslateService and encapsulate repeatedly used translation logic
  */
 
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
 import { Injectable } from '@angular/core';
 
 @Injectable({
   providedIn: 'root'
 })
-export class TranslateHelperService {
+export class TranslateService {
   constructor(
-    private translateService:TranslateService,
+    private ngxTraslateService:NgxTranslateService,
   ) {
   }
 
@@ -30,7 +30,7 @@ export class TranslateHelperService {
       return Promise.resolve(key);
     }
 
-    return this.translateService.get(key, interpolateParams).toPromise();
+    return this.ngxTraslateService.get(key, interpolateParams).toPromise();
   }
 
   instant(key, interpolateParams?) {
@@ -38,6 +38,6 @@ export class TranslateHelperService {
       return key;
     }
 
-    return this.translateService.instant(key, interpolateParams);
+    return this.ngxTraslateService.instant(key, interpolateParams);
   }
 }

--- a/webapp/tests/karma/ts/components/filters/facility-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/facility-filter.component.spec.ts
@@ -283,29 +283,23 @@ describe('Facility Filter Component', () => {
   });
 
   describe('getLabel', () => {
-    it('should return the facility name, if existent', async(() => {
+    it('should return the facility name, if existent', async () => {
       const facility = { doc: { name: 'fancy' } };
-      component.itemLabel(facility).subscribe(value => {
-        expect(value).to.equal('fancy');
-      });
-    }));
+      expect(await component.itemLabel(facility)).to.equal('fancy');
+    });
 
-    it('should return deleted for admins when name is not set', async(() => {
+    it('should return deleted for admins when name is not set', async () => {
       const facility = { doc: { _id: 'fancy' } };
-      component.itemLabel(facility).subscribe(value => {
-        expect(value).to.equal('place.deleted');
-      });
-    }));
+      expect(await component.itemLabel(facility)).to.equal('place.deleted');
+    });
 
-    it('should return unavailable for offline users when name is not set', async(() => {
+    it('should return unavailable for offline users when name is not set', async() => {
       sessionService.isOnlineOnly.returns(false);
       component.ngOnInit();
       fixture.detectChanges();
       const facility = { doc: { _id: 'fancy' } };
-      component.itemLabel(facility).subscribe(value => {
-        expect(value).to.equal('place.unavailable');
-      });
-    }));
+      expect(await component.itemLabel(facility)).to.equal('place.unavailable');
+    });
   });
 
   it('clear should clear dropdown filter', () => {

--- a/webapp/tests/karma/ts/modals/edit-user/update-password.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/edit-user/update-password.component.spec.ts
@@ -11,7 +11,7 @@ import { UserSettingsService } from '@mm-services/user-settings.service';
 import { UpdateUserService } from '@mm-services/update-user.service';
 import { UserLoginService } from '@mm-services/user-login.service';
 import { MmModal, MmModalAbstract } from '@mm-modals/mm-modal/mm-modal';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 import { ModalService } from '@mm-modals/mm-modal/mm-modal';
 import { ConfirmPasswordUpdatedComponent } from '@mm-modals/edit-user/confirm-password-updated.component';
 
@@ -21,7 +21,7 @@ describe('UpdatePasswordComponent', () => {
   let fixture: ComponentFixture<UpdatePasswordComponent>;
   let userSettingsService;
   let updateUserService;
-  let translateHelperService;
+  let translateService;
   let bsModalRef;
   let userLoginService;
   let modalService;
@@ -51,7 +51,7 @@ describe('UpdatePasswordComponent', () => {
         }
       )
     };
-    translateHelperService = {
+    translateService = {
       fieldIsRequired: sinon.stub().resolvesArg(0),
       get: sinon.stub().resolvesArg(0),
     };
@@ -74,7 +74,7 @@ describe('UpdatePasswordComponent', () => {
           { provide: ModalService, useValue: modalService },
           { provide: UserSettingsService, useValue: userSettingsService },
           { provide: BsModalRef, useValue: bsModalRef },
-          { provide: TranslateHelperService, useValue: translateHelperService },
+          { provide: TranslateService, useValue: translateService },
         ]
       })
       .compileComponents()
@@ -110,8 +110,8 @@ describe('UpdatePasswordComponent', () => {
     const consoleErrorMock = sinon.stub(console, 'error');
     component.editUserModel.password = '';
     component.updatePassword();
-    expect(translateHelperService.fieldIsRequired.called).to.equal(true);
-    expect(translateHelperService.fieldIsRequired.args[0]).to.deep.equal(['Password']);
+    expect(translateService.fieldIsRequired.called).to.equal(true);
+    expect(translateService.fieldIsRequired.args[0]).to.deep.equal(['Password']);
     expect(updateUserService.update.called).to.equal(false);
     expect(consoleErrorMock.callCount).to.equal(1);
     expect(consoleErrorMock.args[0][0]).to.equal('Error submitting modal');
@@ -123,8 +123,8 @@ describe('UpdatePasswordComponent', () => {
     component.editUserModel.passwordConfirm = '2sml4me';
     component.editUserModel.currentPassword = '2xml4me';
     component.updatePassword();
-    expect(translateHelperService.get.called).to.equal(true);
-    expect(translateHelperService.get.getCall(0).args[0]).to.equal('password.length.minimum');
+    expect(translateService.get.called).to.equal(true);
+    expect(translateService.get.getCall(0).args[0]).to.equal('password.length.minimum');
     expect(updateUserService.update.called).to.equal(false);
     expect(consoleErrorMock.callCount).to.equal(1);
     expect(consoleErrorMock.args[0][0]).to.equal('Error submitting modal');
@@ -136,8 +136,8 @@ describe('UpdatePasswordComponent', () => {
     component.editUserModel.passwordConfirm = 'password';
     component.editUserModel.currentPassword = '2xml4me';
     component.updatePassword();
-    expect(translateHelperService.get.called).to.equal(true);
-    expect(translateHelperService.get.getCall(0).args[0]).to.equal('password.weak');
+    expect(translateService.get.called).to.equal(true);
+    expect(translateService.get.getCall(0).args[0]).to.equal('password.weak');
     expect(updateUserService.update.called).to.equal(false);
     expect(consoleErrorMock.callCount).to.equal(1);
     expect(consoleErrorMock.args[0][0]).to.equal('Error submitting modal');
@@ -150,8 +150,8 @@ describe('UpdatePasswordComponent', () => {
     component.editUserModel.passwordConfirm = password + 'a';
     component.editUserModel.currentPassword = '2xml4me';
     component.updatePassword();
-    expect(translateHelperService.get.called).to.equal(true);
-    expect(translateHelperService.get.getCall(0).args[0]).to.equal('Passwords must match');
+    expect(translateService.get.called).to.equal(true);
+    expect(translateService.get.getCall(0).args[0]).to.equal('Passwords must match');
     expect(updateUserService.update.called).to.equal(false);
     expect(consoleErrorMock.callCount).to.equal(1);
     expect(consoleErrorMock.args[0][0]).to.equal('Error submitting modal');
@@ -167,7 +167,7 @@ describe('UpdatePasswordComponent', () => {
     userLoginService.login.resolves({});
     await component.updatePassword();
 
-    expect(translateHelperService.get.called).to.equal(false);
+    expect(translateService.get.called).to.equal(false);
     expect(component.errors).to.deep.equal({});
     expect(updateUserService.update.called).to.equal(true);
     expect(updateUserService.update.getCall(0).args[0]).to.equal(user);
@@ -230,8 +230,8 @@ describe('UpdatePasswordComponent', () => {
     component.editUserModel.passwordConfirm = password;
 
     component.updatePassword();
-    expect(translateHelperService.fieldIsRequired.called).to.equal(true);
-    expect(translateHelperService.fieldIsRequired.getCall(0).args[0]).to.deep.equal('Current Password');
+    expect(translateService.fieldIsRequired.called).to.equal(true);
+    expect(translateService.fieldIsRequired.getCall(0).args[0]).to.deep.equal('Current Password');
     expect(updateUserService.update.called).to.equal(false);
     expect(consoleErrorMock.callCount).to.equal(1);
     expect(consoleErrorMock.args[0][0]).to.equal('Error submitting modal');

--- a/webapp/tests/karma/ts/modules/analytics/analytics-target-aggregates-detail.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/analytics/analytics-target-aggregates-detail.component.spec.ts
@@ -142,6 +142,6 @@ describe('AnalyticsTargetAggregatesDetailComponent', () => {
       heading: 'the translated title',
     });
     expect(translateService.instant.callCount).to.equal(1);
-    expect(translateService.instant.args[0]).to.deep.equal(['analytics.target.aggregates']);
+    expect(translateService.instant.args[0]).to.deep.equal(['analytics.target.aggregates', undefined]);
   }));
 });

--- a/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
@@ -11,7 +11,7 @@ import { ContactTypesService } from '@mm-services/contact-types.service';
 import { EnketoComponent } from '@mm-components/enketo/enketo.component';
 import { ContactsEditComponent } from '@mm-modules/contacts/contacts-edit.component';
 import { ComponentsModule } from '@mm-components/components.module';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 import { DbService } from '@mm-services/db.service';
 import { Selectors } from '@mm-selectors/index';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
@@ -22,7 +22,7 @@ import { GlobalActions } from '@mm-actions/global';
 
 describe('ContactsEdit component', () => {
   let contactTypesService;
-  let translateHelperService;
+  let translateService;
   let router;
   let route;
   let dbGet;
@@ -39,7 +39,7 @@ describe('ContactsEdit component', () => {
       get: sinon.stub().resolves(),
       getTypeId: sinon.stub().callsFake(contact => contact?.type === 'contact' ? contact.contact_type : contact?.type),
     };
-    translateHelperService = { get: sinon.stub().resolvesArg(0) };
+    translateService = { get: sinon.stub().resolvesArg(0) };
     dbGet = sinon.stub().resolves();
     router = { navigate: sinon.stub() };
     routeSnapshot = { params: {}, queryParams: {} };
@@ -76,7 +76,7 @@ describe('ContactsEdit component', () => {
       ],
       providers: [
         provideMockStore({ selectors: mockedSelectors }),
-        { provide: TranslateHelperService, useValue: translateHelperService },
+        { provide: TranslateService, useValue: translateService },
         { provide: DbService, useValue: { get: () => ({ get: dbGet }) } },
         { provide: Router, useValue: router  },
         { provide: ActivatedRoute, useValue: route },

--- a/webapp/tests/karma/ts/pipes/date.pipe.spec.ts
+++ b/webapp/tests/karma/ts/pipes/date.pipe.spec.ts
@@ -20,13 +20,13 @@ import {
 } from '@mm-pipes/date.pipe';
 import { RelativeDateService } from '@mm-services/relative-date.service';
 import { FormatDateService } from '@mm-services/format-date.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 
 describe('date pipes', () => {
   let relativeDateService;
   let formatDateService;
-  let translateHelperService;
+  let translateService;
   let sanitizer;
 
   const TEST_TASK = {
@@ -49,7 +49,7 @@ describe('date pipes', () => {
       datetime: d => `${d.toISOString()}`,
       relative: (d:number) => `${Math.floor((d - TEST_DATE.valueOf()) / 86400000)} days`,
     };
-    translateHelperService = {
+    translateService = {
       instant: sinon.stub().returnsArg(0),
       get: sinon.stub().resolvesArg(0),
     };
@@ -59,7 +59,7 @@ describe('date pipes', () => {
         providers: [
           { provide: RelativeDateService, useValue: relativeDateService },
           { provide: FormatDateService, useValue: formatDateService },
-          { provide: TranslateHelperService, useValue: translateHelperService },
+          { provide: TranslateService, useValue: translateService },
           { provide: DomSanitizer, useValue: { bypassSecurityTrustHtml: sinon.stub().returnsArg(0) } },
         ],
         declarations: [
@@ -100,7 +100,7 @@ describe('date pipes', () => {
 
   describe('autoreply', () => {
     it('should return nicely-formatted output', async () => {
-      const pipe = new AutoreplyPipe(translateHelperService, formatDateService, relativeDateService, sanitizer);
+      const pipe = new AutoreplyPipe(translateService, formatDateService, relativeDateService, sanitizer);
       const expected = '<span><span class="state STATE">state.STATE</span>&nbsp;' +
         '<span class="autoreply" title="MESSAGE"><span class="autoreply-content">autoreply</span></span>&nbsp</span>';
       const actual = await pipe.transform(TEST_TASK);
@@ -175,7 +175,7 @@ describe('date pipes', () => {
 
   describe('state', () => {
     it('should return nicely-formatted output', async () => {
-      const pipe = new StatePipe(translateHelperService, formatDateService, relativeDateService, sanitizer);
+      const pipe = new StatePipe(translateService, formatDateService, relativeDateService, sanitizer);
       const expected = '<span><span class="state STATE">state.STATE</span>&nbsp;</span>';
       const actual = await pipe.transform(TEST_TASK);
       assert.equal(actual, expected);
@@ -246,7 +246,7 @@ describe('date pipes rendering', () => {
         providers: [
           { provide: RelativeDateService, useValue: relativeDate },
           { provide: FormatDateService, useValue: formatDate },
-          { provide: TranslateHelperService, useValue: translate },
+          { provide: TranslateService, useValue: translate },
         ],
         declarations: [
           AgePipe,

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -470,6 +470,30 @@ describe('RulesEngineService', () => {
     expect(telemetryService.record.args[2][0]).to.equal('rules-engine:tasks:some-contacts');
   });
 
+  it('fetchTaskDocsFor() should not crash with empty priority label', async () => {
+    const taskDoc = JSON.parse(JSON.stringify(sampleTaskDoc));
+    taskDoc.emission.priorityLabel = '';
+    const contactIds = ['a', 'b', 'c'];
+    fetchTasksResult = sinon.stub().resolves([taskDoc]);
+    rulesEngineCoreStubs.getDirtyContacts.returns(['a', 'b']);
+    service = TestBed.inject(RulesEngineService);
+
+    const actual = await service.fetchTaskDocsFor(contactIds);
+
+    expect(rulesEngineCoreStubs.fetchTasksFor.callCount).to.eq(1);
+    expect(rulesEngineCoreStubs.fetchTasksFor.args[0][0]).to.eq(contactIds);
+    expect(actual.length).to.eq(1);
+    expect(actual[0]).to.nested.include({
+      _id: 'taskdoc',
+      'emission.title': 'translate.this',
+      'emission.priorityLabel': '',
+      'emission.other': true,
+    });
+    expect(telemetryService.record.callCount).to.equal(3);
+    expect(telemetryService.record.args[1]).to.deep.equal(['rules-engine:tasks:dirty-contacts', 2]);
+    expect(telemetryService.record.args[2][0]).to.equal('rules-engine:tasks:some-contacts');
+  });
+
   it('fetchTargets() should send correct range to Rules Engine Core when getting targets', async () => {
     fetchTargetsResult = sinon.stub().resolves([]);
     service = TestBed.inject(RulesEngineService);

--- a/webapp/tests/karma/ts/services/translate-helper.service.spec.ts
+++ b/webapp/tests/karma/ts/services/translate-helper.service.spec.ts
@@ -11,7 +11,10 @@ describe('TranslateHelperService', () => {
   let translateService;
 
   beforeEach(() => {
-    translateService = { get: sinon.stub().callsFake((arg) => of(arg)) };
+    translateService = {
+      get: sinon.stub().callsFake((arg) => of(arg)),
+      instant: sinon.stub().returnsArg(0),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -26,14 +29,14 @@ describe('TranslateHelperService', () => {
   });
 
   describe('get', () => {
-    it('should get translated value', (async () => {
+    it('should get translated value', async () => {
       const expected = 'expected translation';
       const actual = await service.get(expected);
 
       expect(actual).to.equal(expected);
       expect(translateService.get.callCount).to.equal(1);
       expect(translateService.get.args[0]).to.deep.equal([expected, undefined]);
-    }));
+    });
 
     it('should pass interpolation params', async () => {
       const expected = 'expected translation';
@@ -43,6 +46,47 @@ describe('TranslateHelperService', () => {
       expect(actual).to.equal(expected);
       expect(translateService.get.callCount).to.equal(1);
       expect(translateService.get.args[0]).to.deep.equal([expected, params]);
+    });
+
+    it('should validate the key', async () => {
+      const empty = await service.get('');
+      const notDefined = await service.get(undefined);
+
+      expect(empty).to.equal('');
+      expect(notDefined).to.equal(undefined);
+
+      expect(translateService.get.callCount).to.equal(0);
+    });
+  });
+
+  describe('instant', () => {
+    it('should get translated value', () => {
+      const expected = 'expected translation';
+      const actual = service.instant(expected);
+
+      expect(actual).to.equal(expected);
+      expect(translateService.instant.callCount).to.equal(1);
+      expect(translateService.instant.args[0]).to.deep.equal([expected, undefined]);
+    });
+
+    it('should pass interpolation params', () => {
+      const expected = 'expected translation';
+      const params = { param: 'one', other: 'two' };
+      const actual = service.instant(expected, params);
+
+      expect(actual).to.equal(expected);
+      expect(translateService.instant.callCount).to.equal(1);
+      expect(translateService.instant.args[0]).to.deep.equal([expected, params]);
+    });
+
+    it('should validate the key', () => {
+      const empty = service.instant('');
+      const notDefined = service.instant(undefined);
+
+      expect(empty).to.equal('');
+      expect(notDefined).to.equal(undefined);
+
+      expect(translateService.instant.callCount).to.equal(0);
     });
   });
 

--- a/webapp/tests/karma/ts/services/translate.service.spec.ts
+++ b/webapp/tests/karma/ts/services/translate.service.spec.ts
@@ -1,27 +1,27 @@
 import { TestBed } from '@angular/core/testing';
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { TranslateService } from '@ngx-translate/core';
+import { TranslateService as NgxTranslateService } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
+import { TranslateService } from '@mm-services/translate.service';
 
 describe('TranslateHelperService', () => {
-  let service:TranslateHelperService;
-  let translateService;
+  let service:TranslateService;
+  let ngxTranslateService;
 
   beforeEach(() => {
-    translateService = {
+    ngxTranslateService = {
       get: sinon.stub().callsFake((arg) => of(arg)),
       instant: sinon.stub().returnsArg(0),
     };
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: TranslateService, useValue: translateService },
+        { provide: NgxTranslateService, useValue: ngxTranslateService },
       ]
     });
-    service = TestBed.inject(TranslateHelperService);
+    service = TestBed.inject(TranslateService);
   });
 
   afterEach(() => {
@@ -34,8 +34,8 @@ describe('TranslateHelperService', () => {
       const actual = await service.get(expected);
 
       expect(actual).to.equal(expected);
-      expect(translateService.get.callCount).to.equal(1);
-      expect(translateService.get.args[0]).to.deep.equal([expected, undefined]);
+      expect(ngxTranslateService.get.callCount).to.equal(1);
+      expect(ngxTranslateService.get.args[0]).to.deep.equal([expected, undefined]);
     });
 
     it('should pass interpolation params', async () => {
@@ -44,8 +44,8 @@ describe('TranslateHelperService', () => {
       const actual = await service.get(expected, params);
 
       expect(actual).to.equal(expected);
-      expect(translateService.get.callCount).to.equal(1);
-      expect(translateService.get.args[0]).to.deep.equal([expected, params]);
+      expect(ngxTranslateService.get.callCount).to.equal(1);
+      expect(ngxTranslateService.get.args[0]).to.deep.equal([expected, params]);
     });
 
     it('should validate the key', async () => {
@@ -55,7 +55,7 @@ describe('TranslateHelperService', () => {
       expect(empty).to.equal('');
       expect(notDefined).to.equal(undefined);
 
-      expect(translateService.get.callCount).to.equal(0);
+      expect(ngxTranslateService.get.callCount).to.equal(0);
     });
   });
 
@@ -65,8 +65,8 @@ describe('TranslateHelperService', () => {
       const actual = service.instant(expected);
 
       expect(actual).to.equal(expected);
-      expect(translateService.instant.callCount).to.equal(1);
-      expect(translateService.instant.args[0]).to.deep.equal([expected, undefined]);
+      expect(ngxTranslateService.instant.callCount).to.equal(1);
+      expect(ngxTranslateService.instant.args[0]).to.deep.equal([expected, undefined]);
     });
 
     it('should pass interpolation params', () => {
@@ -75,8 +75,8 @@ describe('TranslateHelperService', () => {
       const actual = service.instant(expected, params);
 
       expect(actual).to.equal(expected);
-      expect(translateService.instant.callCount).to.equal(1);
-      expect(translateService.instant.args[0]).to.deep.equal([expected, params]);
+      expect(ngxTranslateService.instant.callCount).to.equal(1);
+      expect(ngxTranslateService.instant.args[0]).to.deep.equal([expected, params]);
     });
 
     it('should validate the key', () => {
@@ -86,7 +86,7 @@ describe('TranslateHelperService', () => {
       expect(empty).to.equal('');
       expect(notDefined).to.equal(undefined);
 
-      expect(translateService.instant.callCount).to.equal(0);
+      expect(ngxTranslateService.instant.callCount).to.equal(0);
     });
   });
 
@@ -97,9 +97,9 @@ describe('TranslateHelperService', () => {
 
       expect(actual).to.equal('field is required');
 
-      expect(translateService.get.callCount).to.equal(2);
-      expect(translateService.get.args[0]).to.deep.equal([field, undefined]);
-      expect(translateService.get.args[1]).to.deep.equal(['field is required', { field }]);
+      expect(ngxTranslateService.get.callCount).to.equal(2);
+      expect(ngxTranslateService.get.args[0]).to.deep.equal([field, undefined]);
+      expect(ngxTranslateService.get.args[1]).to.deep.equal(['field is required', { field }]);
     });
   });
 });

--- a/webapp/tsconfig.base.json
+++ b/webapp/tsconfig.base.json
@@ -34,6 +34,7 @@
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "preserveWhitespaces": true
+    "preserveWhitespaces": true,
+    "skipTemplateCodegen": false
   }
 }


### PR DESCRIPTION
# Description

Renames `TranslateHelperService` to `TranslateService`. 
Adds a wrapper for `ngx-translate.TranslateService.instant` in `webapp.TranslateService`. 
Consolidates use of our `webapp.TranslateService` instead of `ngx-translate.TranslateService` across the app. 
Replaces the integration api Translate to `webapp.TranslateService`.
The `ngx-translate` directive and pipe do these checks already, so the views are "safe". 
Fixes flaky angular build: https://github.com/angular/angular-cli/issues/19866

medic/cht-core#7137

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
