### PR TITLE
EndToEnd Test Implementation For Default Delivery Form GitHub Issue: …

### DIFF
--- a/tests/e2e/forms/forms-against-muted-contacts.spec.js
+++ b/tests/e2e/forms/forms-against-muted-contacts.spec.js
@@ -66,7 +66,7 @@ describe('Submitting forms for muted contacts', () => {
     await utils.updateSettings(settings);
   });
 
-  afterEach(() => utils.revertDb());
+  afterEach(async () => { await utils.revertDb(); });
 
   it('should not show popup for unmuted persons', async () => {
     await contactsObjects.selectLHSRowByText(patient2.name);

--- a/tests/e2e/forms/forms-against-muted-contacts.spec.js
+++ b/tests/e2e/forms/forms-against-muted-contacts.spec.js
@@ -66,7 +66,7 @@ describe('Submitting forms for muted contacts', () => {
     await utils.updateSettings(settings);
   });
 
-  afterEach(async () => { await utils.revertDb(); });
+  afterEach(async () => await utils.revertDb());
 
   it('should not show popup for unmuted persons', async () => {
     await contactsObjects.selectLHSRowByText(patient2.name);

--- a/tests/e2e/forms/submit-default-delivery-form.specs.js
+++ b/tests/e2e/forms/submit-default-delivery-form.specs.js
@@ -4,7 +4,6 @@ const common = require('../../page-objects/common/common.po');
 const utils = require('../../utils');
 const userData = require('../../page-objects/forms/data/user.po.data');
 const _ = require('lodash');
-_.uniq = require('lodash/uniq');
 const { assert } = require('chai');
 
 describe('Submit Default Delivery Report', () => {
@@ -38,7 +37,7 @@ describe('Submit Default Delivery Report', () => {
     await deliveryReport.selectConvulsionsButton();
     await genericForm.nextPageNative();
 
-    // // Delivery Outcome
+    // Delivery Outcome
     await deliveryReport.selectBabiesDeliveredButton();
     await deliveryReport.enterNoOfBabiesDelivered(6);
     await deliveryReport.selectBabiesAliveButton(3);
@@ -49,16 +48,19 @@ describe('Submit Default Delivery Report', () => {
     await deliveryReport.selectDeliveryMethod();
     await genericForm.nextPageNative();
 
-    // // Dead Babies Information
-    // // We need to loop through all dead babies and fill out information
-    for (let i = 1; i <= 3; i++) {
+    const noOfDeadBabies = 3;
+    const noOfAliveBabies = 3;
+
+    // Dead Babies Information
+    // We need to loop through all dead babies and fill out information
+    for (let i = 1; i <= noOfDeadBabies; i++) {
       await deliveryReport.populateDeadBabyInformation(i);
     }
     await genericForm.nextPageNative();
 
-    // // Alive Babies Information
-    // // We need to loop through all alive babies and fill out information
-    for (let i = 4; i <= 6; i++) {
+    // Alive Babies Information
+    // We need to loop through all alive babies and fill out information
+    for (let i = noOfDeadBabies + 1; i <= noOfDeadBabies + noOfAliveBabies; i++) {
       await deliveryReport.populateAliveBabyInformation(i);
     }
     await genericForm.nextPageNative();
@@ -69,25 +71,22 @@ describe('Submit Default Delivery Report', () => {
     await deliveryReport.pncCheckBox();
     await genericForm.nextPageNative();
 
-    // //submit
+    //submit
     await genericForm.submitReports();
 
     // Verify dead babies UUIDs are unique
     const deadBabyUUIds = [];
-    for (let i = 0; i <= 2; i++) {
+    for (let i = 0; i <= noOfDeadBabies - 1; i++) {
       deadBabyUUIds.push(await deliveryReport.getDeadBabyUUID(i));
     }
-    console.log(`Dead UUIDS: ${deadBabyUUIds}`);
 
     // Verify alive babies UUIDs are unique
     const aliveBabyUUIds = [];
-    for (let i = 0; i <= 2; i++) {
+    for (let i = 0; i <= noOfAliveBabies - 1; i++) {
       aliveBabyUUIds.push(await deliveryReport.getAliveBabyUUID(i));
     }
-    console.log(`Alive UUIDS: ${aliveBabyUUIds}`);
 
-    assert.equal(_.uniq(deadBabyUUIds).length,3);
-    assert.equal(_.uniq(aliveBabyUUIds).length,3);
-
+    assert.equal(_.uniq(deadBabyUUIds).length, noOfDeadBabies);
+    assert.equal(_.uniq(aliveBabyUUIds).length,noOfAliveBabies);
   });
 });

--- a/tests/e2e/forms/submit-default-delivery-form.specs.js
+++ b/tests/e2e/forms/submit-default-delivery-form.specs.js
@@ -1,0 +1,93 @@
+const deliveryReport = require('../../page-objects/forms/default-delivery-report.po');
+const genericForm = require('../../page-objects/forms/generic-form.po');
+const common = require('../../page-objects/common/common.po');
+const utils = require('../../utils');
+const userData = require('../../page-objects/forms/data/user.po.data');
+const _ = require('lodash');
+_.uniq = require('lodash/uniq');
+const { assert } = require('chai');
+
+describe('Submit Default Delivery Report', () => {
+  const { userContactDoc, docs } = userData;
+
+  beforeAll(async () => {
+    await utils.saveDocs(docs);
+    await deliveryReport.configureForm(userContactDoc);
+  });
+
+
+  afterEach(async () => {
+    await utils.resetBrowser();
+    await utils.revertDb();
+  });
+
+  it('open and submit default delivery form', async () => {
+    await common.goToReportsNative();
+
+    await genericForm.selectFormNative('DD');
+    //select name
+    await deliveryReport.selectPatientName('jack');
+    await genericForm.nextPageNative();
+    await deliveryReport.selectAliveAndWell();
+    await genericForm.nextPageNative();
+    //check Dangersign
+    await deliveryReport.selectFeverButton();
+    await deliveryReport.selectSevereHeadacheButton();
+    await deliveryReport.selectVaginalbleedingButton();
+    await deliveryReport.selectVaginalDischargeButton();
+    await deliveryReport.selectConvulsionsButton();
+    await genericForm.nextPageNative();
+
+    // // Delivery Outcome
+    await deliveryReport.selectBabiesDeliveredButton();
+    await deliveryReport.enterNoOfBabiesDelivered(6);
+    await deliveryReport.selectBabiesAliveButton(3);
+
+    await deliveryReport.enterDeliveryDate('');
+
+    await deliveryReport.selectDeliveryPlaceButton();
+    await deliveryReport.selectDeliveryMethod();
+    await genericForm.nextPageNative();
+
+    // // Dead Babies Information
+    // // We need to loop through all dead babies and fill out information
+    for (let i = 1; i <= 3; i++) {
+      await deliveryReport.populateDeadBabyInformation(i);
+    }
+    await genericForm.nextPageNative();
+
+    // // Alive Babies Information
+    // // We need to loop through all alive babies and fill out information
+    for (let i = 4; i <= 6; i++) {
+      await deliveryReport.populateAliveBabyInformation(i);
+    }
+    await genericForm.nextPageNative();
+
+    await genericForm.nextPageNative();
+    await genericForm.nextPageNative();
+    await genericForm.nextPageNative();
+    await deliveryReport.pncCheckBox();
+    await genericForm.nextPageNative();
+
+    // //submit
+    await genericForm.submitReports();
+
+    // Verify dead babies UUIDs are unique
+    const deadBabyUUIds = [];
+    for (let i = 0; i <= 2; i++) {
+      deadBabyUUIds.push(await deliveryReport.getDeadBabyUUID(i));
+    }
+    console.log(`Dead UUIDS: ${deadBabyUUIds}`);
+
+    // Verify alive babies UUIDs are unique
+    const aliveBabyUUIds = [];
+    for (let i = 0; i <= 2; i++) {
+      aliveBabyUUIds.push(await deliveryReport.getAliveBabyUUID(i));
+    }
+    console.log(`Alive UUIDS: ${aliveBabyUUIds}`);
+
+    assert.equal(_.uniq(deadBabyUUIds).length,3);
+    assert.equal(_.uniq(aliveBabyUUIds).length,3);
+
+  });
+});

--- a/tests/page-objects/forms/default-delivery-report.po.js
+++ b/tests/page-objects/forms/default-delivery-report.po.js
@@ -1,0 +1,225 @@
+const utils = require('../../utils');
+const helper = require('../../helper');
+const fs = require('fs');
+const { element, by } = require('protractor');
+
+const xml = fs.readFileSync(`${__dirname}/../../../config/default/forms/app/delivery.xml`, 'utf8');
+
+const docs = [
+  {
+    _id: 'form:dd',
+    internalId: 'DD',
+    title: 'Default Delivery',
+    type: 'form',
+    _attachments: {
+      xml: {
+        content_type: 'application/octet-stream',
+        data: Buffer.from(xml).toString('base64'),
+      },
+    },
+  },
+];
+
+const selectRadioButtonByValue = async value => {
+  const radioElement = element(by.css(`[value=${value}]`));
+  await helper.waitElementToBeVisible(radioElement);
+  await helper.clickElementNative(radioElement);
+};
+
+const selectRadioButtonByNameAndValue = async (name, value) => {
+  const radioElement = element(by.css(`[name="${name}"][value="${value}"]`));
+  await helper.waitElementToBeVisible(radioElement);
+  await helper.clickElementNative(radioElement);
+};
+
+module.exports = {
+  configureForm: (userContactDoc) => {
+    return utils.seedTestData(userContactDoc, docs);
+  },
+
+  //patient page
+  getPatientPageTitle: () => {
+    return element(by.css('span[data-itext-id=/delivery/inputs:label]'));
+  },
+
+  selectPatientName: async name => {
+    const select = element(by.css('section[name="/delivery/inputs/contact"] .select2-selection'));
+    await helper.waitUntilReadyNative(select);
+    await helper.clickElementNative(select);
+    const search = element(by.css('.select2-search__field'));
+    await helper.waitUntilReadyNative(search);
+    await helper.clickElementNative(search);
+    await search.sendKeys(name);
+    const nameElm = element(by.css('.name'));
+    await helper.waitElementToBeVisibleNative(nameElm);
+    await helper.clickElementNative(nameElm);
+  },
+
+  //outcome for women
+  selectAliveAndWell: async () => {
+    await selectRadioButtonByValue('alive_well');
+  },
+
+  //danger sign check- Fever*
+  selectFeverButton: async () => {
+    await selectRadioButtonByNameAndValue('/delivery/pnc_danger_sign_check/fever', 'no');
+  },
+
+  //Severe headache
+  selectSevereHeadacheButton : async () => {
+    await selectRadioButtonByNameAndValue('/delivery/pnc_danger_sign_check/severe_headache', 'no');
+  },
+
+  //Vaginal bleeding
+  selectVaginalbleedingButton: async () => {
+    await selectRadioButtonByNameAndValue('/delivery/pnc_danger_sign_check/vaginal_bleeding', 'no');
+  },
+
+  //Foul smelling vaginal discharge
+  selectVaginalDischargeButton: async () => {
+    await selectRadioButtonByNameAndValue('/delivery/pnc_danger_sign_check/vaginal_discharge', 'yes');
+  },
+
+  //Convulsions
+  selectConvulsionsButton: async () => {
+    await selectRadioButtonByNameAndValue('/delivery/pnc_danger_sign_check/convulsion', 'no');
+  },
+
+  //DeliveryOutcomes- Babies delivered
+  selectBabiesDeliveredButton: async () => {
+    await selectRadioButtonByNameAndValue('/delivery/delivery_outcome/babies_delivered', 'other');
+  },
+
+  enterNoOfBabiesDelivered : async (noOfBabies) => {
+    await helper.waitElementToBeVisibleNative(element(by.name('/delivery/delivery_outcome/babies_delivered_other')));
+    const noOfBabyTextBox= await element(by.name('/delivery/delivery_outcome/babies_delivered_other'));
+    await noOfBabyTextBox.sendKeys(noOfBabies).sendKeys(protractor.Key.ENTER);
+  },
+
+  //Babies alive
+  selectBabiesAliveButton: async (noOfBabiesAlive) => {
+    await helper.waitElementToBeVisibleNative(element(
+      by.css(`[name="/delivery/delivery_outcome/babies_alive"][value="3"]`)));
+    await selectRadioButtonByNameAndValue('/delivery/delivery_outcome/babies_alive', noOfBabiesAlive);
+  },
+
+  //Delivery date
+  enterDeliveryDate: async deliveryDate => {
+    const datePicker = await element(by.xpath(
+      `//*[@data-itext-id="/delivery/delivery_outcome/delivery_date:label"]/..//*[@placeholder="yyyy-mm-dd"]`));
+    await datePicker.click();
+    await datePicker.sendKeys(deliveryDate).sendKeys(protractor.Key.ENTER);
+  },
+
+  //Delivery Place
+  selectDeliveryPlaceButton: async () => {
+    await selectRadioButtonByNameAndValue('/delivery/delivery_outcome/delivery_place', 'health_facility');
+  },
+
+  //Delivery Method
+  selectDeliveryMethod: async () => {
+    await helper.waitElementToBeVisibleNative(element(by.name('/delivery/delivery_outcome/delivery_mode')));
+    await selectRadioButtonByValue('vaginal');
+  },
+
+  populateDeadBabyInformation: async (deadBabyIndex) => {
+    const basePath = `(//*[@class="repeat-number"])[${deadBabyIndex}]/..//`;
+    const dateOfDeathPicker = await element(by.xpath(`${basePath}*[@placeholder="yyyy-mm-dd"]`));
+    await dateOfDeathPicker.click();
+    await dateOfDeathPicker.sendKeys('').sendKeys(protractor.Key.ENTER);
+
+    const placeOfDeathRadio = await element(by.xpath(`${basePath}*[@value="health_facility"]`));
+    await placeOfDeathRadio.click();
+
+    const wasStillBirthRadio = await element(by.xpath(`${basePath}*[@value="yes"]`));
+    await wasStillBirthRadio.click();
+  },
+
+  populateAliveBabyInformation: async (aliveBabyIndex) => {
+    const basePath = `(//*[@class="repeat-number"])[${aliveBabyIndex}]/..//`;
+
+    const babyConditionRadio = await element(by.xpath(`${basePath}*[@value="alive_well"]`));
+    await babyConditionRadio.click();
+
+    const babyNameTextBox = await element(by.xpath(`${basePath}*
+    [@name="/delivery/babys_condition/baby_repeat/baby_details/baby_name"]`));
+    babyNameTextBox.sendKeys(`AliveBaby-${aliveBabyIndex}`);
+
+    const sexRadio = await element(by.xpath(`${basePath}*[@value="male"]`));
+    await sexRadio.click();
+
+    const birthWeightRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/birth_weight_know"]`));
+    await birthWeightRadio.click();
+
+    const birthLengthRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/birth_length_know"]`));
+    await birthLengthRadio.click();
+
+    const vaccineRadio = await element(by.xpath(`${basePath}*[@value="bcg_only"]`));
+    await vaccineRadio.click();
+
+    const breastFeedingRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/breatfeeding"]`));
+    await breastFeedingRadio.click();
+
+    const initiatedBreastFeedingRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/breastfed_within_1_hour"]`));
+    await initiatedBreastFeedingRadio.click();
+
+    const umbilicalCordRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/infected_umbilical_cord"]`));
+    await umbilicalCordRadio.click();
+
+    const convulsionsRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/convulsion"]`));
+    await convulsionsRadio.click();
+
+    const feedingDifficultyRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/difficulty_feeding"]`));
+    await feedingDifficultyRadio.click();
+
+    const vomitRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/vomit"]`));
+    await vomitRadio.click();
+
+    const drowsyRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/drowsy"]`));
+    await drowsyRadio.click();
+
+    const stiffnessRadio = await element(by.xpath(`${basePath}*[@value="no"][
+      @data-name="/delivery/babys_condition/baby_repeat/baby_details/stiff"]`));
+    await stiffnessRadio.click();
+
+    const yellowSkinColorRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/yellow_skin"]`));
+    await yellowSkinColorRadio.click();
+
+    const feverRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/fever"]`));
+    await feverRadio.click();
+
+    const blueSkinColorRadio = await element(by.xpath(`${basePath}*[@value="no"]
+    [@data-name="/delivery/babys_condition/baby_repeat/baby_details/blue_skin"]`));
+    await blueSkinColorRadio.click();
+
+  },
+
+  //PNC visits
+  pncCheckBox: async () => {
+    await helper.waitElementToBeVisibleNative(element(by.xpath('//*[@value="within_24_hrs"]')));
+    await element(by.xpath('//*[@value="within_24_hrs"]')).click();
+  },
+
+  getDeadBabyUUID: async (deadBabyIndex) => {
+    const uuidElement = await element(by.xpath(
+      `//*[text()="report.DD.baby_death.baby_death_repeat.${deadBabyIndex}.baby_death_profile_doc"]/../../p`));
+    return uuidElement.getText();
+  },
+
+  getAliveBabyUUID: async (aliveBabyIndex) => {
+    const uuidaliveElement = await element(by.xpath(
+      `//*[text()="report.DD.babys_condition.baby_repeat.${aliveBabyIndex}.baby_details.child_doc"]/../../p`));
+    return uuidaliveElement.getText();
+  }
+};


### PR DESCRIPTION
When submitting a delivery form as part of the default config and when we enter multiple babies (either alive or not), the report will have as many entries for every repeat type, but the uuids of each repeat saved in the report were same. So defect [6728](https://github.com/medic/cht-core/issues/6718) was raised for this.

There was no existing End2End test cases for Default Delivery form, so this pull request attempts to create one.

medic/cht-core#[6718]

Code review checklist
[ x] Readable: Concise, well named, follows the style guide, documented if necessary.
[ x] Tested: Unit and/or e2e where appropriate

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
