### PR TITLE
Fix missed jobs from schedules ahead of time less than 1 second

### DIFF
--- a/sentinel/src/lib/scheduling.js
+++ b/sentinel/src/lib/scheduling.js
@@ -1,0 +1,45 @@
+const later = require('later');
+
+/**
+ * Fetch a schedule based on the configuration, parsing it as a "cron"
+ * or "text" statement see:
+ * http://bunkat.github.io/later/parsers.html
+ *
+ * @param {Object} config
+ * @param {string} config.text_expression a text expression, like 'every 12 hours'
+ * @param {string} config.cron a cron expression, like '* 1 * * *'
+ * @return {Object} the schedule object parsed by later
+ */
+const getSchedule = config => {
+  if (!config) {
+    return;
+  }
+  if (config.text_expression) {
+    // text expression takes precedence over cron
+    return later.parse.text(config.text_expression);
+  }
+  if (config.cron) {
+    return later.parse.cron(config.cron);
+  }
+};
+
+/**
+ * Return the milliseconds ahead for the first job scheduled.
+ * If the first job time is less than 1 second ahead of time,
+ * add a thousand milliseconds to the response.
+ * @param scheduleConfig a scheduling configuration parsed by "later"
+ * @return {number} milliseconds ahead
+ */
+const nextScheduleMillis = scheduleConfig => {
+  const schedule = later.schedule(scheduleConfig);
+  const diff = schedule.next().getTime() - Date.now();
+  if (diff <= 1000) {
+    return diff + 1000;
+  }
+  return diff;
+};
+
+module.exports = {
+  getSchedule,
+  nextScheduleMillis,
+};

--- a/sentinel/src/lib/scheduling.js
+++ b/sentinel/src/lib/scheduling.js
@@ -25,17 +25,12 @@ const getSchedule = config => {
 
 /**
  * Return the milliseconds ahead for the first job scheduled.
- * If the first job time is less than 1 second ahead of time,
- * add a thousand milliseconds to the response.
  * @param scheduleConfig a scheduling configuration parsed by "later"
  * @return {number} milliseconds ahead
  */
 const nextScheduleMillis = scheduleConfig => {
   const schedule = later.schedule(scheduleConfig);
   const diff = schedule.next().getTime() - Date.now();
-  if (diff <= 1000) {
-    return diff + 1000;
-  }
   return diff;
 };
 

--- a/sentinel/src/schedule/reminders.js
+++ b/sentinel/src/schedule/reminders.js
@@ -5,6 +5,7 @@ const request = require('request-promise-native');
 
 const config = require('../config');
 const db = require('../db');
+const scheduling = require('../lib/scheduling');
 const later = require('later');
 const lineage = require('@medic/lineage')(Promise, db.medic);
 const logger = require('../lib/logger');
@@ -40,16 +41,7 @@ const isConfigValid = (reminder) => {
 };
 
 const getSchedule = (config) => {
-  // fetch a schedule based on the configuration, parsing it as a "cron"
-  // or "text" statement see:
-  // http://bunkat.github.io/later/parsers.html
-  if (config.text_expression) {
-    // text expression takes precedence over cron
-    return later.schedule(later.parse.text(config.text_expression));
-  }
-  if (config.cron) {
-    return later.schedule(later.parse.cron(config.cron));
-  }
+  return later.schedule(scheduling.getSchedule(config));
 };
 
 const getReminderWindowStart = (reminder) => {

--- a/sentinel/tests/unit/lib/scheduling.js
+++ b/sentinel/tests/unit/lib/scheduling.js
@@ -1,6 +1,8 @@
 const sinon = require('sinon');
 const assert = require('chai').assert;
+
 const later = require('later');
+const moment = require('moment');
 
 const scheduling = require('../../../src/lib/scheduling');
 
@@ -38,6 +40,25 @@ describe('scheduling', () => {
       assert.equal(later.parse.text.callCount, 1);
       assert.deepEqual(later.parse.text.args[0], ['text']);
       assert.equal(later.parse.cron.callCount, 0);
+    });
+  });
+
+  describe('nextScheduleMillis', () => {
+
+    let clock;
+
+    afterEach(() => clock.restore());
+
+    it('should return the exact milliseconds for next schedule', () => {
+      clock = sinon.useFakeTimers(moment('2021-06-07T11:59:05').valueOf());       // 55 sec before 12 o'clock
+      const scheduleConfig = later.parse.cron('0 * * * *');                  // Run every hour at minute 0
+      assert.equal(scheduling.nextScheduleMillis(scheduleConfig), 55 * 1000);
+    });
+
+    it('should return the exact milliseconds for next schedule with less than 1 sec', () => {
+      clock = sinon.useFakeTimers(moment('2021-06-07T11:59:59.910').valueOf());   // 90 millis before 12 o'clock
+      const scheduleConfig = later.parse.cron('0 12 * * *');                 // Run 12 o'clock
+      assert.equal(scheduling.nextScheduleMillis(scheduleConfig), 90);
     });
   });
 });

--- a/sentinel/tests/unit/lib/scheduling.js
+++ b/sentinel/tests/unit/lib/scheduling.js
@@ -1,0 +1,43 @@
+const sinon = require('sinon');
+const assert = require('chai').assert;
+const later = require('later');
+
+const scheduling = require('../../../src/lib/scheduling');
+
+describe('scheduling', () => {
+  describe('getSchedule', () => {
+    beforeEach(() => {
+      sinon.stub(later.parse, 'text');
+      sinon.stub(later.parse, 'cron');
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('should return schedule for cron', () => {
+      later.parse.cron.returns('parsed cron');
+      later.parse.text.returns('parsed text');
+      assert.equal(scheduling.getSchedule({ cron: 'something' }), 'parsed cron');
+      assert.equal(later.parse.cron.callCount, 1);
+      assert.deepEqual(later.parse.cron.args[0], ['something']);
+      assert.equal(later.parse.text.callCount, 0);
+    });
+
+    it('should return schedule for text_expression', () => {
+      later.parse.text.returns('parsed text');
+      later.parse.cron.returns('parsed cron');
+      assert.equal(scheduling.getSchedule({ text_expression: 'other' }), 'parsed text');
+      assert.equal(later.parse.text.callCount, 1);
+      assert.deepEqual(later.parse.text.args[0], ['other']);
+      assert.equal(later.parse.cron.callCount, 0);
+    });
+
+    it('should prioritize text_expression', () => {
+      later.parse.text.returns('parsed text');
+      later.parse.cron.returns('parsed cron');
+      assert.equal(scheduling.getSchedule({ text_expression: 'text', cron: 'cron'}), 'parsed text');
+      assert.equal(later.parse.text.callCount, 1);
+      assert.deepEqual(later.parse.text.args[0], ['text']);
+      assert.equal(later.parse.cron.callCount, 0);
+    });
+  });
+});

--- a/sentinel/tests/unit/schedule/index.js
+++ b/sentinel/tests/unit/schedule/index.js
@@ -339,7 +339,7 @@ describe('scheduler', () => {
     // Difference in seconds without taking into account milliseconds
     const secondsDiff = (moment1, moment2) => {
       return moment1.milliseconds(0).diff(moment2.milliseconds(0), 'seconds');
-    }
+    };
 
     beforeEach(() => {
       realSetTimeout = setTimeout;

--- a/sentinel/tests/unit/schedule/purging.js
+++ b/sentinel/tests/unit/schedule/purging.js
@@ -1,13 +1,26 @@
 const chai = require('chai');
 const sinon = require('sinon');
+const rewire = require('rewire');
 
 const config = require('../../../src/config');
 const later = require('later');
 const purgeLib = require('../../../src/lib/purging');
-const scheduler = require('../../../src/schedule/purging');
+
+let clock;
+let scheduler;
 
 describe('Purging Schedule', () => {
-  afterEach(() => sinon.restore());
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(new Date());
+    scheduler = rewire('../../../src/schedule/purging');
+  });
+
+  afterEach(() => {
+    clearTimeout(scheduler.__get__('purgeTimeout'));
+    sinon.restore();
+    clock.restore();
+  });
 
   it('should abort if no purging configuration', () => {
     sinon.stub(config, 'get');
@@ -54,42 +67,42 @@ describe('Purging Schedule', () => {
   });
 
   it('should create purge timeout', () => {
-    sinon.stub(config, 'get').returns({ cron: '* * something' });
-    sinon.stub(later.parse, 'cron').returns('my schedule');
-    sinon.stub(later, 'setTimeout');
+    sinon.stub(config, 'get').returns({ cron: '* 1 * * *' });
+    sinon.spy(later.parse, 'cron');
+    sinon.spy(clock, 'setTimeout');
 
     return scheduler.execute().then(() => {
       chai.expect(config.get.callCount).to.equal(1);
       chai.expect(later.parse.cron.callCount).to.equal(1);
-      chai.expect(later.parse.cron.args[0]).to.deep.equal(['* * something']);
-      chai.expect(later.setTimeout.callCount).to.equal(1);
-      chai.expect(later.setTimeout.args[0]).to.deep.equal([purgeLib.purge, 'my schedule']);
+      chai.expect(later.parse.cron.args[0]).to.deep.equal(['* 1 * * *']);
+      chai.expect(clock.setTimeout.callCount).to.equal(1);
+      chai.expect(clock.setTimeout.args[0][0]).to.equal(purgeLib.purge);
     });
   });
 
   it('should clear previous timeout when re-running', () => {
-    sinon.stub(config, 'get').returns({ cron: '* * something' });
-    sinon.stub(later.parse, 'cron').returns('my schedule');
-    const timeout = { clear: sinon.stub() };
-    sinon.stub(later, 'setTimeout').returns(timeout);
+    sinon.stub(config, 'get').returns({ cron: '* 1 * * *' });
+    sinon.spy(later.parse, 'cron');
+    sinon.spy(clock, 'setTimeout');
+    sinon.spy(clock, 'clearTimeout');
 
     return scheduler.execute()
       .then(() => {
         chai.expect(config.get.callCount).to.equal(1);
         chai.expect(later.parse.cron.callCount).to.equal(1);
-        chai.expect(later.parse.cron.args[0]).to.deep.equal(['* * something']);
-        chai.expect(later.setTimeout.callCount).to.equal(1);
-        chai.expect(later.setTimeout.args[0]).to.deep.equal([purgeLib.purge, 'my schedule']);
-        chai.expect(timeout.clear.callCount).to.equal(0);
+        chai.expect(later.parse.cron.args[0]).to.deep.equal(['* 1 * * *']);
+        chai.expect(clock.setTimeout.callCount).to.equal(1);
+        chai.expect(clock.setTimeout.args[0][0]).to.equal(purgeLib.purge);
+        chai.expect(clock.clearTimeout.callCount).to.equal(0);
       })
       .then(() => scheduler.execute())
       .then(() => {
         chai.expect(config.get.callCount).to.equal(2);
         chai.expect(later.parse.cron.callCount).to.equal(2);
-        chai.expect(later.parse.cron.args[1]).to.deep.equal(['* * something']);
-        chai.expect(later.setTimeout.callCount).to.equal(2);
-        chai.expect(later.setTimeout.args[1]).to.deep.equal([purgeLib.purge, 'my schedule']);
-        chai.expect(timeout.clear.callCount).to.equal(1);
+        chai.expect(later.parse.cron.args[1]).to.deep.equal(['* 1 * * *']);
+        chai.expect(clock.setTimeout.callCount).to.equal(2);
+        chai.expect(clock.setTimeout.args[1][0]).to.deep.equal(purgeLib.purge);
+        chai.expect(clock.clearTimeout.callCount).to.equal(1);
       });
   });
 });

--- a/sentinel/tests/unit/schedule/reminders.js
+++ b/sentinel/tests/unit/schedule/reminders.js
@@ -112,6 +112,23 @@ describe('reminders', () => {
     });
   });
 
+  describe('getSchedule', () => {
+    let getSchedule;
+    beforeEach(() => {
+      getSchedule = reminders.__get__('getSchedule');
+    });
+
+    it('should return date from next schedule for cron', () => {
+      clock = sinon.useFakeTimers(moment('2021-06-17T10:48:54.000Z').valueOf());
+      assert.equal(getSchedule({ cron: '0 * * * *' }).next().toISOString(), '2021-06-17T11:00:00.000Z');
+    });
+
+    it('should return date from next schedule for text_expression', () => {
+      clock = sinon.useFakeTimers(moment('2021-06-17T10:48:54.000Z').valueOf());
+      assert.equal(getSchedule({ text_expression: 'every 5 mins' }).next().toISOString(), '2021-06-17T10:50:00.000Z');
+    });
+  });
+
   describe('runReminder', () => {
     let runReminder;
     beforeEach(() => {

--- a/sentinel/tests/unit/schedule/reminders.js
+++ b/sentinel/tests/unit/schedule/reminders.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const assert = require('chai').assert;
 const rewire = require('rewire');
 const db = require('../../../src/db');
-const later = require('later');
 const request = require('request-promise-native');
 
 let reminders;
@@ -110,49 +109,6 @@ describe('reminders', () => {
     it('should return false when given invalid contact type', () => {
       assert.equal(isConfigValid({ form: 'a', message: 'b', cron: 'c', contact_types: [] }), false);
       assert.equal(isConfigValid({ form: 'a', message: 'b', cron: 'c', contact_types: [ 'unknown' ] }), false);
-    });
-  });
-
-  describe('getSchedule', () => {
-    let getSchedule;
-    beforeEach(() => {
-      sinon.stub(later, 'schedule');
-      sinon.stub(later.parse, 'text');
-      sinon.stub(later.parse, 'cron');
-      getSchedule = reminders.__get__('getSchedule');
-    });
-
-    it('should return schedule for cron', () => {
-      later.parse.cron.returns('parsed cron');
-      later.schedule.returns('schedule');
-      assert.equal(getSchedule({ cron: 'something' }), 'schedule');
-      assert.equal(later.parse.cron.callCount, 1);
-      assert.deepEqual(later.parse.cron.args[0], ['something']);
-      assert.equal(later.parse.text.callCount, 0);
-      assert.equal(later.schedule.callCount, 1);
-      assert.deepEqual(later.schedule.args[0], ['parsed cron']);
-    });
-
-    it('should return schedule for text_expression', () => {
-      later.parse.text.returns('parsed expression');
-      later.schedule.returns('schedule');
-      assert.equal(getSchedule({ text_expression: 'other' }), 'schedule');
-      assert.equal(later.parse.text.callCount, 1);
-      assert.deepEqual(later.parse.text.args[0], ['other']);
-      assert.equal(later.parse.cron.callCount, 0);
-      assert.equal(later.schedule.callCount, 1);
-      assert.deepEqual(later.schedule.args[0], ['parsed expression']);
-    });
-
-    it('should prioritize text_expression', () => {
-      later.parse.text.returns('parsed expression');
-      later.schedule.returns('schedule');
-      assert.equal(getSchedule({ text_expression: 'text', cron: 'cron'}), 'schedule');
-      assert.equal(later.parse.text.callCount, 1);
-      assert.deepEqual(later.parse.text.args[0], ['text']);
-      assert.equal(later.parse.cron.callCount, 0);
-      assert.equal(later.schedule.callCount, 1);
-      assert.deepEqual(later.schedule.args[0], ['parsed expression']);
     });
   });
 


### PR DESCRIPTION
# Description

Fix missed jobs from schedules ahead of time less than 1 second.

medic/cht-core#6634

- The issue was fixed replacing the use of `later.setTimeout` by the native `setTimeout` and the milliseconds ahead that is calculated before hand, taking into account the difference between "now" and the schedule to not be less than 1 second.
- Add regression tests.
- Minor refactor: method `getSchedule` was repeated in the code twice.

## About the error and how to test it

Doing some tests I found a bit different scenario of why this happen. Contrary to what we think, timers are likely to be executed in less than 1 seconds, here is a small test that can be executed under the `sentinel` folder (because it has the `later` dependency in the `node_modules`):

```js
$ sudo date --set="2021-06-09T14:59:59.900Z" && node -e "
  var later = require('later');
  console.log('Date from Node:', new Date());
  var cron = later.parse.cron('00 * * * *');
  var schedule = later.schedule(cron);
  console.log('Next 3 schedules:', schedule.next(3));
  later.setTimeout(()=> console.log('Schedule executed at', new Date()), cron);
"
```

The output:

```
Wed 09 Jun 2021 11:59:59 AM -03
Date from Node: 2021-06-09T14:59:59.923Z
Next 3 schedules: [
  2021-06-09T15:00:00.928Z,
  2021-06-09T16:00:00.928Z,
  2021-06-09T17:00:00.928Z
]
Schedule executed at 2021-06-09T15:00:00.932Z
```

Basically it crates a cron to be executed at 00 minutes of any hour, the process is launched 100 millis before 12:00 UTC, and it works (tried dozens of times, all them worked, and you have to have disable automatic Date & Time sync in your system).

Then if you try to do the same but milliseconds AFTER, despite an entry is created to be executed, the scheduling for that first entry is not executed (`2021-06-09T15:00:00.117Z`):

```
$ sudo date --set="2021-06-09T15:00:00.090Z" && node -e "
  var later = require('later');
  console.log('Date from Node:', new Date());
  var cron = later.parse.cron('00 * * * *');
  var schedule = later.schedule(cron);
  console.log('Next 3 schedules:', schedule.next(3));
  later.setTimeout(()=> console.log('Schedule executed at', new Date()), cron);
"
Wed 09 Jun 2021 12:00:00 PM -03
Date from Node: 2021-06-09T15:00:00.112Z
Next 3 schedules: [
  2021-06-09T15:00:00.117Z,
  2021-06-09T16:00:00.117Z,
  2021-06-09T17:00:00.117Z
]
```

However testing the bug with the application is almost impossible, because even configuring the system clock to a fixed time like the tests above don't warranty at what time the main loops starts, and how much it takes to reach the purging timer. The only way I could reproduce the error consistently was adding 2 regressions tests to this PR, both uses real timers instead of fake ones because was not possible to test it properly with the ones provided by the sinon mocking library.

I tried the following that only failed in master as expected one time, and at this point I'm not even sure whether the failure was because I did configure the cron wrong in the DB or was the perfect timing to reach the bug.

First setup the purge scheduling as described [here](https://docs.communityhealthtoolkit.org/apps/guides/performance/purging/) in Couch at http://localhost:5984/_utils/#database/medic/settings with something like:


```js
{
  ...
  "settings": {
    ...
    "purge": {
      "fn": "function(userCtx, contact, reports, messages) { const old = Date.now() - (1000 * 60 * 60 * 24 * 365); return reports.filter(r => r.reported_date < old).map(r => r._id);}",
      "cron": "*/5 * * * *"
    },

  }

```

The purging is configured to run each 5 minutes on each minute that is multiple of 5: 0, 5, 10, ...

Then execute:


```
sudo date --set="2021-06-14T19:50:00.010Z" && node server.js
```

In `master` you won't see the purging process being executed, and after 5 minutes, it may not be executed either. But switching to this branch, you will see in the logs that the purging is executed both at the beginning and after 5 min:

```
2021-06-14 16:50:01 INFO: Running server side purge 
...
2021-06-14 16:50:01 INFO: Server Side Purge completed successfully in 0.0009530372333402435 minutes

```

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
