### PR TITLE
6213 - Select2 search missed contact show set empty value

### DIFF
--- a/webapp/src/ts/services/select2-search.service.ts
+++ b/webapp/src/ts/services/select2-search.service.ts
@@ -127,7 +127,13 @@ export class Select2SearchService {
         resolution = Promise.resolve();
       } else {
         resolution = this.getDoc(value)
-          .then((doc) => selectEl.select2('data')[0].doc = doc)
+          .then((doc) => {
+            if (doc) {
+              selectEl.select2('data')[0].doc = doc;
+            } else {
+              selectEl.select2('data')[0].text = '';
+            }
+          })
           .catch(err => console.error('Select2 failed to get document', err));
       }
     }
@@ -173,7 +179,11 @@ export class Select2SearchService {
         if (docId) {
           this.getDoc(docId)
             .then((doc) => {
-              selectEl.select2('data')[0].doc = doc;
+              if (doc) {
+                selectEl.select2('data')[0].doc = doc;
+              } else {
+                selectEl.select2('data')[0].text = '';
+              }
               selectEl.trigger('change');
             })
             .catch(err => console.error('Select2 failed to get document', err));

--- a/webapp/src/ts/services/select2-search.service.ts
+++ b/webapp/src/ts/services/select2-search.service.ts
@@ -131,7 +131,7 @@ export class Select2SearchService {
             if (doc) {
               selectEl.select2('data')[0].doc = doc;
             } else {
-              selectEl.select2('data')[0].text = '';
+              selectEl.val('');
             }
           })
           .catch(err => console.error('Select2 failed to get document', err));
@@ -182,7 +182,7 @@ export class Select2SearchService {
               if (doc) {
                 selectEl.select2('data')[0].doc = doc;
               } else {
-                selectEl.select2('data')[0].text = '';
+                selectEl.val('');
               }
               selectEl.trigger('change');
             })

--- a/webapp/tests/karma/ts/services/select2-search.service.spec.ts
+++ b/webapp/tests/karma/ts/services/select2-search.service.spec.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { TestBed } from '@angular/core/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
+import { ContactMutedService } from '@mm-services/contact-muted.service';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
 import { SearchService } from '@mm-services/search.service';
 import { Select2SearchService } from '@mm-services/select2-search.service';
@@ -12,11 +13,14 @@ import { SettingsService } from '@mm-services/settings.service';
 describe('Select2SearchService', () => {
   let service: Select2SearchService;
 
+  let contactMutedService;
+  let lineageModelGeneratorService;
   let sessionService;
   let settingsService;
 
   let selectEl;
   let val;
+  let select2Val;
 
   beforeEach(() => {
     settingsService = {
@@ -25,13 +29,20 @@ describe('Select2SearchService', () => {
     sessionService = {
       isOnlineOnly: sinon.stub().returns(true)
     };
+    lineageModelGeneratorService = {
+      contact: sinon.stub()
+    };
+    contactMutedService = {
+      getMuted: sinon.stub().returns(false)
+    };
 
     val = '';
+    select2Val = [{}];
     selectEl = {
       append: sinon.stub(),
       children: sinon.stub(),
       on: sinon.stub(),
-      select2: sinon.stub(),
+      select2: sinon.stub().returns(select2Val),
       trigger: sinon.stub(),
       val: sinon.stub().callsFake(v => {
         if (v !== undefined) {
@@ -46,7 +57,8 @@ describe('Select2SearchService', () => {
         TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
       ],
       providers: [
-        { provide: LineageModelGeneratorService, useValue: {} },
+        { provide: ContactMutedService, useValue: contactMutedService },
+        { provide: LineageModelGeneratorService, useValue: lineageModelGeneratorService },
         { provide: SearchService, useValue: { } },
         { provide: SessionService, useValue: sessionService },
         { provide: SettingsService, useValue: settingsService },
@@ -59,13 +71,37 @@ describe('Select2SearchService', () => {
 
   describe('init', () => {
     it('should set empty value when initial value is empty', async () => {
-      //selectEl.children.returns({ length: 0 });
       await service.init(selectEl, [ 'person' ], {initialValue: ''});
       expect(selectEl.val.callCount).to.equal(3);
-      expect(selectEl.val.args[0]).to.deep.equal([]);   // first time the component reads the current value
-      expect(selectEl.val.args[1]).to.deep.equal(['']); // set the value
-      expect(selectEl.val.args[2]).to.deep.equal([]);   // read the value
-      expect(val).to.equal('');                         // current value ''
+      expect(selectEl.val.args[0]).to.deep.equal([ ]);    // first time the component reads the current value
+      expect(selectEl.val.args[1]).to.deep.equal([ '' ]); // set the value
+      expect(selectEl.val.args[2]).to.deep.equal([ ]);    // read the value
+      expect(val).to.equal('');                           // current value ''
+      expect(lineageModelGeneratorService.contact.callCount).to.equal(0);   // empty initial value => no calls to DB
+    });
+
+    it('should set right label and value when initial reference is set', async () => {
+      selectEl.children.returns({ length: 0 });
+      const person = {
+        _id: 'aaa-222-333',
+        doc: {
+          _id: 'aaa-222-333',
+          _rev: '1-000123',
+          type: 'person',
+          name: 'Charles C'
+        },
+      };
+      lineageModelGeneratorService.contact.resolves(person);
+      await service.init(selectEl, [ 'person' ], {initialValue: 'aaa-222-333'});
+      expect(selectEl.val.callCount).to.equal(2);
+      expect(selectEl.val.args[0]).to.deep.equal([ 'aaa-222-333' ]);  // set the value
+      expect(selectEl.val.args[1]).to.deep.equal([ ]);               // read the value
+      expect(lineageModelGeneratorService.contact.callCount).to.equal(1);
+      expect(lineageModelGeneratorService.contact.args[0]).to.deep.equal([ 'aaa-222-333', { merge: true } ]);
+      expect(contactMutedService.getMuted.callCount).to.equal(1);
+      expect(contactMutedService.getMuted.args[0]).to.deep.equal([ person.doc ]);
+      expect(val).to.equal('aaa-222-333');                          // current value
+      expect(select2Val[0]).to.deep.equal({ doc: person.doc });
     });
 
     // TODO more tests...

--- a/webapp/tests/karma/ts/services/select2-search.service.spec.ts
+++ b/webapp/tests/karma/ts/services/select2-search.service.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { TestBed } from '@angular/core/testing';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+
+import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
+import { SearchService } from '@mm-services/search.service';
+import { Select2SearchService } from '@mm-services/select2-search.service';
+import { SessionService } from '@mm-services/session.service';
+import { SettingsService } from '@mm-services/settings.service';
+
+describe('Select2SearchService', () => {
+  let service: Select2SearchService;
+
+  let sessionService;
+  let settingsService;
+
+  let selectEl;
+  let val;
+
+  beforeEach(() => {
+    settingsService = {
+      get: sinon.stub().resolves({})
+    };
+    sessionService = {
+      isOnlineOnly: sinon.stub().returns(true)
+    };
+
+    val = '';
+    selectEl = {
+      append: sinon.stub(),
+      children: sinon.stub(),
+      on: sinon.stub(),
+      select2: sinon.stub(),
+      trigger: sinon.stub(),
+      val: sinon.stub().callsFake(v => {
+        if (v !== undefined) {
+          val = v;
+        }
+        return val;
+      }),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
+      ],
+      providers: [
+        { provide: LineageModelGeneratorService, useValue: {} },
+        { provide: SearchService, useValue: { } },
+        { provide: SessionService, useValue: sessionService },
+        { provide: SettingsService, useValue: settingsService },
+      ]
+    });
+    service = TestBed.inject(Select2SearchService);
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('init', () => {
+    it('should set empty value when initial value is empty', async () => {
+      //selectEl.children.returns({ length: 0 });
+      await service.init(selectEl, [ 'person' ], {initialValue: ''});
+      expect(selectEl.val.callCount).to.equal(3);
+      expect(selectEl.val.args[0]).to.deep.equal([]);   // first time the component reads the current value
+      expect(selectEl.val.args[1]).to.deep.equal(['']); // set the value
+      expect(selectEl.val.args[2]).to.deep.equal([]);   // read the value
+      expect(val).to.equal('');                         // current value ''
+    });
+
+    // TODO more tests...
+  });
+});


### PR DESCRIPTION
# Description

When editing a record (report, health center), if the contact reference has been deleted from the DB, set in the Select2 component an empty value as default instead of shown the __id_ of the missed record.

medic/cht-core#6213

**Note:**
- In the previous behavior, not only the __id_ is shown, also if the user forget to change the value and save the form, the record is stored again with the invalid value. Now if the user does not change the value, because an empty value is set by default, the value is changed to an empty id after save, e.g. `{ "contact": { "_id": "" }, ... }`. This is the same value stored when the user creates or edit a record without setting a value in the Select2 field, e.g. when creating a new health center without setting a contact.
- The PR also adds a new spec file with tests for the component that didn't have any test at all.

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
