### PR TITLE
Pass contact form's title translation key to EnketoService

### DIFF
--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -5,7 +5,7 @@ import { isEqual as _isEqual } from 'lodash-es';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
-import { EnketoService, ContactFormContext } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { DbService } from '@mm-services/db.service';
 import { ContactSaveService } from '@mm-services/contact-save.service';
@@ -257,7 +257,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     const instanceData = this.getFormInstanceData();
     const markFormEdited = this.markFormEdited.bind(this);
     const resetFormError = this.resetFormError.bind(this);
-    const contactFormContext: ContactFormContext = {
+    const formContext: EnketoFormContext = {
       selector: '#contact-form',
       formDoc,
       instanceData,
@@ -266,7 +266,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
       titleKey,
     };
 
-    return this.enketoService.renderContactForm(contactFormContext);
+    return this.enketoService.renderContactForm(formContext);
   }
 
   private setEnketoContact(formInstance) {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -163,19 +163,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
         throw new Error('Unknown form');
       }
 
-      const formDoc = await this.dbService.get().get(formId);
-      const instanceData = this.getFormInstanceData();
-      const markFormEdited = this.markFormEdited.bind(this);
-      const resetFormError = this.resetFormError.bind(this);
-      const formContext: EnketoFormContext = {
-        selector: '#contact-form',
-        formDoc,
-        instanceData,
-        editedListener: markFormEdited,
-        valuechangeListener: resetFormError,
-        titleKey,
-      };
-      const formInstance = await this.renderForm(formContext);
+      const formInstance = await this.renderForm(formId, titleKey);
       this.setEnketoContact(formInstance);
 
       this.globalActions.setLoadingContent(false);
@@ -245,7 +233,20 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  private async renderForm(formContext: EnketoFormContext) {
+  private async renderForm(formId: string, titleKey: string) {
+    const formDoc = await this.dbService.get().get(formId);
+    const instanceData = this.getFormInstanceData();
+    const markFormEdited = this.markFormEdited.bind(this);
+    const resetFormError = this.resetFormError.bind(this);
+    const formContext: EnketoFormContext = {
+      selector: '#contact-form',
+      formDoc,
+      instanceData,
+      editedListener: markFormEdited,
+      valuechangeListener: resetFormError,
+      titleKey,
+    };
+
     this.globalActions.setEnketoEditedStatus(false);
 
     return this.enketoService.renderContactForm(formContext);

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -5,7 +5,7 @@ import { isEqual as _isEqual } from 'lodash-es';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
-import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext, EnketoService } from '@mm-services/enketo.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { DbService } from '@mm-services/db.service';
 import { ContactSaveService } from '@mm-services/contact-save.service';
@@ -154,8 +154,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
       const contactTypeId = this.contactTypesService.getTypeId(contact) || this.routeSnapshot.params?.type;
       const contactType = await this.contactTypesService.get(contactTypeId);
       if (!contactType) {
-        console.error(`Unknown contact type "${contactTypeId}"`);
-        return;
+        throw new Error(`Unknown contact type "${contactTypeId}"`);
       }
 
       const formId = this.getForm(contact, contactType);

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -235,23 +235,15 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     }
   }
 
-  private getTitleKey(contact) {
+  private async getTitleKey(contact) {
     const typeId = this.contactTypesService.getTypeId(contact) || this.routeSnapshot.params?.type;
+    const type = await this.contactTypesService.get(typeId);
+    if (!type) {
+      console.error(`Unknown contact type "${typeId}"`);
+      return;
+    }
 
-    return this.contactTypesService
-      .get(typeId)
-      .then(type => {
-        if (!type) {
-          console.error(`Unknown contact type "${typeId}"`);
-          return;
-        }
-
-        if (contact) { // editing
-          return type.edit_key;
-        } else { // adding
-          return type.create_key;
-        }
-      });
+    return contact ? type.edit_key : type.create_key;
   }
 
   private async renderForm(formId, contact) {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -157,12 +157,13 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
         throw new Error(`Unknown contact type "${contactTypeId}"`);
       }
 
-      const titleKey = contact ? contactType.edit_key : contactType.create_key;
-      const formId = this.getForm(contact, contactType, titleKey);
+      const formId = this.getForm(contact, contactType);
       if (!formId) {
         throw new Error('Unknown form');
       }
 
+      const titleKey = contact ? contactType.edit_key : contactType.create_key;
+      this.setTitle(titleKey);
       const formInstance = await this.renderForm(formId, titleKey);
       this.setEnketoContact(formInstance);
 
@@ -194,7 +195,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
       .then((result) => result.doc);
   }
 
-  private getForm(contact, contactType, titleKey) {
+  private getForm(contact, contactType) {
     let formId;
     if (contact) { // editing
       this.contact = contact;
@@ -210,6 +211,10 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
       formId = contactType.create_form;
     }
 
+    return formId;
+  }
+
+  private setTitle(titleKey: string) {
     this.translationsLoadedSubscription?.unsubscribe();
     this.translationsLoadedSubscription = this.store
       .select(Selectors.getTranslationsLoaded)
@@ -220,7 +225,6 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
             .then((title) => this.globalActions.setTitle(title));
         }
       });
-    return formId;
   }
 
   private markFormEdited() {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -5,7 +5,7 @@ import { isEqual as _isEqual } from 'lodash-es';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, ContactFormContext } from '@mm-services/enketo.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { DbService } from '@mm-services/db.service';
 import { ContactSaveService } from '@mm-services/contact-save.service';
@@ -257,7 +257,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     const instanceData = this.getFormInstanceData();
     const markFormEdited = this.markFormEdited.bind(this);
     const resetFormError = this.resetFormError.bind(this);
-    const contactFormContext = {
+    const contactFormContext: ContactFormContext = {
       selector: '#contact-form',
       formDoc,
       instanceData,

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -252,21 +252,21 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     this.globalActions.setEnketoEditedStatus(false);
-    const [titleKey, form] = await Promise.all([
-      this.getTitleKey(contact),
-      this.dbService.get().get(formId),
-    ]);
-    const formInstanceData = this.getFormInstanceData();
+    const titleKey = await this.getTitleKey(contact);
+    const formDoc = await this.dbService.get().get(formId);
+    const instanceData = this.getFormInstanceData();
     const markFormEdited = this.markFormEdited.bind(this);
     const resetFormError = this.resetFormError.bind(this);
-    return this.enketoService.renderContactForm({
+    const contactFormContext = {
       selector: '#contact-form',
-      formDoc: form,
-      instanceData: formInstanceData,
+      formDoc,
+      instanceData,
       editedListener: markFormEdited,
       valuechangeListener: resetFormError,
       titleKey,
-    });
+    };
+
+    return this.enketoService.renderContactForm(contactFormContext);
   }
 
   private setEnketoContact(formInstance) {

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -300,11 +300,12 @@ export class EnketoService {
     const formContainer = wrapper.find('.container').first();
     formContainer.html(xmlFormContext.doc.html.get(0));
 
-    return this.getEnketoOptions(xmlFormContext.doc, xmlFormContext.instanceData)
+    return this
+      .getEnketoOptions(xmlFormContext.doc, xmlFormContext.instanceData)
       .then((options) => {
         this.currentForm = new window.EnketoForm(wrapper.find('form').first(), options);
         const loadErrors = this.currentForm.init();
-        if (loadErrors && loadErrors.length) {
+        if (loadErrors?.length) {
           return Promise.reject(new Error(JSON.stringify(loadErrors)));
         }
       })

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -24,7 +24,6 @@ import { ServicesActions } from '@mm-actions/services';
 import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TransitionsService } from '@mm-services/transitions.service';
-import { TranslateHelperService } from '@mm-services/translate-helper.service';
 
 @Injectable({
   providedIn: 'root'
@@ -51,7 +50,6 @@ export class EnketoService {
     private transitionsService:TransitionsService,
     private translateService:TranslateService,
     private ngZone:NgZone,
-    private translateHelperService:TranslateHelperService,
   ) {
     this.inited = this.init();
     this.servicesActions = new ServicesActions(this.store);
@@ -311,7 +309,7 @@ export class EnketoService {
       const $title = wrapper.find('#form-title');
       if (titleKey) {
         // using translation key - overwrite contents
-        this.translateHelperService
+        this.translateService
           .get(titleKey)
           .then(title => $title.text(title));
       } else if (doc.title) {

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -329,7 +329,9 @@ export class EnketoService {
     if (titleKey) {
       // using translation key
       return this.translateService.get(titleKey);
-    } else if (doc.title) {
+    }
+
+    if (doc.title) {
       // title defined in the doc
       return Promise.resolve(this.translateFromService.get(doc.title));
     }
@@ -412,14 +414,14 @@ export class EnketoService {
     });
   }
 
-  private renderForm(contactFormContext: ContactFormContext) {
+  private renderForm(formContext: EnketoFormContext) {
     return this.languageService.get().then(language => {
-      const $selector = $(contactFormContext.selector);
+      const $selector = $(formContext.selector);
       return this
-        .transformXml(contactFormContext.formDoc, language)
+        .transformXml(formContext.formDoc, language)
         .then(doc => {
-          this.replaceJavarosaMediaWithLoaders(contactFormContext.formDoc, doc.html);
-          const { instanceData, titleKey } = contactFormContext;
+          this.replaceJavarosaMediaWithLoaders(formContext.formDoc, doc.html);
+          const { instanceData, titleKey } = formContext;
           const xmlFormContext: XmlFormContext = {
             doc,
             wrapper: $selector,
@@ -430,10 +432,10 @@ export class EnketoService {
         })
         .then((form) => {
           const formContainer = $selector.find('.container').first();
-          this.replaceMediaLoaders(formContainer, contactFormContext.formDoc);
-          this.registerAddrepeatListener($selector, contactFormContext.formDoc);
-          this.registerEditedListener($selector, contactFormContext.editedListener);
-          this.registerValuechangeListener($selector, contactFormContext.valuechangeListener);
+          this.replaceMediaLoaders(formContainer, formContext.formDoc);
+          this.registerAddrepeatListener($selector, formContext.formDoc);
+          this.registerEditedListener($selector, formContext.editedListener);
+          this.registerValuechangeListener($selector, formContext.valuechangeListener);
 
           window.CHTCore.debugFormModel = () => form.model.getStr();
           return form;
@@ -454,19 +456,19 @@ export class EnketoService {
         this.getUserContact(),
       ])
       .then(() => {
-        const contactFormContext: ContactFormContext = {
+        const formContext: EnketoFormContext = {
           selector,
           formDoc: form,
           instanceData,
           editedListener,
           valuechangeListener,
         };
-        return this.renderForm(contactFormContext);
+        return this.renderForm(formContext);
       });
   }
 
-  renderContactForm(contactFormContext: ContactFormContext) {
-    return this.renderForm(contactFormContext);
+  renderContactForm(formContext: EnketoFormContext) {
+    return this.renderForm(formContext);
   }
 
   private xmlToDocs(doc, formXml, record) {
@@ -760,7 +762,7 @@ interface XmlFormContext {
   titleKey: string;
 }
 
-export interface ContactFormContext {
+export interface EnketoFormContext {
   selector: string;
   formDoc: string;
   instanceData: Record<string, any>;

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -306,9 +306,9 @@ export class EnketoService {
           return Promise.reject(new Error(JSON.stringify(loadErrors)));
         }
       })
-      .then(() => this.getFormTitle({ titleKey, doc }))
+      .then(() => this.getFormTitle(titleKey, doc))
       .then((title) => {
-        this.setFormTitle({ wrapper, title });
+        this.setFormTitle(wrapper, title);
         wrapper.show();
 
         wrapper.find('input').on('keydown', this.handleKeypressOnInputField);
@@ -323,7 +323,7 @@ export class EnketoService {
       });
   }
 
-  private getFormTitle({ titleKey, doc }) {
+  private getFormTitle(titleKey, doc) {
     if (titleKey) {
       // using translation key
       return this.translateService.get(titleKey);
@@ -333,7 +333,7 @@ export class EnketoService {
     }
   }
 
-  private setFormTitle({ wrapper, title }) {
+  private setFormTitle(wrapper, title) {
     // manually translate the title as enketo-core doesn't have any way to do this
     // https://github.com/enketo/enketo-core/issues/405
     const $title = wrapper.find('#form-title');

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -290,7 +290,7 @@ export class EnketoService {
   }
 
   private renderFromXmls(xmlFormContext: XmlFormContext) {
-    const { wrapper } = xmlFormContext;
+    const { doc, instanceData, titleKey, wrapper } = xmlFormContext;
     wrapper
       .find('.form-footer')
       .addClass('end')
@@ -298,10 +298,10 @@ export class EnketoService {
       .addClass('disabled');
 
     const formContainer = wrapper.find('.container').first();
-    formContainer.html(xmlFormContext.doc.html.get(0));
+    formContainer.html(doc.html.get(0));
 
     return this
-      .getEnketoOptions(xmlFormContext.doc, xmlFormContext.instanceData)
+      .getEnketoOptions(doc, instanceData)
       .then((options) => {
         this.currentForm = new window.EnketoForm(wrapper.find('form').first(), options);
         const loadErrors = this.currentForm.init();
@@ -309,7 +309,7 @@ export class EnketoService {
           return Promise.reject(new Error(JSON.stringify(loadErrors)));
         }
       })
-      .then(() => this.getFormTitle(xmlFormContext.titleKey, xmlFormContext.doc))
+      .then(() => this.getFormTitle(titleKey, doc))
       .then((title) => {
         this.setFormTitle(wrapper, title);
         wrapper.show();
@@ -416,13 +416,21 @@ export class EnketoService {
   }
 
   private renderForm(formContext: EnketoFormContext) {
+    const {
+      editedListener,
+      formDoc,
+      instanceData,
+      selector,
+      titleKey,
+      valuechangeListener,
+    } = formContext;
+
     return this.languageService.get().then(language => {
-      const $selector = $(formContext.selector);
+      const $selector = $(selector);
       return this
-        .transformXml(formContext.formDoc, language)
+        .transformXml(formDoc, language)
         .then(doc => {
-          this.replaceJavarosaMediaWithLoaders(formContext.formDoc, doc.html);
-          const { instanceData, titleKey } = formContext;
+          this.replaceJavarosaMediaWithLoaders(formDoc, doc.html);
           const xmlFormContext: XmlFormContext = {
             doc,
             wrapper: $selector,
@@ -433,10 +441,10 @@ export class EnketoService {
         })
         .then((form) => {
           const formContainer = $selector.find('.container').first();
-          this.replaceMediaLoaders(formContainer, formContext.formDoc);
-          this.registerAddrepeatListener($selector, formContext.formDoc);
-          this.registerEditedListener($selector, formContext.editedListener);
-          this.registerValuechangeListener($selector, formContext.valuechangeListener);
+          this.replaceMediaLoaders(formContainer, formDoc);
+          this.registerAddrepeatListener($selector, formDoc);
+          this.registerEditedListener($selector, editedListener);
+          this.registerValuechangeListener($selector, valuechangeListener);
 
           window.CHTCore.debugFormModel = () => form.model.getStr();
           return form;

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -337,12 +337,12 @@ export class EnketoService {
     // manually translate the title as enketo-core doesn't have any way to do this
     // https://github.com/enketo/enketo-core/issues/405
     const $title = wrapper.find('#form-title');
-    if ($title.text() === 'No Title') {
-      // useless enketo default - remove it
-      $title.remove();
-    } else if (title) {
+    if (title) {
       // overwrite contents
       $title.text(title);
+    } else if ($title.text() === 'No Title') {
+      // useless enketo default - remove it
+      $title.remove();
     } // else the title is hardcoded in the form definition - leave it alone
   }
 

--- a/webapp/src/ts/services/translate.service.ts
+++ b/webapp/src/ts/services/translate.service.ts
@@ -10,7 +10,7 @@ import { Injectable } from '@angular/core';
 })
 export class TranslateService {
   constructor(
-    private ngxTraslateService:NgxTranslateService,
+    private ngxTranslateService:NgxTranslateService,
   ) {
   }
 
@@ -30,7 +30,7 @@ export class TranslateService {
       return Promise.resolve(key);
     }
 
-    return this.ngxTraslateService.get(key, interpolateParams).toPromise();
+    return this.ngxTranslateService.get(key, interpolateParams).toPromise();
   }
 
   instant(key, interpolateParams?) {
@@ -38,6 +38,6 @@ export class TranslateService {
       return key;
     }
 
-    return this.ngxTraslateService.instant(key, interpolateParams);
+    return this.ngxTranslateService.instant(key, interpolateParams);
   }
 }

--- a/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
@@ -222,14 +222,15 @@ describe('ContactsEdit component', () => {
       await createComponent();
       await fixture.whenStable();
 
-      expect(contactTypesService.get.callCount).to.equal(1);
+      expect(contactTypesService.get.callCount).to.equal(2);
       expect(enketoService.renderContactForm.callCount).to.equal(1);
 
-      expect(enketoService.renderContactForm.args[0]).to.deep.include.ordered.members([
-        '#contact-form',
-        { _id: 'random_create', the: 'form' },
-        { random: { type: 'contact', contact_type: 'random', parent: '' } },
-      ]);
+      expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
+        selector: '#contact-form',
+        formDoc: { _id: 'random_create', the: 'form' },
+        instanceData: { random: { type: 'contact', contact_type: 'random', parent: '' } },
+        titleKey: 'random',
+      });
 
       routeSnapshot = { params: { type: 'other' } };
       route.params.next({ type: 'other' });
@@ -238,13 +239,14 @@ describe('ContactsEdit component', () => {
       flushMicrotasks();
 
       expect(dbGet.callCount).to.equal(2);
-      expect(contactTypesService.get.callCount).to.equal(2);
+      expect(contactTypesService.get.callCount).to.equal(4);
       expect(enketoService.renderContactForm.callCount).to.equal(2);
-      expect(enketoService.renderContactForm.args[1]).to.deep.include.ordered.members([
-        '#contact-form',
-        { _id: 'other_create' },
-        { other: { type: 'contact', contact_type: 'other', parent: '' } },
-      ]);
+      expect(enketoService.renderContactForm.args[1][0]).to.deep.include({
+        selector: '#contact-form',
+        formDoc: { _id: 'other_create' },
+        instanceData: { other: { type: 'contact', contact_type: 'other', parent: '' } },
+        titleKey: 'other_key',
+      });
     }));
   });
 
@@ -287,7 +289,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['person']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['person_create_form_id']);
@@ -307,7 +309,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['clinic']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['clinic_create_form_id']);
@@ -317,11 +319,12 @@ describe('ContactsEdit component', () => {
           docId: null,
         });
         expect(enketoService.renderContactForm.callCount).to.equal(1);
-        expect(enketoService.renderContactForm.args[0]).to.deep.include.ordered.members([
-          '#contact-form',
-          { _id: 'clinic_create_form_id', the: 'form' },
-          { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
-        ]);
+        expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
+          selector: '#contact-form',
+          formDoc: { _id: 'clinic_create_form_id', the: 'form' },
+          instanceData: { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
+          titleKey: 'clinic_create_key',
+        });
         expect(component.contentError).to.equal(false);
       });
 
@@ -337,7 +340,7 @@ describe('ContactsEdit component', () => {
         await fixture.whenStable();
 
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['district_hospital']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['district_create_form_id']);
@@ -347,11 +350,12 @@ describe('ContactsEdit component', () => {
           docId: null,
         });
         expect(enketoService.renderContactForm.callCount).to.equal(1);
-        expect(enketoService.renderContactForm.args[0]).to.deep.include.ordered.members([
-          '#contact-form',
-          { _id: 'district_create_form_id', the: 'form' },
-          { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
-        ]);
+        expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
+          selector: '#contact-form',
+          formDoc: { _id: 'district_create_form_id', the: 'form' },
+          instanceData: { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
+          titleKey: 'district_create_key',
+        });
         expect(component.contentError).to.equal(false);
       });
     });
@@ -415,7 +419,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
@@ -441,16 +445,17 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
         expect(enketoService.renderContactForm.callCount).to.equal(1);
-        expect(enketoService.renderContactForm.args[0]).to.deep.include.ordered.members([
-          '#contact-form',
-          { _id: 'patient_edit_form', form: true },
-          { patient: { type: 'patient', _id: 'the_patient' } },
-        ]);
+        expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
+          selector: '#contact-form',
+          formDoc: { _id: 'patient_edit_form', form: true },
+          instanceData: { patient: { type: 'patient', _id: 'the_patient' } },
+          titleKey: 'patient_edit_key',
+        });
         expect(component.enketoContact).to.deep.equal({
           docId: 'the_patient',
           formInstance: undefined,
@@ -476,16 +481,17 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['a_clinic_type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['a_clinic_type_create_form']);
         expect(enketoService.renderContactForm.callCount).to.equal(1);
-        expect(enketoService.renderContactForm.args[0]).to.deep.include.ordered.members([
-          '#contact-form',
-          { _id: 'a_clinic_type_create_form', data: true },
-          { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
-        ]);
+        expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
+          selector: '#contact-form',
+          formDoc: { _id: 'a_clinic_type_create_form', data: true },
+          instanceData: { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
+          titleKey: 'edit_key',
+        });
         expect(component.enketoContact).to.deep.equal({
           docId: 'the_clinic',
           formInstance: undefined,
@@ -514,16 +520,17 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(1);
+        expect(contactTypesService.get.callCount).to.equal(2);
         expect(contactTypesService.get.args[0]).to.deep.equal(['the correct type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['the correct_edit_form']);
         expect(enketoService.renderContactForm.callCount).to.equal(1);
-        expect(enketoService.renderContactForm.args[0]).to.deep.include.ordered.members([
-          '#contact-form',
-          { _id: 'the correct_edit_form', data: true },
-          { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
-        ]);
+        expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
+          selector: '#contact-form',
+          formDoc: { _id: 'the correct_edit_form', data: true },
+          instanceData: { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
+          titleKey: 'edit_key',
+        });
         expect(component.enketoContact).to.deep.equal({
           docId: 'the_clinic',
           formInstance: undefined,

--- a/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
@@ -222,7 +222,7 @@ describe('ContactsEdit component', () => {
       await createComponent();
       await fixture.whenStable();
 
-      expect(contactTypesService.get.callCount).to.equal(2);
+      expect(contactTypesService.get.callCount).to.equal(1);
       expect(enketoService.renderContactForm.callCount).to.equal(1);
 
       expect(enketoService.renderContactForm.args[0][0]).to.deep.include({
@@ -239,7 +239,7 @@ describe('ContactsEdit component', () => {
       flushMicrotasks();
 
       expect(dbGet.callCount).to.equal(2);
-      expect(contactTypesService.get.callCount).to.equal(4);
+      expect(contactTypesService.get.callCount).to.equal(2);
       expect(enketoService.renderContactForm.callCount).to.equal(2);
       expect(enketoService.renderContactForm.args[1][0]).to.deep.include({
         selector: '#contact-form',
@@ -289,7 +289,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['person']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['person_create_form_id']);
@@ -309,7 +309,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['clinic']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['clinic_create_form_id']);
@@ -340,7 +340,7 @@ describe('ContactsEdit component', () => {
         await fixture.whenStable();
 
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['district_hospital']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['district_create_form_id']);
@@ -419,7 +419,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
@@ -445,7 +445,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
@@ -481,7 +481,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['a_clinic_type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['a_clinic_type_create_form']);
@@ -520,7 +520,7 @@ describe('ContactsEdit component', () => {
         await createComponent();
         await fixture.whenStable();
 
-        expect(contactTypesService.get.callCount).to.equal(2);
+        expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['the correct type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['the correct_edit_form']);

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -61,6 +61,7 @@ describe('Enketo service', () => {
   let Search;
   let LineageModelGenerator;
   let transitionsService;
+  let translateService;
 
   beforeEach(() => {
     enketoInit = sinon.stub();
@@ -93,12 +94,15 @@ describe('Enketo service', () => {
       output: { update: () => {} },
     });
     transitionsService = { applyTransitions: sinon.stub().resolvesArg(0) };
+    translateService = {
+      instant: sinon.stub().returnsArg(0),
+      get: sinon.stub(),
+    };
 
     setLastChangedDoc = sinon.stub(ServicesActions.prototype, 'setLastChangedDoc');
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: TranslateService, useValue: { instant: sinon.stub().returnsArg(0) } },
         provideMockStore(),
         {
           provide: DbService,
@@ -127,7 +131,7 @@ describe('Enketo service', () => {
         },
         { provide: ZScoreService, useValue: { getScoreUtil: sinon.stub().resolves(sinon.stub())} },
         { provide: TransitionsService, useValue: transitionsService },
-        { provide: TranslateService, useValue: { get: sinon.stub().callsFake((key) => `translated key ${key}`) } },
+        { provide: TranslateService, useValue: translateService },
       ],
     });
 
@@ -1475,6 +1479,7 @@ describe('Enketo service', () => {
     beforeEach(() => {
       service.setFormTitle = sinon.stub();
       dbGetAttachment.resolves('<form/>');
+      translateService.get.callsFake((key) => `translated key ${key}`);
     });
 
     const callbackMock = () => {};

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1477,7 +1477,7 @@ describe('Enketo service', () => {
       dbGetAttachment.resolves('<form/>');
     });
 
-    const noop = () => {};
+    const callbackMock = () => {};
     const instanceData = {
       health_center: {
         type: 'contact',
@@ -1495,8 +1495,8 @@ describe('Enketo service', () => {
         selector: $('<div></div>'),
         formDoc,
         instanceData,
-        editedListener: noop,
-        valuechangeListener: noop,
+        editedListener: callbackMock,
+        valuechangeListener: callbackMock,
         titleKey: 'contact.type.health_center.new',
       });
 
@@ -1511,8 +1511,8 @@ describe('Enketo service', () => {
         selector: $('<div></div>'),
         formDoc,
         instanceData,
-        editedListener: noop,
-        valuechangeListener: noop,
+        editedListener: callbackMock,
+        valuechangeListener: callbackMock,
       });
 
       expect(service.setFormTitle.callCount).to.be.equal(1);

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1490,7 +1490,7 @@ describe('Enketo service', () => {
       title: 'New Area',
     };
 
-    it('translate titleKey when provided', async () => {
+    it('should translate titleKey when provided', async () => {
       await service.renderContactForm({
         selector: $('<div></div>'),
         formDoc,
@@ -1506,7 +1506,7 @@ describe('Enketo service', () => {
       });
     });
 
-    it('fallback to translate document title when titleKey is not available', async () => {
+    it('should fallback to translate document title when the titleKey is not available', async () => {
       await service.renderContactForm({
         selector: $('<div></div>'),
         formDoc,

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1506,9 +1506,7 @@ describe('Enketo service', () => {
       });
 
       expect(service.setFormTitle.callCount).to.be.equal(1);
-      expect(service.setFormTitle.args[0][0]).to.deep.include({
-        title: 'translated key contact.type.health_center.new',
-      });
+      expect(service.setFormTitle.args[0][1]).to.be.equal('translated key contact.type.health_center.new');
     });
 
     it('should fallback to translate document title when the titleKey is not available', async () => {
@@ -1521,7 +1519,7 @@ describe('Enketo service', () => {
       });
 
       expect(service.setFormTitle.callCount).to.be.equal(1);
-      expect(service.setFormTitle.args[0][0]).to.deep.include({ title: 'translated' });
+      expect(service.setFormTitle.args[0][1]).to.be.equal('translated');
     });
   });
 });

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1475,7 +1475,7 @@ describe('Enketo service', () => {
     });
   });
 
-  describe.only('renderContactForm', () => {
+  describe('renderContactForm', () => {
     beforeEach(() => {
       service.setFormTitle = sinon.stub();
       dbGetAttachment.resolves('<form/>');

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1475,11 +1475,12 @@ describe('Enketo service', () => {
     });
   });
 
-  describe('renderContactForm', () => {
+  describe.only('renderContactForm', () => {
     beforeEach(() => {
       service.setFormTitle = sinon.stub();
       dbGetAttachment.resolves('<form/>');
       translateService.get.callsFake((key) => `translated key ${key}`);
+      TranslateFrom.callsFake((sentence) => `translated sentence ${sentence}`);
     });
 
     const callbackMock = () => {};
@@ -1519,7 +1520,7 @@ describe('Enketo service', () => {
       });
 
       expect(service.setFormTitle.callCount).to.be.equal(1);
-      expect(service.setFormTitle.args[0][1]).to.be.equal('translated');
+      expect(service.setFormTitle.args[0][1]).to.be.equal('translated sentence New Area');
     });
   });
 });


### PR DESCRIPTION
# Description

Pass the contact form's title translation key to EnketoService to correctly translate the title on desktop view and keep a consistent behavior with the mobile view.  
To keep backwards compatibility, we fallback to the old code in case the translation key is not provided.

medic/cht-core#6392

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
