### PR TITLE
Prevent users being logged out incorrectly

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -86,14 +86,17 @@ module.exports = {
   getUserCtx: req => {
     return get('/_session', req.headers)
       .catch(err => {
-        throw { code: 401, message: 'Not logged in', err: err };
+        if (err.statusCode === 401) {
+          throw { code: 401, message: 'Not logged in', err: err };
+        }
+        throw err;
       })
       .then(auth => {
         if (auth && auth.userCtx && auth.userCtx.name) {
           req.headers['X-Medic-User'] = auth.userCtx.name;
           return auth.userCtx;
         }
-        throw { code: 401, message: 'Not logged in' };
+        throw { code: 500, message: 'Failed to authenticate' };
       });
   },
 

--- a/api/src/middleware/authorization.js
+++ b/api/src/middleware/authorization.js
@@ -31,22 +31,24 @@ module.exports = {
       .then(next);
   },
 
-  handleAuthentication: (allowAuthorized) => {
-    return (req, res, next) => {
-      if (allowAuthorized && req.authorized) {
-        return next();
-      }
+  handleAuthErrors: (req, res, next) => {
+    if (req.authErr) {
+      return serverUtils.error(req.authErr, req, res);
+    }
 
-      if (req.authErr) {
-        return serverUtils.error(req.authErr, req, res);
-      }
+    if (!req.userCtx) {
+      return serverUtils.error('Authentication error', req, res);
+    }
 
-      if (!req.userCtx) {
-        return serverUtils.error('Authentication error', req, res);
-      }
+    next();
+  },
 
-      next();
-    };
+  handleAuthErrorsAllowingAuthorized: (req, res, next) => {
+    if (req.authorized) {
+      return next();
+    }
+
+    return module.exports.handleAuthErrors(req, res, next);
   },
 
   // blocks offline users not-authorized requests

--- a/api/src/middleware/authorization.js
+++ b/api/src/middleware/authorization.js
@@ -41,6 +41,10 @@ module.exports = {
         return serverUtils.error(req.authErr, req, res);
       }
 
+      if (!req.userCtx) {
+        return serverUtils.error('Authentication error', req, res);
+      }
+
       next();
     };
   },

--- a/api/src/middleware/connected-user-log.js
+++ b/api/src/middleware/connected-user-log.js
@@ -8,6 +8,11 @@ module.exports = {
       .getUserCtx(req)
       .then(({ name }) => connectedUserLogService.save(name))
       .catch(err => {
+        if (err && err.code === 401) {
+          // don't spam the logs with authentication errors
+          return;
+        }
+
         logger.error('Error recording user connection:', err);
       })
       .then(() => next());

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -265,7 +265,7 @@ const ONLINE_ONLY_ENDPOINTS = [
 
 // block offline users from accessing some unaudited CouchDB endpoints
 ONLINE_ONLY_ENDPOINTS.forEach(url =>
-  app.all(routePrefix + url, authorization.handleAuthentication(), authorization.offlineUserFirewall)
+  app.all(routePrefix + url, authorization.handleAuthErrors, authorization.offlineUserFirewall)
 );
 
 // allow anyone to access their session
@@ -433,14 +433,14 @@ app.postJson('/api/v1/bulk-delete', bulkDocs.bulkDelete);
 // offline users are not allowed to hydrate documents via the hydrate API
 app.get(
   '/api/v1/hydrate',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.offlineUserFirewall,
   jsonQueryParser,
   hydration.hydrate
 );
 app.post(
   '/api/v1/hydrate',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.offlineUserFirewall,
   jsonParser,
   jsonQueryParser,
@@ -450,13 +450,13 @@ app.post(
 // offline users are not allowed to get contacts by phone
 app.get(
   '/api/v1/contacts-by-phone',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.offlineUserFirewall,
   contactsByPhone.request
 );
 app.post(
   '/api/v1/contacts-by-phone',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.offlineUserFirewall,
   jsonParser,
   contactsByPhone.request
@@ -473,19 +473,19 @@ app.get('/api/couch-config-attachments', couchConfigController.getAttachments);
 
 app.get(
   '/purging',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough,
   purgedDocsController.info
 );
 app.get(
   '/purging/changes',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough,
   purgedDocsController.getPurgedDocs
 );
 app.get(
   '/purging/checkpoint',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough,
   purgedDocsController.checkpoint
 );
@@ -506,13 +506,13 @@ const changesPath = routePrefix + '_changes(/*)?';
 
 app.get(
   changesPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserChangesProxy,
   changesHandler
 );
 app.post(
   changesPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserChangesProxy,
   jsonParser,
   changesHandler
@@ -524,14 +524,14 @@ const allDocsPath = routePrefix + '_all_docs(/*)?';
 
 app.get(
   allDocsPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserProxy,
   jsonQueryParser,
   allDocsHandler
 );
 app.post(
   allDocsPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserProxy,
   jsonParser,
   jsonQueryParser,
@@ -542,7 +542,7 @@ app.post(
 const bulkGetHandler = require('./controllers/bulk-get').request;
 app.post(
   routePrefix + '_bulk_get(/*)?',
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserProxy,
   jsonParser,
   jsonQueryParser,
@@ -555,7 +555,7 @@ app.post(
   routePrefix + '_bulk_docs(/*)?',
   jsonParser,
   infodoc.mark,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonQueryParser,
   bulkDocs.request,
@@ -571,7 +571,7 @@ const ddocPath = routePrefix + '_design/+:ddocId*';
 
 app.get(
   ddocPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserProxy,
   jsonQueryParser,
   _.partial(dbDocHandler.requestDdoc, environment.ddoc),
@@ -580,7 +580,7 @@ app.get(
 
 app.get(
   docPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   onlineUserProxy, // online user GET requests are proxied directly to CouchDB
   jsonQueryParser,
   dbDocHandler.request
@@ -589,7 +589,7 @@ app.post(
   `/+${environment.db}/?`,
   jsonParser,
   infodoc.mark,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonQueryParser,
   dbDocHandler.request,
@@ -599,7 +599,7 @@ app.put(
   docPath,
   jsonParser,
   infodoc.mark,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   jsonQueryParser,
   dbDocHandler.request,
@@ -607,7 +607,7 @@ app.put(
 );
 app.delete(
   docPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   jsonQueryParser,
   dbDocHandler.request,
@@ -615,7 +615,7 @@ app.delete(
 );
 app.all(
   attachmentPath,
-  authorization.handleAuthentication(),
+  authorization.handleAuthErrors,
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonQueryParser,
   dbDocHandler.request,
@@ -760,7 +760,7 @@ app.all(appPrefix + '*', authorization.setAuthorized);
 // block offline users requests from accessing CouchDB directly, via Proxy
 // requests which are authorized (fe: by BulkDocsHandler or DbDocHandler) can pass through
 // unauthenticated requests will be redirected to login or given a meaningful error
-app.use(authorization.handleAuthentication(true));
+app.use(authorization.handleAuthErrorsAllowingAuthorized);
 app.use(authorization.offlineUserFirewall);
 
 const canEdit = function(req, res) {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -265,7 +265,7 @@ const ONLINE_ONLY_ENDPOINTS = [
 
 // block offline users from accessing some unaudited CouchDB endpoints
 ONLINE_ONLY_ENDPOINTS.forEach(url =>
-  app.all(routePrefix + url, authorization.offlineUserFirewall)
+  app.all(routePrefix + url, authorization.handleAuthentication(), authorization.offlineUserFirewall)
 );
 
 // allow anyone to access their session
@@ -431,12 +431,36 @@ app.postJson('/api/v1/people', function(req, res) {
 app.postJson('/api/v1/bulk-delete', bulkDocs.bulkDelete);
 
 // offline users are not allowed to hydrate documents via the hydrate API
-app.get('/api/v1/hydrate', authorization.offlineUserFirewall, jsonQueryParser, hydration.hydrate);
-app.post('/api/v1/hydrate', authorization.offlineUserFirewall, jsonParser, jsonQueryParser, hydration.hydrate);
+app.get(
+  '/api/v1/hydrate',
+  authorization.handleAuthentication(),
+  authorization.offlineUserFirewall,
+  jsonQueryParser,
+  hydration.hydrate
+);
+app.post(
+  '/api/v1/hydrate',
+  authorization.handleAuthentication(),
+  authorization.offlineUserFirewall,
+  jsonParser,
+  jsonQueryParser,
+  hydration.hydrate
+);
 
 // offline users are not allowed to get contacts by phone
-app.get('/api/v1/contacts-by-phone', authorization.offlineUserFirewall, contactsByPhone.request);
-app.post('/api/v1/contacts-by-phone', authorization.offlineUserFirewall, jsonParser, contactsByPhone.request);
+app.get(
+  '/api/v1/contacts-by-phone',
+  authorization.handleAuthentication(),
+  authorization.offlineUserFirewall,
+  contactsByPhone.request
+);
+app.post(
+  '/api/v1/contacts-by-phone',
+  authorization.handleAuthentication(),
+  authorization.offlineUserFirewall,
+  jsonParser,
+  contactsByPhone.request
+);
 
 app.get(`${appPrefix}app_settings/${environment.ddoc}/:path?`, settings.getV0); // deprecated
 app.get('/api/v1/settings', settings.get);
@@ -447,9 +471,24 @@ app.putJson('/api/v1/settings', settings.put);
 
 app.get('/api/couch-config-attachments', couchConfigController.getAttachments);
 
-app.get('/purging', authorization.onlineUserPassThrough, purgedDocsController.info);
-app.get('/purging/changes', authorization.onlineUserPassThrough, purgedDocsController.getPurgedDocs);
-app.get('/purging/checkpoint', authorization.onlineUserPassThrough, purgedDocsController.checkpoint);
+app.get(
+  '/purging',
+  authorization.handleAuthentication(),
+  authorization.onlineUserPassThrough,
+  purgedDocsController.info
+);
+app.get(
+  '/purging/changes',
+  authorization.handleAuthentication(),
+  authorization.onlineUserPassThrough,
+  purgedDocsController.getPurgedDocs
+);
+app.get(
+  '/purging/checkpoint',
+  authorization.handleAuthentication(),
+  authorization.onlineUserPassThrough,
+  purgedDocsController.checkpoint
+);
 
 app.get('/api/v1/users-doc-count', replicationLimitLogController.get);
 
@@ -467,11 +506,13 @@ const changesPath = routePrefix + '_changes(/*)?';
 
 app.get(
   changesPath,
+  authorization.handleAuthentication(),
   onlineUserChangesProxy,
   changesHandler
 );
 app.post(
   changesPath,
+  authorization.handleAuthentication(),
   onlineUserChangesProxy,
   jsonParser,
   changesHandler
@@ -481,9 +522,16 @@ app.post(
 const allDocsHandler = require('./controllers/all-docs').request;
 const allDocsPath = routePrefix + '_all_docs(/*)?';
 
-app.get(allDocsPath, onlineUserProxy, jsonQueryParser, allDocsHandler);
+app.get(
+  allDocsPath,
+  authorization.handleAuthentication(),
+  onlineUserProxy,
+  jsonQueryParser,
+  allDocsHandler
+);
 app.post(
   allDocsPath,
+  authorization.handleAuthentication(),
   onlineUserProxy,
   jsonParser,
   jsonQueryParser,
@@ -494,6 +542,7 @@ app.post(
 const bulkGetHandler = require('./controllers/bulk-get').request;
 app.post(
   routePrefix + '_bulk_get(/*)?',
+  authorization.handleAuthentication(),
   onlineUserProxy,
   jsonParser,
   jsonQueryParser,
@@ -506,6 +555,7 @@ app.post(
   routePrefix + '_bulk_docs(/*)?',
   jsonParser,
   infodoc.mark,
+  authorization.handleAuthentication(),
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonQueryParser,
   bulkDocs.request,
@@ -521,6 +571,7 @@ const ddocPath = routePrefix + '_design/+:ddocId*';
 
 app.get(
   ddocPath,
+  authorization.handleAuthentication(),
   onlineUserProxy,
   jsonQueryParser,
   _.partial(dbDocHandler.requestDdoc, environment.ddoc),
@@ -529,6 +580,7 @@ app.get(
 
 app.get(
   docPath,
+  authorization.handleAuthentication(),
   onlineUserProxy, // online user GET requests are proxied directly to CouchDB
   jsonQueryParser,
   dbDocHandler.request
@@ -537,6 +589,7 @@ app.post(
   `/+${environment.db}/?`,
   jsonParser,
   infodoc.mark,
+  authorization.handleAuthentication(),
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonQueryParser,
   dbDocHandler.request,
@@ -546,6 +599,7 @@ app.put(
   docPath,
   jsonParser,
   infodoc.mark,
+  authorization.handleAuthentication(),
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   jsonQueryParser,
   dbDocHandler.request,
@@ -553,6 +607,7 @@ app.put(
 );
 app.delete(
   docPath,
+  authorization.handleAuthentication(),
   authorization.onlineUserPassThrough, // online user requests pass through to the next route,
   jsonQueryParser,
   dbDocHandler.request,
@@ -560,6 +615,7 @@ app.delete(
 );
 app.all(
   attachmentPath,
+  authorization.handleAuthentication(),
   authorization.onlineUserPassThrough, // online user requests pass through to the next route
   jsonQueryParser,
   dbDocHandler.request,
@@ -700,6 +756,7 @@ app.all(appPrefix + '*', authorization.setAuthorized);
 // block offline users requests from accessing CouchDB directly, via Proxy
 // requests which are authorized (fe: by BulkDocsHandler or DbDocHandler) can pass through
 // unauthenticated requests will be redirected to login or given a meaningful error
+app.use(authorization.handleAuthentication(true));
 app.use(authorization.offlineUserFirewall);
 
 const canEdit = function(req, res) {
@@ -742,8 +799,18 @@ proxyForAuth.on('proxyReq', function(proxyReq, req) {
   writeParsedBody(proxyReq, req);
 });
 
+proxy.on('proxyRes', (proxyRes, req, res) => {
+  if (proxyRes.statusCode === 401) {
+    serverUtils.notLoggedIn(req, res);
+  }
+});
+
 // intercept responses from filtered offline endpoints to fill in with forbidden docs stubs
 proxyForAuth.on('proxyRes', (proxyRes, req, res) => {
+  if (proxyRes.statusCode === 401) {
+    return serverUtils.notLoggedIn(req, res);
+  }
+
   copyProxyHeaders(proxyRes, res);
 
   if (res.interceptResponse) {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -733,6 +733,10 @@ proxyForChanges.on('proxyReq', (proxyReq, req) => {
 
 // because these are longpolls, we need to manually flush the CouchDB heartbeats through compression
 proxyForChanges.on('proxyRes', (proxyRes, req, res) => {
+  if (proxyRes.statusCode === 401) {
+    return serverUtils.notLoggedIn(req, res);
+  }
+
   copyProxyHeaders(proxyRes, res);
 
   proxyRes.pipe(res);

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -8,8 +8,10 @@ const MEDIC_BASIC_AUTH = 'Basic realm="Medic Mobile Web Services"';
 const wantsJSON = req => req.get('Accept') === 'application/json';
 
 const writeJSON = (res, code, error, details) => {
-  res.status(code);
-  res.json({ code, error, details });
+  if (!res.headersSent && !res.ended) {
+    res.status(code);
+    res.json({ code, error, details });
+  }
 };
 
 const respond = (req, res, code, message, details) => {
@@ -72,7 +74,9 @@ module.exports = {
    * an authentication error.
    */
   notLoggedIn: (req, res, showPrompt) => {
-    res.setHeader('Authorization', 'CHT-Core');
+    if (!res.headersSent) {
+      res.setHeader('logout-authorization', 'CHT-Core API');
+    }
 
     if (showPrompt) {
       // api access - basic auth allowed

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -72,6 +72,8 @@ module.exports = {
    * an authentication error.
    */
   notLoggedIn: (req, res, showPrompt) => {
+    res.setHeader('Authorization', 'CHT-Core');
+
     if (showPrompt) {
       // api access - basic auth allowed
       promptForBasicAuth(res);

--- a/api/tests/mocha/middleware/authorization.spec.js
+++ b/api/tests/mocha/middleware/authorization.spec.js
@@ -83,6 +83,7 @@ describe('Authorization middleware', () => {
     it('should allow authorized when no param is passed and request has no error', () => {
       const fn = middleware.handleAuthentication();
       testReq.authorized = true;
+      testReq.userCtx = { };
       fn(testReq, testRes, next);
       next.callCount.should.equal(1);
       serverUtils.error.callCount.should.equal(0);
@@ -91,6 +92,7 @@ describe('Authorization middleware', () => {
     it('should allow not authorized when no param is passed and request has no auth error', () => {
       const fn = middleware.handleAuthentication();
       testReq.authorized = false;
+      testReq.userCtx = {};
       fn(testReq, testRes, next);
       next.callCount.should.equal(1);
       serverUtils.error.callCount.should.equal(0);
@@ -112,6 +114,14 @@ describe('Authorization middleware', () => {
       fn(testReq, testRes, next);
       next.callCount.should.equal(1);
       serverUtils.error.callCount.should.equal(0);
+    });
+
+    it('should error when no authErr and no userCtx', () => {
+      const fn = middleware.handleAuthentication();
+      fn(testReq, testRes, next);
+      next.callCount.should.equal(0);
+      serverUtils.error.callCount.should.equal(1);
+      serverUtils.error.args[0].should.deep.equal(['Authentication error', testReq, testRes]);
     });
   });
 

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -12,7 +12,8 @@ const res = {
   end: () => {},
   json: () => {},
   redirect: () => {},
-  status: () => {}
+  status: () => {},
+  setHeader: () => {},
 };
 
 let originalDb;
@@ -46,9 +47,14 @@ describe('Server utils', () => {
     });
 
     it('calls notLoggedIn when given 401 error', () => {
-      const notLoggedIn = sinon.stub(serverUtils, 'notLoggedIn');
+      sinon.stub(serverUtils, 'notLoggedIn');
+      sinon.spy(serverUtils, 'serverError');
+      sinon.stub(res, 'end');
       serverUtils.error({ code: 401 }, req, res);
-      chai.expect(notLoggedIn.callCount).to.equal(1);
+      chai.expect(serverUtils.notLoggedIn.callCount).to.equal(1);
+      chai.expect(serverUtils.notLoggedIn.args[0]).to.deep.equal([req, res, undefined]);
+      chai.expect(serverUtils.serverError.callCount).to.equal(0);
+      chai.expect(res.end.callCount).to.equal(0);
     });
 
     it('function handles 503 errors - #3821', () => {
@@ -132,25 +138,33 @@ describe('Server utils', () => {
 
     it('redirects to login page for human user', () => {
       const redirect = sinon.stub(res, 'redirect');
+      sinon.stub(res, 'setHeader');
       req.url = 'someurl';
       req.headers = { 'user-agent': 'Mozilla/1.0' };
       serverUtils.notLoggedIn(req, res);
       chai.expect(redirect.callCount).to.equal(1);
       chai.expect(redirect.args[0][0]).to.equal(302);
       chai.expect(redirect.args[0][1]).to.equal('/medic/login?redirect=someurl');
+      chai.expect(res.setHeader.callCount).to.equal(1);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
     });
 
     it('returns 401 for medic-collect', () => {
       const writeHead = sinon.stub(res, 'writeHead');
+      sinon.stub(res, 'setHeader');
       req.url = 'someurl';
       req.headers = { 'user-agent': null };
       serverUtils.notLoggedIn(req, res);
       chai.expect(writeHead.callCount).to.equal(1);
       chai.expect(writeHead.args[0][0]).to.equal(401);
+
+      chai.expect(res.setHeader.callCount).to.equal(1);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
     });
 
     it('shows prompt if requested', () => {
       const writeHead = sinon.stub(res, 'writeHead');
+      sinon.stub(res, 'setHeader');
       const end = sinon.stub(res, 'end');
       serverUtils.notLoggedIn(req, res, true);
       chai.expect(writeHead.callCount).to.equal(1);
@@ -159,6 +173,9 @@ describe('Server utils', () => {
       chai.expect(writeHead.args[0][1]['WWW-Authenticate']).to.equal('Basic realm="Medic Mobile Web Services"');
       chai.expect(end.callCount).to.equal(1);
       chai.expect(end.args[0][0]).to.equal('not logged in');
+
+      chai.expect(res.setHeader.callCount).to.equal(1);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
     });
 
     it('responds with JSON if requested', () => {
@@ -166,6 +183,7 @@ describe('Server utils', () => {
       const json = sinon.stub(res, 'json');
       const get = sinon.stub(req, 'get');
       get.returns('application/json');
+      sinon.stub(res, 'setHeader');
       serverUtils.notLoggedIn(req, res);
       chai.expect(get.callCount).to.equal(1);
       chai.expect(get.args[0][0]).to.equal('Accept');
@@ -174,6 +192,9 @@ describe('Server utils', () => {
       chai.expect(json.callCount).to.equal(1);
       chai.expect(json.args[0][0].error).to.equal('unauthorized');
       chai.expect(json.args[0][0].code).to.equal(401);
+
+      chai.expect(res.setHeader.callCount).to.equal(1);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
     });
 
   });

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -146,7 +146,7 @@ describe('Server utils', () => {
       chai.expect(redirect.args[0][0]).to.equal(302);
       chai.expect(redirect.args[0][1]).to.equal('/medic/login?redirect=someurl');
       chai.expect(res.setHeader.callCount).to.equal(1);
-      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
     });
 
     it('returns 401 for medic-collect', () => {
@@ -159,7 +159,7 @@ describe('Server utils', () => {
       chai.expect(writeHead.args[0][0]).to.equal(401);
 
       chai.expect(res.setHeader.callCount).to.equal(1);
-      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
     });
 
     it('shows prompt if requested', () => {
@@ -175,7 +175,7 @@ describe('Server utils', () => {
       chai.expect(end.args[0][0]).to.equal('not logged in');
 
       chai.expect(res.setHeader.callCount).to.equal(1);
-      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
     });
 
     it('responds with JSON if requested', () => {
@@ -194,7 +194,7 @@ describe('Server utils', () => {
       chai.expect(json.args[0][0].code).to.equal(401);
 
       chai.expect(res.setHeader.callCount).to.equal(1);
-      chai.expect(res.setHeader.args[0]).to.deep.equal(['Authorization', 'CHT-Core']);
+      chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
     });
 
   });

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -204,7 +204,7 @@ describe('routing', () => {
       ]).then(results => {
         results.forEach(result => {
           expect(result.statusCode).toEqual(401);
-          expect(result.response.headers['authorization']).toEqual('CHT-Core');
+          expect(result.response.headers['logout-authorization']).toEqual('CHT-Core API');
           expect(result.responseBody.error).toEqual('unauthorized');
         });
       });

--- a/tests/page-objects/forms/default-delivery-report.po.js
+++ b/tests/page-objects/forms/default-delivery-report.po.js
@@ -22,13 +22,13 @@ const docs = [
 
 const selectRadioButtonByValue = async value => {
   const radioElement = element(by.css(`[value=${value}]`));
-  await helper.waitElementToBeVisible(radioElement);
+  await helper.waitElementToBeVisibleNative(radioElement);
   await helper.clickElementNative(radioElement);
 };
 
 const selectRadioButtonByNameAndValue = async (name, value) => {
   const radioElement = element(by.css(`[name="${name}"][value="${value}"]`));
-  await helper.waitElementToBeVisible(radioElement);
+  await helper.waitElementToBeVisibleNative(radioElement);
   await helper.clickElementNative(radioElement);
 };
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -55,7 +55,7 @@ const request = (options, { debug } = {}) => {
 
   return rpn(options).catch(err => {
     err.responseBody = err.response && err.response.body;
-    console.warn(`A request error occurred ${err.options.uri}`);
+    debug && console.warn(`A request error occurred ${err.options.uri}`);
     throw err;
   });
 };
@@ -509,7 +509,7 @@ const parseCookieResponse = (cookieString) => {
     cookieObject.value = cookieValue;
     cookieSplit.forEach((cookieValues) => {
       const [key, value] = cookieValues.split('=');
-      cookieObject[key] = (key.includes('Secure') || key.includes('HttpOnly')) ? true : value;    
+      cookieObject[key] = (key.includes('Secure') || key.includes('HttpOnly')) ? true : value;
     });
     return cookieObject;
   });
@@ -932,7 +932,7 @@ module.exports = {
   closeTour: async () => {
     const closeButton = element(by.css('#tour-select a.btn.cancel'));
     try {
-      await browser.wait(protractor.ExpectedConditions.visibilityOf(closeButton),);
+      await browser.wait(protractor.ExpectedConditions.visibilityOf(closeButton), 10000);
       await browser.wait(protractor.ExpectedConditions.elementToBeClickable(closeButton), 1000);
       await closeButton.click();
       // wait for the request to the server to execute

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -196,12 +196,8 @@ export class AppComponent implements OnInit {
       return dbFetch
         .apply(dbFetch, args)
         .then((response) => {
-          const getAuthorizationHeader = (response) => {
-            return response.headers?.get('Authorization') ||
-              response.headers?.get('authorization');
-          };
           // ignore 401 that could code through other channels than CHT API
-          if (response.status === 401 && getAuthorizationHeader(response) === 'CHT-Core') {
+          if (response.status === 401 && response.headers?.get('logout-authorization') === 'CHT-Core API') {
             this.showSessionExpired();
             setTimeout(() => {
               console.info('Redirect to login after 1 minute of inactivity');

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -196,7 +196,12 @@ export class AppComponent implements OnInit {
       return dbFetch
         .apply(dbFetch, args)
         .then((response) => {
-          if (response.status === 401) {
+          const getAuthorizationHeader = (response) => {
+            return response.headers?.get('Authorization') ||
+              response.headers?.get('authorization');
+          };
+          // ignore 401 that could code through other channels than CHT API
+          if (response.status === 401 && getAuthorizationHeader(response) === 'CHT-Core') {
             this.showSessionExpired();
             setTimeout(() => {
               console.info('Redirect to login after 1 minute of inactivity');

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -196,7 +196,7 @@ export class AppComponent implements OnInit {
       return dbFetch
         .apply(dbFetch, args)
         .then((response) => {
-          // ignore 401 that could code through other channels than CHT API
+          // ignore 401 that could come through other channels than CHT API
           if (response.status === 401 && response.headers?.get('logout-authorization') === 'CHT-Core API') {
             this.showSessionExpired();
             setTimeout(() => {


### PR DESCRIPTION
# Description

Updates API code to:
1. Only consider 401s from CouchDB to be valid missing authentication
2. Throw other _session errors without changes
3. Malformed _session responses result in a 500 
4. Don't send 401s for missing userCtx, instead send the actual authentication error or a 500. 
5. Add a custom header to 401 responses that webapp checks for, and only when matched it would log users out. (prevents man-in-the-middle from logging users out with 401s)

medic/cht-core#7169

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
