### PR TITLE
7173 Reverting jQuery upgrade to 3.5.1

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -164,9 +164,9 @@
       }
     },
     "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/admin/package.json
+++ b/admin/package.json
@@ -21,7 +21,7 @@
     "font-awesome": "^4.7.0",
     "google-libphonenumber": "^3.2.19",
     "gsm": "^0.1.4",
-    "jquery": "^3.6.0",
+    "jquery": "^3.5.1",
     "lodash": "^4.17.19",
     "messageformat": "^2.3.0",
     "moment": "^2.29.1",


### PR DESCRIPTION
# Description

This is a known issue between jQuery and Select2 where the search input isn't auto focusing in jQuery 3.6.0.
Reverting jQuery version to 3.5.1

https://github.com/medic/cht-core/issues/7173

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
