### PR TITLE
revert docker-compose to allow for env var for couch pass 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - medic-net
     environment:
       - DOCKER_NETWORK_NAME=haproxy
-      - DOCKER_COUCHDB_ADMIN_PASSWORD=password
+      - DOCKER_COUCHDB_ADMIN_PASSWORD=${DOCKER_COUCHDB_ADMIN_PASSWORD:-password}
 
   haproxy:
     container_name: haproxy


### PR DESCRIPTION
# Description

per #7206

This PR returns the ability to dynamically declare couchdb default password for `medic` user via the `DOCKER_COUCHDB_ADMIN_PASSWORD` environment variable.  If not declared, it will default to `password`. 

These two tests worked as expected:
* Set password to `foobar`: `DOCKER_COUCHDB_ADMIN_PASSWORD=foobar docker-compose up`
* Use default `password` as password: `docker-compose up`

Tested on `docker-compose` version `1.26.0, build d4451659`

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
