### PR TITLE
Properly set Enketo form's language

### DIFF
--- a/demo-forms/repeat-translation.xml
+++ b/demo-forms/repeat-translation.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms">
+    <h:head>
+        <h:title>Repeat</h:title>
+        <model>
+            <itext>
+                <translation lang="en">
+                    <text id="/repeat/basic/rep/city_1/melbourne:label">
+                        <value>Melbourne</value>
+                    </text>
+                    <text id="/repeat/basic/rep/city_1:label">
+                        <value>Select a city:</value>
+                    </text>
+                    <text id="/repeat/basic/state_1/VIC:label">
+                        <value>Victoria</value>
+                    </text>
+                    <text id="/repeat/basic/state_1:label">
+                        <value>Select a state:</value>
+                    </text>
+                    <text id="/repeat/basic:label">
+                        <value>Cascading Selects:</value>
+                    </text>
+                </translation>
+                <translation lang="sw">
+                    <text id="/repeat/basic/rep/city_1/melbourne:label">
+                        <value>ML</value>
+                    </text>
+                    <text id="/repeat/basic/rep/city_1:label">
+                        <value>Select a city: - SV</value>
+                    </text>
+                    <text id="/repeat/basic/state_1/VIC:label">
+                        <value>VIC</value>
+                    </text>
+                    <text id="/repeat/basic/state_1:label">
+                        <value>Select a state: - SV</value>
+                    </text>
+                    <text id="/repeat/basic:label">
+                        <value>Cascading Selects: - SV</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <repeat id="repeat" prefix="J1!repeat!" delimiter="#" version="2019-08-09">
+                    <basic>
+                        <state_1/>
+                        <rep jr:template="">
+                            <city_1/>
+                        </rep>
+                    </basic>
+                    <meta tag="hidden">
+                        <instanceID/>
+                    </meta>
+                </repeat>
+            </instance>
+            <instance id="contact-summary"/>
+            <bind nodeset="/repeat/basic/state_1" type="select1"/>
+            <bind nodeset="/repeat/basic/rep/city_1" type="select1"/>
+            <bind nodeset="/repeat/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+        </model>
+    </h:head>
+    <h:body class="pages">
+        <group appearance="field-list" ref="/repeat/basic">
+            <label ref="jr:itext('/repeat/basic:label')"/>
+            <select1 ref="/repeat/basic/state_1">
+                <label ref="jr:itext('/repeat/basic/state_1:label')"/>
+                <item>
+                    <label ref="jr:itext('/repeat/basic/state_1/VIC:label')"/>
+                    <value>VIC</value>
+                </item>
+            </select1>
+            <group ref="/repeat/basic/rep">
+                <label></label>
+                <repeat nodeset="/repeat/basic/rep">
+                    <select1 ref="/repeat/basic/rep/city_1">
+                        <label ref="jr:itext('/repeat/basic/rep/city_1:label')"/>
+                        <item>
+                            <label ref="jr:itext('/repeat/basic/rep/city_1/melbourne:label')"/>
+                            <value>melbourne</value>
+                        </item>
+                    </select1>
+                </repeat>
+            </group>
+        </group>
+    </h:body>
+</h:html>

--- a/demo-forms/repeat-translation.xml
+++ b/demo-forms/repeat-translation.xml
@@ -5,42 +5,42 @@
         <model>
             <itext>
                 <translation lang="en">
-                    <text id="/repeat/basic/rep/city_1/melbourne:label">
+                    <text id="/repeat-translation/basic/rep/city_1/melbourne:label">
                         <value>Melbourne</value>
                     </text>
-                    <text id="/repeat/basic/rep/city_1:label">
+                    <text id="/repeat-translation/basic/rep/city_1:label">
                         <value>Select a city:</value>
                     </text>
-                    <text id="/repeat/basic/state_1/VIC:label">
+                    <text id="/repeat-translation/basic/state_1/VIC:label">
                         <value>Victoria</value>
                     </text>
-                    <text id="/repeat/basic/state_1:label">
+                    <text id="/repeat-translation/basic/state_1:label">
                         <value>Select a state:</value>
                     </text>
-                    <text id="/repeat/basic:label">
+                    <text id="/repeat-translation/basic:label">
                         <value>Cascading Selects:</value>
                     </text>
                 </translation>
                 <translation lang="sw">
-                    <text id="/repeat/basic/rep/city_1/melbourne:label">
+                    <text id="/repeat-translation/basic/rep/city_1/melbourne:label">
                         <value>ML</value>
                     </text>
-                    <text id="/repeat/basic/rep/city_1:label">
+                    <text id="/repeat-translation/basic/rep/city_1:label">
                         <value>Select a city: - SV</value>
                     </text>
-                    <text id="/repeat/basic/state_1/VIC:label">
+                    <text id="/repeat-translation/basic/state_1/VIC:label">
                         <value>VIC</value>
                     </text>
-                    <text id="/repeat/basic/state_1:label">
+                    <text id="/repeat-translation/basic/state_1:label">
                         <value>Select a state: - SV</value>
                     </text>
-                    <text id="/repeat/basic:label">
+                    <text id="/repeat-translation/basic:label">
                         <value>Cascading Selects: - SV</value>
                     </text>
                 </translation>
             </itext>
             <instance>
-                <repeat id="repeat" prefix="J1!repeat!" delimiter="#" version="2019-08-09">
+                <repeat id="repeat-translation" prefix="J1!repeat-translation!" delimiter="#" version="2019-08-09">
                     <basic>
                         <state_1/>
                         <rep jr:template="">
@@ -53,28 +53,28 @@
                 </repeat>
             </instance>
             <instance id="contact-summary"/>
-            <bind nodeset="/repeat/basic/state_1" type="select1"/>
-            <bind nodeset="/repeat/basic/rep/city_1" type="select1"/>
-            <bind nodeset="/repeat/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+            <bind nodeset="/repeat-translation/basic/state_1" type="select1"/>
+            <bind nodeset="/repeat-translation/basic/rep/city_1" type="select1"/>
+            <bind nodeset="/repeat-translation/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
         </model>
     </h:head>
     <h:body class="pages">
-        <group appearance="field-list" ref="/repeat/basic">
-            <label ref="jr:itext('/repeat/basic:label')"/>
-            <select1 ref="/repeat/basic/state_1">
-                <label ref="jr:itext('/repeat/basic/state_1:label')"/>
+        <group appearance="field-list" ref="/repeat-translation/basic">
+            <label ref="jr:itext('/repeat-translation/basic:label')"/>
+            <select1 ref="/repeat-translation/basic/state_1">
+                <label ref="jr:itext('/repeat-translation/basic/state_1:label')"/>
                 <item>
-                    <label ref="jr:itext('/repeat/basic/state_1/VIC:label')"/>
+                    <label ref="jr:itext('/repeat-translation/basic/state_1/VIC:label')"/>
                     <value>VIC</value>
                 </item>
             </select1>
-            <group ref="/repeat/basic/rep">
+            <group ref="/repeat-translation/basic/rep">
                 <label></label>
-                <repeat nodeset="/repeat/basic/rep">
-                    <select1 ref="/repeat/basic/rep/city_1">
-                        <label ref="jr:itext('/repeat/basic/rep/city_1:label')"/>
+                <repeat nodeset="/repeat-translation/basic/rep">
+                    <select1 ref="/repeat-translation/basic/rep/city_1">
+                        <label ref="jr:itext('/repeat-translation/basic/rep/city_1:label')"/>
                         <item>
-                            <label ref="jr:itext('/repeat/basic/rep/city_1/melbourne:label')"/>
+                            <label ref="jr:itext('/repeat-translation/basic/rep/city_1/melbourne:label')"/>
                             <value>melbourne</value>
                         </item>
                     </select1>

--- a/tests/e2e/contacts/person-under-area.wdio-spec.js
+++ b/tests/e2e/contacts/person-under-area.wdio-spec.js
@@ -55,7 +55,7 @@ describe('Create Person Under Area', async () => {
     await usersAdminPage.inputAddUserFields(username, 'Jack', 'CHW', healthCenter2.name, person2.name, password);
     await usersAdminPage.saveUser();
     await usersAdminPage.logout();
-    await loginPage.login(username, password);
+    await loginPage.login({ username, password });
     await commonPage.closeTour();
 
     await commonPage.goToPeople();

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -50,7 +50,7 @@ describe('RepeatForm', () => {
     await loginPage.cookieLogin({ locale: currentLanguage.code });
     await commonPage.goToReports();
     await (await reportsPage.submitReportButton()).click();
-    await (await reportsPage.formLinkByHref(formDocument.internalId)).click();
+    await (await reportsPage.formActionsLink(formDocument.internalId)).click();
 
     const stateLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/state_1:label"]');
     expect(await stateLabel.getText()).toBe('Select a state: - SV');
@@ -73,7 +73,7 @@ describe('RepeatForm', () => {
     await loginPage.cookieLogin({ locale: currentLanguage.code });
     await commonPage.goToReports();
     await (await reportsPage.submitReportButton()).click();
-    await (await reportsPage.formLinkByHref(formDocument.internalId)).click();
+    await (await reportsPage.formActionsLink(formDocument.internalId)).click();
 
     const stateLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/state_1:label"]');
     expect(await stateLabel.getText()).toBe('Select a state:');

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -43,6 +43,12 @@ describe('RepeatForm', () => {
     await browser.refresh();
   });
 
+  /* eslint-disable max-len */
+  const stateLabelPath = '#report-form .question-label.active[data-itext-id="/repeat-translation/basic/state_1:label"]';
+  const cityLabelPath = '#report-form .question-label.active[data-itext-id="/repeat-translation/basic/rep/city_1:label"]';
+  const melbourneLabelPath = '#report-form .option-label.active[data-itext-id="/repeat-translation/basic/rep/city_1/melbourne:label"]';
+  /* eslint-enable max-len */
+
   it('should display the initial form and its repeated content in Swahili', async () => {
     const swUserName = 'Jina la mtumizi';
     await loginPage.changeLanguage('sw', swUserName);
@@ -52,17 +58,16 @@ describe('RepeatForm', () => {
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formActionsLink(formDocument.internalId)).click();
 
-    const stateLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/state_1:label"]');
+    const stateLabel = await $(stateLabelPath);
     expect(await stateLabel.getText()).toBe('Select a state: - SV');
 
     const addRepeatButton = await $('.btn.btn-default.add-repeat-btn');
     await addRepeatButton.click();
 
-    const cityLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/rep/city_1:label"]');
+    const cityLabel = await $(cityLabelPath);
     expect(await cityLabel.getText()).toBe('Select a city: - SV');
 
-    // eslint-disable-next-line max-len
-    const melbourneLabel = await $('#report-form .option-label.active[data-itext-id="/repeat/basic/rep/city_1/melbourne:label"]');
+    const melbourneLabel = await $(melbourneLabelPath);
     expect(await melbourneLabel.getText()).toBe('ML');
   });
 
@@ -75,17 +80,16 @@ describe('RepeatForm', () => {
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formActionsLink(formDocument.internalId)).click();
 
-    const stateLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/state_1:label"]');
+    const stateLabel = await $(stateLabelPath);
     expect(await stateLabel.getText()).toBe('Select a state:');
 
     const addRepeatButton = await $('.btn.btn-default.add-repeat-btn');
     await addRepeatButton.click();
 
-    const cityLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/rep/city_1:label"]');
+    const cityLabel = await $(cityLabelPath);
     expect(await cityLabel.getText()).toBe('Select a city:');
 
-    // eslint-disable-next-line max-len
-    const melbourneLabel = await $('#report-form .option-label.active[data-itext-id="/repeat/basic/rep/city_1/melbourne:label"]');
+    const melbourneLabel = await $(melbourneLabelPath);
     expect(await melbourneLabel.getText()).toBe('Melbourne');
   });
 });

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+
+const constants = require('../../constants');
+const utils = require('../../utils');
+const loginPage = require('../../page-objects/login/login.wdio.page');
+const commonPage = require('../../page-objects/common/common.wdio.page');
+const reportsPage = require('../../page-objects/reports/reports.wdio.page');
+
+const xml = fs.readFileSync(`${__dirname}/../../../demo-forms/repeat-translation.xml`, 'utf8');
+const formDocument = {
+  _id: 'form:repeat-translation',
+  internalId: 'repeat-translation',
+  title: 'Repeat',
+  type: 'form',
+  _attachments: {
+    xml: {
+      content_type: 'application/octet-stream',
+      data: Buffer.from(xml).toString('base64')
+    }
+  }
+};
+const userContactDoc = {
+  _id: constants.USER_CONTACT_ID,
+  name: 'Jack',
+  date_of_birth: '',
+  phone: '+64274444444',
+  alternate_phone: '',
+  notes: '',
+  type: 'person',
+  reported_date: 1478469976421,
+  parent: {
+    _id: 'some_parent'
+  }
+};
+
+describe('RepeatForm', () => {
+  before(async () => {
+    await utils.seedTestData(userContactDoc, [formDocument]);
+  });
+
+  afterEach(async () => {
+    await browser.deleteCookies();
+    await browser.refresh();
+  });
+
+  it('should display the initial form and its repeated content in Swahili', async () => {
+    const swUserName = 'Jina la mtumizi';
+    await loginPage.changeLanguage('sw', swUserName);
+    await loginPage.cookieLogin();
+    await commonPage.goToReports();
+    await (await reportsPage.submitReportButton()).click();
+    await (await reportsPage.formLinkByHref(formDocument.internalId)).click();
+
+    const stateLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/state_1:label"]');
+    expect(await stateLabel.getText()).toBe('Select a state: - SV');
+
+    const addRepeatButton = await $('.btn.btn-default.add-repeat-btn');
+    await addRepeatButton.click();
+
+    const cityLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/rep/city_1:label"]');
+    expect(await cityLabel.getText()).toBe('Select a city: - SV');
+  });
+
+  it('should display the initial form and its repeated content in English', async () => {
+    const enUserName = 'User name';
+    await loginPage.changeLanguage('en', enUserName);
+    await loginPage.cookieLogin();
+    await commonPage.goToReports();
+    await (await reportsPage.submitReportButton()).click();
+    await (await reportsPage.formLinkByHref(formDocument.internalId)).click();
+
+    const stateLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/state_1:label"]');
+    expect(await stateLabel.getText()).toBe('Select a state:');
+
+    const addRepeatButton = await $('.btn.btn-default.add-repeat-btn');
+    await addRepeatButton.click();
+
+    const cityLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/rep/city_1:label"]');
+    expect(await cityLabel.getText()).toBe('Select a city:');
+  });
+});

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -2,9 +2,11 @@ const fs = require('fs');
 
 const constants = require('../../constants');
 const utils = require('../../utils');
+const auth = require('../../auth')();
 const loginPage = require('../../page-objects/login/login.wdio.page');
 const commonPage = require('../../page-objects/common/common.wdio.page');
 const reportsPage = require('../../page-objects/reports/reports.wdio.page');
+const waitUntil = require("webdriverio/build/commands/browser/waitUntil");
 
 const xml = fs.readFileSync(`${__dirname}/../../../demo-forms/repeat-translation.xml`, 'utf8');
 const formDocument = {
@@ -52,8 +54,8 @@ describe('RepeatForm', () => {
   it('should display the initial form and its repeated content in Swahili', async () => {
     const swUserName = 'Jina la mtumizi';
     await loginPage.changeLanguage('sw', swUserName);
-    const currentLanguage = await loginPage.getCurrentLanguage();
-    await loginPage.cookieLogin({ locale: currentLanguage.code });
+    await loginPage.login({ username: auth.username, password: auth.password, createUser: true });
+    await commonPage.goToBase();
     await commonPage.goToReports();
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formActionsLink(formDocument.internalId)).click();
@@ -74,8 +76,8 @@ describe('RepeatForm', () => {
   it('should display the initial form and its repeated content in English', async () => {
     const enUserName = 'User name';
     await loginPage.changeLanguage('en', enUserName);
-    const currentLanguage = await loginPage.getCurrentLanguage();
-    await loginPage.cookieLogin({ locale: currentLanguage.code });
+    await loginPage.login({ username: auth.username, password: auth.password, createUser: true });
+    await commonPage.goToBase();
     await commonPage.goToReports();
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formActionsLink(formDocument.internalId)).click();

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -39,16 +39,17 @@ describe('RepeatForm', () => {
     await utils.seedTestData(userContactDoc, [formDocument]);
   });
 
+  after(() => utils.revertDb([], true));
+
   afterEach(async () => {
     await browser.deleteCookies();
     await browser.refresh();
   });
 
-  /* eslint-disable max-len */
-  const stateLabelPath = '#report-form .question-label.active[data-itext-id="/repeat-translation/basic/state_1:label"]';
-  const cityLabelPath = '#report-form .question-label.active[data-itext-id="/repeat-translation/basic/rep/city_1:label"]';
-  const melbourneLabelPath = '#report-form .option-label.active[data-itext-id="/repeat-translation/basic/rep/city_1/melbourne:label"]';
-  /* eslint-enable max-len */
+  const selectorPrefix = '#report-form .active';
+  const stateLabelPath = `${selectorPrefix}.question-label[data-itext-id="/repeat-translation/basic/state_1:label"]`;
+  const cityLabelPath = `${selectorPrefix}.question-label[data-itext-id="/repeat-translation/basic/rep/city_1:label"]`;
+  const melbourneLabelPath = `${selectorPrefix}[data-itext-id="/repeat-translation/basic/rep/city_1/melbourne:label"]`;
 
   it('should display the initial form and its repeated content in Swahili', async () => {
     const swUserName = 'Jina la mtumizi';

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -46,7 +46,8 @@ describe('RepeatForm', () => {
   it('should display the initial form and its repeated content in Swahili', async () => {
     const swUserName = 'Jina la mtumizi';
     await loginPage.changeLanguage('sw', swUserName);
-    await loginPage.cookieLogin();
+    const currentLanguage = await loginPage.getCurrentLanguage();
+    await loginPage.cookieLogin({ locale: currentLanguage.code });
     await commonPage.goToReports();
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formLinkByHref(formDocument.internalId)).click();
@@ -68,7 +69,8 @@ describe('RepeatForm', () => {
   it('should display the initial form and its repeated content in English', async () => {
     const enUserName = 'User name';
     await loginPage.changeLanguage('en', enUserName);
-    await loginPage.cookieLogin();
+    const currentLanguage = await loginPage.getCurrentLanguage();
+    await loginPage.cookieLogin({ locale: currentLanguage.code });
     await commonPage.goToReports();
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formLinkByHref(formDocument.internalId)).click();

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -6,7 +6,6 @@ const auth = require('../../auth')();
 const loginPage = require('../../page-objects/login/login.wdio.page');
 const commonPage = require('../../page-objects/common/common.wdio.page');
 const reportsPage = require('../../page-objects/reports/reports.wdio.page');
-const waitUntil = require("webdriverio/build/commands/browser/waitUntil");
 
 const xml = fs.readFileSync(`${__dirname}/../../../demo-forms/repeat-translation.xml`, 'utf8');
 const formDocument = {
@@ -63,8 +62,7 @@ describe('RepeatForm', () => {
     const stateLabel = await $(stateLabelPath);
     expect(await stateLabel.getText()).toBe('Select a state: - SV');
 
-    const addRepeatButton = await $('.btn.btn-default.add-repeat-btn');
-    await addRepeatButton.click();
+    await reportsPage.repeatForm();
 
     const cityLabel = await $(cityLabelPath);
     expect(await cityLabel.getText()).toBe('Select a city: - SV');
@@ -85,8 +83,7 @@ describe('RepeatForm', () => {
     const stateLabel = await $(stateLabelPath);
     expect(await stateLabel.getText()).toBe('Select a state:');
 
-    const addRepeatButton = await $('.btn.btn-default.add-repeat-btn');
-    await addRepeatButton.click();
+    await reportsPage.repeatForm();
 
     const cityLabel = await $(cityLabelPath);
     expect(await cityLabel.getText()).toBe('Select a city:');

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -61,15 +61,15 @@ describe('RepeatForm', () => {
     await (await reportsPage.formActionsLink(formDocument.internalId)).click();
 
     const stateLabel = await $(stateLabelPath);
-    expect(await stateLabel.getText()).toBe('Select a state: - SV');
+    expect(await stateLabel.getText()).to.equal('Select a state: - SV');
 
     await reportsPage.repeatForm();
 
     const cityLabel = await $(cityLabelPath);
-    expect(await cityLabel.getText()).toBe('Select a city: - SV');
+    expect(await cityLabel.getText()).to.equal('Select a city: - SV');
 
     const melbourneLabel = await $(melbourneLabelPath);
-    expect(await melbourneLabel.getText()).toBe('ML');
+    expect(await melbourneLabel.getText()).to.equal('ML');
   });
 
   it('should display the initial form and its repeated content in English', async () => {
@@ -82,14 +82,14 @@ describe('RepeatForm', () => {
     await (await reportsPage.formActionsLink(formDocument.internalId)).click();
 
     const stateLabel = await $(stateLabelPath);
-    expect(await stateLabel.getText()).toBe('Select a state:');
+    expect(await stateLabel.getText()).to.equal('Select a state:');
 
     await reportsPage.repeatForm();
 
     const cityLabel = await $(cityLabelPath);
-    expect(await cityLabel.getText()).toBe('Select a city:');
+    expect(await cityLabel.getText()).to.equal('Select a city:');
 
     const melbourneLabel = await $(melbourneLabelPath);
-    expect(await melbourneLabel.getText()).toBe('Melbourne');
+    expect(await melbourneLabel.getText()).to.equal('Melbourne');
   });
 });

--- a/tests/e2e/forms/repeat-form.wdio-spec.js
+++ b/tests/e2e/forms/repeat-form.wdio-spec.js
@@ -59,6 +59,10 @@ describe('RepeatForm', () => {
 
     const cityLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/rep/city_1:label"]');
     expect(await cityLabel.getText()).toBe('Select a city: - SV');
+
+    // eslint-disable-next-line max-len
+    const melbourneLabel = await $('#report-form .option-label.active[data-itext-id="/repeat/basic/rep/city_1/melbourne:label"]');
+    expect(await melbourneLabel.getText()).toBe('ML');
   });
 
   it('should display the initial form and its repeated content in English', async () => {
@@ -77,5 +81,9 @@ describe('RepeatForm', () => {
 
     const cityLabel = await $('#report-form .question-label.active[data-itext-id="/repeat/basic/rep/city_1:label"]');
     expect(await cityLabel.getText()).toBe('Select a city:');
+
+    // eslint-disable-next-line max-len
+    const melbourneLabel = await $('#report-form .option-label.active[data-itext-id="/repeat/basic/rep/city_1/melbourne:label"]');
+    expect(await melbourneLabel.getText()).toBe('Melbourne');
   });
 });

--- a/tests/e2e/login/db-sync.wdio-spec.js
+++ b/tests/e2e/login/db-sync.wdio-spec.js
@@ -200,7 +200,7 @@ describe('db-sync', () => {
       body: restrictedUser
     });
     await sentinelUtils.waitForSentinel();
-    await loginPage.login(restrictedUserName, restrictedPass);
+    await loginPage.login({ username: restrictedUserName, password: restrictedPass });
     await (await commonElements.analyticsTab()).waitForDisplayed();
   });
 

--- a/tests/e2e/login/login-logout.wdio-spec.js
+++ b/tests/e2e/login/login-logout.wdio-spec.js
@@ -40,11 +40,13 @@ describe('Login and logout tests', () => {
   it('should change locale to French', async () => {
     //French translations
     expect(await loginPage.changeLanguage('fr',frTranslations.user)).to.deep.equal(frTranslations);
+    expect(await loginPage.getCurrentLanguage()).to.deep.equal({ code: 'fr', name: 'Français (French)' });
   });
 
   it('should change locale to Spanish', async () => {
     //Spanish translations
     expect(await loginPage.changeLanguage('es',esTranslations.user)).to.deep.equal(esTranslations);
+    expect(await loginPage.getCurrentLanguage()).to.deep.equal({ code: 'es', name: 'Español (Spanish)' });
   });
 
   it('should show a warning before log out', async () => {

--- a/tests/e2e/login/login-logout.wdio-spec.js
+++ b/tests/e2e/login/login-logout.wdio-spec.js
@@ -59,7 +59,10 @@ describe('Login and logout tests', () => {
   });
 
   it('should log in using username and password fields', async () => {
-    await loginPage.login(auth.username, auth.password);
+    await loginPage.login({
+      username: auth.username,
+      password: auth.password,
+    });
     await (await commonPage.analyticsTab()).waitForDisplayed();
     await (await commonPage.messagesTab()).waitForDisplayed();
   });

--- a/tests/e2e/login/login-logout.wdio-spec.js
+++ b/tests/e2e/login/login-logout.wdio-spec.js
@@ -50,7 +50,10 @@ describe('Login and logout tests', () => {
   });
 
   it('should show a warning before log out', async () => {
-    await loginPage.cookieLogin(auth.username, auth.password);
+    await loginPage.cookieLogin({
+      username: auth.username,
+      password: auth.password,
+    });
     const warning = await commonPage.getLogoutMessage();
     expect(warning).to.equal('Are you sure you want to log out?');
   });

--- a/tests/e2e/tasks/task-due-dates.wdio-spec.js
+++ b/tests/e2e/tasks/task-due-dates.wdio-spec.js
@@ -58,7 +58,7 @@ describe('Task list due dates', () => {
     await utils.createUsers([ chw ]);
     await sentinelUtils.waitForSentinel();
 
-    await loginPage.login(chw.username, chw.password);
+    await loginPage.login({ username: chw.username, password: chw.password });
     await commonPage.closeTour();
     await (await commonPage.analyticsTab()).waitForDisplayed();
   });

--- a/tests/e2e/tasks/tasks-group.wdio-spec.js
+++ b/tests/e2e/tasks/tasks-group.wdio-spec.js
@@ -187,7 +187,7 @@ describe('Tasks group landing page', () => {
 
   describe('for chw', () => {
     before(async () => {
-      await loginPage.login(chw.username, chw.password);
+      await loginPage.login({ username: chw.username, password: chw.password });
       await commonPage.closeTour();
       await (await commonPage.analyticsTab()).waitForDisplayed();
     });
@@ -331,7 +331,7 @@ describe('Tasks group landing page', () => {
 
   describe('for supervisor', () => {
     before(async () => {
-      await loginPage.login(supervisor.username, supervisor.password);
+      await loginPage.login({ username: supervisor.username, password: supervisor.password });
       await commonPage.closeTour();
       await (await commonPage.analyticsTab()).waitForDisplayed();
     });

--- a/tests/page-objects/login/login.wdio.page.js
+++ b/tests/page-objects/login/login.wdio.page.js
@@ -15,10 +15,11 @@ const login = async (username, password) => {
   await (await loginButton()).click();
 };
 
-const cookieLogin = async (username = auth.username, password = auth.password, createUser = true) => {
+const cookieLogin = async (username = auth.username, password = auth.password, createUser = true, locale) => {
+  const currentLanguage = locale || await getCurrentLanguage();
   const opts = {
     path: '/medic/login',
-    body: { user: username, password: password },
+    body: { user: username, password, locale: currentLanguage.code },
     method: 'POST',
     simple: false,
   };
@@ -40,6 +41,14 @@ const getLanguage = async (selector) => {
     };
   }));
   return lang;
+};
+
+const getCurrentLanguage = async () => {
+  const localeElement = await $('.locale.selected');
+  return {
+    code: await localeElement.getAttribute('name'),
+    name: await localeElement.getText(),
+  };
 };
 
 const changeLocale = async locale => {
@@ -65,4 +74,5 @@ module.exports = {
   cookieLogin,
   getAllLocales: () => getLanguage('.locale'),
   changeLanguage,
+  getCurrentLanguage,
 };

--- a/tests/page-objects/login/login.wdio.page.js
+++ b/tests/page-objects/login/login.wdio.page.js
@@ -15,11 +15,16 @@ const login = async (username, password) => {
   await (await loginButton()).click();
 };
 
-const cookieLogin = async (username = auth.username, password = auth.password, createUser = true, locale) => {
-  const currentLanguage = locale || await getCurrentLanguage();
+const cookieLogin = async (options = {}) => {
+  const {
+    username = auth.username,
+    password = auth.password,
+    createUser = true,
+    locale = 'en',
+  } = options;
   const opts = {
     path: '/medic/login',
-    body: { user: username, password, locale: currentLanguage.code },
+    body: { user: username, password, locale },
     method: 'POST',
     simple: false,
   };

--- a/tests/page-objects/login/login.wdio.page.js
+++ b/tests/page-objects/login/login.wdio.page.js
@@ -8,11 +8,18 @@ const labelForUser = () => $('label[for="user"]');
 const labelForPassword = () => $('label[for="password"]');
 const errorMessageField = () => $('p.error.incorrect');
 
-
-const login = async (username, password) => {
+const login = async ({ username, password, createUser = false }) => {
   await (await userField()).setValue(username);
   await (await passwordField()).setValue(password);
   await (await loginButton()).click();
+
+  if (createUser) {
+    await browser.waitUntil(async () => {
+      const cookies = await browser.getCookies('userCtx');
+      return cookies.some(cookie => cookie.name === 'userCtx');
+    });
+    await utils.setupUserDoc(username);
+  }
 };
 
 const cookieLogin = async (options = {}) => {

--- a/tests/page-objects/reports/reports.wdio.page.js
+++ b/tests/page-objects/reports/reports.wdio.page.js
@@ -11,6 +11,8 @@ const submitReportButton = () => $('.action-container .general-actions:not(.ng-h
 const formActionsLink = (formId) => {
   return $(`.action-container .general-actions .dropup.open .dropdown-menu li a[href="#/reports/add/${formId}"]`);
 };
+const addRepeatButton = () => $('.btn.btn-default.add-repeat-btn');
+const repeatForm = async () => (await addRepeatButton()).click();
 const unreadCount = () => $('#reports-tab .mm-badge');
 
 // warning: the unread element is not displayed when there are no unread reports
@@ -29,5 +31,7 @@ module.exports = {
   selectedCaseIdLabel,
   submitReportButton,
   formActionsLink,
+  addRepeatButton,
+  repeatForm,
   getUnreadCount,
 };

--- a/tests/page-objects/reports/reports.wdio.page.js
+++ b/tests/page-objects/reports/reports.wdio.page.js
@@ -1,12 +1,16 @@
 const reportListID = '#reports-list';
 const reportBodyDetails = '#reports-content .report-body .details';
-const reportList = () => $(`${reportListID}`);
 const selectedCaseId = () => $(`${reportBodyDetails} > ul > li > p > span > a`);
 const selectedCaseIdLabel = () => $(`${reportBodyDetails} ul > li > label > span`);
 const submitterPlace = () => $('.position a');
 const submitterPhone = () => $('.sender .phone');
 const submitterName = () => $('.sender .name');
 const firstReport = () => $(`${reportListID} li:first-child`);
+const reportList = () => $(`${reportListID}`);
+const submitReportButton = () => $('.action-container .general-actions:not(.ng-hide) .fa-plus');
+const formLinkByHref = (href) => {
+  return $(`.action-container .general-actions .dropup.open .dropdown-menu li a[href="#/reports/add/${href}"]`);
+};
 const unreadCount = () => $('#reports-tab .mm-badge');
 
 // warning: the unread element is not displayed when there are no unread reports
@@ -23,5 +27,7 @@ module.exports = {
   submitterPlace,
   selectedCaseId,
   selectedCaseIdLabel,
+  submitReportButton,
+  formLinkByHref,
   getUnreadCount,
 };

--- a/tests/page-objects/reports/reports.wdio.page.js
+++ b/tests/page-objects/reports/reports.wdio.page.js
@@ -8,8 +8,8 @@ const submitterName = () => $('.sender .name');
 const firstReport = () => $(`${reportListID} li:first-child`);
 const reportList = () => $(`${reportListID}`);
 const submitReportButton = () => $('.action-container .general-actions:not(.ng-hide) .fa-plus');
-const formLinkByHref = (href) => {
-  return $(`.action-container .general-actions .dropup.open .dropdown-menu li a[href="#/reports/add/${href}"]`);
+const formActionsLink = (formId) => {
+  return $(`.action-container .general-actions .dropup.open .dropdown-menu li a[href="#/reports/add/${formId}"]`);
 };
 const unreadCount = () => $('#reports-tab .mm-badge');
 
@@ -28,6 +28,6 @@ module.exports = {
   selectedCaseId,
   selectedCaseIdLabel,
   submitReportButton,
-  formLinkByHref,
+  formActionsLink,
   getUnreadCount,
 };

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -289,11 +289,14 @@ export class EnketoService {
         if (loadErrors?.length) {
           return Promise.reject(new Error(JSON.stringify(loadErrors)));
         }
+        const language = options.language;
+        this.currentForm.view.$.on(
+          'click',
+          'button.add-repeat-btn:enabled',
+          () => this.currentForm.langs.setAll(language),
+        );
+        this.currentForm.langs.$formLanguages.val(language).trigger('change');
       })
-      .then(() => this.languageService.get())
-      // TODO remove this when our enketo-core dependency is updated as the latest
-      //      version uses the language passed to the constructor
-      .then((language) => this.currentForm.langs.$formLanguages.val(language).trigger('change'))
       .then(() => this.getFormTitle(titleKey, doc))
       .then((title) => {
         this.setFormTitle(wrapper, title);

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -122,7 +122,7 @@ export class EnketoService {
     return this.getAttachment(doc._id, this.xmlFormsService.findXFormAttachmentName(doc));
   }
 
-  private transformXml(form, language) {
+  private transformXml(form) {
     return Promise
       .all([
         this.getAttachment(form._id, this.HTML_ATTACHMENT_NAME),
@@ -134,25 +134,6 @@ export class EnketoService {
           const $element = $(element);
           $element.text(this.translateService.instant('enketo.' + $element.attr('data-i18n')));
         });
-
-        // TODO remove this when our enketo-core dependency is updated as the latest
-        //      version uses the language passed to the constructor
-        const languages = $html.find('#form-languages option');
-        if (languages.length > 1) { // TODO how do we detect a non-localized form?
-          // for localized forms, change language to user's language
-          $html
-            .find('[lang]')
-            .removeClass('active')
-            .filter('[lang="' + language + '"], [lang=""]')
-            .filter((idx, element) => {
-              // localized forms can support a short and long version for labels
-              // Enketo takes this into account when switching languages
-              // https://opendatakit.github.io/xforms-spec/#languages
-              return !$(element).hasClass('or-form-short') ||
-                ($(element).hasClass('or-form-short') && $(element).siblings( '.or-form-long' ).length === 0 );
-            })
-            .addClass( 'active' );
-        }
 
         const hasContactSummary = $(model).find('> instance[id="contact-summary"]').length === 1;
         return {
@@ -309,6 +290,10 @@ export class EnketoService {
           return Promise.reject(new Error(JSON.stringify(loadErrors)));
         }
       })
+      .then(() => this.languageService.get())
+      // TODO remove this when our enketo-core dependency is updated as the latest
+      //      version uses the language passed to the constructor
+      .then((language) => this.currentForm.langs.$formLanguages.val(language).trigger('change'))
       .then(() => this.getFormTitle(titleKey, doc))
       .then((title) => {
         this.setFormTitle(wrapper, title);
@@ -425,31 +410,29 @@ export class EnketoService {
       valuechangeListener,
     } = formContext;
 
-    return this.languageService.get().then(language => {
-      const $selector = $(selector);
-      return this
-        .transformXml(formDoc, language)
-        .then(doc => {
-          this.replaceJavarosaMediaWithLoaders(formDoc, doc.html);
-          const xmlFormContext: XmlFormContext = {
-            doc,
-            wrapper: $selector,
-            instanceData,
-            titleKey,
-          };
-          return this.renderFromXmls(xmlFormContext);
-        })
-        .then((form) => {
-          const formContainer = $selector.find('.container').first();
-          this.replaceMediaLoaders(formContainer, formDoc);
-          this.registerAddrepeatListener($selector, formDoc);
-          this.registerEditedListener($selector, editedListener);
-          this.registerValuechangeListener($selector, valuechangeListener);
+    const $selector = $(selector);
+    return this
+      .transformXml(formDoc)
+      .then(doc => {
+        this.replaceJavarosaMediaWithLoaders(formDoc, doc.html);
+        const xmlFormContext: XmlFormContext = {
+          doc,
+          wrapper: $selector,
+          instanceData,
+          titleKey,
+        };
+        return this.renderFromXmls(xmlFormContext);
+      })
+      .then((form) => {
+        const formContainer = $selector.find('.container').first();
+        this.replaceMediaLoaders(formContainer, formDoc);
+        this.registerAddrepeatListener($selector, formDoc);
+        this.registerEditedListener($selector, editedListener);
+        this.registerValuechangeListener($selector, valuechangeListener);
 
-          window.CHTCore.debugFormModel = () => form.model.getStr();
-          return form;
-        });
-    });
+        window.CHTCore.debugFormModel = () => form.model.getStr();
+        return form;
+      });
   }
 
   render(selector, form, instanceData, editedListener, valuechangeListener) {

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -89,7 +89,10 @@ describe('Enketo service', () => {
     window.URL.createObjectURL = createObjectURL;
     EnketoForm.returns({
       init: enketoInit,
-      langs: { setAll: () => {} },
+      langs: {
+        setAll: () => {},
+        $formLanguages: $('<select><option value="en">en</option></select>'),
+      },
       calc: { update: () => {} },
       output: { update: () => {} },
     });

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -88,6 +88,9 @@ describe('Enketo service', () => {
     window.EnketoForm = EnketoForm;
     window.URL.createObjectURL = createObjectURL;
     EnketoForm.returns({
+      view: {
+        $: { on: sinon.stub() },
+      },
       init: enketoInit,
       langs: {
         setAll: () => {},


### PR DESCRIPTION
# Description

Trigger a change on Enketo's form language selector, making Enketo swap in the form's inputs corresponding to the user's language.

medic/cht-core#6964

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
