### PR TITLE
Set default password for HA proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - medic-data:/srv
     environment:
       - COUCHDB_HOST=medic-os
-      - HA_PASSWORD=password
+      - HA_PASSWORD=${DOCKER_COUCHDB_ADMIN_PASSWORD:-password}
     networks:
       - medic-net
 


### PR DESCRIPTION


# Description

The HA proxy password should match with the docker CouchDB admin password.



# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
