### PR TITLE
Replace authenticated env var.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,8 @@ env:
   COUCH_NODE_NAME: nonode@nohost
   BUILDS_SERVER: _couch/builds_testing
   STAGING_SERVER: _couch/builds
-  MARKET_URL: ${{ secrets.MARKET_URL }}
+  AUTH_MARKET_URL: ${{ secrets.MARKET_URL }}
+  MARKET_URL: https://staging.dev.medicmobile.org
 
 jobs:
   build:
@@ -26,7 +27,7 @@ jobs:
       if: steps.get-docker-hub-username.outputs.dockerhub_username
     - name: Set MARKET_URL var for external users
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
+          echo "AUTH_MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}
@@ -98,9 +99,6 @@ jobs:
     needs: build
     name: e2e Integration Tests for Node version ${{ matrix.node-version }}
     runs-on: ubuntu-18.04
-
-    env: 
-      MARKET_URL: https://staging.dev.medicmobile.org
 
     strategy:
       matrix:
@@ -177,9 +175,6 @@ jobs:
     needs: build
     name: e2e Tests for Node version ${{ matrix.node-version }}
     runs-on: ubuntu-18.04
-
-    env: 
-      MARKET_URL: https://staging.dev.medicmobile.org
 
     strategy:
       matrix:
@@ -260,9 +255,6 @@ jobs:
     strategy:
       matrix:
         node-version: [8.x, 10.x, 12.x]
-    
-    env: 
-      MARKET_URL: https://staging.dev.medicmobile.org
 
     steps:
     - name: Get Docker Hub username
@@ -336,9 +328,6 @@ jobs:
     name: Publish branch build
     runs-on: ubuntu-18.04
 
-    env: 
-      MARKET_URL: https://staging.dev.medicmobile.org
-
     steps:
     - uses: actions/checkout@v2
     - name: Set MARKET_URL var for external users
@@ -368,9 +357,6 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-    
-    env: 
-      MARKET_URL: https://staging.dev.medicmobile.org
 
     steps:
     - name: Get Docker Hub username
@@ -444,9 +430,6 @@ jobs:
       matrix:
         node-version: [12.x]
         config-type: [default, standard]
-
-    env: 
-      MARKET_URL: https://staging.dev.medicmobile.org
 
     steps:
     - name: Get Docker Hub username

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,9 @@ jobs:
     name: e2e Integration Tests for Node version ${{ matrix.node-version }}
     runs-on: ubuntu-18.04
 
+    env: 
+      MARKET_URL: https://staging.dev.medicmobile.org
+
     strategy:
       matrix:
         node-version: [8.x, 10.x, 12.x]
@@ -119,7 +122,6 @@ jobs:
         echo "TEST_SUITE=integration" >> $GITHUB_ENV
     - name: Set UPLOARD_URL var
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}
@@ -176,6 +178,9 @@ jobs:
     name: e2e Tests for Node version ${{ matrix.node-version }}
     runs-on: ubuntu-18.04
 
+    env: 
+      MARKET_URL: https://staging.dev.medicmobile.org
+
     strategy:
       matrix:
         node-version: [8.x, 10.x, 12.x]
@@ -196,7 +201,6 @@ jobs:
         echo "TEST_SUITE=integration" >> $GITHUB_ENV
     - name: Set UPLOARD_URL var
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}
@@ -256,6 +260,9 @@ jobs:
     strategy:
       matrix:
         node-version: [8.x, 10.x, 12.x]
+    
+    env: 
+      MARKET_URL: https://staging.dev.medicmobile.org
 
     steps:
     - name: Get Docker Hub username
@@ -273,7 +280,6 @@ jobs:
         echo "TEST_SUITE=integration" >> $GITHUB_ENV
     - name: Set UPLOARD_URL var
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}
@@ -330,11 +336,13 @@ jobs:
     name: Publish branch build
     runs-on: ubuntu-18.04
 
+    env: 
+      MARKET_URL: https://staging.dev.medicmobile.org
+
     steps:
     - uses: actions/checkout@v2
     - name: Set MARKET_URL var for external users
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}
@@ -360,6 +368,9 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+    
+    env: 
+      MARKET_URL: https://staging.dev.medicmobile.org
 
     steps:
     - name: Get Docker Hub username
@@ -377,7 +388,6 @@ jobs:
         echo "TEST_SUITE=integration" >> $GITHUB_ENV
     - name: Set MARKET_URL var for external users
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}
@@ -433,7 +443,9 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        config-type: [default, standard]
+
+    env: 
+      MARKET_URL: https://staging.dev.medicmobile.org
 
     steps:
     - name: Get Docker Hub username
@@ -451,7 +463,6 @@ jobs:
         echo "TEST_SUITE=integration" >> $GITHUB_ENV
     - name: Set MARKET_URL var for external users
       run: |
-          echo "MARKET_URL=https://staging.dev.medicmobile.org" >> $GITHUB_ENV
           echo "BUILDS_SERVER=_couch/builds_external" >> $GITHUB_ENV
           echo "STAGING_SERVER=_couch/builds_external" >> $GITHUB_ENV
       if:  ${{ !env.MARKET_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,6 +443,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+        config-type: [default, standard]
 
     env: 
       MARKET_URL: https://staging.dev.medicmobile.org

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
         files: [
           {
             src: 'build/ddocs/medic.json',
-            dest: `${MARKET_URL}/${STAGING_SERVER}`,
+            dest: `${AUTH_MARKET_URL}/${STAGING_SERVER}`,
           },
         ],
       },
@@ -144,7 +144,7 @@ module.exports = function(grunt) {
         files: [
           {
             src: 'build/ddocs/medic.json',
-            dest: `${MARKET_URL}/${BUILDS_SERVER}`,
+            dest: `${AUTH_MARKET_URL}/${BUILDS_SERVER}`,
           },
         ],
       }

--- a/scripts/travis/publish.js
+++ b/scripts/travis/publish.js
@@ -2,7 +2,7 @@
  * Publish the ddoc from the testing db to staging.
  */
 const {
-  MARKET_URL,
+  AUTH_MARKET_URL,
   TRAVIS_BUILD_NUMBER,
   BUILDS_SERVER,
   STAGING_SERVER,
@@ -18,8 +18,8 @@ if (!releaseName) {
   process.exit(0);
 }
 
-const testingDb = new PouchDB(`${MARKET_URL}/${BUILDS_SERVER}`);
-const stagingDb = new PouchDB(`${MARKET_URL}/${STAGING_SERVER}`);
+const testingDb = new PouchDB(`${AUTH_MARKET_URL}/${BUILDS_SERVER}`);
+const stagingDb = new PouchDB(`${AUTH_MARKET_URL}/${STAGING_SERVER}`);
 
 const testingDocId = `medic:medic:test-${TRAVIS_BUILD_NUMBER}`;
 const stagingDocId = `medic:medic:${releaseName}`;


### PR DESCRIPTION
# Description

Setting new env var name for authenticated market url. Setting a static var for any other access. 

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
