### PR TITLE
Bump version to 3.12.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -466,8 +466,8 @@ module.exports = function(grunt) {
       'start-webdriver': {
         cmd:
           'mkdir -p tests/logs && ' +
-          './node_modules/.bin/webdriver-manager update --versions.chrome 90.0.4430.24 && ' +
-          './node_modules/.bin/webdriver-manager start --versions.chrome 90.0.4430.24 > tests/logs/webdriver.log & ' +
+          './node_modules/.bin/webdriver-manager update && ' +
+          './node_modules/.bin/webdriver-manager start > tests/logs/webdriver.log & ' +
           'until nc -z localhost 4444; do sleep 1; done',
       },
       'start-webdriver-ci': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "medic",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medic",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {

--- a/scripts/e2e/start_webdriver.sh
+++ b/scripts/e2e/start_webdriver.sh
@@ -2,7 +2,6 @@ mkdir -p tests/logs &&
 CHROME_VERSION=`google-chrome-stable --version | grep -Po '(\d+)(?=\.\d+\.\d+\.\d+)'` &&
 echo 'Detected chrome version ' $CHROME_VERSION &&
 CHROMEDRIVER_VERSION=$(curl -sS https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION) &&
-CHROMEDRIVER_VERSION="90.0.4430.24" # temporary fix because of regression in driver v91
 echo 'Getting Chrome driver version ' $CHROMEDRIVER_VERSION &&
 ./node_modules/.bin/webdriver-manager update --versions.chrome $CHROMEDRIVER_VERSION &&
 ./node_modules/.bin/webdriver-manager start --versions.chrome $CHROMEDRIVER_VERSION > tests/logs/webdriver.log &


### PR DESCRIPTION
# Description

This PR:
- Bumps version to 3.12.1
- Removes hard coded CHROMEDRIVER_VERSION

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
