### PR TITLE
Message in the error logs when xsltproc is not found

### DIFF
--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -38,14 +38,14 @@ const transform = (formXml, stylesheet) => {
     xsltproc.stderr.on('data', data => stderr += data);
     xsltproc.stdin.setEncoding('utf-8');
     xsltproc.stdin.on('error', err => {
-      // Errors related with spawned process and stdin are handled here on OSX
+      // Errors related with spawned processes and stdin are handled here on OSX
       return stdinErrorHandler(xsltproc, err, reject);
     });
     try {
       xsltproc.stdin.write(formXml);
       xsltproc.stdin.end();
     } catch (err) {
-      // Errors related with spawned process and stdin are handled here on *nix
+      // Errors related with spawned processes and stdin are handled here on *nix
       return stdinErrorHandler(xsltproc, err, reject);
     }
     xsltproc.on('close', (code, signal) => {

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -37,7 +37,7 @@ const transform = (formXml, stylesheet) => {
     xsltproc.stdout.on('data', data => stdout += data);
     xsltproc.stderr.on('data', data => stderr += data);
     xsltproc.stdin.setEncoding('utf-8');
-    xsltproc.stdin.on('error', (err) => {
+    xsltproc.stdin.on('error', err => {
       // Errors related with spawned process and stdin are handled here on OSX
       return stdinErrorHandler(xsltproc, err, reject);
     });

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -30,7 +30,8 @@ const transform = (formXml, stylesheet) => {
       xsltproc.stdin.write(formXml);
     } catch (err) {
       if (err.code === 'EPIPE') {
-        return reject(new Error(`Command ${XSLTPROC_CMD} not found`));
+        return reject(
+          new Error(`Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`));
       }
       logger.error(err);
       return reject(new Error(`Unknown error calling ${XSLTPROC_CMD}`));

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -18,6 +18,17 @@ const FORM_STYLESHEET = path.join(__dirname, '../xsl/openrosa2html5form.xsl');
 const MODEL_STYLESHEET = path.join(__dirname, '../../node_modules/enketo-xslt/xsl/openrosa2xmlmodel.xsl');
 const XSLTPROC_CMD = 'xsltproc';
 
+const stdinErrorHandler = function (xsltproc, err, reject) {
+  xsltproc.stdin.end();
+  if (err.code === 'EPIPE') {
+    const errMsg = `Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`;
+    logger.error(errMsg);
+    return reject(new Error(errMsg));
+  }
+  logger.error(err);
+  return reject(new Error(`Unknown Error: An error occurred when executing '${XSLTPROC_CMD}' command`));
+};
+
 const transform = (formXml, stylesheet) => {
   return new Promise((resolve, reject) => {
     const xsltproc = childProcess.spawn(XSLTPROC_CMD, [ stylesheet, '-' ]);
@@ -26,17 +37,16 @@ const transform = (formXml, stylesheet) => {
     xsltproc.stdout.on('data', data => stdout += data);
     xsltproc.stderr.on('data', data => stderr += data);
     xsltproc.stdin.setEncoding('utf-8');
+    xsltproc.stdin.on('error', (err) => {
+      // Errors related with spawned process and stdin are handled here on OSX
+      return stdinErrorHandler(xsltproc, err, reject);
+    });
     try {
       xsltproc.stdin.write(formXml);
-    } catch (err) {
-      if (err.code === 'EPIPE') {
-        const errMsg = `Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`;
-        return reject(new Error(errMsg));
-      }
-      logger.error(err);
-      return reject(new Error(`Unknown Error: An error occurred when executing '${XSLTPROC_CMD}' command`));
-    } finally {
       xsltproc.stdin.end();
+    } catch (err) {
+      // Errors related with spawned process and stdin are handled here on *nix
+      return stdinErrorHandler(xsltproc, err, reject);
     }
     xsltproc.on('close', (code, signal) => {
       if (code !== 0 || signal || stderr.length) {

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -34,7 +34,7 @@ const transform = (formXml, stylesheet) => {
           new Error(`Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`));
       }
       logger.error(err);
-      return reject(new Error(`Unknown error calling ${XSLTPROC_CMD}`));
+      return reject(new Error(`Unknown Error: An error occurred when executing '${XSLTPROC_CMD}' command`));
     } finally {
       xsltproc.stdin.end();
     }

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -30,8 +30,8 @@ const transform = (formXml, stylesheet) => {
       xsltproc.stdin.write(formXml);
     } catch (err) {
       if (err.code === 'EPIPE') {
-        return reject(
-          new Error(`Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`));
+        const errMsg = `Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`;
+        return reject(new Error(errMsg));
       }
       logger.error(err);
       return reject(new Error(`Unknown Error: An error occurred when executing '${XSLTPROC_CMD}' command`));

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -102,19 +102,16 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('errors if xsltproc command not found', async () => {
+    it('should fail when xsltproc command not found', async () => {
       try {
         const writeErr = new Error('Error: write EPIPE');
         writeErr.code = 'EPIPE';
         const spawnedEpipe = {
-          stdout: { on: sinon.stub() },
-          stderr: { on: sinon.stub() },
+          ...spawned,
           stdin: {
-            setEncoding: sinon.stub(),
+            ...spawned.stdin,
             write: sinon.stub().throws(writeErr),
-            end: sinon.stub()
-          },
-          on: sinon.stub()
+          }
         };
         await runTest('simple', spawnedEpipe, null, false);
         assert.fail('expected error to be thrown');
@@ -124,17 +121,14 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('errors if xsltproc raises unknown exception', async () => {
+    it('should fail when xsltproc raises unknown exception', async () => {
       try {
         const spawnedUnknownWriteErr = {
-          stdout: { on: sinon.stub() },
-          stderr: { on: sinon.stub() },
+          ...spawned,
           stdin: {
-            setEncoding: sinon.stub(),
+            ...spawned.stdin,
             write: sinon.stub().throws('mystery error'),
-            end: sinon.stub()
-          },
-          on: sinon.stub()
+          }
         };
         await runTest('simple', spawnedUnknownWriteErr, null, false);
         assert.fail('expected error to be thrown');

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -107,11 +107,14 @@ describe('generate-xform service', () => {
         const writeErr = new Error('Error: write EPIPE');
         writeErr.code = 'EPIPE';
         const spawnedEpipe = {
-          ...spawned,
+          stdout: { on: sinon.stub() },
+          stderr: { on: sinon.stub() },
           stdin: {
-            ...spawned.stdin,
+            setEncoding: sinon.stub(),
             write: sinon.stub().throws(writeErr),
-          }
+            end: sinon.stub()
+          },
+          on: sinon.stub()
         };
         await runTest('simple', spawnedEpipe, null, false);
         assert.fail('expected error to be thrown');
@@ -124,11 +127,14 @@ describe('generate-xform service', () => {
     it('should fail when xsltproc raises unknown exception', async () => {
       try {
         const spawnedUnknownWriteErr = {
-          ...spawned,
+          stdout: { on: sinon.stub() },
+          stderr: { on: sinon.stub() },
           stdin: {
-            ...spawned.stdin,
+            setEncoding: sinon.stub(),
             write: sinon.stub().throws('mystery error'),
-          }
+            end: sinon.stub()
+          },
+          on: sinon.stub()
         };
         await runTest('simple', spawnedUnknownWriteErr, null, false);
         assert.fail('expected error to be thrown');

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -100,12 +100,12 @@ describe('generate-xform service', () => {
 
     it('errors if xsltproc command not found', async () => {
       try {
-        const err = new Error('Command xsltproc not found');
+        const err = new Error('Error: write EPIPE');
         err.code = 'EPIPE';
         await runTest('simple', null, err);
         assert.fail('expected error to be thrown');
       } catch (err) {
-        expect(err.message).to.equal('Command xsltproc not found');
+        expect(err.message).to.equal('Error: write EPIPE');
       }
     });
 

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -84,13 +84,13 @@ describe('generate-xform service', () => {
       });
     };
 
-    it('generates form and model', () => runTest('simple', spawned));
+    it('should generates form and model', () => runTest('simple', spawned));
 
-    it('replaces multimedia src elements', () => runTest('multimedia', spawned));
+    it('should replaces multimedia src elements', () => runTest('multimedia', spawned));
 
-    it('correctly replaces models with nested "</root>" - #5971', () => runTest('nested-root', spawned));
+    it('should correctly replaces models with nested "</root>" - #5971', () => runTest('nested-root', spawned));
 
-    it('errors if child process errors', async () => {
+    it('should fail when child process errors', async () => {
       try {
         await runTest('simple', spawned, 'some error');
         assert.fail('expected error to be thrown');
@@ -147,7 +147,7 @@ describe('generate-xform service', () => {
 
   describe('update', () => {
 
-    it('errors if no form found', done => {
+    it('should fail when no form found', done => {
       sinon.stub(db.medic, 'get').rejects('boom');
       service.update('form:missing')
         .then(() => done(new Error('expected error to be thrown')))
@@ -159,7 +159,7 @@ describe('generate-xform service', () => {
         });
     });
 
-    it('does nothing if doc does not have form attachment', () => {
+    it('should do nothing when doc does not have form attachment', () => {
       sinon.stub(db.medic, 'get').resolves({ _attachments: { image: {} } });
       sinon.stub(db.medic, 'put');
       return service.update('form:exists').then(() => {
@@ -168,7 +168,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('does nothing if the attachments are up to date', () => {
+    it('should do nothing when the attachments are up to date', () => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const currentModel = '<xml/>';
@@ -186,7 +186,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('updates doc if attachments do not exist', () => {
+    it('should update doc when attachments do not exist', () => {
       const formXml = '<my-xml/>';
       const newForm = '<html><title>Hello</title></html>';
       const newModel = '<instance><multimedia/></instance>';
@@ -201,7 +201,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('updates doc if attachments have changed', () => {
+    it('should update doc when attachments have changed', () => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const newForm = '<html><title>Hello</title></html>';
@@ -238,7 +238,7 @@ describe('generate-xform service', () => {
       }
     };
 
-    it('handles no forms', () => {
+    it('should handle no forms', () => {
       sinon.stub(db.medic, 'query').resolves({ rows: [] });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
@@ -247,7 +247,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('ignores json forms', () => {
+    it('should ignore json forms', () => {
       sinon.stub(db.medic, 'query').resolves({ rows: [ JSON_FORM_ROW ] });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
@@ -256,7 +256,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('ignores collect forms', () => {
+    it('should ignore collect forms', () => {
       sinon.stub(db.medic, 'query').resolves({ rows: [ COLLECT_FORM_ROW ] });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
@@ -265,7 +265,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('does nothing if no forms have changed', () => {
+    it('should do nothing when no forms have changed', () => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const currentModel = '<xml/>';
@@ -284,7 +284,7 @@ describe('generate-xform service', () => {
       });
     });
 
-    it('throws if not all updated successfully', done => {
+    it('should throw when not all updated successfully', done => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const newForm = '<html><title>Hello</title></html>';
@@ -312,7 +312,7 @@ describe('generate-xform service', () => {
         });
     });
 
-    it('saves all updated forms', () => {
+    it('should save all updated forms', () => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const newForm = '<html><title>Hello</title></html>';

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -84,9 +84,9 @@ describe('generate-xform service', () => {
       });
     };
 
-    it('should generates form and model', () => runTest('simple', spawned));
+    it('should generate form and model', () => runTest('simple', spawned));
 
-    it('should replaces multimedia src elements', () => runTest('multimedia', spawned));
+    it('should replace multimedia src elements', () => runTest('multimedia', spawned));
 
     it('should correctly replaces models with nested "</root>" - #5971', () => runTest('nested-root', spawned));
 


### PR DESCRIPTION
# Description

Add clear message in the error logs when the command `xsltproc` used to process forms is not found.

medic/cht-core#6674

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
