### PR TITLE
Fix flaking contact summary test

### DIFF
--- a/webapp/tests/karma/ts/services/contact-summary.service.spec.ts
+++ b/webapp/tests/karma/ts/services/contact-summary.service.spec.ts
@@ -152,8 +152,7 @@ describe('ContactSummary service', () => {
         expect(consoleErrorMock.callCount).to.equal(1);
         expect(consoleErrorMock.args[0][0].startsWith('Configuration error in contact-summary')).to.be.true;
         expect(feedbackService.submit.callCount).to.equal(1);
-        expect(feedbackService.submit.args[0][0])
-          .to.equal('Configuration error in contact-summary function: Cannot read property \'field\' of undefined');
+        expect(feedbackService.submit.args[0][0].startsWith('Configuration error in contact-summary')).to.be.true;
       });
   });
 


### PR DESCRIPTION
# Description

Fixes the  contact summary unit test that started failing because it was asserting the text of an error message that originated from the browser (and so changes to the wording of the error message from the browser could cause the test to fail).  

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
