### PR TITLE
Fixes one flaky unit test and one flaky e2e test

### DIFF
--- a/admin/src/js/controllers/forms-xml.js
+++ b/admin/src/js/controllers/forms-xml.js
@@ -108,10 +108,11 @@ angular.module('controllers').controller('FormsXmlCtrl',
         return uploadFinished(new Error('JSON meta file not found'));
       }
 
-      $q.all([
-        FileReader.utf8(formFiles[0]),
-        FileReader.utf8(metaFiles[0]).then(JsonParse)
-      ])
+      return $q
+        .all([
+          FileReader.utf8(formFiles[0]),
+          FileReader.utf8(metaFiles[0]).then(JsonParse),
+        ])
         .then(results => {
           const xml = results[0];
           const meta = results[1];
@@ -123,7 +124,8 @@ angular.module('controllers').controller('FormsXmlCtrl',
           return ValidateForm(xml)
             .then(() => {
               const couchId = 'form:' + formId;
-              return DB().get(couchId, { include_attachments:true })
+              return DB()
+                .get(couchId, { include_attachments:true })
                 .catch(err => {
                   if (err.status === 404) {
                     return { _id: couchId };

--- a/tests/e2e/tasks/tasks-group.wdio-spec.js
+++ b/tests/e2e/tasks/tasks-group.wdio-spec.js
@@ -292,6 +292,7 @@ describe('Tasks group landing page', () => {
       await expectTasksGroupLeaveModal();
       await (await modalPage.confirm()).click();
       await (await contactsPage.contactList()).waitForDisplayed();
+      await (await commonPage.waitForLoaders());
     });
 
     it('should not show page when there are no more household tasks', async () => {


### PR DESCRIPTION
# Description

Switches to returning and waiting for promises before assertions in admin unit test. 
Waits for the homeplace contact to load before switching to next test in tasks-group e2e test. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
