### PR TITLE
Fix CI running twice

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: Build cht-core and test against node versions
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
 
 env:
   COUCH_URL: http://admin:pass@localhost:5984/medic-test


### PR DESCRIPTION
Github triggers 2 jobs when we push commits in a pull request. This PR changes the default behavior:

- When changes are pushed in a PR only run once
- Only run when commits are pushed to `master` if there is no PR
- Skip CI when only `**.md` files are affected

The changes only affect the "build" workflow, not affecting others defined under the `.github/` folder.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
