### PR TITLE
Fix missed xsltproc error in different node versions

### DIFF
--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -21,7 +21,7 @@ const XSLTPROC_CMD = 'xsltproc';
 const processErrorHandler = function (xsltproc, err, reject) {
   xsltproc.stdin.end();
   if (err.code === 'EPIPE'                                                    // Node v10-12-14
-      || (err.code === 'ENOENT' && err.syscall === `spawn ${XSLTPROC_CMD}`)   // Node v8,v16
+      || (err.code === 'ENOENT' && err.syscall === `spawn ${XSLTPROC_CMD}`)   // Node v8,v16+
   ) {
     const errMsg = `Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`;
     logger.error(errMsg);

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -20,7 +20,7 @@ const XSLTPROC_CMD = 'xsltproc';
 
 const processErrorHandler = (xsltproc, err, reject) => {
   xsltproc.stdin.end();
-  if (err.code === 'EPIPE'                                                    // Node v10-12-14
+  if (err.code === 'EPIPE'                                                    // Node v10,v12,v14
       || (err.code === 'ENOENT' && err.syscall === `spawn ${XSLTPROC_CMD}`)   // Node v8,v16+
   ) {
     const errMsg = `Unable to continue execution, check that '${XSLTPROC_CMD}' command is available.`;
@@ -64,7 +64,7 @@ const transform = (formXml, stylesheet) => {
       resolve(stdout);
     });
     xsltproc.on('error', err => {
-      // Errors related with spawned processes are handled here on Node v8, v14, v16+
+      // Errors related with spawned processes are handled here on Node v8,v14,v16+
       return processErrorHandler(xsltproc, err, reject);
     });
   });

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -18,7 +18,7 @@ const FORM_STYLESHEET = path.join(__dirname, '../xsl/openrosa2html5form.xsl');
 const MODEL_STYLESHEET = path.join(__dirname, '../../node_modules/enketo-xslt/xsl/openrosa2xmlmodel.xsl');
 const XSLTPROC_CMD = 'xsltproc';
 
-const processErrorHandler = function (xsltproc, err, reject) {
+const processErrorHandler = (xsltproc, err, reject) => {
   xsltproc.stdin.end();
   if (err.code === 'EPIPE'                                                    // Node v10-12-14
       || (err.code === 'ENOENT' && err.syscall === `spawn ${XSLTPROC_CMD}`)   // Node v8,v16+

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -243,6 +243,7 @@ describe('generate-xform service', () => {
           'Unknown Error: An error occurred when executing \'xsltproc\' command');
       }
     });
+
   });
 
   describe('update', () => {

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -110,7 +110,7 @@ describe('generate-xform service', () => {
 
     it('should fail when xsltproc command not found in Node v8 and v16+', async () => {
       try {
-        const errOn = new Error('Error: unknown');
+        const errOn = new Error('Error: ENOENT');
         errOn.code = 'ENOENT';
         errOn.syscall = 'spawn xsltproc';
         const spawnedEpipe = {
@@ -180,7 +180,7 @@ describe('generate-xform service', () => {
 
     it('should fail when xsltproc command not found in Node v14', async () => {
       try {
-        const errOn = new Error('Error: unknown');
+        const errOn = new Error('Error: some EPIPE');
         errOn.code = 'EPIPE';
         const spawnedEpipe = {
           stdout: { on: sinon.stub() },
@@ -201,7 +201,7 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('should fail when xsltproc raises write error', async () => {
+    it('should fail when xsltproc raises unknown write error', async () => {
       try {
         const writeErr = new Error('Error: unknown');
         const spawnedEpipe = {
@@ -223,7 +223,7 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('should fail when xsltproc raises stdin write exception', async () => {
+    it('should fail when xsltproc raises unknown exception', async () => {
       try {
         const spawnedUnknownWriteErr = {
           stdout: { on: sinon.stub() },

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -64,7 +64,7 @@ describe('generate-xform service', () => {
       });
     };
 
-    const runTest = (dirname, spawned, stdErr, errIn, successClose = true) => {
+    const runTest = (dirname, spawned, stdErr, errIn, errOn, successClose = true) => {
       sinon.stub(childProcess, 'spawn').returns(spawned);
       return setup(dirname).then(files => {
         const generate = service.generate(files.xform);
@@ -74,6 +74,8 @@ describe('generate-xform service', () => {
         } else if (errIn) {
           spawned.stdin.on.args[0][1](errIn);
           spawned.on.args[0][1](100);
+        } else if (errOn) {
+          spawned.on.args[1][1](errOn);
         } else if (successClose) {
           // child process outputs then closes with code 0
           spawned.stdout.on.args[0][1](files.givenForm);
@@ -106,7 +108,54 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('should fail when xsltproc command not found', async () => {
+    it('should fail when xsltproc command not found in Node v8 and v16+', async () => {
+      try {
+        const errOn = new Error('Error: unknown');
+        errOn.code = 'ENOENT';
+        errOn.syscall = 'spawn xsltproc';
+        const spawnedEpipe = {
+          stdout: { on: sinon.stub() },
+          stderr: { on: sinon.stub() },
+          stdin: {
+            setEncoding: sinon.stub(),
+            write: sinon.stub(),
+            end: sinon.stub(),
+            on: sinon.stub()
+          },
+          on: sinon.stub()
+        };
+        await runTest('simple', spawnedEpipe, null, null, errOn, false);
+        assert.fail('expected error to be thrown');
+      } catch (err) {
+        expect(err.message).to.equal(
+          'Unable to continue execution, check that \'xsltproc\' command is available.');
+      }
+    });
+
+    it('should fail when xsltproc command not found in Node v10', async () => {
+      try {
+        const writeErr = new Error('Error: write EPIPE');
+        writeErr.code = 'EPIPE';
+        const spawnedErr = {
+          stdout: { on: sinon.stub() },
+          stderr: { on: sinon.stub() },
+          stdin: {
+            setEncoding: sinon.stub(),
+            write: sinon.stub().throws(writeErr),
+            end: sinon.stub(),
+            on: sinon.stub(),
+          },
+          on: sinon.stub()
+        };
+        await runTest('simple', spawnedErr, null, null, null, false);
+        assert.fail('expected error to be thrown');
+      } catch (err) {
+        expect(err.message).to.equal(
+          'Unable to continue execution, check that \'xsltproc\' command is available.');
+      }
+    });
+
+    it('should fail when xsltproc command not found in Node v12', async () => {
       try {
         const writeErr = new Error('Error: write EPIPE');
         writeErr.code = 'EPIPE';
@@ -121,7 +170,7 @@ describe('generate-xform service', () => {
           },
           on: sinon.stub()
         };
-        await runTest('simple', spawnedEpipe, null, null, false);
+        await runTest('simple', spawnedEpipe, null, null, null, false);
         assert.fail('expected error to be thrown');
       } catch (err) {
         expect(err.message).to.equal(
@@ -129,7 +178,30 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('should fail when xsltproc command not found also in OSX', async () => {
+    it('should fail when xsltproc command not found in Node v14', async () => {
+      try {
+        const errOn = new Error('Error: unknown');
+        errOn.code = 'EPIPE';
+        const spawnedEpipe = {
+          stdout: { on: sinon.stub() },
+          stderr: { on: sinon.stub() },
+          stdin: {
+            setEncoding: sinon.stub(),
+            write: sinon.stub(),
+            end: sinon.stub(),
+            on: sinon.stub()
+          },
+          on: sinon.stub()
+        };
+        await runTest('simple', spawnedEpipe, null, null, errOn, false);
+        assert.fail('expected error to be thrown');
+      } catch (err) {
+        expect(err.message).to.equal(
+          'Unable to continue execution, check that \'xsltproc\' command is available.');
+      }
+    });
+
+    it('should fail when xsltproc raises write error', async () => {
       try {
         const writeErr = new Error('Error: unknown');
         const spawnedEpipe = {
@@ -151,7 +223,7 @@ describe('generate-xform service', () => {
       }
     });
 
-    it('should fail when xsltproc raises unknown exception', async () => {
+    it('should fail when xsltproc raises stdin write exception', async () => {
       try {
         const spawnedUnknownWriteErr = {
           stdout: { on: sinon.stub() },
@@ -164,7 +236,7 @@ describe('generate-xform service', () => {
           },
           on: sinon.stub()
         };
-        await runTest('simple', spawnedUnknownWriteErr, null, null, false);
+        await runTest('simple', spawnedUnknownWriteErr, null, null, null, false);
         assert.fail('expected error to be thrown');
       } catch (err) {
         expect(err.message).to.equal(


### PR DESCRIPTION
# Description

Provide a clear message when the command `xsltproc` doesn't exist. This same problem was addressed in https://github.com/medic/cht-core/pull/7301 , but the workaround doesn't work in Node v8, and Node v14+, so improvements were made to also catch the errors properly in these versions.

medic/cht-core#6674

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
