### PR TITLE
Renaming medicConfPath per cht-conf#407

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -578,7 +578,7 @@ module.exports = function(grunt) {
       'audit-whitelist': { cmd: 'git diff $(cat .auditignore | git hash-object -w --stdin) $(node ./scripts/audit-all.js | git hash-object -w --stdin) --word-diff --exit-code' },
       'build-config': {
         cmd: () => {
-          const medicConfPath = path.resolve('./node_modules/medic-conf/src/bin/medic-conf.js');
+          const medicConfPath = path.resolve('./node_modules/medic-conf/src/bin/index.js');
           const configPath = path.resolve('./config/default');
           const buildPath = path.resolve('./build/ddocs/medic/_attachments/default-docs');
           const actions = ['upload-app-settings', 'upload-app-forms', 'upload-collect-forms', 'upload-contact-forms', 'upload-resources', 'upload-custom-translations'];


### PR DESCRIPTION
See https://github.com/medic/cht-conf/pull/407/files?file-filters%5B%5D=.bash&file-filters%5B%5D=.js#diff-9fb0cafd0671851ff59bb0591653e31131cd684de662a052646d2d4976bd46f5

# Description

This file path was never updated.

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
