### PR TITLE
Pause video and audio when nav to next and prev pages in a form

### DIFF
--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -331,17 +331,17 @@ export class EnketoService {
     $wrapper
       .find('.btn.next-page')
       .off('.pagemode')
-      .on('click.pagemode',() => {
-
+      .on('click.pagemode', () => {
         form.pages
           ._next()
-          .then((valid) => {
-            if(valid) {
+          .then(valid => {
+            if (valid) {
               const currentIndex = form.pages._getCurrentIndex();
-              if(typeof currentIndex === 'number') {
+              if (typeof currentIndex === 'number') {
                 window.history.pushState({ enketo_page_number: currentIndex }, '');
               }
               this.setupNavButtons($wrapper, currentIndex);
+              this.pauseMultimedia($wrapper);
             }
             this.forceRecalculate(form);
           });
@@ -355,8 +355,15 @@ export class EnketoService {
         window.history.back();
         this.setupNavButtons($wrapper, form.pages._getCurrentIndex() - 1);
         this.forceRecalculate(form);
+        this.pauseMultimedia($wrapper);
         return false;
       });
+  }
+
+  private pauseMultimedia($wrapper) {
+    $wrapper
+      .find('audio, video')
+      .each((idx, element) => element.pause());
   }
 
   private addPopStateHandler(form, $wrapper) {
@@ -671,7 +678,7 @@ export class EnketoService {
   }
 
   private setupNavButtons($wrapper, currentIndex) {
-    if(this.currentForm.pages) {
+    if(this.currentForm?.pages) {
       const lastIndex = this.currentForm.pages.activePages.length - 1;
       const footer = $wrapper.find('.form-footer');
       footer.removeClass('end');


### PR DESCRIPTION
# Description

Pausing multimedia (video and audio) when navigating to the form's next/previous page. 

NOTE: This PR will be merged into `master` after `6345-enketo-uplift` branch is merged. 

https://github.com/medic/cht-core/issues/6589

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
