### PR TITLE
Add a common after hook. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ config/*/forms/contact/*.xlsx
 /**/*/.snapshots/local.json
 tests/integration/results/
 allure*
+tests/config-temp

--- a/tests/e2e/contacts/new-lineage-structure.wdio-spec.js
+++ b/tests/e2e/contacts/new-lineage-structure.wdio-spec.js
@@ -3,7 +3,6 @@ const chai = require('chai');
 const contactPage = require('../../page-objects/contacts/contacts.wdio.page');
 const loginPage = require('../../page-objects/login/login.wdio.page');
 const commonPage = require('../../page-objects/common/common.wdio.page');
-const utils = require('../../utils');
 const sentinelUtils = require('../sentinel/utils');
 
 const centerName = 'Franklin';
@@ -18,10 +17,6 @@ describe('Create new lineage structure', () => {
     await loginPage.cookieLogin();
     await commonPage.hideSnackbar();
     await commonPage.goToPeople();
-  });
-
-  after(async () => {
-    await utils.revertDb([], true);
   });
 
   afterEach(async () => {

--- a/tests/e2e/contacts/person-under-area.wdio-spec.js
+++ b/tests/e2e/contacts/person-under-area.wdio-spec.js
@@ -49,10 +49,6 @@ describe('Create Person Under Area', async () => {
     await loginPage.cookieLogin();
   });
 
-  afterEach(async () => {
-    await utils.revertDb([], true);
-  });
-
   it('create person under area should only see children', async () => {
     await usersAdminPage.goToAdminUser();
     await usersAdminPage.openAddUserDialog();

--- a/tests/e2e/login/db-sync.wdio-spec.js
+++ b/tests/e2e/login/db-sync.wdio-spec.js
@@ -204,11 +204,6 @@ describe('db-sync', () => {
     await (await commonElements.analyticsTab()).waitForDisplayed();
   });
 
-  after(async () => {
-    await utils.revertDb([], true);
-    await utils.deleteUsers([restrictedUserName]);
-  });
-
   it('should not filter allowed docs', async () => {
     await updateDoc(report1, { extra: '1' });
     await updateDoc(report2, { extra: '2' });

--- a/tests/e2e/release/cht-config/generate-short-codes.wdio-spec.js
+++ b/tests/e2e/release/cht-config/generate-short-codes.wdio-spec.js
@@ -42,8 +42,6 @@ describe('generating short codes', () => {
     await loginPage.cookieLogin();
   });
 
-  after(async () => await utils.revertDb([], true));
-
   it('create case ID', async () => {
     await utils.request({
       method: 'POST',

--- a/tests/e2e/search/search-contacts.wdio-spec.js
+++ b/tests/e2e/search/search-contacts.wdio-spec.js
@@ -58,10 +58,6 @@ describe('Test Contact Search Functionality', async () => {
     await commonPage.goToPeople();
   });
 
-  after(async () => {
-    await utils.revertDb([], true);
-  });
-
   it('search by NON empty string should display results with contains match and clears search', async () => {
     // Waiting for initial load
     await contactPage.getAllLHSContactsNames();

--- a/tests/e2e/search/search-reports.wdio-spec.js
+++ b/tests/e2e/search/search-reports.wdio-spec.js
@@ -97,10 +97,6 @@ describe('Test Reports Search Functionality', async () => {
     await commonPage.goToReports();
   });
 
-  after(async () => {
-    await utils.revertDb([], true);
-  });
-
   it('search by NON empty string should display results with contains match and then clears', async () => {
     // Waiting for initial load
     await contactPage.getAllReportsText();

--- a/tests/e2e/sms/link-sms-to-patient.wdio-spec.js
+++ b/tests/e2e/sms/link-sms-to-patient.wdio-spec.js
@@ -42,8 +42,6 @@ describe('Link SMS to patient without passing id', () => {
     await loginPage.cookieLogin();
   });
 
-  after(async () => await utils.revertDb([], true));
-
   it('Send SMS without patient_id and report created under person', async () => {
     await utils.createUsers([user]);
     await sentinelUtils.waitForSentinel();

--- a/tests/e2e/tasks/task-due-dates.wdio-spec.js
+++ b/tests/e2e/tasks/task-due-dates.wdio-spec.js
@@ -63,11 +63,6 @@ describe('Task list due dates', () => {
     await (await commonPage.analyticsTab()).waitForDisplayed();
   });
 
-  after(async () => {
-    await utils.deleteUsers([ chw ]);
-    await utils.revertDb([], true);
-  });
-
   afterEach(async () => {
     await utils.revertSettings(true);
   });

--- a/tests/e2e/tasks/tasks-group.wdio-spec.js
+++ b/tests/e2e/tasks/tasks-group.wdio-spec.js
@@ -185,11 +185,6 @@ describe('Tasks group landing page', () => {
     await utils.updateSettings({ tasks: compiledTasks }, 'api');
   });
 
-  after(async () => {
-    await utils.deleteUsers([chw, supervisor]);
-    await utils.revertDb([], true);
-  });
-
   describe('for chw', () => {
     before(async () => {
       await loginPage.login(chw.username, chw.password);

--- a/tests/e2e/translations/message-format.wdio-spec.js
+++ b/tests/e2e/translations/message-format.wdio-spec.js
@@ -15,10 +15,6 @@ describe('MessageFormat', () => {
     await loginPage.cookieLogin();
   });
 
-  after(async () => {
-    await utils.revertDb([], true);
-  });
-
   it('should display plurals correctly', async () => {
     await commonPage.goToPeople();
     await contactElements.selectLHSRowByText(district_hospital.name, false);

--- a/tests/e2e/users/add-user.wdio-spec.js
+++ b/tests/e2e/users/add-user.wdio-spec.js
@@ -30,10 +30,6 @@ describe('User Test Cases ->', () => {
     await loginPage.cookieLogin();
   });
 
-  after(async () => {
-    await utils.revertDb([], true);
-  });
-
   beforeEach(async () => {
     await usersAdminPage.goToAdminUser();
     await usersAdminPage.openAddUserDialog();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -281,7 +281,7 @@ const getCreatedUsers = async () => {
   const adminUserId = COUCH_USER_ID_PREFIX + auth.username;
   const users = await request({ path: `/_users/_all_docs?start_key="${COUCH_USER_ID_PREFIX}"` });
   return users.rows.filter(user => user.id !== adminUserId)
-    .map((user) => { return { ...user, username: user.id.replace(COUCH_USER_ID_PREFIX, '') }; });
+    .map((user) => ({ ...user, username: user.id.replace(COUCH_USER_ID_PREFIX, '') }));
 };
 
 const deleteUsers = async (users, meta = false) => {
@@ -679,7 +679,7 @@ module.exports = {
   },
 
   getDoc: (id, rev) => {
-    const params = { };
+    const params = {};
     if (rev) {
       params.rev = rev;
     }

--- a/tests/wdio.conf.js
+++ b/tests/wdio.conf.js
@@ -307,8 +307,14 @@ const baseConfig = {
    * @param {Array.<Object>} capabilities list of capabilities details
    * @param {Array.<String>} specs List of spec file paths that ran
    */
-  // after: function (result, capabilities, specs) {
-  // },
+  after: async () => {
+    // Replaces After hook in test file with a common clean up
+    const users = await utils.getCreatedUsers();
+    if (users.length) {
+      await utils.deleteUsers(users);
+    }
+    await utils.revertDb([], true);
+  },
   /**
    * Gets executed right after terminating the webdriver session.
    * @param {Object} config wdio configuration object


### PR DESCRIPTION
Now each file doesn't need to revert db or delete users in the after. It's done in one place. 

@dianabarsan  I pulled this change out so that it could go in without working on getting the migrating done. 

# Description

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
