### PR TITLE
7262 Fix navigation to new place form

### DIFF
--- a/webapp/src/ts/app-route.guard.provider.ts
+++ b/webapp/src/ts/app-route.guard.provider.ts
@@ -19,7 +19,7 @@ export class AppRouteGuardProvider implements CanActivate {
     return from(
       this.authService.has(route.data.permissions).then((canActivate) => {
         if (!canActivate) {
-          const redirectPath = route.data.redirect || ['error/403'];
+          const redirectPath = route.data.redirect || ['error', '403'];
           this.router.navigate(redirectPath);
         }
         return canActivate;

--- a/webapp/src/ts/effects/global.effects.ts
+++ b/webapp/src/ts/effects/global.effects.ts
@@ -72,10 +72,10 @@ export class GlobalEffects {
       .catch(() => false);
   }
 
-  private navigate(nextUrl, cancelCallback) {
+  private navigate(nextUrl: string, cancelCallback: Function) {
     try {
       if (nextUrl) {
-        return this.router.navigate([nextUrl]);
+        return this.router.navigateByUrl(nextUrl);
       }
 
       if (cancelCallback) {

--- a/webapp/tests/karma/ts/effects/global.effects.spec.ts
+++ b/webapp/tests/karma/ts/effects/global.effects.spec.ts
@@ -38,7 +38,7 @@ describe('GlobalEffects', () => {
     };
 
     router = {
-      navigate: sinon.stub(),
+      navigateByUrl: sinon.stub(),
     };
 
     initialModalState = { initialState: { messageTranslationKey: undefined, telemetryEntry: undefined } };
@@ -100,7 +100,7 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(cancelCallback.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
       }));
 
       it('when not saving and not edited and no cancelCallback', async(async () => {
@@ -109,8 +109,8 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(modalService.show.callCount).to.equal(0);
         await Promise.resolve(); // wait for modalService to resolve: means user clicks to confirm navigation
-        expect(router.navigate.callCount).to.equal(1);
-        expect(router.navigate.args[0]).to.deep.equal([['next']]);
+        expect(router.navigateByUrl.callCount).to.equal(1);
+        expect(router.navigateByUrl.args[0]).to.deep.equal(['next']);
       }));
 
       it('when not saving edited and no cancel callback and no route', async (async () => {
@@ -119,9 +119,9 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([NavigationConfirmComponent, initialModalState]);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         await Promise.resolve(); // wait for modalService to resolve: means user clicks to confirm navigation
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
       }));
 
       it('when not saving edited and no cancel callback and route', async (async () => {
@@ -130,10 +130,9 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([NavigationConfirmComponent, initialModalState]);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         await Promise.resolve(); // wait for modalService to resolve: means user clicks to confirm navigation
-        expect(router.navigate.callCount).to.equal(0);
-        //expect(router.navigate.args[0]).to.deep.equal([['next']]);
+        expect(router.navigateByUrl.callCount).to.equal(0);
       }));
 
       it('when not saving edited and cancel callback but user cancels modal', async (async () => {
@@ -144,9 +143,9 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([NavigationConfirmComponent, initialModalState]);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         await Promise.resolve(); // wait for modalService to reject: means user clicks to cancel navigation
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         expect(cancelCallback.callCount).to.equal(0);
       }));
 
@@ -158,7 +157,7 @@ describe('GlobalEffects', () => {
         expect(cancelCallback.callCount).to.equal(1);
         expect(cancelCallback.args[0]).to.deep.equal([]);
         expect(modalService.show.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
       }));
     });
 
@@ -169,8 +168,8 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(cancelCallback.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(1);
-        expect(router.navigate.args[0]).to.deep.equal([['route']]);
+        expect(router.navigateByUrl.callCount).to.equal(1);
+        expect(router.navigateByUrl.args[0]).to.deep.equal(['route']);
       }));
 
       it('when navigation is not prevented and no route', async(() => {
@@ -180,7 +179,7 @@ describe('GlobalEffects', () => {
         expect(cancelCallback.callCount).to.equal(1);
         expect(cancelCallback.args[0]).to.deep.equal([]);
         expect(modalService.show.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
       }));
 
       it('when navigation is not prevented and no route and no cancel callback', async(() => {
@@ -189,7 +188,7 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
         expect(cancelCallback.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
       }));
 
       it('when navigation is prevented and user cancels modal', async(async () => {
@@ -199,12 +198,12 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
 
         await Promise.resolve(); // wait for modal cancel
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([NavigationConfirmComponent, initialModalState]);
       }));
@@ -216,7 +215,7 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
 
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([NavigationConfirmComponent, initialModalState]);
@@ -224,8 +223,8 @@ describe('GlobalEffects', () => {
         await nextTick(); // wait for modal confirm
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(1);
-        expect(router.navigate.args[0]).to.deep.equal([['path']]);
+        expect(router.navigateByUrl.callCount).to.equal(1);
+        expect(router.navigateByUrl.args[0]).to.deep.equal(['path']);
 
       }));
 
@@ -236,12 +235,12 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
 
         await nextTick(); // wait for modal confirm
 
         expect(cancelCallback.callCount).to.equal(1);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([NavigationConfirmComponent, initialModalState]);
       }));
@@ -258,12 +257,12 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
 
         await nextTick();
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0][1]).to.deep.equal({
           initialState: {
@@ -286,12 +285,12 @@ describe('GlobalEffects', () => {
         effects.navigationCancel.subscribe();
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
 
         await Promise.resolve(); // wait for modal confirm
 
         expect(cancelCallback.callCount).to.equal(0);
-        expect(router.navigate.callCount).to.equal(0);
+        expect(router.navigateByUrl.callCount).to.equal(0);
         expect(modalService.show.callCount).to.equal(1);
         expect(modalService.show.args[0]).to.deep.equal([
           NavigationConfirmComponent,

--- a/webapp/tests/karma/ts/providers/app-route.guard.provider.spec.ts
+++ b/webapp/tests/karma/ts/providers/app-route.guard.provider.spec.ts
@@ -45,7 +45,7 @@ describe('RouteGuard provider', () => {
       expect(authService.has.callCount).to.equal(1);
       expect(authService.has.args[0]).to.deep.equal(['can_activate']);
       expect(router.navigate.callCount).to.equal(1);
-      expect(router.navigate.args[0]).to.deep.equal([['error/403']]);
+      expect(router.navigate.args[0]).to.deep.equal([['error', '403']]);
     });
   }));
 


### PR DESCRIPTION
# Description

This PR fixes navigation to a new place. Additionally, improves how url fragments are passed for error page

https://github.com/medic/cht-core/issues/7262

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
