### PR TITLE
Remove skip check in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,24 +12,9 @@ env:
 
 jobs:
 
-  skip_check:
-
-    name: Skip Check
-    runs-on: ubuntu-18.04
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
-        with:
-          skip_after_successful_duplicate: 'false'
-          paths_ignore: '["**.md", "release-notes/**", "demo-forms/**"]'
-
   build:
     name: Compile the app
     runs-on: ubuntu-18.04
-    needs: skip_check
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
 
     steps:
     - name: Get Docker Hub username
@@ -71,7 +56,6 @@ jobs:
 
   config-tests:
     needs: build
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     name: Config Tests
     runs-on: ubuntu-18.04
     strategy:
@@ -93,7 +77,6 @@ jobs:
 
   publish:
     needs: [tests,config-tests]
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     name: Publish branch build
     runs-on: ubuntu-18.04
 
@@ -114,7 +97,6 @@ jobs:
 
   tests:
     needs: build
-    if: ${{ needs.skip_check.outputs.should_skip != 'true' }}
     name: ${{ matrix.grunt-cmd }} on node ${{ matrix.node-version }}
     runs-on: ubuntu-18.04
     env:


### PR DESCRIPTION
The GH Action doesn't work well with jobs that have matrix strategies (https://github.com/fkirc/skip-duplicate-actions/issues/56), making some times to stuck PRs with jobs that aren't skipped nor scheduled.

So  I'm removing it for now, at least for cht-core that use matrix strategy to launch some jobs.