### PR TITLE
6670 - Meta's end field not refreshing when saving contact form

### DIFF
--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -283,6 +283,9 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
           throw new Error('Validation failed.');
         }
 
+        // Updating fields before save. Ref: #6670.
+        $('form.or').trigger('beforesave');
+
         return this.contactSaveService
           .save(form, docId, this.enketoContact.type)
           .then((result) => {

--- a/webapp/src/ts/services/enketo-translation.service.ts
+++ b/webapp/src/ts/services/enketo-translation.service.ts
@@ -159,11 +159,11 @@ export class EnketoTranslationService {
    */
   contactRecordToJs(record) {
     const root = $.parseXML(record).firstChild;
-
     const result:any = {
       doc: null,
       siblings: {},
     };
+
     const repeats = this.repeatsToJs(root);
     if (repeats) {
       result.repeats = repeats;
@@ -171,16 +171,18 @@ export class EnketoTranslationService {
 
     const NODE_NAMES_TO_IGNORE = ['meta', 'inputs', 'repeat'];
 
-    this.withElements(root.childNodes)
-      .filter((node:any) => !NODE_NAMES_TO_IGNORE.includes(node.nodeName))
+    this
+      .withElements(root.childNodes)
+      .filter((node:any) => !NODE_NAMES_TO_IGNORE.includes(node.nodeName) && node.childElementCount > 0)
       .forEach((child:any) => {
-        // First child is the main result, rest are siblings
-        if(!result.doc) {
+        if (!result.doc) {
+          // First child is the main result, rest are siblings
           result.doc = this.nodesToJs(child.childNodes);
-        } else {
-          result.siblings[child.nodeName] = this.nodesToJs(child.childNodes);
+          return;
         }
+        result.siblings[child.nodeName] = this.nodesToJs(child.childNodes);
       });
+
     return result;
   }
 }

--- a/webapp/tests/karma/ts/services/enketo-translation.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo-translation.service.spec.ts
@@ -226,6 +226,43 @@ describe('EnketoTranslation service', () => {
         },
       });
     });
+
+    it('should ignore first level elements with no children', () => {
+      const xml =
+        `<data id="clinic" version="1">
+          <start/>
+          <clinic>
+            <name>A House in the Woods</name>
+            <parent>eeb17d6d-5dde-c2c0-48ac53f275043126</parent>
+            <contact>abc-123-xyz-987</contact>
+          </clinic>
+          <today/>
+          <contact>
+            <name>Mummy Bear</name>
+            <phone>123</phone>
+          </contact>
+          <meta>
+            <instanceID>uuid:ecded7c5-5c8d-4195-8e08-296de6557f1e</instanceID>
+          </meta>
+          <end/>
+        </data>`;
+
+      const js = service.contactRecordToJs(xml);
+
+      assert.deepEqual(js, {
+        doc: {
+          name: 'A House in the Woods',
+          parent: 'eeb17d6d-5dde-c2c0-48ac53f275043126',
+          contact: 'abc-123-xyz-987',
+        },
+        siblings: {
+          contact: {
+            name: 'Mummy Bear',
+            phone: '123',
+          },
+        },
+      });
+    });
   });
 
   describe('#reportRecordToJs()', () => {


### PR DESCRIPTION
# Description

This PR:
- Adds a trigger of Enketo beforeSave event when saving contact form, this will refresh the meta's fields (Reports already has it)
- Filters out the 1st level fields in contact form since it only process groups to be docs, this prevents incomplete data in couch's docs when saving the place. I found this behaviour while testing the meta fields. 

https://github.com/medic/cht-core/issues/6670

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
