### PR TITLE
7409 - Display the tabs' label

### DIFF
--- a/tests/mobile/common/common.specs.js
+++ b/tests/mobile/common/common.specs.js
@@ -105,13 +105,13 @@ describe('Navigation tests : ', () => {
       await commonElements.waitForLoaderToDisappear();
     });
 
-    it('No tab text labels displayed  on mobile view for over 3 tabs', async () => {
+    it('should display tab labels on mobile view, when all tabs are enabled', async () => {
       const tabTexts = await element.all(by.css('.button-label')).getText();
       expect(tabTexts.length).toBe(5);
-      expect(tabTexts).toEqual([ '', '', '', '', '' ]);
+      expect(tabTexts).toEqual([ 'Messages', 'Tasks', 'Reports', 'People', 'Targets' ]);
     });
 
-    it('Display page tab text labels even on mobile view, whenever there are 3 or fewer tabs', async () => {
+    it('should display tab labels on mobile view, when some tabs are enabled', async () => {
       //change permissions
       const originalSettings = await utils.getSettings();
       const permissions = originalSettings.permissions;

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1539,11 +1539,14 @@ a.fa:hover {
       a {
         min-width: 40px;
         .button-label {
-          font-size: @font-extra-small;
+          font-size: @font-extra-extra-small;
         }
-      }
-      .configuration-tab {
-        display: none;
+
+        // If there are 4 or less tabs, then use bigger font.
+        .child-button-label(1, @font-extra-small);
+        .child-button-label(2, @font-extra-small);
+        .child-button-label(3, @font-extra-small);
+        .child-button-label(4, @font-extra-small);
       }
     }
     .mm-badge-overlay {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1465,11 +1465,8 @@ a.fa:hover {
     .header {
       display: none;
     }
-    &,
-    &.hide-mobile-tab-labels {
-      .content .page {
-        top: 46px;
-      }
+    .content .page {
+      top: 46px;
     }
     .left-pane {
       left: -100%;
@@ -1541,6 +1538,9 @@ a.fa:hover {
       padding-left: 2px;
       a {
         min-width: 40px;
+        .button-label {
+          font-size: @font-extra-small;
+        }
       }
       .configuration-tab {
         display: none;
@@ -1578,17 +1578,6 @@ a.fa:hover {
   .app-root.testing {
     .page {
       top: 55px;
-    }
-  }
-  .hide-mobile-tab-labels {
-    .button-label {
-      display: none;
-    }
-    .header .inner {
-      height: 50px;
-    }
-    .content .page {
-      top: 101px;
     }
   }
 }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1543,11 +1543,8 @@ a.fa:hover {
         }
       }
 
-      // If there are 4 or less tabs, then use bigger font.
-      .child-element-label(a, button-label, 1, @font-extra-small);
-      .child-element-label(a, button-label, 2, @font-extra-small);
-      .child-element-label(a, button-label, 3, @font-extra-small);
-      .child-element-label(a, button-label, 4, @font-extra-small);
+      // Use bigger font when there are 4 or less tabs.
+      .elements-label(a, button-label, 4, @font-extra-small);
     }
     .mm-badge-overlay {
       right: 10%;

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1541,13 +1541,13 @@ a.fa:hover {
         .button-label {
           font-size: @font-extra-extra-small;
         }
-
-        // If there are 4 or less tabs, then use bigger font.
-        .child-button-label(1, @font-extra-small);
-        .child-button-label(2, @font-extra-small);
-        .child-button-label(3, @font-extra-small);
-        .child-button-label(4, @font-extra-small);
       }
+
+      // If there are 4 or less tabs, then use bigger font.
+      .child-element-label(a, button-label, 1, @font-extra-small);
+      .child-element-label(a, button-label, 2, @font-extra-small);
+      .child-element-label(a, button-label, 3, @font-extra-small);
+      .child-element-label(a, button-label, 4, @font-extra-small);
     }
     .mm-badge-overlay {
       right: 10%;

--- a/webapp/src/css/mixins.less
+++ b/webapp/src/css/mixins.less
@@ -3,11 +3,11 @@
   border-radius: @radius;
 }
 
-.child-button-label(@num, @font) {
-  &:first-child:nth-last-child(@{num}),
-  &:first-child:nth-last-child(@{num}) ~ & {
-    .button-label {
-      font-size: @font;
+.child-element-label(@container, @child, @num, @fontSize) {
+  @{container}:first-child:nth-last-child(@{num}),
+  @{container}:first-child:nth-last-child(@{num}) ~ @{container} {
+    .@{child} {
+      font-size: @fontSize;
     }
   }
 }

--- a/webapp/src/css/mixins.less
+++ b/webapp/src/css/mixins.less
@@ -4,8 +4,8 @@
 }
 
 .child-button-label(@num, @font) {
-  &:first-child:nth-last-child(@num),
-  &:first-child:nth-last-child(@num) ~ & {
+  &:first-child:nth-last-child(@{num}),
+  &:first-child:nth-last-child(@{num}) ~ & {
     .button-label {
       font-size: @font;
     }

--- a/webapp/src/css/mixins.less
+++ b/webapp/src/css/mixins.less
@@ -3,10 +3,13 @@
   border-radius: @radius;
 }
 
-.child-element-label(@container, @child, @num, @fontSize) {
-  @{container}:first-child:nth-last-child(@{num}),
-  @{container}:first-child:nth-last-child(@{num}) ~ @{container} {
-    .@{child} {
+// Style the label of 1 to N elements in a container.
+.elements-label(@container, @element, @count, @fontSize) when (@count > 0) {
+  .elements-label(@container, @element, @count - 1, @fontSize);
+
+  @{container}:first-child:nth-last-child(@{count}),
+  @{container}:first-child:nth-last-child(@{count}) ~ @{container} {
+    .@{element} {
       font-size: @fontSize;
     }
   }

--- a/webapp/src/css/mixins.less
+++ b/webapp/src/css/mixins.less
@@ -2,3 +2,12 @@
 .border-radius(@radius) {
   border-radius: @radius;
 }
+
+.child-button-label(@num, @font) {
+  &:first-child:nth-last-child(@num),
+  &:first-child:nth-last-child(@num) ~ & {
+    .button-label {
+      font-size: @font;
+    }
+  }
+}

--- a/webapp/src/css/variables.less
+++ b/webapp/src/css/variables.less
@@ -90,6 +90,8 @@
 @font-large: 1.125rem;
 @font-medium: 1rem;
 @font-small: 0.875rem;
+@font-extra-small: 0.8125rem;
+@font-extra-extra-small: 0.625rem;
 
 @icon-small: 30px;
 @icon-large: 60px;

--- a/webapp/src/ts/actions/global.ts
+++ b/webapp/src/ts/actions/global.ts
@@ -4,7 +4,6 @@ import { createSingleValueAction, createMultiValueAction } from './actionUtils';
 
 export const Actions = {
   updateReplicationStatus: createSingleValueAction('UPDATE_REPLICATION_STATUS', 'replicationStatus'),
-  setMinimalTabs: createSingleValueAction('SET_MINIMAL_TABS', 'minimalTabs'),
   setAndroidAppVersion: createSingleValueAction('SET_ANDROID_APP_VERSION', 'androidAppVersion'),
   setCurrentTab: createSingleValueAction('SET_CURRENT_TAB', 'currentTab'),
   setSnapshotData: createSingleValueAction('SET_SNAPSHOT_DATA', 'snapshotData'),
@@ -46,10 +45,6 @@ export class GlobalActions {
 
   updateReplicationStatus(replicationStatus) {
     return this.store.dispatch(Actions.updateReplicationStatus(replicationStatus));
-  }
-
-  setMinimalTabs(minimal) {
-    return this.store.dispatch(Actions.setMinimalTabs(minimal));
   }
 
   setAndroidAppVersion(androidAppVersion) {

--- a/webapp/src/ts/app.component.html
+++ b/webapp/src/ts/app.component.html
@@ -1,7 +1,6 @@
 <div class="app-root {{currentTab}}"
      [class.bootstrapped]="privacyPolicyAccepted"
-     [class.select-mode]="selectMode"
-     [class.hide-mobile-tab-labels]="minimalTabs">
+     [class.select-mode]="selectMode">
   <div class="bootstrap-layer">
     <div>
       <div class="loader"></div>

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -82,7 +82,6 @@ export class AppComponent implements OnInit {
   privacyPolicyAccepted;
   showPrivacyPolicy;
   selectMode;
-  minimalTabs;
   adminUrl;
   canLogOut;
   replicationStatus;
@@ -420,7 +419,6 @@ export class AppComponent implements OnInit {
       this.store.select(Selectors.getReplicationStatus),
       this.store.select(Selectors.getAndroidAppVersion),
       this.store.select(Selectors.getCurrentTab),
-      this.store.select(Selectors.getMinimalTabs),
       this.store.select(Selectors.getPrivacyPolicyAccepted),
       this.store.select(Selectors.getShowPrivacyPolicy),
       this.store.select(Selectors.getSelectMode),
@@ -428,7 +426,6 @@ export class AppComponent implements OnInit {
       replicationStatus,
       androidAppVersion,
       currentTab,
-      minimalTabs,
       privacyPolicyAccepted,
       showPrivacyPolicy,
       selectMode,
@@ -436,7 +433,6 @@ export class AppComponent implements OnInit {
       this.replicationStatus = replicationStatus;
       this.androidAppVersion = androidAppVersion;
       this.currentTab = currentTab;
-      this.minimalTabs = minimalTabs;
       this.showPrivacyPolicy = showPrivacyPolicy;
       this.privacyPolicyAccepted = privacyPolicyAccepted;
       this.selectMode = selectMode;

--- a/webapp/src/ts/components/header/header.component.ts
+++ b/webapp/src/ts/components/header/header.component.ts
@@ -88,7 +88,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
       .then(settings => this.headerTabsService.getAuthorizedTabs(settings))
       .then(permittedTabs => {
         this.permittedTabs = permittedTabs;
-        this.globalActions.setMinimalTabs(this.permittedTabs.length > 3);
       });
   }
 

--- a/webapp/src/ts/modals/tour/tour-select.component.html
+++ b/webapp/src/ts/modals/tour/tour-select.component.html
@@ -3,7 +3,7 @@
   [titleKey]="'tour.select'"
   (onCancel)="close()"
 >
-  <div role="document" class="tour-select" [class.hide-mobile-tab-labels]="minimalTabs">
+  <div role="document" class="tour-select">
     <div class="modal-body">
       <p>{{'tour.select.description' | translate}}</p>
       <a *ngFor="let tour of tours; trackBy: listTrackBy" class="btn tour-option" (click)="start(tour.id)" [ngClass]="'tour-option-' + tour.id">

--- a/webapp/src/ts/modals/tour/tour-select.component.ts
+++ b/webapp/src/ts/modals/tour/tour-select.component.ts
@@ -1,47 +1,31 @@
-import { MmModalAbstract } from '../mm-modal/mm-modal';
-import { TourService } from '@mm-services/tour.service';
-
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
-import { Subscription } from 'rxjs';
-import { Selectors } from '@mm-selectors/index';
-import { Store } from '@ngrx/store';
+
+import { MmModalAbstract } from '@mm-modals/mm-modal/mm-modal';
+import { TourService } from '@mm-services/tour.service';
 
 @Component({
   selector: 'tour-select',
   templateUrl: './tour-select.component.html'
 })
-export class TourSelectComponent extends MmModalAbstract implements OnInit, OnDestroy {
-
-  @Input() minimalTabs = false;
+export class TourSelectComponent extends MmModalAbstract implements OnInit {
 
   tours: object[];
 
-  subscription: Subscription = new Subscription();
-
   constructor(
     bsModalRef: BsModalRef,
-    private store: Store,
     private tourService: TourService,
   ) {
     super(bsModalRef);
   }
 
   ngOnInit() {
-    const subscription = this.store
-      .select(Selectors.getMinimalTabs)
-      .subscribe(minimalTabs => {
-        this.minimalTabs = minimalTabs;
-      });
-    this.subscription.add(subscription);
     this.tourService.endCurrent();
-    this.tourService.getTours().then(tours => {
-      this.tours = tours.sort((a: any, b: any) => a.order - b.order);
-    });
-  }
-
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
+    this.tourService
+      .getTours()
+      .then(tours => {
+        this.tours = tours.sort((a: any, b: any) => a.order - b.order);
+      });
   }
 
   start(name) {

--- a/webapp/src/ts/reducers/global.ts
+++ b/webapp/src/ts/reducers/global.ts
@@ -28,7 +28,6 @@ const initialState = {
   lastChangedDoc: false,
   loadingContent: false,
   loadingSubActionBar: false,
-  minimalTabs: false,
   replicationStatus: {},
   selectMode: false,
   privacyPolicyAccepted: false,
@@ -66,9 +65,6 @@ const _globalReducer = createReducer(
   }),
   on(Actions.setAndroidAppVersion, (state, { payload: { androidAppVersion } }) => {
     return { ...state, androidAppVersion };
-  }),
-  on(Actions.setMinimalTabs, (state, { payload: { minimalTabs } } ) => {
-    return { ...state, minimalTabs };
   }),
   on(Actions.setCurrentTab, (state, { payload: { currentTab } }) => {
     return { ...state, currentTab };

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -23,7 +23,6 @@ export const Selectors = {
   getSnapshotData: createSelector(getGlobalState, (globalState) => globalState.snapshotData),
   getSnackbarContent: createSelector(getGlobalState, (globalState) => globalState.snackbarContent),
   getLoadingContent: createSelector(getGlobalState, (globalState) => globalState.loadingContent),
-  getMinimalTabs: createSelector(getGlobalState, (globalState) => globalState.minimalTabs),
   getShowContent: createSelector(getGlobalState, (globalState) => globalState.showContent),
   getSelectMode: createSelector(getGlobalState, (globalState) => globalState.selectMode),
   getShowActionBar: createSelector(getGlobalState, (globalState) => globalState.showActionBar),

--- a/webapp/tests/karma/ts/reducers/global.spec.ts
+++ b/webapp/tests/karma/ts/reducers/global.spec.ts
@@ -35,11 +35,6 @@ describe('Global Reducer', () => {
     });
   });
 
-  it('should update minimal tabs', () => {
-    expect(globalReducer(state, Actions.setMinimalTabs(true))).to.deep.equal({ minimalTabs: true });
-    expect(globalReducer(state, Actions.setMinimalTabs(false))).to.deep.equal({ minimalTabs: false });
-  });
-
   it('should update snackbar content', () => {
     const content = 'this is just a random text';
     expect(globalReducer(state, Actions.setSnackbarContent(content))).to.deep.equal({

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -13,7 +13,6 @@ const state = {
     snapshotData: { snapshot: 'data' },
     snackbarContent: 'this is just some text',
     loadingContent: 'is loading content',
-    minimalTabs: 'uses minimal tabs',
     showContent: 'is showing content',
     selectMode: 'is in select mode',
     showActionBar: 'is showing action bar',
@@ -151,10 +150,6 @@ describe('Selectors', () => {
 
     it('should getLoadingContent', () => {
       expect(Selectors.getLoadingContent(state)).to.equal(clonedState.global.loadingContent);
-    });
-
-    it('should getMinimalTabs', () => {
-      expect(Selectors.getMinimalTabs(state)).to.equal(clonedState.global.minimalTabs);
     });
 
     it('should getShowContent', () => {


### PR DESCRIPTION
# Description

In this PR:
- Always display the tab's labels in the header bar and in the tour modal. 
- When having a small device (w: 400px) and there are more than 4 tabs in the header bar, the font size will be smaller.
- The javascript logic for minimalTabs is removed, CSS can handle the logic fine.

[medic/cht-core#7409](https://github.com/medic/cht-core/issues/7409)

View when having <= 4 tabs
<img width="300" alt="Screen Shot 2021-11-12 at 1 31 01 pm" src="https://user-images.githubusercontent.com/66472237/141424478-de7566e3-4728-4fe7-a21f-de1871829ab2.png">

View when having > 4 tabs (smaller font)
<img width="300" alt="Screen Shot 2021-11-12 at 1 30 49 pm" src="https://user-images.githubusercontent.com/66472237/141424580-ac3eff95-cfaf-468d-b90b-013e7774ddf6.png">

Tour, same size font no matter how many tabs since elements are stacking
<img width="300" alt="Screen Shot 2021-11-12 at 1 30 29 pm" src="https://user-images.githubusercontent.com/66472237/141424780-bdbaf441-cac2-4bbe-8d70-46dfc3cf69ff.png">

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
