### PR TITLE
fixed broken reference to old docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Setup
 
-These instructions are for developers who want to contribute to the Core Framework (this repository). If you only need to run the Framework (ie with a Reference App configuration), or you are a developer building configurations, you can follow the [easy deployment instructions](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/#1-install-the-core-framework) instead.
+These instructions are for developers who want to contribute to the Core Framework (this repository). If you only need to run the Framework (ie with a Reference App configuration), or you are a developer building configurations, you can follow the [easy deployment instructions](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/) instead.
 
 Before getting started, read about our [development workflow](https://docs.communityhealthtoolkit.org/contribute/code/workflow/) and the [architecture overview](https://docs.communityhealthtoolkit.org/core/overview/architecture/). With the setup instructions below the tools will run directly on your machine, rather than via Docker.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Setup
 
-These instructions are for developers who want to contribute to the Core Framework (this repository). If you only need to run the Framework (ie with a Reference App configuration), or you are a developer building configurations, you can follow the [easy deployment instructions](./INSTALL.md) instead.
+These instructions are for developers who want to contribute to the Core Framework (this repository). If you only need to run the Framework (ie with a Reference App configuration), or you are a developer building configurations, you can follow the [easy deployment instructions](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/#1-install-the-core-framework) instead.
 
 Before getting started, read about our [development workflow](https://docs.communityhealthtoolkit.org/contribute/code/workflow/) and the [architecture overview](https://docs.communityhealthtoolkit.org/core/overview/architecture/). With the setup instructions below the tools will run directly on your machine, rather than via Docker.
 
@@ -50,7 +50,7 @@ Medic recommends you familiarise yourself with other Docker commands to make doc
 
 ### CouchDB on Ubuntu
 
-While we recommend use Docker to install CouchDB for development, it is still possible to install CouchDB on bare metal in Ubuntu, but there are some caveats: 
+While we recommend use Docker to install CouchDB for development, it is still possible to install CouchDB on bare metal in Ubuntu, but there are some caveats:
 
 * For Ubuntu 18.04 and earlier, you need to specify in `apt` version to install with the `-V` flag.  For example, on a clean 18.04 install you would run:
     ```bash
@@ -192,7 +192,7 @@ $ sudo ufw allow proto tcp from  172.16.0.0/16 to any port 5988
 
 ### Remote Proxies
 
-`ngrok` and `pagekite` are remote proxies that route local traffic between your client and the CHT via a remote SSL terminator. While easy and handy, they introduce latency and are sometimes throttled.  
+`ngrok` and `pagekite` are remote proxies that route local traffic between your client and the CHT via a remote SSL terminator. While easy and handy, they introduce latency and are sometimes throttled.
 
 #### ngrok
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -192,7 +192,7 @@ $ sudo ufw allow proto tcp from  172.16.0.0/16 to any port 5988
 
 ### Remote Proxies
 
-`ngrok` and `pagekite` are remote proxies that route local traffic between your client and the CHT via a remote SSL terminator. While easy and handy, they introduce latency and are sometimes throttled. 
+`ngrok` and `pagekite` are remote proxies that route local traffic between your client and the CHT via a remote SSL terminator. While easy and handy, they introduce latency and are sometimes throttled.
 
 #### ngrok
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -192,7 +192,7 @@ $ sudo ufw allow proto tcp from  172.16.0.0/16 to any port 5988
 
 ### Remote Proxies
 
-`ngrok` and `pagekite` are remote proxies that route local traffic between your client and the CHT via a remote SSL terminator. While easy and handy, they introduce latency and are sometimes throttled.
+`ngrok` and `pagekite` are remote proxies that route local traffic between your client and the CHT via a remote SSL terminator. While easy and handy, they introduce latency and are sometimes throttled. 
 
 #### ngrok
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information about the SMS exchange protocol between webapp and gateway,
 
 If you are a developer looking to contribute to the Core Framework itself, you should follow the [development setup instructions](./DEVELOPMENT.md).
 
-If you wish to evaluate the Core Framework, _or_ you are a developer looking to create or modify applications built with the Core Framework, you can instead follow the [easy deployment](./INSTALL.md) instructions, which will get the latest stable release running locally via Docker.
+If you wish to evaluate the Core Framework, _or_ you are a developer looking to create or modify applications built with the Core Framework, you can instead follow the [easy deployment](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/#1-install-the-core-framework) instructions, which will get the latest stable release running locally via Docker.
 
 You will need to also familiarise yourself with [medic-conf](https://github.com/medic/medic-conf), a tool to manage and configure your apps built using the Core Framework. A brief guide for modifying the config is available [alongside the config](./config/default/GUIDE.md). A more detailed guide is available in [cht-docs](https://docs.communityhealthtoolkit.org/apps/).
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information about the SMS exchange protocol between webapp and gateway,
 
 If you are a developer looking to contribute to the Core Framework itself, you should follow the [development setup instructions](./DEVELOPMENT.md).
 
-If you wish to evaluate the Core Framework, _or_ you are a developer looking to create or modify applications built with the Core Framework, you can instead follow the [easy deployment](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/#1-install-the-core-framework) instructions, which will get the latest stable release running locally via Docker.
+If you wish to evaluate the Core Framework, _or_ you are a developer looking to create or modify applications built with the Core Framework, you can instead follow the [easy deployment](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/) instructions, which will get the latest stable release running locally via Docker.
 
 You will need to also familiarise yourself with [medic-conf](https://github.com/medic/medic-conf), a tool to manage and configure your apps built using the Core Framework. A brief guide for modifying the config is available [alongside the config](./config/default/GUIDE.md). A more detailed guide is available in [cht-docs](https://docs.communityhealthtoolkit.org/apps/).
 

--- a/config/default/GUIDE.md
+++ b/config/default/GUIDE.md
@@ -6,7 +6,7 @@ Detailed tutorials on how to build apps from scratch with the Core Framework wil
 
 ## Modifying the Reference Application
 
-You should have the [Core Framework running](../../INSTALL.md), have installed [medic-conf](https://github.com/medic/medic-conf) and have checked out or otherwise downloaded the [Reference Application](./).
+You should have the [Core Framework running](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/#1-install-the-core-framework), have installed [medic-conf](https://github.com/medic/medic-conf) and have checked out or otherwise downloaded the [Reference Application](./).
 
 Once you've made a change you must compile and upload that configuration to the Core Framework to see the change. You can do this by using `medic-conf`'s default action:
 

--- a/config/default/GUIDE.md
+++ b/config/default/GUIDE.md
@@ -6,7 +6,7 @@ Detailed tutorials on how to build apps from scratch with the Core Framework wil
 
 ## Modifying the Reference Application
 
-You should have the [Core Framework running](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/#1-install-the-core-framework), have installed [medic-conf](https://github.com/medic/medic-conf) and have checked out or otherwise downloaded the [Reference Application](./).
+You should have the [Core Framework running](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/), have installed [medic-conf](https://github.com/medic/medic-conf) and have checked out or otherwise downloaded the [Reference Application](./).
 
 Once you've made a change you must compile and upload that configuration to the Core Framework to see the change. You can do this by using `medic-conf`'s default action:
 


### PR DESCRIPTION
# Description

fixed broken reference to old docs - `install.md`

medic/cht-core#7445

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
