### PR TITLE
Add API route to create many users

### DIFF
--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -131,6 +131,13 @@ module.exports = {
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
   },
+  createMany: (req, res) => {
+    return auth
+      .check(req, ['can_create_users', 'can_create_places', 'can_create_people'])
+      .then(() => usersService.createManyUsers(req.body, getAppUrl(req)))
+      .then(body => res.json(body))
+      .catch(err => serverUtils.error(err, req, res));
+  },
   update: (req, res) => {
     if (_.isEmpty(req.body)) {
       return serverUtils.emptyJSONBodyError(req, res);

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -127,13 +127,6 @@ module.exports = {
   create: (req, res) => {
     return auth
       .check(req, 'can_create_users')
-      .then(() => usersService.createUser(req.body, getAppUrl(req)))
-      .then(body => res.json(body))
-      .catch(err => serverUtils.error(err, req, res));
-  },
-  createMany: (req, res) => {
-    return auth
-      .check(req, ['can_create_users', 'can_create_places', 'can_create_people'])
       .then(() => usersService.createUsers(req.body, getAppUrl(req)))
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -134,7 +134,7 @@ module.exports = {
   createMany: (req, res) => {
     return auth
       .check(req, ['can_create_users', 'can_create_places', 'can_create_people'])
-      .then(() => usersService.createManyUsers(req.body, getAppUrl(req)))
+      .then(() => usersService.createUsers(req.body, getAppUrl(req)))
       .then(body => res.json(body))
       .catch(err => serverUtils.error(err, req, res));
   },

--- a/api/src/promise-utils.js
+++ b/api/src/promise-utils.js
@@ -1,0 +1,8 @@
+module.exports = {
+  allPromisesSettled: promises =>
+    Promise.all(promises.map(p =>
+      p
+        .then(value => ({ status: 'fulfilled', value }))
+        .catch(reason => ({ status: 'rejected', reason })),
+    )),
+};

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -390,6 +390,7 @@ app.post('/api/v1/forms/validate', textParser, forms.validate);
 
 app.get('/api/v1/users', users.get);
 app.postJson('/api/v1/users', users.create);
+app.postJson('/api/v2/users', users.createMany);
 app.postJson('/api/v1/users/:username', users.update);
 app.delete('/api/v1/users/:username', users.delete);
 app.get('/api/v1/users-info', authorization.handleAuthErrors, authorization.getUserSettings, users.info);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -390,7 +390,6 @@ app.post('/api/v1/forms/validate', textParser, forms.validate);
 
 app.get('/api/v1/users', users.get);
 app.postJson('/api/v1/users', users.create);
-app.postJson('/api/v2/users', users.createMany);
 app.postJson('/api/v1/users/:username', users.update);
 app.delete('/api/v1/users/:username', users.delete);
 app.get('/api/v1/users-info', authorization.handleAuthErrors, authorization.getUserSettings, users.info);

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -67,7 +67,7 @@ module.exports = {
     if (code >= 500 && code < 600) {
       return module.exports.serverError(err, req, res);
     }
-    respond(req, res, code, err.message || err.reason);
+    respond(req, res, code, err.message || err.reason, err.details);
   },
 
   /**

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -635,6 +635,26 @@ module.exports = {
       error.failingIndexes = failingIndexes;
       return Promise.reject(error);
     }
+
+    const passwordErrors = users.map(user => validatePassword(user.password));
+    const hasPasswordError = passwordErrors.some(error => !!error);
+    if (hasPasswordError) {
+      const failingIndexes = passwordErrors
+        .map((passwordError, index) => {
+          if (passwordError) {
+            return { passwordError, index };
+          }
+        })
+        .filter(index => index);
+      let errorMessge = 'Password errors:\n';
+      for (const { passwordError, index } of failingIndexes) {
+        errorMessge += `\nError ${passwordError} for user at index ${index}`;
+      }
+      const error = new Error(errorMessge);
+      error.code = 400;
+      error.failingIndexes = failingIndexes;
+      return Promise.reject(error);
+    }
   },
 
   /*

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -65,14 +65,12 @@ const error400 = (msg, key, params) => {
   error.code = 400;
 
   if (typeof key === 'string') {
-    Object.assign(error, {
+    return Object.assign(error, {
       message: { message: msg, translationKey: key, translationParams: params },
     });
-    return error;
   }
 
-  Object.assign(error, { details: key });
-  return error;
+  return Object.assign(error, { details: key });
 };
 
 const getType = user => {

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -581,18 +581,17 @@ module.exports = {
    * Take the request data and create valid users, user-settings and contacts
    * objects. Returns the response body in the callback.
    * @param {Object[]} users
-   * @param {string} users[].name
-   * @param {string=} users[].phone User's phone number. Not required if the password is provided.
-   * @param {string=} users[].password User's password. Not required if the phone number is provided.
+   * @param {string} users[].username
+   * @param {string=} users[].phone Not required if the password is provided.
+   * @param {string=} users[].password Not required if the phone number is provided.
    * @param {string[]} users[].roles
-   * @param {string=} users[].place
-   * @param {string=} users[].contact
-   * @param {string=} users[].type
-   * @param {String} appUrl   request protocol://hostname
+   * @param {(Object|string)=} users[].place Can either be a place object or an existing place id.
+   * @param {(Object|string)=} users[].contact Can either be a contact object or an existing place id.
+   * @param {string=} users[].type Deprecated. Used to infer user's roles
+   * @param {string} appUrl   request protocol://hostname
    */
   async createManyUsers(users, appUrl) {
     if (!Array.isArray(users)) {
-      // TODO: alternatively, `return module.exports.createUser(users, appUrl);`
       return Promise.reject(error400('Wrong type, body should be an array of users'));
     }
 

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -693,7 +693,7 @@ module.exports = {
     if (passwordFailingIndexes.length > 0) {
       let errorMessage = 'Password errors:\n';
       for (const { passwordError, index } of passwordFailingIndexes) {
-        errorMessage += `\nError ${passwordError} for user at index ${index}`;
+        errorMessage += `\nError ${passwordError.message.message} for user at index ${index}`;
       }
       return Promise.reject(error400(errorMessage, { failingIndexes: passwordFailingIndexes }));
     }
@@ -717,7 +717,7 @@ module.exports = {
         .filter(reason => reason);
 
       for (const { reason, index } of failingIndexes) {
-        response[index].error = reason;
+        response[index].error = reason.message;
       }
     }
 

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -9,6 +9,7 @@ const getRoles = require('./types-and-roles');
 const auth = require('../auth');
 const tokenLogin = require('./token-login');
 const moment = require('moment');
+const { allPromisesSettled } = require('../promise-utils');
 
 const USER_PREFIX = 'org.couchdb.user:';
 const DOC_IDS_WARN_LIMIT = 10000;
@@ -656,8 +657,8 @@ module.exports = {
     }
 
     const response = Array(users.length).fill({});
-    // use Promise.allSettled to create all valid users even if some are failing
-    const promises = await Promise.allSettled(users.map(async (user, index) => {
+    // create all valid users even if some are failing
+    const promises = await allPromisesSettled(users.map(async (user, index) => {
       await validateNewUsername(user.username);
       await createPlace(user);
       await setContactParent(user);

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -655,17 +655,17 @@ module.exports = {
       return Promise.reject(error);
     }
 
-    const responses = Array(users.length).fill({});
+    const response = Array(users.length).fill({});
     // use Promise.allSettled to create all valid users even if some are failing
     const promises = await Promise.allSettled(users.map(async (user, index) => {
       await validateNewUsername(user.username);
       await createPlace(user);
       await setContactParent(user);
-      await createContact(user, responses[index]);
+      await createContact(user, response[index]);
       await storeUpdatedPlace(user);
-      await createUser(user, responses[index]);
-      await createUserSettings(user, responses[index]);
-      await tokenLogin.manageTokenLogin(user, appUrl, responses[index]);
+      await createUser(user, response[index]);
+      await createUserSettings(user, response[index]);
+      await tokenLogin.manageTokenLogin(user, appUrl, response[index]);
     }));
     const hasFailures = promises.some(promise => promise.status === 'rejected');
     if (hasFailures) {
@@ -681,11 +681,11 @@ module.exports = {
         .filter(reason => reason);
 
       for (const { reason, index } of failingIndexes) {
-        responses[index].error = reason;
+        response[index].error = reason;
       }
     }
 
-    return responses;
+    return response;
   },
 
   /*

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -69,7 +69,7 @@ const error400 = (msg, key, params) => {
       message: { message: msg, translationKey: key, translationParams: params },
     });
   } else {
-    Object.assign(error, key);
+    Object.assign(error, { details: key });
   }
 
   return error;

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -586,7 +586,7 @@ module.exports = {
   /**
    * Take the request data and create valid users, user-settings and contacts
    * objects. Returns the response body in the callback.
-   * @param {Object[]} users
+   * @param {Object|Object[]} users
    * @param {string} users[].username
    * @param {string=} users[].phone Not required if the password is provided.
    * @param {string=} users[].password Not required if the phone number is provided.
@@ -598,7 +598,7 @@ module.exports = {
    */
   async createUsers(users, appUrl) {
     if (!Array.isArray(users)) {
-      return Promise.reject(error400('Wrong type, body should be an array of users'));
+      return module.exports.createUser(users, appUrl);
     }
 
     const missingFieldsFailingIndexes = [];

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -60,9 +60,19 @@ const illegalDataModificationAttempts = data =>
 /*
  * Set error codes to 400 to minimize 500 errors and stacktraces in the logs.
  */
-const error400 = (msg, key, params) => ({
-  code: 400, message: { message: msg, translationKey: key, translationParams: params }
-});
+const error400 = (msg, key, params) => {
+  const error = new Error(msg);
+  error.code = 400;
+  const payload = {
+    message: {
+      message: msg,
+      translationKey: key,
+      translationParams: params,
+    },
+  };
+  Object.assign(error, payload);
+  return error;
+};
 
 const getType = user => {
   if (user.roles && user.roles.length) {

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -645,26 +645,26 @@ module.exports = {
 
     const { missingFieldsFailingIndexes, tokenLoginFailingIndexes, passwordFailingIndexes } = validateUserFields(users);
     if (missingFieldsFailingIndexes.length > 0) {
-      let errorMessage = 'Missing required fields:\n';
-      for (const { fields, index } of missingFieldsFailingIndexes) {
-        errorMessage += `\nMissing fields ${fields.join(', ')} for user at index ${index}`;
-      }
+      const errorMessages = missingFieldsFailingIndexes.map(({ fields, index }) => {
+        return `Missing fields ${fields.join(', ')} for user at index ${index}`;
+      });
+      const errorMessage = ['Missing required fields:', ...errorMessages].join('\n');
       return Promise.reject(error400(errorMessage, { failingIndexes: missingFieldsFailingIndexes }));
     }
 
     if (tokenLoginFailingIndexes.length > 0) {
-      let errorMessage = 'Token login errors:\n';
-      for (const { tokenLoginError, index } of tokenLoginFailingIndexes) {
-        errorMessage += `\nError ${tokenLoginError.msg} for user at index ${index}`;
-      }
+      const errorMessages = tokenLoginFailingIndexes.map(({ tokenLoginError, index }) => {
+        return `Error ${tokenLoginError.msg} for user at index ${index}`;
+      });
+      const errorMessage = ['Token login errors:', ...errorMessages].join('\n');
       return Promise.reject(error400(errorMessage, { failingIndexes: tokenLoginFailingIndexes }));
     }
 
     if (passwordFailingIndexes.length > 0) {
-      let errorMessage = 'Password errors:\n';
-      for (const { passwordError, index } of passwordFailingIndexes) {
-        errorMessage += `\nError ${passwordError.message.message} for user at index ${index}`;
-      }
+      const errorMessages = tokenLoginFailingIndexes.map(({ passwordError, index }) => {
+        return `Error ${passwordError.message.message} for user at index ${index}`;
+      });
+      const errorMessage = ['Password errors:', ...errorMessages].join('\n');
       return Promise.reject(error400(errorMessage, { failingIndexes: passwordFailingIndexes }));
     }
 

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -68,10 +68,10 @@ const error400 = (msg, key, params) => {
     Object.assign(error, {
       message: { message: msg, translationKey: key, translationParams: params },
     });
-  } else {
-    Object.assign(error, { details: key });
+    return error;
   }
 
+  Object.assign(error, { details: key });
   return error;
 };
 

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -670,15 +670,7 @@ module.exports = {
 
     // create all valid users even if some are failing
     const promises = await allPromisesSettled(users.map(async (user) => await createUserEntities(user, appUrl)));
-    const response = promises.map((promise) => {
-      if (promise.status === 'rejected') {
-        return { error: promise.reason.message };
-      }
-
-      return promise.value;
-    });
-
-    return response;
+    return promises.map((promise) => promise.status === 'rejected' ? { error: promise.reason.message } : promise.value);
   },
 
   /*

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -596,7 +596,7 @@ module.exports = {
    * @param {string=} users[].type Deprecated. Used to infer user's roles
    * @param {string} appUrl   request protocol://hostname
    */
-  async createManyUsers(users, appUrl) {
+  async createUsers(users, appUrl) {
     if (!Array.isArray(users)) {
       return Promise.reject(error400('Wrong type, body should be an array of users'));
     }

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -675,20 +675,11 @@ module.exports = {
     );
     const hasFailures = promises.some(promise => promise.status === 'rejected');
     if (hasFailures) {
-      const failingIndexes = promises
-        .map((promise, index) => {
-          if (promise.status === 'rejected') {
-            return {
-              reason: promise.reason,
-              index,
-            };
-          }
-        })
-        .filter(reason => reason);
-
-      for (const { reason, index } of failingIndexes) {
-        response[index].error = reason.message;
-      }
+      promises.forEach((promise, index) => {
+        if (promise.status === 'rejected') {
+          response[index].error = promise.reason.message;
+        }
+      });
     }
 
     return response;

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -655,6 +655,20 @@ module.exports = {
       error.failingIndexes = failingIndexes;
       return Promise.reject(error);
     }
+
+    const responses = Array(users.length).fill({});
+    await Promise.all(users.map(async (user, index) => {
+      await validateNewUsername(user.username);
+      await createPlace(user);
+      await setContactParent(user);
+      await createContact(user, responses[index]);
+      await storeUpdatedPlace(user);
+      await createUser(user, responses[index]);
+      await createUserSettings(user, responses[index]);
+      await tokenLogin.manageTokenLogin(user, appUrl, responses[index]);
+    }));
+
+    return responses;
   },
 
   /*

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -657,7 +657,7 @@ module.exports = {
       return Promise.reject(error);
     }
 
-    const response = Array(users.length).fill({});
+    const response = Array(users.length).fill(null).map(() => ({}));
     // create all valid users even if some are failing
     const promises = await allPromisesSettled(
       users.map(async (user, index) => await createUserEntities(user, response[index], appUrl)),

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -680,6 +680,8 @@ describe('Users service', () => {
         await service.createManyUsers([{}]);
       } catch (error) {
         // empty
+        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['username', 'password', 'type or roles']);
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
         chai.expect(error.code).to.equal(400);
       }
 
@@ -687,6 +689,8 @@ describe('Users service', () => {
         await service.createManyUsers([{ password: 'x', place: 'x', contact: { parent: 'x' }}]);
       } catch (error) {
         // missing username
+        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['username', 'type or roles']);
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
         chai.expect(error.code).to.equal(400);
       }
 
@@ -694,6 +698,8 @@ describe('Users service', () => {
         await service.createManyUsers([{ username: 'x', place: 'x', contact: { parent: 'x' }}]);
       } catch (error) {
         // missing password
+        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
         chai.expect(error.code).to.equal(400);
       }
 
@@ -701,6 +707,8 @@ describe('Users service', () => {
         await service.createManyUsers([{ username: 'x', password: 'x', contact: { parent: 'x' }}]);
       } catch (error) {
         // missing place
+        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['type or roles']);
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
         chai.expect(error.code).to.equal(400);
       }
 
@@ -708,6 +716,8 @@ describe('Users service', () => {
         await service.createManyUsers([{ username: 'x', place: 'x', contact: { parent: 'x' }}]);
       } catch (error) {
         // missing contact
+        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
         chai.expect(error.code).to.equal(400);
       }
 
@@ -715,6 +725,8 @@ describe('Users service', () => {
         await service.createManyUsers([{ username: 'x', place: 'x', contact: {}}]);
       } catch (error) {
         // missing contact.parent
+        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
         chai.expect(error.code).to.equal(400);
       }
     });

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -675,58 +675,41 @@ describe('Users service', () => {
   });
 
   describe.only('createManyUsers', () => {
-    it('returns error if missing fields', async () => {
+    it('returns error if one of the users has missing fields', async () => {
       try {
-        await service.createManyUsers([{}]);
+        await service.createManyUsers([
+          {},
+          { password: 'x', place: 'x', contact: { parent: 'x' }},
+          { username: 'x', place: 'x', contact: { parent: 'x' }},
+          { username: 'x', password: 'x', contact: { parent: 'x' }},
+          { username: 'x', place: 'x', contact: { parent: 'x' }},
+          { username: 'x', place: 'x', contact: {}},
+        ]);
       } catch (error) {
         // empty
         chai.expect(error.failingIndexes[0].fields).to.deep.equal(['username', 'password', 'type or roles']);
         chai.expect(error.failingIndexes[0].index).to.equal(0);
-        chai.expect(error.code).to.equal(400);
-      }
 
-      try {
-        await service.createManyUsers([{ password: 'x', place: 'x', contact: { parent: 'x' }}]);
-      } catch (error) {
         // missing username
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['username', 'type or roles']);
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
-        chai.expect(error.code).to.equal(400);
-      }
+        chai.expect(error.failingIndexes[1].fields).to.deep.equal(['username', 'type or roles']);
+        chai.expect(error.failingIndexes[1].index).to.equal(1);
 
-      try {
-        await service.createManyUsers([{ username: 'x', place: 'x', contact: { parent: 'x' }}]);
-      } catch (error) {
         // missing password
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['password', 'type or roles']);
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
-        chai.expect(error.code).to.equal(400);
-      }
+        chai.expect(error.failingIndexes[2].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.failingIndexes[2].index).to.equal(2);
 
-      try {
-        await service.createManyUsers([{ username: 'x', password: 'x', contact: { parent: 'x' }}]);
-      } catch (error) {
         // missing place
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['type or roles']);
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
-        chai.expect(error.code).to.equal(400);
-      }
+        chai.expect(error.failingIndexes[3].fields).to.deep.equal(['type or roles']);
+        chai.expect(error.failingIndexes[3].index).to.equal(3);
 
-      try {
-        await service.createManyUsers([{ username: 'x', place: 'x', contact: { parent: 'x' }}]);
-      } catch (error) {
         // missing contact
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['password', 'type or roles']);
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
-        chai.expect(error.code).to.equal(400);
-      }
+        chai.expect(error.failingIndexes[4].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.failingIndexes[4].index).to.equal(4);
 
-      try {
-        await service.createManyUsers([{ username: 'x', place: 'x', contact: {}}]);
-      } catch (error) {
         // missing contact.parent
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['password', 'type or roles']);
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
+        chai.expect(error.failingIndexes[5].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.failingIndexes[5].index).to.equal(5);
+
         chai.expect(error.code).to.equal(400);
       }
     });

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -762,7 +762,9 @@ describe('Users service', () => {
         chai.expect(error.details.failingIndexes[0].passwordError.message.translationKey).to.equal(
           'password.length.minimum',
         );
-        chai.expect(error.details.failingIndexes[0].passwordError.message.translationParams).to.have.property('minimum');
+        chai.expect(
+          error.details.failingIndexes[0].passwordError.message.translationParams,
+        ).to.have.property('minimum');
         chai.expect(error.details.failingIndexes[0].index).to.equal(0);
 
         // weak password
@@ -833,7 +835,9 @@ describe('Users service', () => {
         chai.expect(error.details.failingIndexes[0].tokenLoginError.msg).to.equal(
           'A valid phone number is required for SMS login.'
         );
-        chai.expect(error.details.failingIndexes[0].tokenLoginError.key).to.equal('configuration.enable.token.login.phone');
+        chai.expect(
+          error.details.failingIndexes[0].tokenLoginError.key,
+        ).to.equal('configuration.enable.token.login.phone');
         chai.expect(error.details.failingIndexes[0].index).to.equal(1);
       }
     });

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -704,6 +704,7 @@ describe('Users service', () => {
           { username: 'x', place: 'x', contact: { parent: 'x' }},
           { username: 'x', place: 'x', contact: {}},
         ]);
+        chai.assert.fail('Should have thrown');
       } catch (error) {
         // empty
         chai.expect(error.failingIndexes[0].fields).to.deep.equal(['username', 'password', 'type or roles']);
@@ -751,6 +752,7 @@ describe('Users service', () => {
             password: 'password',
           },
         ]);
+        chai.assert.fail('Should have thrown');
       } catch (error) {
         // short password
         chai.expect(error.failingIndexes[0].passwordError.message.message).to.equal(

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -674,7 +674,7 @@ describe('Users service', () => {
 
   });
 
-  describe.only('createManyUsers', () => {
+  describe('createManyUsers', () => {
     it('returns error if one of the users has missing fields', async () => {
       try {
         await service.createManyUsers([

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -676,6 +676,13 @@ describe('Users service', () => {
 
   describe('createUsers', () => {
     it('calls `createUser` if the body is not an array', async () => {
+      const userData = {
+        username: 'x',
+        password: COMPLEX_PASSWORD,
+        place: 'foo',
+        contact: { 'parent': 'x' },
+        type: 'national-manager'
+      };
       service.__set__('validateNewUsername', sinon.stub().resolves());
       service.__set__('createPlace', sinon.stub().resolves());
       service.__set__('createUser', sinon.stub().resolves());
@@ -683,7 +690,6 @@ describe('Users service', () => {
       service.__set__('storeUpdatedPlace', sinon.stub().resolves());
       service.__set__('createUserSettings', sinon.stub().resolves());
       sinon.stub(places, 'getPlace').resolves({ _id: 'foo' });
-      userData.place = 'foo';
       const response = await service.createUsers(userData);
       chai.expect(response).to.deep.equal({});
     });
@@ -769,6 +775,13 @@ describe('Users service', () => {
 
     describe('errors at insertion', () => {
       it('returns responses with errors if contact.parent lookup fails', async () => {
+        const userData = {
+          username: 'x',
+          password: COMPLEX_PASSWORD,
+          place: { name: 'x' },
+          contact: { 'parent': 'x' },
+          type: 'national-manager'
+        };
         service.__set__('validateNewUsername', sinon.stub().resolves());
         service.__set__('createPlace', sinon.stub().resolves());
         service.__set__('setContactParent', sinon.stub().rejects(new Error('kablooey')));
@@ -778,6 +791,13 @@ describe('Users service', () => {
       });
 
       it('returns responses with errors if place lookup fails', async () => {
+        const userData = {
+          username: 'x',
+          password: COMPLEX_PASSWORD,
+          place: { name: 'x' },
+          contact: { 'parent': 'x' },
+          type: 'national-manager'
+        };
         service.__set__('validateNewUsername', sinon.stub().resolves());
         service.__set__('createPlace', sinon.stub().rejects(new Error('fail')));
 
@@ -786,6 +806,13 @@ describe('Users service', () => {
       });
 
       it('returns responses with errors if place is not within contact', async () => {
+        const userData = {
+          username: 'x',
+          password: COMPLEX_PASSWORD,
+          place: 'georgia',
+          contact: { 'parent': 'x' },
+          type: 'national-manager'
+        };
         service.__set__('validateNewUsername', sinon.stub().resolves());
         service.__set__('createPlace', sinon.stub().resolves());
         sinon.stub(places, 'getPlace').resolves({
@@ -794,7 +821,6 @@ describe('Users service', () => {
             _id: 'florida'
           }
         });
-        userData.place = 'georgia';
 
         const response = await service.createUsers([userData]);
         chai.expect(response[0].error.message).to.equal('Contact is not within place.');
@@ -842,6 +868,13 @@ describe('Users service', () => {
     });
 
     it('succeeds if contact and place are the same', async () => {
+      const userData = {
+        username: 'x',
+        password: COMPLEX_PASSWORD,
+        place: 'foo',
+        contact: { 'parent': 'x' },
+        type: 'national-manager'
+      };
       service.__set__('validateNewUsername', sinon.stub().resolves());
       service.__set__('createPlace', sinon.stub().resolves());
       service.__set__('createUser', sinon.stub().resolves());
@@ -855,6 +888,13 @@ describe('Users service', () => {
     });
 
     it('succeeds if contact is within place', async () => {
+      const userData = {
+        username: 'x',
+        password: COMPLEX_PASSWORD,
+        place: 'florida',
+        contact: { 'parent': 'x' },
+        type: 'national-manager'
+      };
       service.__set__('validateNewUsername', sinon.stub().resolves());
       service.__set__('createPlace', sinon.stub().resolves());
       service.__set__('createUser', sinon.stub().resolves());
@@ -873,6 +913,13 @@ describe('Users service', () => {
     });
 
     it('errors if username exists in _users db', async () => {
+      const userData = {
+        username: 'x',
+        password: COMPLEX_PASSWORD,
+        place: { name: 'x' },
+        contact: { 'parent': 'x' },
+        type: 'national-manager'
+      };
       sinon.stub(db.users, 'get').resolves('bob lives here already.');
       sinon.stub(db.medic, 'get').resolves();
       const insert = sinon.stub(db.medic, 'put');
@@ -884,6 +931,13 @@ describe('Users service', () => {
     });
 
     it('errors if username exists in medic db', async () => {
+      const userData = {
+        username: 'x',
+        password: COMPLEX_PASSWORD,
+        place: { name: 'x' },
+        contact: { 'parent': 'x' },
+        type: 'national-manager'
+      };
       sinon.stub(db.users, 'get').resolves();
       sinon.stub(db.medic, 'get').resolves('jane lives here too.');
       const insert = sinon.stub(db.medic, 'put');

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -674,10 +674,10 @@ describe('Users service', () => {
 
   });
 
-  describe('createManyUsers', () => {
+  describe('createUsers', () => {
     it('returns error if one of the users has missing fields', async () => {
       try {
-        await service.createManyUsers([
+        await service.createUsers([
           {},
           { password: 'x', place: 'x', contact: { parent: 'x' }},
           { username: 'x', place: 'x', contact: { parent: 'x' }},
@@ -716,7 +716,7 @@ describe('Users service', () => {
 
     it('returns error if one of the users has password errors', async () => {
       try {
-        await service.createManyUsers([
+        await service.createUsers([
           {
             username: 'x',
             place: 'x',
@@ -760,7 +760,7 @@ describe('Users service', () => {
         service.__set__('createPlace', sinon.stub().resolves());
         service.__set__('setContactParent', sinon.stub().rejects('kablooey'));
 
-        const response = await service.createManyUsers([userData]);
+        const response = await service.createUsers([userData]);
         chai.expect(response[0].error.name).to.equal('kablooey');
       });
 
@@ -768,7 +768,7 @@ describe('Users service', () => {
         service.__set__('validateNewUsername', sinon.stub().resolves());
         service.__set__('createPlace', sinon.stub().rejects('fail'));
 
-        const response = await service.createManyUsers([userData]);
+        const response = await service.createUsers([userData]);
         chai.expect(response[0].error.name).to.equal('fail');
       });
 
@@ -783,7 +783,7 @@ describe('Users service', () => {
         });
         userData.place = 'georgia';
 
-        const response = await service.createManyUsers([userData]);
+        const response = await service.createUsers([userData]);
         chai.expect(response[0].error.code).to.equal(400);
         chai.expect(response[0].error.message.translationKey).to.equal('configuration.user.place.contact');
         chai.expect(response[0].error.message.message).to.equal('Contact is not within place.');
@@ -799,7 +799,7 @@ describe('Users service', () => {
       service.__set__('createUserSettings', sinon.stub().resolves());
       sinon.stub(places, 'getPlace').resolves({ _id: 'foo' });
       userData.place = 'foo';
-      const response = await service.createManyUsers([userData]);
+      const response = await service.createUsers([userData]);
       chai.expect(response).to.deep.equal([{}]);
     });
 
@@ -817,7 +817,7 @@ describe('Users service', () => {
         }
       });
       userData.place = 'florida';
-      const response = await service.createManyUsers([userData]);
+      const response = await service.createUsers([userData]);
       chai.expect(response).to.deep.equal([{}]);
     });
 
@@ -825,7 +825,7 @@ describe('Users service', () => {
       sinon.stub(db.users, 'get').resolves('bob lives here already.');
       sinon.stub(db.medic, 'get').resolves();
       const insert = sinon.stub(db.medic, 'put');
-      const response = await service.createManyUsers([userData]);
+      const response = await service.createUsers([userData]);
       chai.expect(response[0].error.message.message).to.equal('Username "x" already taken.');
       chai.expect(response[0].error.message.translationKey).to.equal('username.taken');
       chai.expect(response[0].error.message.translationParams).to.have.property('username');
@@ -836,7 +836,7 @@ describe('Users service', () => {
       sinon.stub(db.users, 'get').resolves();
       sinon.stub(db.medic, 'get').resolves('jane lives here too.');
       const insert = sinon.stub(db.medic, 'put');
-      const response = await service.createManyUsers([userData]);
+      const response = await service.createUsers([userData]);
       chai.expect(response[0].error.message.message).to.equal('Username "x" already taken.');
       chai.expect(response[0].error.message.translationKey).to.equal('username.taken');
       chai.expect(response[0].error.message.translationParams).to.have.property('username');

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -713,6 +713,46 @@ describe('Users service', () => {
         chai.expect(error.code).to.equal(400);
       }
     });
+
+    it('returns error if one of the users has password errors', async () => {
+      try {
+        await service.createManyUsers([
+          {
+            username: 'x',
+            place: 'x',
+            contact: { parent: 'x' },
+            type: 'national-manager',
+            password: 'short',
+          },
+          {
+            username: 'x',
+            place: 'x',
+            contact: { parent: 'x' },
+            type: 'national-manager',
+            password: 'password',
+          },
+        ]);
+      } catch (error) {
+        // short password
+        chai.expect(error.failingIndexes[0].passwordError.message.message).to.equal(
+          'The password must be at least 8 characters long.',
+        );
+        chai.expect(error.failingIndexes[0].passwordError.message.translationKey).to.equal(
+          'password.length.minimum',
+        );
+        chai.expect(error.failingIndexes[0].passwordError.message.translationParams).to.have.property('minimum');
+        chai.expect(error.failingIndexes[0].index).to.equal(0);
+
+        // weak password
+        chai.expect(error.failingIndexes[1].passwordError.message.message).to.equal(
+          'The password is too easy to guess. Include a range of types of characters to increase the score.',
+        );
+        chai.expect(error.failingIndexes[1].passwordError.message.translationKey).to.equal('password.weak');
+        chai.expect(error.failingIndexes[1].index).to.equal(1);
+
+        chai.expect(error.code).to.equal(400);
+      }
+    });
   });
 
   describe('setContactParent', () => {

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -764,7 +764,6 @@ describe('Users service', () => {
         chai.expect(responses[0].error.name).to.equal('kablooey');
       });
 
-
       it('returns responses with errors if place lookup fails', async () => {
         service.__set__('validateNewUsername', sinon.stub().resolves());
         service.__set__('createPlace', sinon.stub().rejects('fail'));
@@ -773,7 +772,22 @@ describe('Users service', () => {
         chai.expect(responses[0].error.name).to.equal('fail');
       });
 
+      it('returns responses with errors if place is not within contact', async () => {
+        service.__set__('validateNewUsername', sinon.stub().resolves());
+        service.__set__('createPlace', sinon.stub().resolves());
+        sinon.stub(places, 'getPlace').resolves({
+          _id: 'miami',
+          parent: {
+            _id: 'florida'
+          }
+        });
+        userData.place = 'georgia';
 
+        const responses = await service.createManyUsers([userData]);
+        chai.expect(responses[0].error.code).to.equal(400);
+        chai.expect(responses[0].error.message.translationKey).to.equal('configuration.user.place.contact');
+        chai.expect(responses[0].error.message.message).to.equal('Contact is not within place.');
+      });
     });
   });
 

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -788,7 +788,7 @@ describe('Users service', () => {
           {
             username: 'sally',
             roles: ['a', 'b'],
-            phone: '123',
+            phone: '+40 755 69-69-69',
             token_login: true,
           },
           {

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -674,6 +674,52 @@ describe('Users service', () => {
 
   });
 
+  describe.only('createManyUsers', () => {
+    it('returns error if missing fields', async () => {
+      try {
+        await service.createManyUsers([{}]);
+      } catch (error) {
+        // empty
+        chai.expect(error.code).to.equal(400);
+      }
+
+      try {
+        await service.createManyUsers([{ password: 'x', place: 'x', contact: { parent: 'x' }}]);
+      } catch (error) {
+        // missing username
+        chai.expect(error.code).to.equal(400);
+      }
+
+      try {
+        await service.createManyUsers([{ username: 'x', place: 'x', contact: { parent: 'x' }}]);
+      } catch (error) {
+        // missing password
+        chai.expect(error.code).to.equal(400);
+      }
+
+      try {
+        await service.createManyUsers([{ username: 'x', password: 'x', contact: { parent: 'x' }}]);
+      } catch (error) {
+        // missing place
+        chai.expect(error.code).to.equal(400);
+      }
+
+      try {
+        await service.createManyUsers([{ username: 'x', place: 'x', contact: { parent: 'x' }}]);
+      } catch (error) {
+        // missing contact
+        chai.expect(error.code).to.equal(400);
+      }
+
+      try {
+        await service.createManyUsers([{ username: 'x', place: 'x', contact: {}}]);
+      } catch (error) {
+        // missing contact.parent
+        chai.expect(error.code).to.equal(400);
+      }
+    });
+  });
+
   describe('setContactParent', () => {
 
     it('resolves contact parent in waterfall', () => {

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -776,7 +776,7 @@ describe('Users service', () => {
       }
     });
 
-    it('returns error if one of the users has a missing phone number', async () => {
+    it('returns error if one of the users has a missing phone number and should login by SMS', async () => {
       const tokenLoginConfig = { translation_key: 'sms', enabled: true };
       sinon.stub(config, 'get')
         .withArgs('token_login').returns(tokenLoginConfig)
@@ -805,7 +805,7 @@ describe('Users service', () => {
       }
     });
 
-    it('returns error if one of the users has an invalid phone number', async () => {
+    it('returns error if one of the users has an invalid phone number and should login by SMS', async () => {
       const tokenLoginConfig = { translation_key: 'sms', enabled: true };
       sinon.stub(config, 'get')
         .withArgs('token_login').returns(tokenLoginConfig)
@@ -838,7 +838,7 @@ describe('Users service', () => {
       }
     });
 
-    it('should normalize phone number and change password (if provided)', async () => {
+    it('should normalize phone number and change provided password if should login by SMS', async () => {
       const tokenLoginConfig = { message: 'sms', enabled: true };
       sinon.stub(config, 'get')
         .withArgs('token_login').returns(tokenLoginConfig)
@@ -1215,7 +1215,7 @@ describe('Users service', () => {
         type: 'national-manager'
       };
       sinon.stub(db.users, 'get').resolves('bob lives here already.');
-      sinon.stub(db.medic, 'get').resolves();
+      sinon.stub(db.medic, 'get').rejects({ status: 404 });
       const insert = sinon.stub(db.medic, 'put');
       const response = await service.createUsers([userData]);
       chai.expect(response[0].error.message).to.equal('Username "x" already taken.');
@@ -1232,7 +1232,7 @@ describe('Users service', () => {
         contact: { 'parent': 'x' },
         type: 'national-manager'
       };
-      sinon.stub(db.users, 'get').resolves();
+      sinon.stub(db.users, 'get').rejects({ status: 404 });
       sinon.stub(db.medic, 'get').resolves('jane lives here too.');
       const insert = sinon.stub(db.medic, 'put');
       const response = await service.createUsers([userData]);

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -708,28 +708,28 @@ describe('Users service', () => {
         chai.assert.fail('Should have thrown');
       } catch (error) {
         // empty
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['username', 'password', 'type or roles']);
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
+        chai.expect(error.details.failingIndexes[0].fields).to.deep.equal(['username', 'password', 'type or roles']);
+        chai.expect(error.details.failingIndexes[0].index).to.equal(0);
 
         // missing username
-        chai.expect(error.failingIndexes[1].fields).to.deep.equal(['username', 'type or roles']);
-        chai.expect(error.failingIndexes[1].index).to.equal(1);
+        chai.expect(error.details.failingIndexes[1].fields).to.deep.equal(['username', 'type or roles']);
+        chai.expect(error.details.failingIndexes[1].index).to.equal(1);
 
         // missing password
-        chai.expect(error.failingIndexes[2].fields).to.deep.equal(['password', 'type or roles']);
-        chai.expect(error.failingIndexes[2].index).to.equal(2);
+        chai.expect(error.details.failingIndexes[2].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.details.failingIndexes[2].index).to.equal(2);
 
         // missing place
-        chai.expect(error.failingIndexes[3].fields).to.deep.equal(['type or roles']);
-        chai.expect(error.failingIndexes[3].index).to.equal(3);
+        chai.expect(error.details.failingIndexes[3].fields).to.deep.equal(['type or roles']);
+        chai.expect(error.details.failingIndexes[3].index).to.equal(3);
 
         // missing contact
-        chai.expect(error.failingIndexes[4].fields).to.deep.equal(['password', 'type or roles']);
-        chai.expect(error.failingIndexes[4].index).to.equal(4);
+        chai.expect(error.details.failingIndexes[4].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.details.failingIndexes[4].index).to.equal(4);
 
         // missing contact.parent
-        chai.expect(error.failingIndexes[5].fields).to.deep.equal(['password', 'type or roles']);
-        chai.expect(error.failingIndexes[5].index).to.equal(5);
+        chai.expect(error.details.failingIndexes[5].fields).to.deep.equal(['password', 'type or roles']);
+        chai.expect(error.details.failingIndexes[5].index).to.equal(5);
 
         chai.expect(error.code).to.equal(400);
       }
@@ -756,21 +756,21 @@ describe('Users service', () => {
         chai.assert.fail('Should have thrown');
       } catch (error) {
         // short password
-        chai.expect(error.failingIndexes[0].passwordError.message.message).to.equal(
+        chai.expect(error.details.failingIndexes[0].passwordError.message.message).to.equal(
           'The password must be at least 8 characters long.',
         );
-        chai.expect(error.failingIndexes[0].passwordError.message.translationKey).to.equal(
+        chai.expect(error.details.failingIndexes[0].passwordError.message.translationKey).to.equal(
           'password.length.minimum',
         );
-        chai.expect(error.failingIndexes[0].passwordError.message.translationParams).to.have.property('minimum');
-        chai.expect(error.failingIndexes[0].index).to.equal(0);
+        chai.expect(error.details.failingIndexes[0].passwordError.message.translationParams).to.have.property('minimum');
+        chai.expect(error.details.failingIndexes[0].index).to.equal(0);
 
         // weak password
-        chai.expect(error.failingIndexes[1].passwordError.message.message).to.equal(
+        chai.expect(error.details.failingIndexes[1].passwordError.message.message).to.equal(
           'The password is too easy to guess. Include a range of types of characters to increase the score.',
         );
-        chai.expect(error.failingIndexes[1].passwordError.message.translationKey).to.equal('password.weak');
-        chai.expect(error.failingIndexes[1].index).to.equal(1);
+        chai.expect(error.details.failingIndexes[1].passwordError.message.translationKey).to.equal('password.weak');
+        chai.expect(error.details.failingIndexes[1].index).to.equal(1);
 
         chai.expect(error.code).to.equal(400);
       }
@@ -800,8 +800,8 @@ describe('Users service', () => {
         chai.assert.fail('Should have thrown');
       } catch (error) {
         chai.expect(error.code).to.equal(400);
-        chai.expect(error.failingIndexes[0].fields).to.deep.equal(['phone']);
-        chai.expect(error.failingIndexes[0].index).to.equal(1);
+        chai.expect(error.details.failingIndexes[0].fields).to.deep.equal(['phone']);
+        chai.expect(error.details.failingIndexes[0].index).to.equal(1);
       }
     });
 
@@ -830,11 +830,11 @@ describe('Users service', () => {
         chai.assert.fail('Should have thrown');
       } catch (error) {
         chai.expect(error.code).to.equal(400);
-        chai.expect(error.failingIndexes[0].tokenLoginError.msg).to.equal(
+        chai.expect(error.details.failingIndexes[0].tokenLoginError.msg).to.equal(
           'A valid phone number is required for SMS login.'
         );
-        chai.expect(error.failingIndexes[0].tokenLoginError.key).to.equal('configuration.enable.token.login.phone');
-        chai.expect(error.failingIndexes[0].index).to.equal(1);
+        chai.expect(error.details.failingIndexes[0].tokenLoginError.key).to.equal('configuration.enable.token.login.phone');
+        chai.expect(error.details.failingIndexes[0].index).to.equal(1);
       }
     });
 

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -753,6 +753,20 @@ describe('Users service', () => {
         chai.expect(error.code).to.equal(400);
       }
     });
+
+    it('returns a response with an error if contact.parent lookup fails', async () => {
+      service.__set__('validateNewUsername', sinon.stub().resolves());
+      service.__set__('createPlace', sinon.stub().resolves());
+      service.__set__('setContactParent', sinon.stub().rejects('kablooey'));
+
+      try {
+        const responses = await service.createManyUsers([userData]);
+        chai.expect(responses[0].error.name).to.equal('kablooey');
+      } catch (error) {
+        console.log('error', error);
+        chai.expect(error).to.be.undefined;
+      }
+    });
   });
 
   describe('setContactParent', () => {

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -789,6 +789,37 @@ describe('Users service', () => {
         chai.expect(responses[0].error.message.message).to.equal('Contact is not within place.');
       });
     });
+
+    it('succeeds if contact and place are the same', async () => {
+      service.__set__('validateNewUsername', sinon.stub().resolves());
+      service.__set__('createPlace', sinon.stub().resolves());
+      service.__set__('createUser', sinon.stub().resolves());
+      service.__set__('createContact', sinon.stub().resolves());
+      service.__set__('storeUpdatedPlace', sinon.stub().resolves());
+      service.__set__('createUserSettings', sinon.stub().resolves());
+      sinon.stub(places, 'getPlace').resolves({ _id: 'foo' });
+      userData.place = 'foo';
+      const response = await service.createManyUsers([userData]);
+      chai.expect(response).to.deep.equal([{}]);
+    });
+
+    it('succeeds if contact is within place', async () => {
+      service.__set__('validateNewUsername', sinon.stub().resolves());
+      service.__set__('createPlace', sinon.stub().resolves());
+      service.__set__('createUser', sinon.stub().resolves());
+      service.__set__('createContact', sinon.stub().resolves());
+      service.__set__('storeUpdatedPlace', sinon.stub().resolves());
+      service.__set__('createUserSettings', sinon.stub().resolves());
+      sinon.stub(places, 'getPlace').resolves({
+        _id: 'miami',
+        parent: {
+          _id: 'florida'
+        }
+      });
+      userData.place = 'florida';
+      const response = await service.createManyUsers([userData]);
+      chai.expect(response).to.deep.equal([{}]);
+    });
   });
 
   describe('setContactParent', () => {

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -675,6 +675,19 @@ describe('Users service', () => {
   });
 
   describe('createUsers', () => {
+    it('calls `createUser` if the body is not an array', async () => {
+      service.__set__('validateNewUsername', sinon.stub().resolves());
+      service.__set__('createPlace', sinon.stub().resolves());
+      service.__set__('createUser', sinon.stub().resolves());
+      service.__set__('createContact', sinon.stub().resolves());
+      service.__set__('storeUpdatedPlace', sinon.stub().resolves());
+      service.__set__('createUserSettings', sinon.stub().resolves());
+      sinon.stub(places, 'getPlace').resolves({ _id: 'foo' });
+      userData.place = 'foo';
+      const response = await service.createUsers(userData);
+      chai.expect(response).to.deep.equal({});
+    });
+
     it('returns error if one of the users has missing fields', async () => {
       try {
         await service.createUsers([

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -754,18 +754,26 @@ describe('Users service', () => {
       }
     });
 
-    it('returns a response with an error if contact.parent lookup fails', async () => {
-      service.__set__('validateNewUsername', sinon.stub().resolves());
-      service.__set__('createPlace', sinon.stub().resolves());
-      service.__set__('setContactParent', sinon.stub().rejects('kablooey'));
+    describe('errors at insertion', () => {
+      it('returns responses with errors if contact.parent lookup fails', async () => {
+        service.__set__('validateNewUsername', sinon.stub().resolves());
+        service.__set__('createPlace', sinon.stub().resolves());
+        service.__set__('setContactParent', sinon.stub().rejects('kablooey'));
 
-      try {
         const responses = await service.createManyUsers([userData]);
         chai.expect(responses[0].error.name).to.equal('kablooey');
-      } catch (error) {
-        console.log('error', error);
-        chai.expect(error).to.be.undefined;
-      }
+      });
+
+
+      it('returns responses with errors if place lookup fails', async () => {
+        service.__set__('validateNewUsername', sinon.stub().resolves());
+        service.__set__('createPlace', sinon.stub().rejects('fail'));
+
+        const responses = await service.createManyUsers([userData]);
+        chai.expect(responses[0].error.name).to.equal('fail');
+      });
+
+
     });
   });
 

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -899,6 +899,72 @@ describe('Users API', () => {
         ]);
       });
 
+      it('should fail to create many users with invalid fields w/o token_login', async () => {
+        const users = [
+          {
+            username: 'offline5',
+            password: 'password',
+            place: {
+              _id: 'fixture:offline5',
+              type: 'health_center',
+              name: 'Offline5 place',
+              parent: 'PARENT_PLACE'
+            },
+            contact: {
+              _id: 'fixture:user:offline5',
+              name: 'Offline5User'
+            },
+            roles: ['district_admin', 'this', 'user', 'will', 'be', 'invalid']
+          },
+          {
+            username: 'offline6',
+            place: {
+              _id: 'fixture:offline6',
+              type: 'health_center',
+              name: 'Offline6 place',
+              parent: 'PARENT_PLACE'
+            },
+            contact: {
+              _id: 'fixture:user:offline6',
+              name: 'Offline6User'
+            },
+            roles: ['district_admin', 'this', 'user', 'will', 'be', 'invalid']
+          },
+          {
+            username: 'offline7',
+            password,
+            place: {
+              _id: 'fixture:offline7',
+              type: 'health_center',
+              name: 'Offline7 place',
+              parent: 'PARENT_PLACE'
+            },
+            contact: {
+              _id: 'fixture:user:offline7',
+              name: 'Offline7User'
+            },
+            roles: ['district_admin', 'this', 'user', 'will', 'not', 'be', 'created']
+          },
+        ];
+        const settings = { token_login: { translation_key: 'token_login_sms', enabled: true } };
+        await utils.updateSettings(settings, true);
+        await utils.addTranslations('en', { token_login_sms: 'Instructions sms' });
+
+        try {
+          await utils.request({ path: '/api/v1/users', method: 'POST', body: users });
+          chai.assert.fail('Should have thrown');
+        } catch (error) {
+          const response = error.responseBody;
+          chai.expect(response.code).to.equal(400);
+          chai.expect(response.error).include('Missing fields password for user at index 1');
+          chai.expect(response.details).to.deep.equal({
+            failingIndexes: [
+              { fields: ['password'], index: 1 },
+            ],
+          });
+        }
+      });
+
       it('should create and update many users correctly w/o token_login', async () => {
         const users = [
           {

--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -903,14 +903,13 @@ describe('Users API', () => {
           contact: { id: user.contact._id },
         })));
 
-        await Promise.all(users.map(async (user) => {
+        for (const user of users) {
           let [userInDb, userSettings] = await Promise.all([getUser(user), getUserSettings(user)]);
           const extraProps = { facility_id: user.place._id, name: user.username, roles: user.roles };
           expectCorrectUser(userInDb, extraProps);
           expectCorrectUserSettings(userSettings, { ...extraProps, contact_id: user.contact._id });
           chai.expect(userInDb.token_login).to.be.undefined;
           chai.expect(userSettings.token_login).to.be.undefined;
-          await ((ms) => new Promise(r => setTimeout(r, ms)))(500);
           await expectPasswordLoginToWork(user);
 
           const updates = {
@@ -937,9 +936,8 @@ describe('Users API', () => {
           });
           chai.expect(userInDb.token_login).to.be.undefined;
           chai.expect(userSettings.token_login).to.be.undefined;
-          await ((ms) => new Promise(r => setTimeout(r, ms)))(500);
           await expectPasswordLoginToWork(user);
-        }));
+        }
       });
 
       it('should throw an error when phone is missing when creating a user with token_login', () => {


### PR DESCRIPTION
# Description

This PR adds a `createManyUsers` function to the `usersService` that works in a similar way as the `createUser` function.  
It can be used directly from the service `usersService.createManyUsers([])` within the API or from a standalone API route `POST /api/v2/users`

This is part of the work in progress for CSV bulk users import

[Related cht-docs PR](https://github.com/medic/cht-docs/pull/614)

medic/cht-core#7490

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
