### PR TITLE
Form with truthy expression displayed despite permissions

### DIFF
--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -162,6 +162,9 @@ export class XmlFormsService {
       if (!validSoFar) {
         return false;
       }
+      if (form.context.permission) {
+        return this.authService.has(form.context.permission);
+      }
       if (form.context.expression) {
         try {
           return this.evaluateExpression(form.context.expression, options.doc, user, options.contactSummary);
@@ -174,10 +177,7 @@ export class XmlFormsService {
         !this.evaluateExpression(form.context.expression, options.doc, user, options.contactSummary)) {
         return false;
       }
-      if (!form.context.permission) {
-        return true;
-      }
-      return this.authService.has(form.context.permission);
+      return true;
     });
   }
 

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -137,6 +137,32 @@ export class XmlFormsService {
     });
   }
 
+  private checkFormExpression(form, doc, user, contactSummary) {
+    if (!form.context.expression) {
+      return true;
+    }
+
+    try {
+      return this.evaluateExpression(
+        form.context.expression,
+        doc,
+        user,
+        contactSummary
+      );
+    } catch(err) {
+      console.error(`Unable to evaluate expression for form: ${form._id}`, err);
+      return false;
+    }
+  }
+
+  private checkFormPermissions(form) {
+    if (!form.context.permission) {
+      return true;
+    }
+
+    return this.authService.has(form.context.permission);
+  }
+
   private filter(form, options, user) {
     if (!options.includeCollect && form.context && form.context.collect) {
       return false;
@@ -158,36 +184,10 @@ export class XmlFormsService {
       return true;
     }
 
-    return this.filterContactTypes(form.context, options.doc).then(validSoFar => {
-      if (!validSoFar) {
-        return false;
-      }
-      if (form.context.expression) {
-        try {
-          const evaluatedExpression = this.evaluateExpression(
-            form.context.expression,
-            options.doc,
-            user,
-            options.contactSummary
-          );
-          if (form.context.permission) {
-            return this.authService.has(form.context.permission) && evaluatedExpression;
-          }
-          return evaluatedExpression;
-        } catch(err) {
-          console.error(`Unable to evaluate expression for form: ${form._id}`, err);
-          return false;
-        }
-      }
-      if (form.context.expression &&
-        !this.evaluateExpression(form.context.expression, options.doc, user, options.contactSummary)) {
-        return false;
-      }
-      if (form.context.permission) {
-        return this.authService.has(form.context.permission);
-      }
-      return true;
-    });
+    return this
+      .filterContactTypes(form.context, options.doc)
+      .then(valid => valid && this.checkFormPermissions(form))
+      .then(valid => valid && this.checkFormExpression(form, options.doc, user, options.contactSummary));
   }
 
   private notify(error, forms?) {

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -179,6 +179,10 @@ export class XmlFormsService {
           return false;
         }
       }
+      if (form.context.expression &&
+        !this.evaluateExpression(form.context.expression, options.doc, user, options.contactSummary)) {
+        return false;
+      }
       if (form.context.permission) {
         return this.authService.has(form.context.permission);
       }

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -162,20 +162,25 @@ export class XmlFormsService {
       if (!validSoFar) {
         return false;
       }
-      if (form.context.permission) {
-        return this.authService.has(form.context.permission);
-      }
       if (form.context.expression) {
         try {
-          return this.evaluateExpression(form.context.expression, options.doc, user, options.contactSummary);
+          const evaluatedExpression = this.evaluateExpression(
+            form.context.expression,
+            options.doc,
+            user,
+            options.contactSummary
+          );
+          if (form.context.permission) {
+            return this.authService.has(form.context.permission) && evaluatedExpression;
+          }
+          return evaluatedExpression;
         } catch(err) {
           console.error(`Unable to evaluate expression for form: ${form._id}`, err);
           return false;
         }
       }
-      if (form.context.expression &&
-        !this.evaluateExpression(form.context.expression, options.doc, user, options.contactSummary)) {
-        return false;
+      if (form.context.permission) {
+        return this.authService.has(form.context.permission);
       }
       return true;
     });

--- a/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
+++ b/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
@@ -814,6 +814,42 @@ describe('XmlForms service', () => {
       });
     });
 
+    it('does not return a form with a false expression if the user has the relevant permissions', () => {
+      const given = [
+        {
+          id: 'visit',
+          doc: {
+            _id: 'visit',
+            internalId: 'visit',
+            _attachments: { xml: { something: true } },
+            context: {
+              expression: 'false',
+              permission: [ 'national_admin' ]
+            },
+          },
+        },
+        {
+          id: 'registration',
+          doc: {
+            _id: 'visit',
+            internalId: 'visit',
+            _attachments: { xml: { something: true } },
+            context: {
+              expression: 'false',
+              permission: [ 'district_admin' ]
+            },
+          },
+        }
+      ];
+      dbQuery.resolves({ rows: given });
+      hasAuth.withArgs([ 'national_admin' ]).resolves(true);
+      UserContact.resolves();
+      const service = getService();
+      return service.list().then(actual => {
+        expect(actual.length).to.equal(0);
+      });
+    });
+
   });
 
   describe('listen', () => {

--- a/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
+++ b/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
@@ -777,6 +777,43 @@ describe('XmlForms service', () => {
 
     });
 
+    it('does not return a form with a truthy expression if the user does not have relevant permissions', () => {
+      const given = [
+        {
+          id: 'visit',
+          doc: {
+            _id: 'visit',
+            internalId: 'visit',
+            _attachments: { xml: { something: true } },
+            context: {
+              expression: 'true',
+              permission: [ 'national_admin' ]
+            },
+          },
+        },
+        {
+          id: 'registration',
+          doc: {
+            _id: 'visit',
+            internalId: 'visit',
+            _attachments: { xml: { something: true } },
+            context: {
+              expression: 'true',
+              permission: [ 'district_admin' ]
+            },
+          },
+        }
+      ];
+      dbQuery.resolves({ rows: given });
+      hasAuth.withArgs([ 'national_admin' ]).resolves(true);
+      UserContact.resolves();
+      const service = getService();
+      return service.list().then(actual => {
+        expect(actual.length).to.equal(1);
+        expect(actual[0]).to.deep.equal(given[0].doc);
+      });
+    });
+
   });
 
   describe('listen', () => {


### PR DESCRIPTION
# Description

This PR reorders the checks done before returning a form to take care of the bug below.

medic/cht-core#7021

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
