### PR TITLE
Fix xpath error when repeat is a db-doc

### DIFF
--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -500,7 +500,7 @@ export class EnketoService {
     };
 
     const getRelativePath = (path) => {
-      const repeatReference = repeatPaths?.find(repeat => (new RegExp(`^${repeat}$|${repeat}/`).test(path)));
+      const repeatReference = repeatPaths?.find(repeat => repeat === path || path.startsWith(`${repeat}/`));
       if (repeatReference === path) {
         const lastNode = path.split('/').slice(-1);
         return lastNode;

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -500,7 +500,12 @@ export class EnketoService {
     };
 
     const getRelativePath = (path) => {
-      const repeatReference = repeatPaths?.find(repeat => repeat === path || path.startsWith(`${repeat}/`));
+      if (!path) {
+        return;
+      }
+      path = path.trim();
+
+      const repeatReference = repeatPaths?.find(repeatPath => path === repeatPath || path.startsWith(`${repeatPath}/`));
       if (repeatReference) {
         if (repeatReference === path) {
           // when the path is the repeat element itself, return the repeat element node name
@@ -516,10 +521,7 @@ export class EnketoService {
     };
 
     const getClosestPath = (element, $element, path) => {
-      if (!path) {
-        return;
-      }
-      const relativePath = getRelativePath(path.trim());
+      const relativePath = getRelativePath(path);
       if (!relativePath) {
         return;
       }
@@ -536,7 +538,6 @@ export class EnketoService {
         return closestPath;
       } catch (err) {
         console.error('Error while evaluating closest path', closestPath, err);
-        return path;
       }
     };
 
@@ -564,7 +565,7 @@ export class EnketoService {
         const reference = $element.attr('db-doc-ref');
         const path = getClosestPath(element, $element, reference);
 
-        const refId = path && getId(path) || getId(reference);
+        const refId = (path && getId(path)) || getId(reference);
         $element.text(refId);
       });
 

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -501,12 +501,12 @@ export class EnketoService {
 
     const getRelativePath = (path) => {
       const repeatReference = repeatPaths?.find(repeat => repeat === path || path.startsWith(`${repeat}/`));
-      if (repeatReference === path) {
-        const lastNode = path.split('/').slice(-1);
-        return lastNode;
-      }
-
       if (repeatReference) {
+        if (repeatReference === path) {
+          // when the path is the repeat element itself, return the repeat element node name
+          return path.split('/').slice(-1)[0];
+        }
+
         return path.replace(`${repeatReference}/`, '');
       }
 

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-broken-ref.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-broken-ref.xml
@@ -15,6 +15,7 @@
     <some_property>some_value_2</some_property>
     <my_parent db-doc-ref="/data"/>
     <repeat_doc_ref db-doc-ref="/data/repeat_sectioning">value2</repeat_doc_ref>
+    <ing>something</ing>
   </repeat_section>
   <repeat_section db-doc="true">
     <extra>data3</extra>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-broken-ref.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-broken-ref.xml
@@ -1,0 +1,26 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section db-doc="true">
+    <extra>data1</extra>
+    <type>repeater</type>
+    <some_property>some_value_1</some_property>
+    <my_parent db-doc-ref="/data"/>
+    <repeat_doc_ref db-doc-ref="/data/repeat_sections">value1</repeat_doc_ref>
+  </repeat_section>
+  <repeat_section db-doc="true">
+    <extra>data2</extra>
+    <type>repeater</type>
+    <some_property>some_value_2</some_property>
+    <my_parent db-doc-ref="/data"/>
+    <repeat_doc_ref db-doc-ref="/data/repeat_sectioning">value2</repeat_doc_ref>
+  </repeat_section>
+  <repeat_section db-doc="true">
+    <extra>data3</extra>
+    <type>repeater</type>
+    <some_property>some_value_3</some_property>
+    <my_parent db-doc-ref="/data"/>
+    <repeat_doc_ref db-doc-ref="/data/repeat_section/t">value3</repeat_doc_ref>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-same-as-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-same-as-repeat.xml
@@ -31,4 +31,7 @@
       </repeat_doc_ref>
     </child>
   </repeat_section>
+  <repeat_doc_ref db-doc-ref="/data/repeat_section">
+    value value
+  </repeat_doc_ref>
 </data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-same-as-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-same-as-repeat.xml
@@ -1,0 +1,34 @@
+<data xmlns:jr="http://openrosa.org/javarosa">
+  <name>Sally</name>
+  <lmp>10</lmp>
+  <secret_code_name tag="hidden">S4L</secret_code_name>
+  <repeat_section db-doc="true">
+    <extra>data1</extra>
+    <type>repeater</type>
+    <some_property>some_value_1</some_property>
+    <my_parent db-doc-ref="/data"/>
+    <repeat_doc_ref db-doc-ref="/data/repeat_section">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+  <repeat_section db-doc="true">
+    <extra>data2</extra>
+    <type>repeater</type>
+    <some_property>some_value_2</some_property>
+    <my_parent db-doc-ref="/data"/>
+    <repeat_doc_ref db-doc-ref="/data/repeat_section">
+      value value
+    </repeat_doc_ref>
+  </repeat_section>
+  <repeat_section db-doc="true">
+    <extra>data3</extra>
+    <type>repeater</type>
+    <some_property>some_value_3</some_property>
+    <my_parent db-doc-ref="/data"/>
+    <child>
+      <repeat_doc_ref db-doc-ref="/data/repeat_section">
+        value value
+      </repeat_doc_ref>
+    </child>
+  </repeat_section>
+</data>

--- a/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-same-as-repeat.xml
+++ b/webapp/tests/karma/ts/services/enketo-xml/db-doc-ref-same-as-repeat.xml
@@ -16,7 +16,7 @@
     <type>repeater</type>
     <some_property>some_value_2</some_property>
     <my_parent db-doc-ref="/data"/>
-    <repeat_doc_ref db-doc-ref="/data/repeat_section">
+    <repeat_doc_ref db-doc-ref="./repeat_section">
       value value
     </repeat_doc_ref>
   </repeat_section>

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1299,6 +1299,112 @@ describe('Enketo service', () => {
       });
     });
 
+    it('db-doc-ref with repeats with db-doc as repeat', () => {
+      form.validate.resolves(true);
+      const content = loadXML('db-doc-ref-same-as-repeat');
+      form.getDataStr.returns(content);
+
+      dbBulkDocs.resolves([
+        { ok: true, id: '6', rev: '1-abc' },
+        { ok: true, id: '7', rev: '1-def' },
+      ]);
+      dbGetAttachment.resolves(`<form/>`);
+      FileReader.utf8.resolves(`
+        <data>
+          <repeat nodeset="/data/repeat_section"></repeat>
+        </data>
+      `);
+      UserContact.resolves({ _id: '123', phone: '555' });
+      return service.save('V', form).then(actual => {
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
+
+        expect(actual.length).to.equal(4);
+
+        expect(actual[0]).to.deep.nested.include({
+          form: 'V',
+          'fields.name': 'Sally',
+          'fields.lmp': '10',
+        });
+        expect(actual[1]).to.deep.include({
+          extra: 'data1',
+          type: 'repeater',
+          some_property: 'some_value_1',
+          my_parent: actual[0]._id,
+          repeat_doc_ref: actual[1]._id, // yup, this is how it should be.
+        });
+        expect(actual[2]).to.deep.include({
+          extra: 'data2',
+          type: 'repeater',
+          some_property: 'some_value_2',
+          my_parent: actual[0]._id,
+          repeat_doc_ref: actual[2]._id, // yup, this is how it should be.
+        });
+        expect(actual[3]).to.deep.nested.include({
+          extra: 'data3',
+          type: 'repeater',
+          some_property: 'some_value_3',
+          my_parent: actual[0]._id,
+          'child.repeat_doc_ref': actual[3]._id, // yup, this is how it should be.
+        });
+      });
+    });
+
+    it('db-doc-ref with repeats with invalid ref', () => {
+      form.validate.resolves(true);
+      const content = loadXML('db-doc-ref-broken-ref');
+      form.getDataStr.returns(content);
+
+      dbBulkDocs.resolves([
+        { ok: true, id: '6', rev: '1-abc' },
+        { ok: true, id: '7', rev: '1-def' },
+      ]);
+      dbGetAttachment.resolves(`<form/>`);
+      FileReader.utf8.resolves(`
+        <data>
+          <repeat nodeset="/data/repeat_section"></repeat>
+        </data>
+      `);
+      UserContact.resolves({ _id: '123', phone: '555' });
+      return service.save('V', form).then(actual => {
+        expect(form.validate.callCount).to.equal(1);
+        expect(form.getDataStr.callCount).to.equal(1);
+        expect(dbBulkDocs.callCount).to.equal(1);
+        expect(UserContact.callCount).to.equal(1);
+
+        expect(actual.length).to.equal(4);
+
+        expect(actual[0]).to.deep.nested.include({
+          form: 'V',
+          'fields.name': 'Sally',
+          'fields.lmp': '10',
+        });
+        expect(actual[1]).to.deep.include({
+          extra: 'data1',
+          type: 'repeater',
+          some_property: 'some_value_1',
+          my_parent: actual[0]._id,
+          repeat_doc_ref: 'value1',
+        });
+        expect(actual[2]).to.deep.include({
+          extra: 'data2',
+          type: 'repeater',
+          some_property: 'some_value_2',
+          my_parent: actual[0]._id,
+          repeat_doc_ref: 'value2',
+        });
+        expect(actual[3]).to.deep.include({
+          extra: 'data3',
+          type: 'repeater',
+          some_property: 'some_value_3',
+          my_parent: actual[0]._id,
+          repeat_doc_ref: 'value3',
+        });
+      });
+    });
+
     it('saves attachments', () => {
       const jqFind = $.fn.find;
       sinon.stub($.fn, 'find');

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1327,27 +1327,28 @@ describe('Enketo service', () => {
           form: 'V',
           'fields.name': 'Sally',
           'fields.lmp': '10',
+          'fields.repeat_doc_ref' : actual[1]._id, // this ref is outside any repeat
         });
         expect(actual[1]).to.deep.include({
           extra: 'data1',
           type: 'repeater',
           some_property: 'some_value_1',
           my_parent: actual[0]._id,
-          repeat_doc_ref: actual[1]._id, // yup, this is how it should be.
+          repeat_doc_ref: actual[1]._id,
         });
         expect(actual[2]).to.deep.include({
           extra: 'data2',
           type: 'repeater',
           some_property: 'some_value_2',
           my_parent: actual[0]._id,
-          repeat_doc_ref: actual[2]._id, // yup, this is how it should be.
+          repeat_doc_ref: actual[2]._id,
         });
         expect(actual[3]).to.deep.nested.include({
           extra: 'data3',
           type: 'repeater',
           some_property: 'some_value_3',
           my_parent: actual[0]._id,
-          'child.repeat_doc_ref': actual[3]._id, // yup, this is how it should be.
+          'child.repeat_doc_ref': actual[3]._id,
         });
       });
     });


### PR DESCRIPTION
# Description

Treats cases where repeat elements have `db-doc` attribute, and have references to them. 

medic/cht-core#7485

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
