### PR TITLE
Update release issue templates regarding release documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ If applicable, add screenshots to help explain your problem.
 - Instance: (eg: alpha.dev.medicmobile.org, etc)
 - Browser: (eg: Firefox, Chrome, incognito mode, etc, which worked, which didn't)
 - Client platform: (eg: Windows, MacOS, Linux)
-- App: (eg: webapp, admin, sentinel, api, couch2pg, medic-conf, etc)
+- App: (eg: webapp, admin, sentinel, api, couch2pg, cht-conf, etc)
 - Version: (eg: 2.15.0, 3.0.0, etc)
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/performance.md
+++ b/.github/ISSUE_TEMPLATE/performance.md
@@ -28,7 +28,7 @@ Record at least one measurement that you think should be improved. Ex. 5 seconds
 - Instance: (eg: alpha.dev.medicmobile.org, etc)
 - Browser: (eg: Firefox, Chrome, incognito mode, etc, which worked, which didn't)
 - Client platform: (eg: Windows, MacOS, Linux)
-- App: (eg: webapp, admin, sentinel, api, couch2pg, medic-conf, etc)
+- App: (eg: webapp, admin, sentinel, api, couch2pg, cht-conf, etc)
 - Version: (eg: 2.15.0, 3.0.0, etc)
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -20,7 +20,7 @@ When development is ready to begin one of the engineers should be nominated as a
 
 - [ ] Set the version number in `package.json` and `package-lock.json` and submit a PR. The easiest way to do this is to use `npm --no-git-tag-version version <major|minor>`.
 - [ ] Raise a new issue called `Update dependencies for <version>` with a description that links to [the documentation](https://docs.communityhealthtoolkit.org/core/guides/update-dependencies/). This should be done early in the release cycle so find a volunteer to take this on and assign it to them.
-- [ ] Write an update in the weekly Product Team call agenda summarising development and acceptance testing progress and identifying any blockers. The release Engineer is to update this every week until the version is released.
+- [ ] Write an update in the weekly Product Team call agenda summarising development and acceptance testing progress and identifying any blockers (the [milestone-status](https://github.com/medic/support-scripts/tree/master/milestone-status) script can be used to get a breakdown of the issues). The release Engineer is to update this every week until the version is released.
 
 # Releasing - Release Engineer
 
@@ -31,23 +31,32 @@ Once all issues have passed acceptance testing and have been merged into `master
 @core_devs I've just created the `<major>.<minor>.x` release branch. Please be aware that any further changes intended for this release will have to be merged to `master` then backported. Thanks!
 ```
 - [ ] Build a beta named `<major>.<minor>.<patch>-beta.1` by pushing a git tag and when CI completes successfully notify the QA team that it's ready for release testing.
-- [ ] Create a new document in the [release-notes folder](https://github.com/medic/cht-core/tree/master/release-notes) in `master`. Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. Use [this script](https://github.com/medic/cht-core/blob/master/scripts/release-notes) to export the issues into our release note format. Manually document any known migration steps and known issues. Provide description, screenshots, videos, and anything else to help communicate particularly important changes. Document any required or recommended upgrades to our other products (eg: medic-conf,  medic-gateway, medic-android). Assign the PR to a) the Director of Technology, and b) an SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient.
+- [ ] Add release notes to the [Core Framework Releases](https://docs.communityhealthtoolkit.org/core/releases/) page:
+  - [ ] Create a new document for the release in the [releases folder](https://github.com/medic/cht-docs/tree/main/content/en/core/releases). 
+  - [ ] Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions. 
+  - [ ] Use [this script](https://github.com/medic/cht-core/blob/master/scripts/release-notes) to export the issues into our release note format. 
+  - [ ] Manually document any known migration steps and known issues. 
+  - [ ] Provide description, screenshots, videos, and anything else to help communicate particularly important changes. 
+  - [ ] Document any required or recommended upgrades to our other products (eg: medic-conf,  medic-gateway, medic-android).
+  - [ ] Add the release to the [Supported versions](https://docs.communityhealthtoolkit.org/core/releases/) and update the EOL date and status of previous releases. Also add a link in the `Release Notes` section to the new release page.
+  - [ ] Assign the PR to:
+    - The Director of Technology
+    - An SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient
 - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another beta.
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
 - [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Review the scalability results on S3 at medic-e2e/scalability/$TAG_NAME. Add the release `.jtl` file to `cht-core/tests/scalability/previous_results`. Compare the trend using the [scalability documentation](https://github.com/medic/cht-core/blob/master/tests/scalability/README.md).
 - [ ] Upgrade the `demo-cht.dev` instance to this version.
-- [ ] Add the release to the [Supported versions](https://docs.communityhealthtoolkit.org/core/overview/supported-software/) and update the EOL date and status of previous releases.
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:
 ```
-@channel *We're excited to announce the release of {{version}} of {{product}}*
+*We're excited to announce the release of {{version}} of {{product}}*
 
 New features include {{key_features}}. We've also implemented loads of other improvements and fixed a heap of bugs.
 
-Read the release notes for full details: {{url}}
+Read the [release notes]({{url}}) for full details.
 
-Following our support policy, versions {{versions}} are no longer supported. Projects running these versions should start planning to upgrade in the near future. For more details read our software support documentation: https://docs.communityhealthtoolkit.org/core/overview/supported-software/
+Following our support policy, versions {{versions}} are no longer supported. Projects running these versions should start planning to upgrade in the near future. For more details read our [software support documentation](https://docs.communityhealthtoolkit.org/core/overview/supported-software/).
 
-See what's scheduled for the next releases: https://github.com/medic/cht-core/milestones
+Check our [milesones](https://github.com/medic/cht-core/milestones) to see what's scheduled for the next releases.
 ```
 - [ ] Mark this issue "done" and close the Milestone.

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -57,6 +57,6 @@ Read the [release notes]({{url}}) for full details.
 
 Following our support policy, versions {{versions}} are no longer supported. Projects running these versions should start planning to upgrade in the near future. For more details read our [software support documentation](https://docs.communityhealthtoolkit.org/core/overview/supported-software/).
 
-Check our [milesones](https://github.com/medic/cht-core/milestones) to see what's scheduled for the next releases.
+Check out our [roadmap](https://github.com/orgs/medic/projects/112) to see what we're working on next.
 ```
 - [ ] Mark this issue "done" and close the Milestone.

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -45,7 +45,7 @@ Once all issues have passed acceptance testing and have been merged into `master
 - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another beta.
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
 - [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
-- [ ] Review the scalability results on S3 at medic-e2e/scalability/$TAG_NAME. Add the release `.jtl` file to `cht-core/tests/scalability/previous_results`. Compare the trend using the [scalability documentation](https://github.com/medic/cht-core/blob/master/tests/scalability/README.md).
+- [ ] Execute the scalability testing suite on the final build and download the scalability results on S3 at medic-e2e/scalability/$TAG_NAME. Add the release `.jtl` file to `cht-core/tests/scalability/previous_results`. More info in the  [scalability documentation](https://github.com/medic/cht-core/blob/master/tests/scalability/README.md).
 - [ ] Upgrade the `demo-cht.dev` instance to this version.
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:
 ```

--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -37,7 +37,7 @@ Once all issues have passed acceptance testing and have been merged into `master
   - [ ] Use [this script](https://github.com/medic/cht-core/blob/master/scripts/release-notes) to export the issues into our release note format. 
   - [ ] Manually document any known migration steps and known issues. 
   - [ ] Provide description, screenshots, videos, and anything else to help communicate particularly important changes. 
-  - [ ] Document any required or recommended upgrades to our other products (eg: medic-conf,  medic-gateway, medic-android).
+  - [ ] Document any required or recommended upgrades to our other products (eg: cht-conf, cht-gateway, cht-android).
   - [ ] Add the release to the [Supported versions](https://docs.communityhealthtoolkit.org/core/releases/) and update the EOL date and status of previous releases. Also add a link in the `Release Notes` section to the new release page.
   - [ ] Assign the PR to:
     - The Director of Technology

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -17,21 +17,29 @@ assignees: ''
 When development is ready to begin one of the engineers should be nominated as a Release Engineer. They will be responsible for making sure the following tasks are completed though not necessarily completing them.
 
 - [ ] Set the version number in `package.json` and `package-lock.json` and submit a PR to the release branch. The easiest way to do this is to use `npm --no-git-tag-version version patch`.
-- [ ] Write an update in the weekly Product Team call agenda summarising development and acceptance testing progress and identifying any blockers. The Release Engineer is to update this every week until the version is released.
+- [ ] Write an update in the weekly Product Team call agenda summarising development and acceptance testing progress and identifying any blockers (the [milestone-status](https://github.com/medic/support-scripts/tree/master/milestone-status) script can be used to get a breakdown of the issues). The Release Engineer is to update this every week until the version is released.
 
 # Releasing - Release Engineer
 
 Once all issues have passed acceptance testing and have been merged into `master` and backported to the release branch release testing can begin.
 
 - [ ] Build a beta named `<major>.<minor>.<patch>-beta.1` by pushing a git tag and when CI completes successfully notify the QA team that it's ready for release testing.
-- [ ] Create a new document in the [release-notes folder](https://github.com/medic/cht-core/tree/master/release-notes) in `master`. Ensure all issues are in the GH Milestone, that they're correct labelled, and have human readable descriptions. Use [this script](https://github.com/medic/cht-core/blob/master/scripts/release-notes/) to export the issues into our release note format. Manually document any known migration steps and known issues.
+- [ ] Add release notes to the [Core Framework Releases](https://docs.communityhealthtoolkit.org/core/releases/) page:
+    - [ ] Create a new document for the release in the [releases folder](https://github.com/medic/cht-docs/tree/main/content/en/core/releases).
+    - [ ] Ensure all issues are in the GH Milestone, that they're correctly labelled (in particular: they have the right Type, "UI/UX" if they change the UI, and "Breaking change" if appropriate), and have human readable descriptions.
+    - [ ] Use [this script](https://github.com/medic/cht-core/blob/master/scripts/release-notes) to export the issues into our release note format.
+    - [ ] Manually document any known migration steps and known issues.
+    - [ ] Add a link to the new release page in the [Release Notes](https://docs.communityhealthtoolkit.org/core/releases/#release-notes) section.
+    - [ ] Assign the PR to:
+        - The Director of Technology
+        - An SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient
 - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another beta.
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
 - [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/), under the "Product - Releases" category using this template:
 ```
-@channel *Announcing the release of {{version}}*
+*Announcing the release of {{version}}*
 
-This release fixes {{number of bugs}}. Read the release notes for full details: {{url}}
+This release fixes {{number of bugs}}. Read the [release notes]({{url}}) for full details.
 ```
 - [ ] Mark this issue "done" and close the Milestone.

--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -126,14 +126,14 @@ const outputGroups = (groups) => {
 
 const output = ({ warnings, types }) => {
   console.log(`
-# ${MILESTONE_NAME} Release Notes
-
-- [Known issues](#known-issues)
-- [Upgrade notes](#upgrade-notes)
-- [Breaking changes](#breaking-changes)
-- [UI/UX changes](#uiux-changes)
-- [Highlights](#highlights)
-- [And more...](#and-more)
+  ---
+title: "${MILESTONE_NAME} release notes"
+linkTitle: "${MILESTONE_NAME}"
+weight:
+description: >
+relevantLinks: >
+toc_hide: true
+---
 
 ## Known issues
 

--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -126,7 +126,7 @@ const outputGroups = (groups) => {
 
 const output = ({ warnings, types }) => {
   console.log(`
-  ---
+---
 title: "${MILESTONE_NAME} release notes"
 linkTitle: "${MILESTONE_NAME}"
 weight:


### PR DESCRIPTION
# Description

Now that the release notes were moved to https://github.com/medic/cht-docs in https://github.com/medic/cht-core/commit/61664b8544c1cc02ce32db7270d490f96cc89f7c the documention for creating the release notes on the issue templates is out of date.  

This PR just updates the release templates to include instructions for adding the release notes to https://github.com/medic/cht-docs.

Additionally, I have updated the `release-notes` script to add the proper front-matter to the new release notes pages.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
