### PR TITLE
Handle rejections from privacy policy accept

### DIFF
--- a/webapp/src/ts/modules/privacy-policy/privacy-policy.component.ts
+++ b/webapp/src/ts/modules/privacy-policy/privacy-policy.component.ts
@@ -50,6 +50,7 @@ export class PrivacyPolicyComponent implements OnInit {
     this.accepting = true;
     return this.privacyPoliciesService
       .accept(this.privacyPolicy)
+      .catch(err => console.warn('Error accepting privacy policy - continuing.', err))
       .then(() => this.globalActions.setPrivacyPolicyAccepted(true))
       .then(() => this.startupModalsService.showStartupModals());
   }

--- a/webapp/tests/karma/ts/modules/privacy-policies/privacy-policy.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/privacy-policies/privacy-policy.component.spec.ts
@@ -110,4 +110,25 @@ describe('PrivacyPoliciesComponent', () => {
     expect(setPrivacyPolicyAcceptedSpy.args[0][0]).to.equal(true);
     expect(startupModalsService.showStartupModals.callCount).to.equal(1);
   });
+
+  it('should fail gracefully when accepting privacy policy fails', async () => {
+    const policy = {
+      html: 'html',
+      digest: 'my_digest',
+      language: 'fr',
+    };
+    component.privacyPolicy = { ...policy };
+    privacyPoliciesService.accept.rejects(new Error('error'));
+    const setPrivacyPolicyAcceptedSpy = sinon.spy(GlobalActions.prototype, 'setPrivacyPolicyAccepted');
+
+    await component.accept();
+
+    expect(component.accepting).to.equal(true);
+    expect(privacyPoliciesService.accept.callCount).to.equal(1);
+    expect(privacyPoliciesService.accept.args[0][0]).to.deep.equal(policy);
+    expect(setPrivacyPolicyAcceptedSpy.callCount).to.equal(1);
+    expect(setPrivacyPolicyAcceptedSpy.args[0][0]).to.equal(true);
+    expect(startupModalsService.showStartupModals.callCount).to.equal(1);
+  });
+
 });


### PR DESCRIPTION
If something goes wrong accepting the privacy policy
we should catch the rejection and handle it gracefully.

medic/cht-core#7505

# Description

[description]

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
