### PR TITLE
7529 - Increase Enketo's upload file size limit and add validation when submitting form

### DIFF
--- a/ddocs/medic/_attachments/translations/messages-en.properties
+++ b/ddocs/medic/_attachments/translations/messages-en.properties
@@ -621,6 +621,7 @@ email.invalid = Invalid email address.
 empty = It looks like you sent an empty message, please try to resend. If you continue to have this problem please contact your supervisor.
 enketo.constraint.invalid = Value not allowed
 enketo.constraint.required = This field is required
+enketo.error.max_attachment_size = The uploaded files exceed the total size limit. Please upload smaller files.
 enketo.form.required = required
 error.403.description = You have insufficient privileges to view this page. Talk to an administrator to increase your privileges.
 error.403.title = Access denied

--- a/webapp/src/js/enketo/constants.js
+++ b/webapp/src/js/enketo/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  maxAttachmentSize: 30 * 1024 * 1024, // 30 MB, API's max request body is 32MB.
+};

--- a/webapp/src/js/enketo/widgets.js
+++ b/webapp/src/js/enketo/widgets.js
@@ -1,7 +1,8 @@
 {
+  const enketoConstants = require( './constants' );
   const fileManager = require( 'enketo-core/src/js/file-manager' );
   fileManager.isTooLarge = function( file ) {
-    return file && file.size > 32 * 1024;
+    return file && file.size > enketoConstants.maxAttachmentSize;
   };
 
   const widgets = [

--- a/webapp/src/ts/components/snackbar/snackbar.component.ts
+++ b/webapp/src/ts/components/snackbar/snackbar.component.ts
@@ -42,22 +42,24 @@ export class SnackbarComponent implements OnInit {
 
   ngOnInit() {
     this.changeDetectorRef.detach();
-    const reduxSubscription = this.store.select(Selectors.getSnackbarContent).subscribe((snackbarContent) => {
-      if (!snackbarContent?.message) {
-        this.hide();
+    const reduxSubscription = this.store
+      .select(Selectors.getSnackbarContent)
+      .subscribe((snackbarContent) => {
+        if (!snackbarContent?.message) {
+          this.hide();
 
-        return;
-      }
+          return;
+        }
 
-      const { message, action } = snackbarContent;
-      if (this.active) {
-        this.queueShowMessage(message, action);
+        const { message, action } = snackbarContent;
+        if (this.active) {
+          this.queueShowMessage(message, action);
 
-        return;
-      }
+          return;
+        }
 
-      this.show(message, action);
-    });
+        this.show(message, action);
+      });
     this.subscription.add(reduxSubscription);
     this.hide();
   }

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -28,6 +28,7 @@ import { ServicesActions } from '@mm-actions/services';
 import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TransitionsService } from '@mm-services/transitions.service';
+import { GlobalActions } from '@mm-actions/global';
 
 @Injectable({
   providedIn: 'root'
@@ -56,10 +57,12 @@ export class EnketoService {
     private ngZone:NgZone,
   ) {
     this.inited = this.init();
+    this.globalActions = new GlobalActions(store);
     this.servicesActions = new ServicesActions(this.store);
   }
 
-  private servicesActions;
+  private globalActions: GlobalActions;
+  private servicesActions: ServicesActions;
   private readonly HTML_ATTACHMENT_NAME = 'form.html';
   private readonly MODEL_ATTACHMENT_NAME = 'model.xml';
   private readonly objUrls = [];
@@ -714,16 +717,27 @@ export class EnketoService {
       });
   }
 
-  private validateAttachments(docs) {
-    let attachmentsSize = 0;
+  private async validateAttachments(docs) {
+    const oversizeDoc = docs.find(doc => {
+      let attachmentsSize = 0;
 
-    docs.forEach(doc => Object
-      .keys(doc?._attachments)
-      .forEach(name => attachmentsSize += doc._attachments[name]?.data?.size || 0)
-    );
+      if (doc._attachments) {
+        Object
+          .keys(doc._attachments)
+          .forEach(name => {
+            const data = doc._attachments[name]?.data; // It can be Base64 (binary) or object (file)
+            const size = typeof data === 'string' ? data.length : (data?.size || 0);
+            attachmentsSize += size;
+          });
+      }
 
-    if (attachmentsSize > enketoConstants.maxAttachmentSize) {
-      return Promise.reject(new Error('The uploaded files exceed total size limit.'));
+      return attachmentsSize > enketoConstants.maxAttachmentSize;
+    });
+
+    if (oversizeDoc) {
+      const errorMessage = await this.translateService.get('enketo.error.max_attachment_size');
+      this.globalActions.setSnackbarContent(errorMessage);
+      return Promise.reject(new Error(errorMessage));
     }
 
     return docs;

--- a/webapp/src/ts/services/update-service-worker.service.ts
+++ b/webapp/src/ts/services/update-service-worker.service.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
 import { GlobalActions } from '@mm-actions/global';
-import {environment} from '@mm-environments/environment';
+import { environment } from '@mm-environments/environment';
 
 @Injectable({
   providedIn: 'root'

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -25,6 +25,7 @@ import { ServicesActions } from '@mm-actions/services';
 import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TransitionsService } from '@mm-services/transitions.service';
 import { TranslateService } from '@mm-services/translate.service';
+import { GlobalActions } from '@mm-actions/global';
 import * as medicXpathExtensions from '../../../../src/js/enketo/medic-xpath-extensions';
 
 describe('Enketo service', () => {
@@ -67,6 +68,7 @@ describe('Enketo service', () => {
   let translateService;
   let zScoreService;
   let zScoreUtil;
+  let globalActions;
 
   beforeEach(() => {
     enketoInit = sinon.stub();
@@ -111,7 +113,7 @@ describe('Enketo service', () => {
     };
     zScoreUtil = sinon.stub();
     zScoreService = { getScoreUtil: sinon.stub().resolves(zScoreUtil) };
-
+    globalActions = { setSnackbarContent: sinon.stub(GlobalActions.prototype, 'setSnackbarContent') };
     setLastChangedDoc = sinon.stub(ServicesActions.prototype, 'setLastChangedDoc');
 
     TestBed.configureTestingModule({
@@ -1406,96 +1408,144 @@ describe('Enketo service', () => {
       });
     });
 
-    it('saves attachments', () => {
-      const jqFind = $.fn.find;
-      sinon.stub($.fn, 'find');
-      //@ts-ignore
-      $.fn.find.callsFake(jqFind);
-
-      $.fn.find
+    describe('Saving attachments', () => {
+      it('should save attachments', () => {
+        const jqFind = $.fn.find;
+        sinon.stub($.fn, 'find');
         //@ts-ignore
-        .withArgs('input[type=file][name="/my-form/my_file"]')
-        .returns([{ files: [{ type: 'image', foo: 'bar' }] }]);
+        $.fn.find.callsFake(jqFind);
 
-      form.validate.resolves(true);
-      const content = loadXML('file-field');
+        $.fn.find
+          //@ts-ignore
+          .withArgs('input[type=file][name="/my-form/my_file"]')
+          .returns([{ files: [{ type: 'image', foo: 'bar' }] }]);
 
-      form.getDataStr.returns(content);
-      dbGetAttachment.resolves('<form/>');
-      UserContact.resolves({ _id: 'my-user', phone: '8989' });
-      dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
-      return service.save('my-form', form, () => Promise.resolve(true)).then(() => {
-        expect(AddAttachment.callCount).to.equal(2);
+        form.validate.resolves(true);
+        const content = loadXML('file-field');
 
-        expect(AddAttachment.args[0][1]).to.equal('user-file/my-form/my_file');
-        expect(AddAttachment.args[0][2]).to.deep.equal({ type: 'image', foo: 'bar' });
-        expect(AddAttachment.args[0][3]).to.equal('image');
+        form.getDataStr.returns(content);
+        dbGetAttachment.resolves('<form/>');
+        UserContact.resolves({ _id: 'my-user', phone: '8989' });
+        dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
+        // @ts-ignore
+        const saveDocsSpy = sinon.spy(EnketoService.prototype, 'saveDocs');
 
-        expect(AddAttachment.args[1][1]).to.equal('content');
+        return service
+          .save('my-form', form, () => Promise.resolve(true))
+          .then(() => {
+            expect(AddAttachment.calledTwice);
+            expect(saveDocsSpy.calledOnce);
+
+            expect(AddAttachment.args[0][1]).to.equal('user-file/my-form/my_file');
+            expect(AddAttachment.args[0][2]).to.deep.equal({ type: 'image', foo: 'bar' });
+            expect(AddAttachment.args[0][3]).to.equal('image');
+
+            expect(AddAttachment.args[1][1]).to.equal('content');
+            expect(globalActions.setSnackbarContent.notCalled);
+          });
       });
-    });
 
-    it('removes binary data from content', () => {
-      form.validate.resolves(true);
-      const content = loadXML('binary-field');
+      it('should throw exception if attachments are big', () => {
+        translateService.get.returnsArg(0);
+        form.validate.resolves(true);
+        dbGetAttachment.resolves('<form/>');
+        UserContact.resolves({ _id: 'my-user', phone: '8989' });
+        // @ts-ignore
+        const saveDocsStub = sinon.stub(EnketoService.prototype, 'saveDocs');
+        // @ts-ignore
+        const xmlToDocsStub = sinon.stub(EnketoService.prototype, 'xmlToDocs').resolves([
+          { _id: '1a' },
+          { _id: '1b', _attachments: {} },
+          {
+            _id: '1c',
+            _attachments: {
+              a_file: { data: { size: 10 * 1024 * 1024 } },
+              b_file: { data: 'SSdtIGJhdG1hbg==' },
+              c_file: { data: { size: 20 * 1024 * 1024 } },
+            }
+          },
+          {
+            _id: '1d',
+            _attachments: {
+              a_file: { content_type: 'image/png' }
+            }
+          }
+        ]);
 
-      const expected =
-        `<my-form>
+        return service
+          .save('my-form', form, () => Promise.resolve(true))
+          .then(() => expect.fail('Should have thrown exception.'))
+          .catch(error => {
+            expect(xmlToDocsStub.calledOnce);
+            expect(error.message).to.equal('enketo.error.max_attachment_size');
+            expect(saveDocsStub.notCalled);
+            expect(globalActions.setSnackbarContent.calledOnce);
+            expect(globalActions.setSnackbarContent.args[0]).to.have.members([ 'enketo.error.max_attachment_size' ]);
+          });
+      });
+
+      it('should remove binary data from content', () => {
+        form.validate.resolves(true);
+        const content = loadXML('binary-field');
+
+        const expected =
+          `<my-form>
   <name>Mary</name>
   <age>10</age>
   <gender>f</gender>
   <my_file type="binary"/>
 </my-form>`;
 
-      form.getDataStr.returns(content);
-      dbGetAttachment.resolves('<form/>');
-      UserContact.resolves({ _id: 'my-user', phone: '8989' });
-      dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
-      return service.save('my-form', form, () => Promise.resolve(true)).then(() => {
-        expect(AddAttachment.callCount).to.equal(2);
+        form.getDataStr.returns(content);
+        dbGetAttachment.resolves('<form/>');
+        UserContact.resolves({ _id: 'my-user', phone: '8989' });
+        dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
+        return service.save('my-form', form, () => Promise.resolve(true)).then(() => {
+          expect(AddAttachment.callCount).to.equal(2);
 
-        expect(AddAttachment.args[0][1]).to.equal('user-file/my-form/my_file');
-        expect(AddAttachment.args[0][2]).to.deep.equal('some image data');
-        expect(AddAttachment.args[0][3]).to.equal('image/png');
+          expect(AddAttachment.args[0][1]).to.equal('user-file/my-form/my_file');
+          expect(AddAttachment.args[0][2]).to.deep.equal('some image data');
+          expect(AddAttachment.args[0][3]).to.equal('image/png');
 
-        expect(AddAttachment.args[1][1]).to.equal('content');
-        expect(AddAttachment.args[1][2]).to.equal(expected);
+          expect(AddAttachment.args[1][1]).to.equal('content');
+          expect(AddAttachment.args[1][2]).to.equal(expected);
+        });
       });
-    });
 
-    it('attachment names are relative to the form name not the root node name', () => {
-      const jqFind = $.fn.find;
-      sinon.stub($.fn, 'find');
-      //@ts-ignore
-      $.fn.find.callsFake(jqFind);
-      $.fn.find
+      it('should assign attachment names relative to the form name not the root node name', () => {
+        const jqFind = $.fn.find;
+        sinon.stub($.fn, 'find');
         //@ts-ignore
-        .withArgs('input[type=file][name="/my-root-element/my_file"]')
-        .returns([{ files: [{ type: 'image', foo: 'bar' }] }]);
-      $.fn.find
-        //@ts-ignore
-        .withArgs('input[type=file][name="/my-root-element/sub_element/sub_sub_element/other_file"]')
-        .returns([{ files: [{ type: 'mytype', foo: 'baz' }] }]);
-      form.validate.resolves(true);
-      const content = loadXML('deep-file-fields');
+        $.fn.find.callsFake(jqFind);
+        $.fn.find
+          //@ts-ignore
+          .withArgs('input[type=file][name="/my-root-element/my_file"]')
+          .returns([{ files: [{ type: 'image', foo: 'bar' }] }]);
+        $.fn.find
+          //@ts-ignore
+          .withArgs('input[type=file][name="/my-root-element/sub_element/sub_sub_element/other_file"]')
+          .returns([{ files: [{ type: 'mytype', foo: 'baz' }] }]);
+        form.validate.resolves(true);
+        const content = loadXML('deep-file-fields');
 
-      form.getDataStr.returns(content);
-      dbGetAttachment.resolves('<form/>');
-      UserContact.resolves({ _id: 'my-user', phone: '8989' });
-      dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
-      return service.save('my-form-internal-id', form, () => Promise.resolve(true)).then(() => {
-        expect(AddAttachment.callCount).to.equal(3);
+        form.getDataStr.returns(content);
+        dbGetAttachment.resolves('<form/>');
+        UserContact.resolves({ _id: 'my-user', phone: '8989' });
+        dbBulkDocs.callsFake(docs => Promise.resolve([ { ok: true, id: docs[0]._id, rev: '1-abc' } ]));
+        return service.save('my-form-internal-id', form, () => Promise.resolve(true)).then(() => {
+          expect(AddAttachment.callCount).to.equal(3);
 
-        expect(AddAttachment.args[0][1]).to.equal('user-file/my-form-internal-id/my_file');
-        expect(AddAttachment.args[0][2]).to.deep.equal({ type: 'image', foo: 'bar' });
-        expect(AddAttachment.args[0][3]).to.equal('image');
+          expect(AddAttachment.args[0][1]).to.equal('user-file/my-form-internal-id/my_file');
+          expect(AddAttachment.args[0][2]).to.deep.equal({ type: 'image', foo: 'bar' });
+          expect(AddAttachment.args[0][3]).to.equal('image');
 
-        expect(AddAttachment.args[1][1])
-          .to.equal('user-file/my-form-internal-id/sub_element/sub_sub_element/other_file');
-        expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'mytype', foo: 'baz' });
-        expect(AddAttachment.args[1][3]).to.equal('mytype');
+          expect(AddAttachment.args[1][1])
+            .to.equal('user-file/my-form-internal-id/sub_element/sub_sub_element/other_file');
+          expect(AddAttachment.args[1][2]).to.deep.equal({ type: 'mytype', foo: 'baz' });
+          expect(AddAttachment.args[1][3]).to.equal('mytype');
 
-        expect(AddAttachment.args[2][1]).to.equal('content');
+          expect(AddAttachment.args[2][1]).to.equal('content');
+        });
       });
     });
 
@@ -1611,7 +1661,7 @@ describe('Enketo service', () => {
               transitioned: true,
             },
             {
-            // docs that transitions push don't have geodata, this is intentional!
+              // docs that transitions push don't have geodata, this is intentional!
               type: 'existent doc updated by the transition',
             },
           ]);


### PR DESCRIPTION
# Description

This PR:
- Increases the Enketo's upload file size limit to 30MB, leaving a couple of megas for other things.
- Adds a validation that sums all form's attachments and ensures it's not more than 30MB.
-  Shows error message to the user when limit is exceeded by using the snackbar.

https://github.com/medic/cht-core/issues/7529

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
