### PR TITLE
Remove after all function that repeats work

### DIFF
--- a/tests/e2e/login/token-login.wdio-spec.js
+++ b/tests/e2e/login/token-login.wdio-spec.js
@@ -62,10 +62,6 @@ describe('Token login', () => {
     await utils.revertDb([], true);
   });
 
-  after(async () => {
-    await utils.revertDb([], 'api');
-  });
-
   it('should redirect the user to the app if already logged in', async () => {
     await loginPage.cookieLogin();
     await browser.url(getUrl('this is a random string'));


### PR DESCRIPTION
# Description

Removes the `after` function which only did a `revertDb` that was already done in `afterEach`.

medic/cht-core#7533

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
