### PR TITLE
Fix eslint error in `tests/e2e/api/controllers/users.js`

### DIFF
--- a/tests/e2e/api/controllers/users.js
+++ b/tests/e2e/api/controllers/users.js
@@ -1125,7 +1125,7 @@ describe('Users API', () => {
         await utils.updateSettings(settings, true);
         await utils.addTranslations('en', { token_login_sms: 'Instructions sms' });
         const response = await utils.request({ path: '/api/v1/users', method: 'POST', body: users });
-        response.map((responseUser, index) => {
+        response.forEach((responseUser, index) => {
           chai.expect(responseUser).to.shallowDeepEqual({
             user: { id: getUserId(users[index].username) },
             'user-settings': { id: getUserId(users[index].username) },


### PR DESCRIPTION
# Description

The `array-callback-return` eslint rule was merged to master before the `api/create-many-users` branch which breaks it. This branch fixes it.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
