### PR TITLE
Fix docker run command for CouchDB in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,7 @@ We recommend using Docker to install and use CouchDB. This ensures you are getti
 After [installing docker](https://docs.docker.com/get-docker/), you can create a docker container like so:
 
 ```sh
-docker run -d -p 5984:5984 -p 5986:5986 --name medic-couchdb -e COUCHDB_USER=myadminuser -e COUCHDB_PASSWORD=myadminpass --rm -v <data path>:/opt/couchdb/data -v <config path>:/opt/couchdb/etc/local.d apache/couchdb:2
+docker run -d -p 5984:5984 -p 5986:5986 --name medic-couchdb -e COUCHDB_USER=myadminuser -e COUCHDB_PASSWORD=myadminpass -v <data path>:/opt/couchdb/data -v <config path>:/opt/couchdb/etc/local.d apache/couchdb:2
 ```
 
 Notes before copy pasting:
@@ -44,7 +44,7 @@ Notes before copy pasting:
 
 Once this downloads and starts, you will need to [initialise CouchDB](http://localhost:5984/_utils/#/setup) as noted in [their install instructions](https://docs.couchdb.org/en/2.3.1/setup/index.html#setup).
 
-You can use `docker stop medic-couchdb` to stop it and `docker start medic-couchdb` to start it again. Remember that you'll need to start it whenever you restart your OS, which might not be the case if you use a normal OS package.
+You can use `docker stop medic-couchdb` to stop it and `docker start medic-couchdb` to start it again. Remember that you'll need to start it whenever you restart your OS, which might not be the case if you use a normal OS package. `docker rm medic-couchdb` will totally remove the container.
 
 Medic recommends you familiarise yourself with other Docker commands to make docker image and container management clearer.
 


### PR DESCRIPTION
# Description

Currently the recommended command from the DEVELOPMENT.md docs for running CouchDB on docker contains the `--rm` flag which causes the container to be removed as soon as it is stopped.  This conflicts with later documentation regarding the ability to start and stop the `medic-couchdb` container.  

This PR just removes the `--rm` flag and adds some doc on how the container can be removed.

[Forum post](https://forum.communityhealthtoolkit.org/t/errors-while-trying-to-run-core-locally/1767/2) for context.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
