### PR TITLE
Fix node version in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ Developers are actively using both Linux and MacOS, so both of those platforms a
 
 You will need to install the following:
 
-- [Node.js](https://nodejs.org) 8.11.x and above LTS release (designated with an even major version number)
+- [Node.js](https://nodejs.org) 12.x
 - [npm](https://npmjs.com/) 6.x.x and above (to support npm ci)
 - [grunt cli](https://gruntjs.com/using-the-cli)
 - [CouchDB](https://couchdb.apache.org) 2.x ([installation instructions](http://docs.couchdb.org/en/2.3.1/install/index.html)). For simplicity we [recommend installing via docker](#couchdb-on-docker). If on a Mac, please note that installation via homebrew is **not** supported. If on Ubuntu and you don't want to use docker, see [our notes below](#couchdb-on-docker).


### PR DESCRIPTION
# Description

Updates documentation for the recommended NodeJS version for running the CHT in a development environment to be the required `12.x` (after the changes from https://github.com/medic/cht-core/pull/7257).

Updates were already made to the [doc site](https://github.com/medic/cht-docs/commit/70332ffa01624de14a49d52ea637306cee55a14b).  Note that technically I think we want to keep this dev environment split between the DEVELOPMENT.md (for cht-core development) and the [docs site](https://docs.communityhealthtoolkit.org/apps/tutorials/local-setup/) (for app development).  There is not much duplication here and the purpose/audience of the two is different.

Also, I realize that all of this is changing soon (with `4.0.0`) but it seems appropriate to try to avoid confusion in the meantime by fixing this.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
