### PR TITLE
add step for patch releases to add known issues on prior release

### DIFF
--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -30,6 +30,7 @@ Once all issues have passed acceptance testing and have been merged into `master
     - [ ] Use [this script](https://github.com/medic/cht-core/blob/master/scripts/release-notes) to export the issues into our release note format.
     - [ ] Manually document any known migration steps and known issues.
     - [ ] Add a link to the new release page in the [Release Notes](https://docs.communityhealthtoolkit.org/core/releases/#release-notes) section.
+    - [ ] Go to the applicable prior release and add an entry for fixes in this patch release as "Known Issues".
     - [ ] Assign the PR to:
         - The Director of Technology
         - An SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient


### PR DESCRIPTION
 per #7562

# Description

Adds a 1 liner in the docs PR process to update prior version's release notes "known issues"

medic/cht-core#[number]


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
