### PR TITLE
make the user's language available in Enketo forms

### DIFF
--- a/config/default/app_settings.json
+++ b/config/default/app_settings.json
@@ -261,9 +261,6 @@
     "can_write_wealth_quintiles": [],
     "can_aggregate_targets": [
       "chw_supervisor"
-    ],
-    "can_upgrade": [
-      "program_officer"
     ]
   },
   "changes_controller": {

--- a/config/default/app_settings.json
+++ b/config/default/app_settings.json
@@ -261,6 +261,9 @@
     "can_write_wealth_quintiles": [],
     "can_aggregate_targets": [
       "chw_supervisor"
+    ],
+    "can_upgrade": [
+      "program_officer"
     ]
   },
   "changes_controller": {

--- a/webapp/tests/karma/ts/services/enketo-prepopulation-data.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo-prepopulation-data.service.spec.ts
@@ -4,10 +4,12 @@ import { expect, assert } from 'chai';
 
 import { EnketoPrepopulationDataService } from '@mm-services/enketo-prepopulation-data.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
+import { LanguageService } from '@mm-services/language.service';
 
 describe('EnketoPrepopulationData service', () => {
   let service;
   let UserSettings;
+  let languageSettings;
 
   const generatedForm =
   '<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">' +
@@ -37,6 +39,7 @@ describe('EnketoPrepopulationData service', () => {
           '<inputs>' +
             '<user>' +
               '<name/>' +
+              '<language/>' +
             '</user>' +
             '<meta>' +
               '<location>' +
@@ -140,9 +143,11 @@ describe('EnketoPrepopulationData service', () => {
 
   beforeEach(() => {
     UserSettings = sinon.stub();
+    languageSettings = sinon.stub();
     TestBed.configureTestingModule({
       providers: [
         { provide: UserSettingsService, useValue: { get: UserSettings } },
+        { provide: LanguageService, useValue: { get: languageSettings } },
       ]
     });
     service = TestBed.inject(EnketoPrepopulationDataService);
@@ -216,17 +221,20 @@ describe('EnketoPrepopulationData service', () => {
       });
   });
 
-  it('binds user details and form content into model', () => {
+  it('binds user details, user language and form content into model', () => {
     const data = { person: { last_name: 'salmon' } };
     const user = { name: 'geoff' };
     UserSettings.resolves(user);
+    languageSettings.resolves('en');
     return service
       .get(editPersonForm, data)
       .then((actual) => {
         const xml = $($.parseXML(actual));
         expect(xml.find('inputs > user > name')[0].innerHTML).to.equal(user.name);
+        expect(xml.find('inputs > user > language')[0].innerHTML).to.equal('en');
         expect(xml.find('data > person > last_name')[0].innerHTML).to.equal(data.person.last_name);
         expect(UserSettings.callCount).to.equal(1);
+        expect(languageSettings.callCount).to.equal(1);
       });
   });
 


### PR DESCRIPTION
# Description
enable the ability to get user's language in Enketo forms

medic/cht-core#7559

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
