### PR TITLE
7538 - Validate cookie when restoring the app from the bfcache 

### DIFF
--- a/admin/src/js/services/db.js
+++ b/admin/src/js/services/db.js
@@ -22,6 +22,7 @@ angular.module('inboxServices').factory('DB',
     const isOnlineOnly = Session.isOnlineOnly();
 
     const getUsername = remote => {
+      Session.checkCurrentSession();
       const username = Session.userCtx().name;
       if (!remote) {
         return username;

--- a/admin/src/js/services/session.js
+++ b/admin/src/js/services/session.js
@@ -101,14 +101,6 @@ const _ = require('lodash/core');
         return hasRole(userCtx, '_admin');
       };
 
-      $window.addEventListener('pageshow', (event) => {
-        // eslint-disable-next-line no-console
-        console.log('from bfcache =', event.persisted, ipCookie('userCtx'));
-        if (event.persisted && !ipCookie('userCtx')) {
-          navigateToLogin();
-        }
-      });
-
       return {
         logout: logout,
 
@@ -121,6 +113,8 @@ const _ = require('lodash/core');
         navigateToLogin: navigateToLogin,
 
         init: checkCurrentSession,
+
+        checkCurrentSession: checkCurrentSession,
 
         /**
          * Returns true if the logged in user has the db or national admin role.

--- a/admin/src/js/services/session.js
+++ b/admin/src/js/services/session.js
@@ -112,8 +112,6 @@ const _ = require('lodash/core');
 
         navigateToLogin: navigateToLogin,
 
-        init: checkCurrentSession,
-
         checkCurrentSession: checkCurrentSession,
 
         /**

--- a/admin/src/js/services/session.js
+++ b/admin/src/js/services/session.js
@@ -101,6 +101,14 @@ const _ = require('lodash/core');
         return hasRole(userCtx, '_admin');
       };
 
+      $window.addEventListener('pageshow', (event) => {
+        // eslint-disable-next-line no-console
+        console.log('from bfcache =', event.persisted, ipCookie('userCtx'));
+        if (event.persisted && !ipCookie('userCtx')) {
+          navigateToLogin();
+        }
+      });
+
       return {
         logout: logout,
 

--- a/admin/tests/unit/services/db.js
+++ b/admin/tests/unit/services/db.js
@@ -37,7 +37,8 @@ describe('DB service', () => {
       });
       $provide.value('Session', {
         userCtx: userCtx,
-        isOnlineOnly: isOnlineOnly
+        isOnlineOnly: isOnlineOnly,
+        checkCurrentSession: sinon.stub(),
       } );
       $provide.value('Location', Location);
     });

--- a/admin/tests/unit/services/session.js
+++ b/admin/tests/unit/services/session.js
@@ -69,7 +69,7 @@ describe('Session service', function() {
     $httpBackend
       .expect('DELETE', '/_session')
       .respond(200);
-    service.init();
+    service.checkCurrentSession();
     $httpBackend.flush();
     chai.expect(location.href).to.equal('/DB_NAME/login?redirect=CURRENT_URL');
     chai.expect(ipCookieRemove.args[0][0]).to.equal('userCtx');
@@ -82,7 +82,7 @@ describe('Session service', function() {
     $httpBackend
       .expect('GET', '/_session')
       .respond(401);
-    service.init();
+    service.checkCurrentSession();
     $httpBackend.flush();
     chai.expect(ipCookieRemove.args[0][0]).to.equal('userCtx');
     done();
@@ -93,7 +93,7 @@ describe('Session service', function() {
     $httpBackend
       .expect('GET', '/_session')
       .respond(0);
-    service.init();
+    service.checkCurrentSession();
     $httpBackend.flush();
     chai.expect(ipCookieRemove.callCount).to.equal(0);
     done();
@@ -110,7 +110,7 @@ describe('Session service', function() {
     $httpBackend
       .expect('DELETE', '/_session')
       .respond(200);
-    service.init();
+    service.checkCurrentSession();
     $httpBackend.flush();
     chai.expect(location.href).to.equal(`/DB_NAME/login?redirect=CURRENT_URL&username=${expected.name}`);
     chai.expect(ipCookieRemove.args[0][0]).to.equal('userCtx');
@@ -122,7 +122,7 @@ describe('Session service', function() {
     $httpBackend
       .expect('GET', '/_session')
       .respond(200, { userCtx: { name: 'bryan' } });
-    service.init();
+    service.checkCurrentSession();
     $httpBackend.flush();
     chai.expect(ipCookieRemove.callCount).to.equal(0);
     done();

--- a/admin/tests/unit/services/session.js
+++ b/admin/tests/unit/services/session.js
@@ -25,7 +25,6 @@ describe('Session service', function() {
         return {
           angular: { callbacks: [] },
           location: location,
-          addEventListener: sinon.stub()
         };
       });
     });

--- a/admin/tests/unit/services/session.js
+++ b/admin/tests/unit/services/session.js
@@ -25,6 +25,7 @@ describe('Session service', function() {
         return {
           angular: { callbacks: [] },
           location: location,
+          addEventListener: sinon.stub()
         };
       });
     });

--- a/admin/tests/unit/services/telemetry.js
+++ b/admin/tests/unit/services/telemetry.js
@@ -54,6 +54,7 @@ describe('Telemetry service', () => {
         userCtx: () => {
           return { name: 'greg' };
         },
+        checkCurrentSession: sinon.stub(),
       });
     });
     inject(_Telemetry_ => {

--- a/admin/tests/utils.js
+++ b/admin/tests/utils.js
@@ -63,7 +63,10 @@ window.KarmaUtils = {
       $provide.value('ContactViewModelGenerator', () => {});
       $provide.value('ReportViewModelGenerator', () => {});
       $provide.value('LiveList', mockLiveList);
-      $provide.value('Session', { userCtx: sinon.stub().returns({}) });
+      $provide.value('Session', {
+        userCtx: sinon.stub().returns({}),
+        checkCurrentSession: sinon.stub(),
+      });
     });
   }
 };

--- a/api/src/public/login/script.js
+++ b/api/src/public/login/script.js
@@ -215,7 +215,6 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 window.addEventListener('pageshow', (event) => {
-  console.log('from bfcache =', event.persisted);
   if (event.persisted) {
     checkSession();
   }

--- a/api/src/public/login/script.js
+++ b/api/src/public/login/script.js
@@ -213,3 +213,10 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
 });
+
+window.addEventListener('pageshow', (event) => {
+  console.log('from bfcache =', event.persisted);
+  if (event.persisted) {
+    checkSession();
+  }
+});

--- a/tests/e2e/navigation/bfcache.wdio-spec.js
+++ b/tests/e2e/navigation/bfcache.wdio-spec.js
@@ -33,9 +33,9 @@ describe('bfcache', async () => {
       await commonPage.goToMessages();
       const redirectToLoginBtn = await $('#session-expired .btn.submit.btn-primary');
       await redirectToLoginBtn.click();
-      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+      expect(await browser.getUrl()).to.contain('/login?redirect=');
       await browser.back();
-      await browser.waitUntil(async () => (await browser.getUrl()).includes('/medic/login?redirect='));
+      await browser.waitUntil(async () => (await browser.getUrl()).includes('/login?redirect='));
     });
   });
 
@@ -44,9 +44,9 @@ describe('bfcache', async () => {
       await usersAdminPage.goToAdminUser();
       await browser.deleteCookies('AuthSession');
       await usersAdminPage.goToAdminUpgrade();
-      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+      expect(await browser.getUrl()).to.contain('/login?redirect=');
       await browser.back();
-      await browser.waitUntil(async () => (await browser.getUrl()).includes('/medic/login?redirect='));
+      await browser.waitUntil(async () => (await browser.getUrl()).includes('/login?redirect='));
     });
   });
 });

--- a/tests/e2e/navigation/bfcache.wdio-spec.js
+++ b/tests/e2e/navigation/bfcache.wdio-spec.js
@@ -22,7 +22,7 @@ describe('bfcache', async () => {
       await commonPage.goToBase();
       expect(await browser.getUrl()).to.contain('/messages');
       await browser.back();
-      expect(await browser.getUrl()).to.contain('/messages');
+      await browser.waitUntil(async () => (await browser.getUrl()).includes('/messages'));
     });
   });
 
@@ -35,7 +35,7 @@ describe('bfcache', async () => {
       await redirectToLoginBtn.click();
       expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
       await browser.back();
-      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+      await browser.waitUntil(async () => (await browser.getUrl()).includes('/medic/login?redirect='));
     });
   });
 
@@ -46,7 +46,7 @@ describe('bfcache', async () => {
       await usersAdminPage.goToAdminUpgrade();
       expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
       await browser.back();
-      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+      await browser.waitUntil(async () => (await browser.getUrl()).includes('/medic/login?redirect='));
     });
   });
 });

--- a/tests/e2e/navigation/bfcache.wdio-spec.js
+++ b/tests/e2e/navigation/bfcache.wdio-spec.js
@@ -1,16 +1,52 @@
 const commonPage = require('../../page-objects/common/common.wdio.page');
 const loginPage = require('../../page-objects/login/login.wdio.page');
+const usersAdminPage = require('../../page-objects/admin/user.wdio.page');
+const auth = require('../../auth')();
 
 describe('bfcache', async () => {
-  it('should redirect to login page when session is expired', async () => {
-    await loginPage.cookieLogin();
-    await commonPage.goToPeople();
-    await browser.deleteCookies('AuthSession');
-    await commonPage.goToMessages();
-    const redirectToLoginBtn = await $('#session-expired .btn.submit.btn-primary');
-    await redirectToLoginBtn.click();
-    expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
-    await browser.back();
-    expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+  beforeEach(async () => {
+    await loginPage.login({
+      username: auth.username,
+      password: auth.password,
+      createUser: true,
+    });
+  });
+
+  afterEach(async () => {
+    await browser.deleteCookies();
+    await browser.url('/');
+  });
+
+  describe('login page', () => {
+    it('should redirect to the app page when session is valid', async () => {
+      await commonPage.goToBase();
+      expect(await browser.getUrl()).to.contain('/messages');
+      await browser.back();
+      expect(await browser.getUrl()).to.contain('/messages');
+    });
+  });
+
+  describe('webapp', () => {
+    it('should redirect to login page when session is expired', async () => {
+      await commonPage.goToPeople();
+      await browser.deleteCookies('AuthSession');
+      await commonPage.goToMessages();
+      const redirectToLoginBtn = await $('#session-expired .btn.submit.btn-primary');
+      await redirectToLoginBtn.click();
+      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+      await browser.back();
+      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+    });
+  });
+
+  describe('admin app', () => {
+    it('should redirect to login page when session is expired', async () => {
+      await usersAdminPage.goToAdminUser();
+      await browser.deleteCookies('AuthSession');
+      await usersAdminPage.goToAdminUpgrade();
+      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+      await browser.back();
+      expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+    });
   });
 });

--- a/tests/e2e/navigation/bfcache.wdio-spec.js
+++ b/tests/e2e/navigation/bfcache.wdio-spec.js
@@ -1,0 +1,16 @@
+const commonPage = require('../../page-objects/common/common.wdio.page');
+const loginPage = require('../../page-objects/login/login.wdio.page');
+
+describe('bfcache', async () => {
+  it('should redirect to login page when session is expired', async () => {
+    await loginPage.cookieLogin();
+    await commonPage.goToPeople();
+    await browser.deleteCookies('AuthSession');
+    await commonPage.goToMessages();
+    const redirectToLoginBtn = await $('#session-expired .btn.submit.btn-primary');
+    await redirectToLoginBtn.click();
+    expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+    await browser.back();
+    expect(await browser.getUrl()).to.contain('/medic/login?redirect=');
+  });
+});

--- a/tests/page-objects/admin/user.wdio.page.js
+++ b/tests/page-objects/admin/user.wdio.page.js
@@ -26,6 +26,10 @@ const goToAdminUser = async () => {
   await browser.url('/admin/#/users');
 };
 
+const goToAdminUpgrade = async () => {
+  await browser.url('/admin/#/upgrade');
+};
+
 const openAddUserDialog = async () => {
   await (await addUserButton()).waitForDisplayed();
   await (await addUserButton()).click();
@@ -40,7 +44,7 @@ const closeUserDialog = async () => {
   await (await addUserDialog()).waitForDisplayed({ reverse: true });
 };
 
-const inputAddUserFields = async (username, fullname, role, place, associatedContact, password, 
+const inputAddUserFields = async (username, fullname, role, place, associatedContact, password,
   confirmPassword = password) => {
   await (await userName()).addValue(username);
   await (await userFullName()).addValue(fullname);
@@ -53,7 +57,7 @@ const inputAddUserFields = async (username, fullname, role, place, associatedCon
   if (!_.isEmpty(associatedContact)) {
     await selectContact(associatedContact);
   }
-  
+
   await (await userPassword()).addValue(password);
   await (await userConfirmPassword()).addValue(confirmPassword);
 };
@@ -117,6 +121,7 @@ const getContactErrorText = async () => {
 
 module.exports = {
   goToAdminUser,
+  goToAdminUpgrade,
   openAddUserDialog,
   closeUserDialog,
   inputAddUserFields,

--- a/tests/wdio.conf.js
+++ b/tests/wdio.conf.js
@@ -40,8 +40,7 @@ const baseConfig = {
   // will be called from there.
   //
   specs: [
-    // './tests/e2e/**/*.wdio-spec.js',
-    './tests/e2e/**/bfcache.wdio-spec.js',
+    './tests/e2e/**/*.wdio-spec.js',
   ],
   // Patterns to exclude.
   exclude: [

--- a/tests/wdio.conf.js
+++ b/tests/wdio.conf.js
@@ -40,7 +40,8 @@ const baseConfig = {
   // will be called from there.
   //
   specs: [
-    './tests/e2e/**/*.wdio-spec.js'
+    // './tests/e2e/**/*.wdio-spec.js',
+    './tests/e2e/**/bfcache.wdio-spec.js',
   ],
   // Patterns to exclude.
   exclude: [

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -675,6 +675,13 @@ export class AppComponent implements OnInit {
     this.changesService.killWatchers();
   }
 
+  @HostListener('window:pageshow', ['$event'])
+  private pageshow(event) {
+    if (event.persisted) {
+      this.sessionService.check();
+    }
+  }
+
   private async initAnalyticsModules() {
     try {
       const modules = await this.analyticsModulesService.get();

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -1,7 +1,7 @@
 const COOKIE_NAME = 'userCtx';
 const ONLINE_ROLE = 'mm-online';
 import * as _ from 'lodash-es';
-import { Injectable, Inject } from '@angular/core';
+import { Injectable, Inject, HostListener } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CookieService } from 'ngx-cookie-service';
 import { DOCUMENT } from '@angular/common';
@@ -73,17 +73,17 @@ export class SessionService {
       .catch(this.logout);
   }
 
+  public check() {
+    if (!this.cookieService.check(COOKIE_NAME)) {
+      this.navigateToLogin();
+    }
+  }
+
   init () {
     const userCtx = this.userCtx();
     if (!userCtx || !userCtx.name) {
       return this.logout();
     }
-
-    window.addEventListener('pageshow', (event) => {
-      if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
-        this.navigateToLogin();
-      }
-    });
 
     return this.http
       .get<{ userCtx: { name:string; roles:string[] } }>('/_session', { responseType: 'json' })

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -80,8 +80,9 @@ export class SessionService {
     }
 
     window.addEventListener('pageshow', (event) => {
+      console.log(`${event.persisted ? '' : 'NOT'} from cache`);
       if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
-        this.navigateToLogin();
+        // this.navigateToLogin();
       }
     });
 

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -1,7 +1,7 @@
 const COOKIE_NAME = 'userCtx';
 const ONLINE_ROLE = 'mm-online';
 import * as _ from 'lodash-es';
-import { Injectable, Inject, HostListener } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { CookieService } from 'ngx-cookie-service';
 import { DOCUMENT } from '@angular/common';

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -80,7 +80,9 @@ export class SessionService {
     }
 
     window.addEventListener('pageshow', (event) => {
+      console.log('from bfcache =', event.persisted);
       if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
+        console.log('should navigate to login');
         // this.navigateToLogin();
       }
     });

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -55,7 +55,12 @@ export class SessionService {
    */
   userCtx () {
     if (!this.userCtxCookieValue) {
-      this.userCtxCookieValue = JSON.parse(this.cookieService.get(COOKIE_NAME));
+      try {
+        this.userCtxCookieValue = JSON.parse(this.cookieService.get(COOKIE_NAME));
+      } catch(error) {
+        console.error('Cookie parsing error', error);
+        this.userCtxCookieValue = null;
+      }
     }
 
     return this.userCtxCookieValue;

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -81,7 +81,7 @@ export class SessionService {
 
     window.addEventListener('pageshow', (event) => {
       if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
-        this.navigateToLogin();
+        // this.navigateToLogin();
       }
     });
 

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -78,6 +78,13 @@ export class SessionService {
     if (!userCtx || !userCtx.name) {
       return this.logout();
     }
+
+    window.addEventListener('pageshow', (event) => {
+      if (event.persisted && !document.cookie.match(COOKIE_NAME)) {
+        this.navigateToLogin();
+      }
+    });
+
     return this.http
       .get<{ userCtx: { name:string; roles:string[] } }>('/_session', { responseType: 'json' })
       .toPromise()

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -80,9 +80,8 @@ export class SessionService {
     }
 
     window.addEventListener('pageshow', (event) => {
-      console.log(`${event.persisted ? '' : 'NOT'} from cache`);
       if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
-        // this.navigateToLogin();
+        this.navigateToLogin();
       }
     });
 

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -80,7 +80,7 @@ export class SessionService {
     }
 
     window.addEventListener('pageshow', (event) => {
-      if (event.persisted && !document.cookie.match(COOKIE_NAME)) {
+      if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
         this.navigateToLogin();
       }
     });

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -80,10 +80,8 @@ export class SessionService {
     }
 
     window.addEventListener('pageshow', (event) => {
-      console.log('from bfcache =', event.persisted);
       if (event.persisted && !this.cookieService.check(COOKIE_NAME)) {
-        console.log('should navigate to login');
-        // this.navigateToLogin();
+        this.navigateToLogin();
       }
     });
 


### PR DESCRIPTION
# Description

The bug had to do with the browser's bfcache, see [related documentation](https://web.dev/bfcache/)  
Essentially, it restored the page and its state from memory without even hitting the network. Showing a half logged in/half logged out state when coming back to the app from the login page with the browser's back button.

With this PR, when the app is restored from the bfcache, the session is validated once more to make sure the user doesn't get stuck in an impossible state.

medic/cht-core#7538

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.