### PR TITLE
Store credentials in a cluster safe way

### DIFF
--- a/api/src/controllers/africas-talking.js
+++ b/api/src/controllers/africas-talking.js
@@ -41,7 +41,7 @@ const validateKey = req => {
     const given = req.query.key;
     if (expected !== given) {
       logger.warn(`Attempt to access Africa's Talking endpoint without the correct incoming key`);
-      return Promise.reject({ code: 403, message: `Incorrect key: "${given}"` });
+      return Promise.reject({ code: 403, message: 'Incorrect token' });
     }
   });
 };

--- a/api/src/controllers/credentials.js
+++ b/api/src/controllers/credentials.js
@@ -6,10 +6,14 @@ const auth = require('../auth');
 
 const checkAuth = req => {
   return auth.getUserCtx(req)
-    .then(userCtx => auth.isDbAdmin(userCtx));
+    .then(userCtx => auth.isDbAdmin(userCtx))
+    .then(isDbAdmin => {
+      if (!isDbAdmin) {
+        return Promise.reject({ code: 403, reason: 'Insufficient permissions' });
+      }
+    });
 };
 
-// TODO unit test
 module.exports = {
   put: (req, res) => {
     const key = req.params.key;

--- a/api/src/controllers/credentials.js
+++ b/api/src/controllers/credentials.js
@@ -26,7 +26,7 @@ module.exports = {
       return serverUtils.error({ code: 400, reason: 'Missing required request body' }, req, res);
     }
 
-    return checkAuth(req)
+    return checkAuth(req) // consider removing this step after upgrading to CouchDB v3 which is more secure by default
       .then(() => secureSettings.setCredentials(key, password))
       .then(() => res.json({ ok: true }))
       .catch(err => serverUtils.error(err, req, res));

--- a/api/src/controllers/credentials.js
+++ b/api/src/controllers/credentials.js
@@ -1,0 +1,30 @@
+const _ = require('lodash/core');
+const secureSettings = require('@medic/settings');
+
+const serverUtils = require('../server-utils');
+const auth = require('../auth');
+
+const checkAuth = req => {
+  return auth.getUserCtx(req)
+    .then(userCtx => auth.isDbAdmin(userCtx));
+};
+
+// TODO unit test
+module.exports = {
+  put: (req, res) => {
+    const key = req.params.key;
+    const password = req.body;
+
+    if (!key) {
+      return serverUtils.error({ code: 400, reason: 'Missing required param "key"' }, req, res);
+    }
+    if (_.isEmpty(password)) {
+      return serverUtils.error({ code: 400, reason: 'Missing required request body' }, req, res);
+    }
+
+    return checkAuth(req)
+      .then(() => secureSettings.setCredentials(key, password))
+      .then(() => res.json({ ok: true }))
+      .catch(err => serverUtils.error(err, req, res));
+  }
+};

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -65,6 +65,7 @@ if (UNIT_TEST_ENV) {
   const DB = new PouchDB(environment.couchUrl, { fetch });
   const getDbUrl = name => `${environment.serverUrl}/${name}`;
 
+  // TODO test that non-admins can't access vault
   DB.setMaxListeners(0);
   module.exports.medic = DB;
   module.exports.medicUsersMeta = new PouchDB(`${environment.couchUrl}-users-meta`, { fetch });

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -70,6 +70,8 @@ if (UNIT_TEST_ENV) {
   module.exports.medicUsersMeta = new PouchDB(`${environment.couchUrl}-users-meta`, { fetch });
   module.exports.medicLogs = new PouchDB(`${environment.couchUrl}-logs`, { fetch });
   module.exports.sentinel = new PouchDB(`${environment.couchUrl}-sentinel`, { fetch });
+  module.exports.vault = new PouchDB(`${environment.couchUrl}-vault`, { fetch });
+  module.exports.vault.info(); // create the db if it doesn't exist
   module.exports.users = new PouchDB(getDbUrl('/_users'));
 
   // Get the DB with the given name

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -65,7 +65,6 @@ if (UNIT_TEST_ENV) {
   const DB = new PouchDB(environment.couchUrl, { fetch });
   const getDbUrl = name => `${environment.serverUrl}/${name}`;
 
-  // TODO test that non-admins can't access vault
   DB.setMaxListeners(0);
   module.exports.medic = DB;
   module.exports.medicUsersMeta = new PouchDB(`${environment.couchUrl}-users-meta`, { fetch });

--- a/api/src/migrations/restrict-access-to-vault-db.js
+++ b/api/src/migrations/restrict-access-to-vault-db.js
@@ -1,0 +1,37 @@
+const request = require('request-promise-native');
+const url = require('url');
+const environment = require('../environment');
+
+const addSecurityToDb = () => {
+  const dbAdminRole = '_admin';
+  const securityObject = {
+    admins: { names: [], roles: [ dbAdminRole ] },
+    members: { names: [], roles: [ dbAdminRole ] }
+  };
+  return request.put({
+    url: url.format({
+      protocol: environment.protocol,
+      hostname: environment.host,
+      port: environment.port,
+      pathname: `${environment.db}-vault/_security`,
+    }),
+    auth: {
+      user: environment.username,
+      pass: environment.password
+    },
+    json: true,
+    body: securityObject
+  });
+};
+
+module.exports = {
+  name: 'restrict-access-to-vault-db',
+  created: new Date(2022, 4, 4),
+  run: () => {
+    return addSecurityToDb()
+      .catch(err => {
+        return Promise.reject(new Error('Failed to add security to vault db.' +
+          JSON.stringify(err, null, 2)));
+      });
+  }
+};

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -92,6 +92,9 @@ const textParser = bodyParser.text({limit: '32mb', type: [ 'text/plain', 'applic
 app.set('strict routing', true);
 app.set('trust proxy', true);
 
+// TODO add an endpoint for saving credentials, but not for getting them
+// TODO create medic-vault and set auth just like medic-logs
+
 // When testing random stuff in-browser, it can be useful to access the database
 // from different domains (e.g. localhost:5988 vs localhost:8080).  Adding the
 // --allow-cors commandline switch will enable this from within a web browser.

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -495,8 +495,6 @@ app.get(
   purgedDocsController.checkpoint
 );
 
-// TODO update cht-docs, eg:
-//   curl -X PUT -H "Content-Type: text/plain" -d 'pass' http://admin:pass@localhost:5988/api/v1/credentials/kie
 app.put(
   '/api/v1/credentials/:key',
   authorization.handleAuthErrors,

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -34,6 +34,7 @@ const monitoring = require('./controllers/monitoring');
 const africasTalking = require('./controllers/africas-talking');
 const rapidPro = require('./controllers/rapidpro');
 const infodoc = require('./controllers/infodoc');
+const credentials = require('./controllers/credentials');
 const authorization = require('./middleware/authorization');
 const deprecation = require('./middleware/deprecation');
 const hydration = require('./controllers/hydration');
@@ -495,6 +496,16 @@ app.get(
   authorization.handleAuthErrors,
   authorization.onlineUserPassThrough,
   purgedDocsController.checkpoint
+);
+
+// TODO update cht-docs, eg:
+//   curl -X PUT -H "Content-Type: text/plain" -d 'pass' http://admin:pass@localhost:5988/api/v1/credentials/kie
+app.put(
+  '/api/v1/credentials/:key',
+  authorization.handleAuthErrors,
+  authorization.offlineUserFirewall,
+  textParser,
+  credentials.put
 );
 
 app.get('/api/v1/users-doc-count', replicationLimitLogController.get);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -93,9 +93,6 @@ const textParser = bodyParser.text({limit: '32mb', type: [ 'text/plain', 'applic
 app.set('strict routing', true);
 app.set('trust proxy', true);
 
-// TODO add an endpoint for saving credentials, but not for getting them
-// TODO create medic-vault and set auth just like medic-logs
-
 // When testing random stuff in-browser, it can be useful to access the database
 // from different domains (e.g. localhost:5988 vs localhost:8080).  Adding the
 // --allow-cors commandline switch will enable this from within a web browser.

--- a/api/src/services/rapidpro.js
+++ b/api/src/services/rapidpro.js
@@ -33,8 +33,8 @@ const getCredentials = () => {
   // Supports self-hosted RapidPro instances, but defaults to textit.in
   const smsSettings = config.get('sms');
   const host = smsSettings &&
-                      smsSettings.rapidpro &&
-                      smsSettings.rapidpro.url;
+               smsSettings.rapidpro &&
+               smsSettings.rapidpro.url;
 
   if (!host) {
     return Promise.reject('No RapidPro URL configured. Refer to the RapidPro configuration documentation.');

--- a/api/src/services/rapidpro.js
+++ b/api/src/services/rapidpro.js
@@ -52,7 +52,7 @@ const getRequestOptions = ({ apiToken, host }={}) => ({
   baseUrl: host,
   json: true,
   headers: {
-    Authorization: `Token ${apiToken}`,
+    Authorization: `Token "${apiToken}"`,
     Accept: 'application/json',
   },
 });

--- a/api/src/services/rapidpro.js
+++ b/api/src/services/rapidpro.js
@@ -52,7 +52,7 @@ const getRequestOptions = ({ apiToken, host }={}) => ({
   baseUrl: host,
   json: true,
   headers: {
-    Authorization: `Token "${apiToken}"`,
+    Authorization: `Token ${apiToken}`,
     Accept: 'application/json',
   },
 });

--- a/api/tests/mocha/controllers/credentials.js
+++ b/api/tests/mocha/controllers/credentials.js
@@ -78,6 +78,8 @@ describe('Credentials controller', () => {
       res.json.resolves();
       await controller.put(req, res);
       chai.expect(secureSettings.setCredentials.callCount).to.equal(1);
+      chai.expect(secureSettings.setCredentials.args[0][0]).to.equal('mykey');
+      chai.expect(secureSettings.setCredentials.args[0][1]).to.equal('pwd');
       chai.expect(res.json.callCount).to.equal(1);
       chai.expect(res.json.args[0][0]).to.deep.equal({ ok: true });
     });

--- a/api/tests/mocha/controllers/credentials.js
+++ b/api/tests/mocha/controllers/credentials.js
@@ -5,7 +5,7 @@ const serverUtils = require('../../../src/server-utils');
 const controller = require('../../../src/controllers/credentials');
 const chai = require('chai');
 
-describe.only('Credentials controller', () => {
+describe('Credentials controller', () => {
 
   let req;
   let res;

--- a/api/tests/mocha/controllers/credentials.js
+++ b/api/tests/mocha/controllers/credentials.js
@@ -1,0 +1,87 @@
+const sinon = require('sinon');
+const auth = require('../../../src/auth');
+const secureSettings = require('@medic/settings');
+const serverUtils = require('../../../src/server-utils');
+const controller = require('../../../src/controllers/credentials');
+const chai = require('chai');
+
+describe.only('Credentials controller', () => {
+
+  let req;
+  let res;
+
+  beforeEach(() => {
+    req = { params: {} };
+    res = { json: sinon.stub() };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('put', () => {
+
+    it('errors if no key given', () => {
+      sinon.stub(secureSettings, 'setCredentials');
+      sinon.stub(serverUtils, 'error').returns();
+      controller.put(req, res);
+      chai.expect(secureSettings.setCredentials.callCount).to.equal(0);
+      chai.expect(serverUtils.error.callCount).to.equal(1);
+      chai.expect(serverUtils.error.args[0][0].code).to.equal(400);
+      chai.expect(serverUtils.error.args[0][0].reason).to.equal('Missing required param "key"' );
+    });
+
+    it('errors if no password given', () => {
+      sinon.stub(secureSettings, 'setCredentials');
+      sinon.stub(serverUtils, 'error').returns();
+      req.params.key = 'mykey';
+      req.body = {};
+      controller.put(req, res);
+      chai.expect(secureSettings.setCredentials.callCount).to.equal(0);
+      chai.expect(serverUtils.error.callCount).to.equal(1);
+      chai.expect(serverUtils.error.args[0][0].code).to.equal(400);
+      chai.expect(serverUtils.error.args[0][0].reason).to.equal('Missing required request body' );
+    });
+
+    it('errors if not db admin', async () => {
+      sinon.stub(secureSettings, 'setCredentials');
+      sinon.stub(serverUtils, 'error').returns();
+      req.params.key = 'mykey';
+      req.body = 'pwd';
+      sinon.stub(auth, 'getUserCtx').resolves({ roles: [] });
+      sinon.stub(auth, 'isDbAdmin').returns(false);
+      await controller.put(req, res);
+      chai.expect(secureSettings.setCredentials.callCount).to.equal(0);
+      chai.expect(serverUtils.error.callCount).to.equal(1);
+      chai.expect(serverUtils.error.args[0][0].code).to.equal(403);
+    });
+
+    it('handles error from setting credentials', async () => {
+      sinon.stub(secureSettings, 'setCredentials').rejects({ code: 503 });
+      sinon.stub(serverUtils, 'error').returns();
+      req.params.key = 'mykey';
+      req.body = 'pwd';
+      sinon.stub(auth, 'getUserCtx').resolves({ roles: [] });
+      sinon.stub(auth, 'isDbAdmin').returns(true);
+      await controller.put(req, res);
+      chai.expect(secureSettings.setCredentials.callCount).to.equal(1);
+      chai.expect(serverUtils.error.callCount).to.equal(1);
+      chai.expect(serverUtils.error.args[0][0].code).to.equal(503);
+    });
+
+    it('sets credentials and returns', async () => {
+      sinon.stub(secureSettings, 'setCredentials').resolves();
+      req.params.key = 'mykey';
+      req.body = 'pwd';
+      sinon.stub(auth, 'getUserCtx').resolves({ roles: [] });
+      sinon.stub(auth, 'isDbAdmin').returns(true);
+      res.json.resolves();
+      await controller.put(req, res);
+      chai.expect(secureSettings.setCredentials.callCount).to.equal(1);
+      chai.expect(res.json.callCount).to.equal(1);
+      chai.expect(res.json.args[0][0]).to.deep.equal({ ok: true });
+    });
+
+  });
+
+});

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -172,7 +172,12 @@ const sendPayload = (payload, config) => {
   return auth().then(() => {
     if (logger.isDebugEnabled()) {
       logger.debug('About to send outbound request');
-      logger.debug(JSON.stringify(sendOptions, null, 2));
+      const clone = JSON.parse(JSON.stringify(sendOptions));
+      if (clone.auth && clone.auth.password) {
+        // mask password before logging
+        clone.auth.password = '*****';
+      }
+      logger.debug(JSON.stringify(clone, null, 2));
     }
 
     return request.post(sendOptions)

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -23,14 +23,13 @@ const OUTBOUND_REQ_TIMEOUT = 10 * 1000;
 // set by init()
 let logger;
 
-
 class OutboundError extends Error {}
 
 const fetchPassword = key => {
   return secureSettings.getCredentials(key).then(password => {
     if (!password) {
       throw new OutboundError(
-        `CouchDB config key 'medic-credentials/${key}' has not been populated. See the Outbound documentation.`
+        `Credentials for '${key}' have not been configured. See the Outbound documentation.`
       );
     }
     return password;

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -25,7 +25,7 @@ const getCredentialsDoc = (id) => {
     return Promise.reject(new Error('You must pass the key for the credentials you want'));
   }
   return request
-    .get(`${getVaultUrl(id)}`, { json: true }) // TODO do we allow spaces in credential keys?
+    .get(`${getVaultUrl(id)}`, { json: true })
     .catch(err => {
       if (err.statusCode === 404) {
         // No credentials defined
@@ -37,8 +37,8 @@ const getCredentialsDoc = (id) => {
 };
 
 const getKey = () => {
-  const url = `${getCouchConfigUrl()}/chttpd_auth/secret`;
-  return request.get(url, { json: true }); // TODO need to e2e test this
+  const url = `${getCouchConfigUrl()}/couch_httpd_auth/secret`;
+  return request.get(url, { json: true });
 };
 
 const encrypt = (text) => {

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -32,6 +32,7 @@ const getCredentialsDoc = (key) => {
     });
 };
 
+// TODO use node crypto and couchdb secret to encrypt/decrypt the password
 const getCredentials = (key) => {
   return getCredentialsDoc(key)
     .then(doc => doc && doc.password);

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -17,6 +17,9 @@ const getServerUrl = () => {
 const getVaultUrl = (key) => `${getCouchUrl()}-vault/${getCredentialId(key)}`;
 
 const getCredentialsDoc = (key) => {
+  if (!key) {
+    return Promise.reject(new Error('You must pass the key for the credentials you want'));
+  }
   return request
     .get(`${getVaultUrl(key)}`, { json: true }) // TODO do we allow spaces in credential keys?
     .catch(err => {
@@ -34,7 +37,6 @@ const getCredentials = (key) => {
     .then(doc => doc && doc.password);
 };
 
-// TODO unit test
 const setCredentials = (key, password) => {
   return getCredentialsDoc(key)
     .then(doc => {

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -2,6 +2,7 @@ const request = require('request-promise-native');
 const crypto = require('crypto');
 
 const IV_LENGTH = 16;
+const KEY_LENGTH = 32;
 const CRYPTO_ALGO = 'aes-256-cbc';
 
 const getCredentialId = id => `credential:${id}`;
@@ -40,14 +41,16 @@ const getKey = () => {
   // NB: This path will need to change when we upgrade to CouchDB v3.2
   // https://docs.couchdb.org/en/stable/config/auth.html#chttpd_auth/secret
   const url = `${getCouchConfigUrl()}/couch_httpd_auth/secret`;
-  return request.get(url, { json: true });
+  return request
+    .get(url, { json: true })
+    .then(key => Buffer.from(key).slice(0, KEY_LENGTH));
 };
 
 const encrypt = (text) => {
   return getKey()
     .then(key => {
       const iv = crypto.randomBytes(IV_LENGTH);
-      const cipher = crypto.createCipheriv(CRYPTO_ALGO, Buffer.from(key), iv);
+      const cipher = crypto.createCipheriv(CRYPTO_ALGO, key, iv);
       const start = cipher.update(text);
       const end = cipher.final();
       const encrypted = Buffer.concat([ start, end ]);
@@ -61,7 +64,7 @@ const decrypt = (text) => {
       const parts = text.split(':');
       const iv = Buffer.from(parts.shift(), 'hex');
       const encryptedText = Buffer.from(parts.join(':'), 'hex');
-      const decipher = crypto.createDecipheriv(CRYPTO_ALGO, Buffer.from(key), iv);
+      const decipher = crypto.createDecipheriv(CRYPTO_ALGO, key, iv);
       const start = decipher.update(encryptedText);
       const final = decipher.final();
       return Buffer.concat([ start, final ]).toString();

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -33,6 +33,7 @@ const getCredentialsDoc = (key) => {
 };
 
 // TODO use node crypto and couchdb secret to encrypt/decrypt the password
+// eg: curl /_node/_local/_config/chttpd_auth/secret
 const getCredentials = (key) => {
   return getCredentialsDoc(key)
     .then(doc => doc && doc.password);

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -194,7 +194,7 @@ describe('Settings Shared Library', () => {
 
     it('set and get credentials', () => {
       const requestGet = sinon.stub(request, 'get');
-      requestGet.onCall(0).rejects({ message: 'missing', statusCode: 404 })
+      requestGet.onCall(0).rejects({ message: 'missing', statusCode: 404 });
       requestGet.onCall(1).resolves(secret);
       sinon.stub(request, 'put').resolves();
       return lib

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -184,6 +184,34 @@ describe('Settings Shared Library', () => {
 
   });
 
+  /*
+   * Because the crypto module changes frequently and is difficult to integrate with it's worth
+   * including these integration tests which don't mock the crypto module.
+   */
+  describe('crypto integration', () => {
+
+    const secret = 'myreallylongsecret - myreallylongsecret - myreallylongsecret'; // > 32 characters long
+
+    it('set and get credentials', () => {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.onCall(0).rejects({ message: 'missing', statusCode: 404 })
+      requestGet.onCall(1).resolves(secret);
+      sinon.stub(request, 'put').resolves();
+      return lib
+        .setCredentials('mykey', 'mypass')
+        .then(() => {
+          const doc = request.put.args[0][1].body;
+          requestGet.onCall(2).resolves(doc);
+          requestGet.onCall(3).resolves(secret);
+          return lib.getCredentials('mykey');
+        })
+        .then(pass => {
+          expect(pass).to.equal('mypass');
+        });
+    });
+
+  });
+
 
   describe('getCouchConfig', () => {
 

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -20,10 +20,6 @@ describe('Settings Shared Library', () => {
 
   describe('getCredentials', () => {
 
-    beforeEach(() => {
-
-    });
-
     it('rejects if no key given', () => {
       sinon.stub(request, 'get').rejects({ statusCode: 403, message: 'no perms' });
 

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -18,87 +18,102 @@ describe('Settings Shared Library', () => {
 
   describe('getCredentials', () => {
 
-    it('should throw error if no server url is set', async () => {
+    it('should throw error if no server url is set', () => {
       environment.COUCH_URL = '';
 
-      try {
-        await lib.getCredentials();
-        expect.fail('exception expected')
-      } catch (err) {
-        expect(err.message).to.equal('Failed to find the CouchDB server');
-      }
+      return lib
+        .getCredentials()
+        .then(() => expect.fail('exception expected'))
+        .catch(err => {
+          expect(err.message).to.equal('Failed to find the CouchDB server');
+        });
     });
 
-    it('should throw error from request', async () => {
+    it('should throw error from request', () => {
       environment.COUCH_URL = 'http://user:pass@server.com/medic';
       sinon.stub(request, 'get').rejects({ statusCode: 403, message: 'no perms' });
 
-      try {
-        await lib.getCredentials();
-        return expect.fail('exception expected');
-      } catch (err) {
-        expect(request.get.callCount).to.equal(1);
-        expect(err.message).to.equal('no perms');
-      }
+      return lib
+        .getCredentials()
+        .then(() => expect.fail('exception expected'))
+        .catch(err => {
+          expect(request.get.callCount).to.equal(1);
+          expect(err.message).to.equal('no perms');
+        });
     });
 
-    it('should handle when permissions are not defined', async () => {
+    it('should handle when permissions are not defined', () => {
       environment.COUCH_URL = 'http://user:pass@server.com/medic';
       sinon.stub(request, 'get').rejects({ statusCode: 404 });
 
-      const actual = await lib.getCredentials('mykey');
-      expect(actual).to.equal(undefined);
+      return lib
+        .getCredentials('mykey')
+        .then(actual => {
+          expect(actual).to.be.undefined;
+        });
     });
 
-    it('should handle empty credentials', async () => {
+    it('should handle empty credentials', () => {
       environment.COUCH_URL = 'http://user:pass@server.com/medic';
       sinon.stub(request, 'get').resolves({});
 
-      const actual = await lib.getCredentials('mykey');
-      expect(actual).to.be.undefined;
+      return lib
+        .getCredentials('mykey')
+        .then(actual => {
+          expect(actual).to.be.undefined;
+        });
     });
 
-    it('should parse response format', async () => {
+    it('should parse response format', () => {
       environment.COUCH_URL = 'http://server.com/medic';
-      sinon.stub(request, 'get').resolves({ password: 'mypass' }); // TODO string or JSON response?
+      sinon.stub(request, 'get').resolves({ password: 'mypass' });
 
-      const actual = await lib.getCredentials('mykey');
-      expect(actual).to.equal('mypass');
-      expect(request.get.callCount).to.equal(1);
-      expect(request.get.args[0][0]).to.equal('http://server.com/medic-vault/mykey');
+      return lib
+        .getCredentials('mykey')
+        .then(actual => {
+          expect(actual).to.equal('mypass');
+          expect(request.get.callCount).to.equal(1);
+          expect(request.get.args[0][0]).to.equal('http://server.com/medic-vault/mykey');
+        });
     });
 
   });
 
   describe('getCouchConfig', () => {
 
-    it('should return the expected value', async () => {
+    it('should return the expected value', () => {
       environment.COUCH_URL = 'http://user:pass@localhost:6929/medic';
       environment.COUCH_NODE_NAME = 'nonode@noname';
       sinon.stub(request, 'get').resolves('couch config');
 
-      const actual = await lib.getCouchConfig('attachments');
-      expect(actual).to.equal('couch config');
-      expect(request.get.callCount).to.equal(1);
-      expect(request.get.args[0][0].url).to.equal('http://user:pass@localhost:6929/_node/nonode@noname/_config/attachments');
+      return lib
+        .getCouchConfig('attachments')
+        .then(actual => {
+          expect(actual).to.equal('couch config');
+          expect(request.get.callCount).to.equal(1);
+          expect(request.get.args[0][0].url).to.equal('http://user:pass@localhost:6929/_node/nonode@noname/_config/attachments');
+        });
     });
 
   });
 
   describe('updateAdminPassword', () => {
 
-    it('should save password', async () => {
+    it('should save password', () => {
       environment.COUCH_URL = 'http://user:pass@localhost:6929/medic';
       environment.COUCH_NODE_NAME = 'nonode@noname';
       sinon.stub(request, 'put').resolves('-pbkdf2-8266a0adb');
 
-      const result = await lib.updateAdminPassword('admin1', 'pass1234');
-      expect(result).to.equal('-pbkdf2-8266a0adb');
-      expect(request.put.callCount).to.equal(1);
-      expect(request.put.args[0][0]).to.deep.equal({
-        body: '"pass1234"',
-        url: 'http://user:pass@localhost:6929/_node/nonode@noname/_config/admins/admin1',
-      });
+      return lib
+        .updateAdminPassword('admin1', 'pass1234')
+        .then(result => {
+          expect(result).to.equal('-pbkdf2-8266a0adb');
+          expect(request.put.callCount).to.equal(1);
+          expect(request.put.args[0][0]).to.deep.equal({
+            body: '"pass1234"',
+            url: 'http://user:pass@localhost:6929/_node/nonode@noname/_config/admins/admin1',
+          });
+        });
     });
 
   });

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -79,7 +79,7 @@ describe('Settings Shared Library', () => {
       };
       sinon.stub(request, 'get')
         .withArgs('http://server.com/medic-vault/credential:mykey').resolves({ password: `${iv}:${encryptedPass}` })
-        .withArgs('http://server.com/_node/_local/_config/chttpd_auth/secret').resolves('mysecret');
+        .withArgs('http://server.com/_node/_local/_config/couch_httpd_auth/secret').resolves('mysecret');
       sinon.stub(crypto, 'createDecipheriv').returns(cipher);
 
       return lib
@@ -115,7 +115,7 @@ describe('Settings Shared Library', () => {
     it('rejects if no id given', () => {
       sinon.stub(request, 'get')
         .withArgs('http://server.com/medic-vault/credential:mykey').resolves({ password: `oldiv:oldpass` })
-        .withArgs('http://server.com/_node/_local/_config/chttpd_auth/secret').resolves('mysecret');
+        .withArgs('http://server.com/_node/_local/_config/couch_httpd_auth/secret').resolves('mysecret');
       return lib.setCredentials()
         .then(() => expect.fail('exception expected'))
         .catch(err => {
@@ -138,7 +138,7 @@ describe('Settings Shared Library', () => {
     it('handles creating doc', () => {
       sinon.stub(request, 'get')
         .withArgs('http://server.com/medic-vault/credential:mykey').rejects({ message: 'missing', statusCode: 404 })
-        .withArgs('http://server.com/_node/_local/_config/chttpd_auth/secret').resolves('mysecret');
+        .withArgs('http://server.com/_node/_local/_config/couch_httpd_auth/secret').resolves('mysecret');
       sinon.stub(request, 'put').resolves();
       return lib.setCredentials('mykey', 'mypass')
         .then(() => {
@@ -163,7 +163,7 @@ describe('Settings Shared Library', () => {
     it('handles updating doc', () => {
       sinon.stub(request, 'get')
         .withArgs('http://server.com/medic-vault/credential:mykey').resolves({ _id: 'credential:mykey', _rev: '1', password: 'old' })
-        .withArgs('http://server.com/_node/_local/_config/chttpd_auth/secret').resolves('mysecret');
+        .withArgs('http://server.com/_node/_local/_config/couch_httpd_auth/secret').resolves('mysecret');
       sinon.stub(request, 'put').resolves();
       return lib.setCredentials('mykey', 'mypass')
         .then(() => {

--- a/tests/e2e/africas-talking.js
+++ b/tests/e2e/africas-talking.js
@@ -1,5 +1,4 @@
 const utils = require('../utils');
-const constants = require('../constants');
 const commonElements = require('../page-objects/common/common.po.js');
 const messagesElements = require('../page-objects/messages/messages.po');
 const reportsElements = require('../page-objects/reports/reports.po');
@@ -146,7 +145,7 @@ describe('africas talking api', () => {
       const content = querystring.stringify(body);
       return utils.request({
         method: 'POST',
-        path: `/api/v1/sms/africastalking/incoming-messages?key=${INCOMING_KEY}`,
+        path: `/api/v1/sms/africastalking/incoming-messages?key=${CREDENTIAL_KEY}`,
         body: content,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -199,7 +198,7 @@ describe('africas talking api', () => {
       const content = querystring.stringify(body);
       return utils.request({
         method: 'POST',
-        path: `/api/v1/sms/africastalking/delivery-reports?key=${INCOMING_KEY}`,
+        path: `/api/v1/sms/africastalking/delivery-reports?key=${CREDENTIAL_KEY}`,
         body: content,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/tests/e2e/africas-talking.js
+++ b/tests/e2e/africas-talking.js
@@ -17,7 +17,8 @@ const messageContent1 = 'Thank you for registering Shannon. Their pregnancy ID i
 const messageContent2 = 'Please remind Shannon (28551) to visit the health facility for ANC visit this week. ' +
   'When she does let us know with "V 28551". Thanks!';
 
-const INCOMING_KEY = 'yabbadabbadoo';
+const CREDENTIAL_PASS = 'yabbadabbadoo';
+const CREDENTIAL_KEY = 'africastalking.com:incoming';
 
 const report = {
   type: 'data_record',
@@ -138,14 +139,7 @@ const report = {
 
 describe('africas talking api', () => {
 
-  beforeAll(() => {
-    return utils.request({
-      port: constants.COUCH_PORT,
-      method: 'PUT',
-      path: `/_node/${constants.COUCH_NODE_NAME}/_config/medic-credentials/africastalking.com:incoming`,
-      body: `${INCOMING_KEY}`
-    });
-  });
+  beforeAll(() => utils.saveCredentials(CREDENTIAL_KEY, CREDENTIAL_PASS));
 
   describe('- gateway submits new WT sms messages', () => {
     const submitSms = body => {

--- a/tests/e2e/africas-talking.js
+++ b/tests/e2e/africas-talking.js
@@ -145,7 +145,7 @@ describe('africas talking api', () => {
       const content = querystring.stringify(body);
       return utils.request({
         method: 'POST',
-        path: `/api/v1/sms/africastalking/incoming-messages?key=${CREDENTIAL_KEY}`,
+        path: `/api/v1/sms/africastalking/incoming-messages?key=${CREDENTIAL_PASS}`,
         body: content,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -198,7 +198,7 @@ describe('africas talking api', () => {
       const content = querystring.stringify(body);
       return utils.request({
         method: 'POST',
-        path: `/api/v1/sms/africastalking/delivery-reports?key=${CREDENTIAL_KEY}`,
+        path: `/api/v1/sms/africastalking/delivery-reports?key=${CREDENTIAL_PASS}`,
         body: content,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -733,6 +733,9 @@ describe('routing', () => {
         utils
           .request(Object.assign({ path: '/medic-user-whatever-meta' }, getOfflineRequestOptions('PUT')))
           .catch(err => err),
+        utils
+          .request(Object.assign({ path: '/medic-vault' }, onlineRequestOptions))
+          .catch(err => err),
       ]).then(results => {
         results.forEach(result => {
           expect(result.statusCode).to.equal(403);

--- a/tests/e2e/api/routing.js
+++ b/tests/e2e/api/routing.js
@@ -734,7 +734,7 @@ describe('routing', () => {
           .request(Object.assign({ path: '/medic-user-whatever-meta' }, getOfflineRequestOptions('PUT')))
           .catch(err => err),
         utils
-          .request(Object.assign({ path: '/medic-vault' }, onlineRequestOptions))
+          .request(Object.assign({ path: `/${constants.DB_NAME}-vault` }, onlineRequestOptions))
           .catch(err => err),
       ]).then(results => {
         results.forEach(result => {

--- a/tests/e2e/rapidpro.spec.js
+++ b/tests/e2e/rapidpro.spec.js
@@ -7,7 +7,6 @@ const commonElements = require('../page-objects/common/common.po.js');
 const messagesElements = require('../page-objects/messages/messages.po');
 const reportsElements = require('../page-objects/reports/reports.po');
 const helper = require('../helper');
-const constants = require('../constants');
 const utils = require('../utils');
 
 // Mock rapidpro server

--- a/tests/e2e/rapidpro.spec.js
+++ b/tests/e2e/rapidpro.spec.js
@@ -45,21 +45,11 @@ const INCOMING_KEY = 'thecakeisalie';
 const OUTGOING_KEY = 'ermahgerd';
 
 const setIncomingKey = () => {
-  return utils.request({
-    port: constants.COUCH_PORT,
-    method: 'PUT',
-    path: `/_node/${constants.COUCH_NODE_NAME}/_config/medic-credentials/rapidpro:incoming`,
-    body: `${INCOMING_KEY}`
-  });
+  return utils.saveCredentials('rapidpro:incoming', INCOMING_KEY);
 };
 
 const setOutgoingKey = () => {
-  return utils.request({
-    port: constants.COUCH_PORT,
-    method: 'PUT',
-    path: `/_node/${constants.COUCH_NODE_NAME}/_config/medic-credentials/rapidpro:outgoing`,
-    body: `${OUTGOING_KEY}`
-  });
+  return utils.saveCredentials('rapidpro:outgoing', OUTGOING_KEY);
 };
 
 describe('RapidPro SMS Gateway', () => {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -948,9 +948,9 @@ module.exports = {
 
   saveCredentials: (key, password) => {
     const options = {
-      path: `/${constants.DB_NAME}-vault/${key}`,
+      path: `/api/v1/credentials/${key}`,
       method: 'PUT',
-      body: JSON.stringify({ password })
+      body: password
     };
     return request(options);
   },

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -952,7 +952,7 @@ module.exports = {
       method: 'PUT',
       body: password
     };
-    return request(options);
+    return request(options, { debug: true });
   },
 
   /**

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -950,7 +950,10 @@ module.exports = {
     const options = {
       path: `/api/v1/credentials/${key}`,
       method: 'PUT',
-      body: password
+      body: password,
+      headers: {
+        'Content-Type': 'text/plain'
+      }
     };
     return request(options, { debug: true });
   },

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -946,6 +946,15 @@ module.exports = {
     };
   },
 
+  saveCredentials: (key, password) => {
+    const options = {
+      path: `/${constants.DB_NAME}-vault/${key}`,
+      method: 'PUT',
+      body: JSON.stringify({ password })
+    };
+    return request(options);
+  },
+
   /**
    * Watches a given logfile until at least one line matches one of the given regular expressions.
    * Watch expires after 10 seconds.

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -955,7 +955,7 @@ module.exports = {
         'Content-Type': 'text/plain'
       }
     };
-    return request(options, { debug: true });
+    return request(options);
   },
 
   /**

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -951,6 +951,7 @@ module.exports = {
       path: `/api/v1/credentials/${key}`,
       method: 'PUT',
       body: password,
+      json: false,
       headers: {
         'Content-Type': 'text/plain'
       }


### PR DESCRIPTION
# Description

Replace the old way of storing credentials for authentication with third party services with a new method that supports clustered couchdb. Adds an API for setting the credentials and adds encryption at rest.

Also solves an issue where the plaintext password could be output in the log files.

medic/cht-core#5904
medic/medic-infrastructure#302

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
