### PR TITLE
Upgrade endpoint payload change

### DIFF
--- a/admin/src/js/controllers/upgrade-confirm.js
+++ b/admin/src/js/controllers/upgrade-confirm.js
@@ -26,7 +26,7 @@ angular.module('controllers').controller('UpgradeConfirmCtrl',
         .then(() => $uibModalInstance.close(true))
         .catch(err => {
           $log.error('Error when confirming', err);
-          const key = $scope.model.errorKey || 'instance.upgrade.error.confirm';
+          const key = $scope.model.errorKey || 'instance.upgrade.error.deploy';
           return $translate(key).then(msg => {
             $scope.status.error = msg;
             $scope.status.processing = false;

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -195,11 +195,12 @@ angular.module('controllers').controller('UpgradeCtrl',
         .post(url, { build })
         .catch(err => {
           // todo which status do we get with nginx???
-          if (err && (!err.status || err.status !== 500) && action === 'complete') {
+          // exclude "50x" like statuses that come from nginx
+          if (err && !err.status && action === 'complete') {
             // refresh page after API is back up
             return waitUntilApiStarts().then(() => reloadPage());
           }
-          throw err;
+          return logError(err, 'instance.upgrade.error.deploy');
         })
         .then(() => getCurrentUpgrade());
     };

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -58,7 +58,6 @@ angular.module('controllers').controller('UpgradeCtrl',
         .then(({ data: { upgradeDoc, indexers } }) => {
           if ($scope.upgradeDoc && !upgradeDoc) {
             const expectedVersion = $scope.upgradeDoc.to && $scope.upgradeDoc.to.build;
-            console.log(expectedVersion);
             getExistingDeployment(true, expectedVersion);
           }
 

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -37,12 +37,12 @@ angular.module('controllers').controller('UpgradeCtrl',
         });
     };
 
-    const getExistingDeployment = (expectUpgrade) => {
+    const getExistingDeployment = (expectUpgrade, expectedVersion) => {
       return $http
         .get('/api/deploy-info')
         .then(({ data: deployInfo }) => {
-          if (expectUpgrade && $scope.currentDeploy) {
-            if ($scope.currentDeploy.version !== deployInfo.version) {
+          if (expectUpgrade) {
+            if (expectedVersion === deployInfo.version) {
               return reloadPage();
             }
             logError('instance.upgrade.error.deploy', 'instance.upgrade.error.deploy');
@@ -57,7 +57,9 @@ angular.module('controllers').controller('UpgradeCtrl',
         .get(UPGRADE_URL)
         .then(({ data: { upgradeDoc, indexers } }) => {
           if ($scope.upgradeDoc && !upgradeDoc) {
-            getExistingDeployment(true);
+            const expectedVersion = $scope.upgradeDoc.to && $scope.upgradeDoc.to.build;
+            console.log(expectedVersion);
+            getExistingDeployment(true, expectedVersion);
           }
 
           $scope.upgradeDoc = upgradeDoc;

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -159,7 +159,7 @@ angular.module('controllers').controller('UpgradeCtrl',
     };
 
     const reloadPage = () => {
-      $state.go('upgrade', { upgraded: true });
+      $state.go('upgrade', { upgraded: true }, { reload: true });
     };
 
     $scope.upgrade = (build, action) => {

--- a/admin/tests/unit/controllers/upgrade.spec.js
+++ b/admin/tests/unit/controllers/upgrade.spec.js
@@ -278,8 +278,8 @@ describe('UpgradeCtrl controller', () => {
   it('should continue following when request errors', async () => {
     const deployInfo = { the: 'deplopy info', version: '4.1.0' };
     const upgradeDoc = {
-      from: { version: '4.1.0' },
-      to: { version: '4.2.0' },
+      from: { version: '4.1.0', build: '4.1.0' },
+      to: { version: '4.2.0', build: '4.2.0' },
     };
     Object.freeze(deployInfo);
     Object.freeze(upgradeDoc);
@@ -399,9 +399,19 @@ describe('UpgradeCtrl controller', () => {
       http.get.withArgs('/api/deploy-info')
         .onCall(0).resolves({ data: deployInfo })
         .onCall(1).resolves({ data: deployInfoUpgraded });
+      const upgradeDoc = {
+        from: {
+          version: '4.1.0',
+          build: '4.1.0',
+        },
+        to: {
+          version: '4.2.0',
+          build: '4.2.0',
+        }
+      };
       http.get.withArgs('/api/v2/upgrade')
         .onCall(0).resolves({ data: { upgradeDoc: undefined  } })
-        .onCall(1).resolves({ data: { upgradeDoc: { up: 'grade' }, indexers: [] } })
+        .onCall(1).resolves({ data: { upgradeDoc, indexers: [] } })
         .onCall(2).resolves({ data: { upgradeDoc: undefined, indexers: [] } });
       http.post.withArgs('/api/v2/upgrade').resolves();
 
@@ -429,7 +439,7 @@ describe('UpgradeCtrl controller', () => {
         { build: { version: '4.2.0' } },
       ]);
       expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(2);
-      expect(scope.upgradeDoc).to.deep.equal({ up: 'grade' });
+      expect(scope.upgradeDoc).to.deep.equal(upgradeDoc);
 
       expect(state.go.callCount).to.equal(0);
 

--- a/admin/tests/unit/controllers/upgrade.spec.js
+++ b/admin/tests/unit/controllers/upgrade.spec.js
@@ -452,7 +452,7 @@ describe('UpgradeCtrl controller', () => {
       await nextTick();
       expect(http.get.withArgs('/api/deploy-info').callCount).to.equal(2);
       expect(state.go.callCount).to.equal(1);
-      expect(state.go.args[0]).to.deep.equal(['upgrade', { upgraded: true }]);
+      expect(state.go.args[0]).to.deep.equal(['upgrade', { upgraded: true }, { reload: true }]);
     });
 
     it('should display an error when upgrade could not complete', async () => {

--- a/admin/tests/unit/controllers/upgrade.spec.js
+++ b/admin/tests/unit/controllers/upgrade.spec.js
@@ -501,7 +501,7 @@ describe('UpgradeCtrl controller', () => {
       expect(scope.error).to.equal('instance.upgrade.error.deploy');
     });
 
-    it('should throw 500 errors on complete', async () => {
+    it('should log status errors on complete', async () => {
       modal.resolves();
       buildsDb.query.resolves({
         rows: [
@@ -511,7 +511,7 @@ describe('UpgradeCtrl controller', () => {
       });
       const deployInfo = { the: 'deplopy info', version: '4.1.0' };
       http.get.withArgs('/api/deploy-info').resolves({ data: deployInfo });
-      http.get.withArgs('/api/v2/upgrade').onCall(0).resolves({ data: { upgradeDoc: undefined  } });
+      http.get.withArgs('/api/v2/upgrade').resolves({ data: { upgradeDoc: undefined  } });
 
       http.post.withArgs('/api/v2/upgrade/complete').rejects({ an: 'error', status: 500 });
 
@@ -534,19 +534,14 @@ describe('UpgradeCtrl controller', () => {
       expect(http.post.callCount).to.equal(0);
       expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(1);
 
-      try {
-        await upgradeCb();
-        expect.fail('Should have thrown');
-      } catch (err) {
-        expect(err).to.deep.equal({ an: 'error', status: 500 });
-      }
+      await upgradeCb();
 
       expect(http.post.callCount).to.equal(1);
       expect(http.post.args[0]).to.deep.equal([
         '/api/v2/upgrade/complete',
         { build: { version: '4.2.0' } },
       ]);
-      expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(1);
+      expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(2);
     });
 
     it('should throw any error when action is not complete', async () => {
@@ -559,7 +554,7 @@ describe('UpgradeCtrl controller', () => {
       });
       const deployInfo = { the: 'deplopy info', version: '4.1.0' };
       http.get.withArgs('/api/deploy-info').resolves({ data: deployInfo });
-      http.get.withArgs('/api/v2/upgrade').onCall(0).resolves({ data: { upgradeDoc: undefined  } });
+      http.get.withArgs('/api/v2/upgrade').resolves({ data: { upgradeDoc: undefined  } });
 
       http.post.withArgs('/api/v2/upgrade/stage').rejects({ an: 'error' });
 
@@ -582,19 +577,14 @@ describe('UpgradeCtrl controller', () => {
       expect(http.post.callCount).to.equal(0);
       expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(1);
 
-      try {
-        await upgradeCb();
-        expect.fail('Should have thrown');
-      } catch (err) {
-        expect(err).to.deep.equal({ an: 'error' });
-      }
+      await upgradeCb();
 
       expect(http.post.callCount).to.equal(1);
       expect(http.post.args[0]).to.deep.equal([
         '/api/v2/upgrade/stage',
         { build: { version: '4.2.0' } },
       ]);
-      expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(1);
+      expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(2);
     });
 
     it('should complete an upgrade and reload page', async () => {
@@ -859,7 +849,7 @@ describe('UpgradeCtrl controller', () => {
       expect(scope.upgradeDoc).to.deep.equal(undefined);
     });
 
-    it('should throw 500 errors', async () => {
+    it('should log 500 errors', async () => {
       modal.resolves();
       const upgradeDoc = {
         to: { the: 'buildinfo', version: '4.3.0' },
@@ -867,7 +857,9 @@ describe('UpgradeCtrl controller', () => {
       };
       const deployInfo = { the: 'deplopy info', version: '4.1.0' };
       http.get.withArgs('/api/deploy-info').resolves({ data: deployInfo });
-      http.get.withArgs('/api/v2/upgrade').onCall(0).resolves({ data: { upgradeDoc  } });
+      http.get.withArgs('/api/v2/upgrade')
+        .onCall(0).resolves({ data: { upgradeDoc  } })
+        .onCall(1).resolves({ data: { } });
 
       http.post.withArgs('/api/v2/upgrade').rejects({ an: 'error', status: 500 });
 
@@ -890,19 +882,15 @@ describe('UpgradeCtrl controller', () => {
       expect(http.post.callCount).to.equal(0);
       expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(1);
 
-      try {
-        await upgradeCb();
-        expect.fail('Should have thrown');
-      } catch (err) {
-        expect(err).to.deep.equal({ an: 'error', status: 500 });
-      }
+      await upgradeCb();
 
       expect(http.post.callCount).to.equal(1);
       expect(http.post.args[0]).to.deep.equal([
         '/api/v2/upgrade',
         { build: { the: 'buildinfo', version: '4.3.0' } },
       ]);
-      expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(1);
+      expect(http.get.withArgs('/api/v2/upgrade').callCount).to.equal(2);
+      expect(scope.upgradeDoc).to.be.undefined;
     });
   });
 });

--- a/api/src/services/setup/upgrade.js
+++ b/api/src/services/setup/upgrade.js
@@ -55,7 +55,11 @@ const safeInstall = async (buildInfo, stageOnly) => {
  */
 const complete = async (buildInfo) => {
   try {
-    return await upgradeSteps.complete(buildInfo);
+    // this request, when actually performing an upgrade, would stop the container running API, and restart it using
+    // the updated image. However, when upgrading to the "same" version, the request will just succeed
+    const result = await upgradeSteps.complete(buildInfo);
+    await upgradeSteps.finalize();
+    return result;
   } catch (err) {
     await upgradeLog.setErrored();
     throw err;

--- a/api/src/services/setup/upgrade.js
+++ b/api/src/services/setup/upgrade.js
@@ -54,7 +54,12 @@ const safeInstall = async (buildInfo, stageOnly) => {
  * @return {Promise<void>}
  */
 const complete = async (buildInfo) => {
-  return upgradeSteps.complete(buildInfo);
+  try {
+    return await upgradeSteps.complete(buildInfo);
+  } catch (err) {
+    await upgradeLog.setErrored();
+    throw err;
+  }
 };
 
 const abort = () => {

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -307,14 +307,14 @@ const getUpgradeServicePayload = (stagingDoc) => {
       dockerCompose[fileName] = buffer.toString('utf-8');
     });
 
-  const tags = stagingDoc.tags.map(tag => ({
+  const containers = stagingDoc.tags.map(tag => ({
     containerName: tag.container_name,
     imageTag: tag.image,
   }));
 
   return {
-    tags,
-    'docker-compose': dockerCompose,
+    containers,
+    dockerCompose,
   };
 };
 

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -308,13 +308,13 @@ const getUpgradeServicePayload = (stagingDoc) => {
     });
 
   const containers = stagingDoc.tags.map(tag => ({
-    containerName: tag.container_name,
-    imageTag: tag.image,
+    container_name: tag.container_name,
+    image_tag: tag.image,
   }));
 
   return {
     containers,
-    dockerCompose,
+    docker_compose: dockerCompose,
   };
 };
 

--- a/api/tests/mocha/services/setup/upgrade-steps.spec.js
+++ b/api/tests/mocha/services/setup/upgrade-steps.spec.js
@@ -436,10 +436,12 @@ describe('Upgrade steps', () => {
       sinon.stub(upgradeUtils, 'getStagingDoc').resolves({ the: 'staging_doc' });
       sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ the: 'payload' });
       sinon.stub(upgradeUtils, 'makeUpgradeRequest').rejects({ error: 'boom' });
+      sinon.stub(upgradeSteps, 'finalize');
 
       const buildInfo = { version: '4.0.0' };
 
       await expect(upgradeSteps.complete(buildInfo)).to.be.rejected.and.eventually.deep.equal({ error: 'boom' });
+      expect(upgradeSteps.finalize.callCount).to.equal(0);
     });
   });
 });

--- a/api/tests/mocha/services/setup/upgrade.spec.js
+++ b/api/tests/mocha/services/setup/upgrade.spec.js
@@ -214,10 +214,12 @@ describe('upgrade service', () => {
     });
 
     it('should throw errors', async () => {
+      sinon.stub(upgradeLogService, 'setErrored').resolves();
       sinon.stub(upgradeSteps, 'complete').rejects({ status: 404 });
       const buildInfo = { version: 4 };
 
       await expect(upgrade.complete(buildInfo)).to.be.rejected.and.eventually.deep.equal({ status: 404 });
+      expect(upgradeLogService.setErrored.callCount).to.equal(1);
     });
   });
 });

--- a/api/tests/mocha/services/setup/upgrade.spec.js
+++ b/api/tests/mocha/services/setup/upgrade.spec.js
@@ -54,6 +54,7 @@ describe('upgrade service', () => {
       let indexStagedViews;
       sinon.stub(upgradeSteps, 'indexStagedViews').returns(new Promise(r => indexStagedViews = r));
       sinon.stub(upgradeSteps, 'complete').resolves();
+      sinon.stub(upgradeSteps, 'finalize').resolves();
 
       const upgradePromise = upgrade.upgrade('a_version', 'usr', false);
 
@@ -205,21 +206,25 @@ describe('upgrade service', () => {
   describe('complete', () => {
     it('should call complete upgrade step', async () => {
       sinon.stub(upgradeSteps, 'complete').resolves('???');
+      sinon.stub(upgradeSteps, 'finalize').resolves();
       const buildInfo = { version: 4 };
 
       expect(await upgrade.complete(buildInfo)).to.equal('???');
 
       expect(upgradeSteps.complete.callCount).to.equal(1);
       expect(upgradeSteps.complete.args[0]).to.deep.equal([buildInfo]);
+      expect(upgradeSteps.finalize.callCount).to.equal(1);
     });
 
     it('should throw errors', async () => {
       sinon.stub(upgradeLogService, 'setErrored').resolves();
+      sinon.stub(upgradeSteps, 'finalize');
       sinon.stub(upgradeSteps, 'complete').rejects({ status: 404 });
       const buildInfo = { version: 4 };
 
       await expect(upgrade.complete(buildInfo)).to.be.rejected.and.eventually.deep.equal({ status: 404 });
       expect(upgradeLogService.setErrored.callCount).to.equal(1);
+      expect(upgradeSteps.finalize.callCount).to.equal(0);
     });
   });
 });

--- a/api/tests/mocha/services/setup/utils.spec.js
+++ b/api/tests/mocha/services/setup/utils.spec.js
@@ -846,15 +846,15 @@ describe('Setup utils', () => {
       expect(utils.getUpgradeServicePayload(stagingDoc)).to.deep.equal({
         containers: [
           {
-            containerName: 'cht-api',
-            imageTag: 'registry/cht-api:4.0.0',
+            container_name: 'cht-api',
+            image_tag: 'registry/cht-api:4.0.0',
           },
           {
-            containerName: 'cht-sentinel',
-            imageTag: 'registry/cht-sentinel:4.0.0',
+            container_name: 'cht-sentinel',
+            image_tag: 'registry/cht-sentinel:4.0.0',
           }
         ],
-        dockerCompose: {
+        docker_compose: {
           'file1.yml': 'file1',
           'file2.yml': 'file2',
         },
@@ -879,7 +879,7 @@ describe('Setup utils', () => {
 
       expect(utils.getUpgradeServicePayload(stagingDoc)).to.deep.equal({
         containers: [],
-        dockerCompose: {},
+        docker_compose: {},
       });
     });
   });

--- a/api/tests/mocha/services/setup/utils.spec.js
+++ b/api/tests/mocha/services/setup/utils.spec.js
@@ -844,7 +844,7 @@ describe('Setup utils', () => {
       };
 
       expect(utils.getUpgradeServicePayload(stagingDoc)).to.deep.equal({
-        tags: [
+        containers: [
           {
             containerName: 'cht-api',
             imageTag: 'registry/cht-api:4.0.0',
@@ -854,7 +854,7 @@ describe('Setup utils', () => {
             imageTag: 'registry/cht-sentinel:4.0.0',
           }
         ],
-        'docker-compose': {
+        dockerCompose: {
           'file1.yml': 'file1',
           'file2.yml': 'file2',
         },
@@ -878,8 +878,8 @@ describe('Setup utils', () => {
       };
 
       expect(utils.getUpgradeServicePayload(stagingDoc)).to.deep.equal({
-        tags: [],
-        'docker-compose': {},
+        containers: [],
+        dockerCompose: {},
       });
     });
   });


### PR DESCRIPTION
# Description

Also set the upgrade as errored when the upgrade-service upgrade request fails. 
The alternative would have been to set an upgrade status that allows for a "complete" call retry (which is a bit more complicated). 

medic/cht-core#7601

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
