### PR TITLE
Archv3: HAProxy

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,6 +1,9 @@
-FROM haproxy:1.8.14
+FROM haproxy:2.5.6
 
+USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext -y
+
+USER haproxy
 
 ADD haproxy.cfg /usr/local/etc/haproxy
 ADD haproxy.conf /etc/rsyslog.d

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,13 +1,12 @@
 FROM haproxy:2.3.19
 
-RUN apt-get update && apt-get install rsyslog luarocks gettext -y
+RUN apt-get update && apt-get install rsyslog luarocks gettext jq curl -y
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
 ADD haproxy.cfg /usr/local/etc/haproxy
-ADD haproxy.conf /etc/rsyslog.d
 ADD rsyslog.conf /etc/rsyslog.conf
-ADD scripts /usr/local/etc/haproxy/
+COPY scripts /usr/local/etc/haproxy/
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,0 +1,12 @@
+FROM haproxy:1.8.14
+
+RUN apt-get update && apt-get install rsyslog luarocks gettext -y
+
+ADD haproxy.cfg /usr/local/etc/haproxy
+ADD haproxy.conf /etc/rsyslog.d
+ADD rsyslog.conf /etc/rsyslog.conf
+ADD scripts /usr/local/etc/haproxy/
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -2,9 +2,11 @@ FROM haproxy:2.5.6
 
 USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext -y
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+RUN chown haproxy:haproxy /entrypoint.sh
 
 USER haproxy
-
 ADD haproxy.cfg /usr/local/etc/haproxy
 ADD haproxy.conf /etc/rsyslog.d
 ADD rsyslog.conf /etc/rsyslog.conf

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,17 +1,13 @@
-FROM haproxy:2.5.6
+FROM haproxy:2.3.19
 
-USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext -y
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-RUN chown haproxy:haproxy /entrypoint.sh
 
-USER haproxy
 ADD haproxy.cfg /usr/local/etc/haproxy
 ADD haproxy.conf /etc/rsyslog.d
 ADD rsyslog.conf /etc/rsyslog.conf
 ADD scripts /usr/local/etc/haproxy/
-COPY entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -1,0 +1,33 @@
+### Usage
+
+This directory contains the build files for a pre-configured HAProxy to be used for CHT-Core. It's main objective is to 
+provide an audit log trail between CHT-API and CouchDB, and load balance all queries across the CouchDB Cluster.
+
+
+### Scripts
+
+Inside the scripts folder, you can find a set of custom scripts, please add any future ones here.
+
+
+### Build
+
+After making your changes, build the image locally from inside this directory:
+`docker build -t medicmobile/cht-haproxy:<tag> .`
+
+### Test
+
+Please test this manually until we add CI/CD via GitHub Actions. After building the image locally, you can change the image tag
+for the haproxy declaration in any of your cht-core docker-compose templates.
+
+After testing, please push your image to DockerHub.
+
+
+### Required Variables
+
+In your docker-compose.yml template, the HAproxy container declaration will require the following variables:
+- HAPROXY_IP: This should be the docker service name, `fqdn`, or set to `0.0.0.0`. If not set, our templates will default this to be a service name of `haproxy`. 
+*Note*: For Docker Desktop on Mac users, if you wish to expose HAproxy to your host, you will have to set this as `0.0.0.0`, to expose it as `localhost` outside of the docker network.
+- HAPROXY_PORT: The port you wish HAProxy to run on. Defaults to 5984.
+- COUCHDB1_SERVER: The docker service name or fqdn of the first CouchDB server. Defaults to couchdb.1 in our templates.
+- COUCHDB2_SERVER: The docker service name or fqdn of the second CouchDB server. Defaults to couchdb.2 in our templates.
+- COUCHDB3_SERVER: The docker service name or fqdn of the third CouchDB server. Defaults to couchdb.3 in our templates.

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -31,3 +31,5 @@ In your docker-compose.yml template, the HAproxy container declaration will requ
 - COUCHDB1_SERVER: The docker service name or fqdn of the first CouchDB server. Defaults to couchdb.1 in our templates.
 - COUCHDB2_SERVER: The docker service name or fqdn of the second CouchDB server. Defaults to couchdb.2 in our templates.
 - COUCHDB3_SERVER: The docker service name or fqdn of the third CouchDB server. Defaults to couchdb.3 in our templates.
+- COUCHDB_USER: The admininstrator that created the couchdb cluster
+- COUCHDB_PASSWORD: The above admin's password

--- a/haproxy/entrypoint.sh
+++ b/haproxy/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Make sure service is running
+service rsyslog start
+
+# Make sure logging dir exists
+mkdir -p /srv/storage/audit
+
+# Touch the log file so we can tail on it
+touch /srv/storage/audit/haproxy.log
+
+# Throw the log to output
+tail -f /srv/storage/audit/haproxy.log &
+
+# Place environment variables into config
+envsubst < /usr/local/etc/haproxy/haproxy.cfg
+
+# Start haproxy
+exec /docker-entrypoint.sh "$@"

--- a/haproxy/entrypoint.sh
+++ b/haproxy/entrypoint.sh
@@ -3,17 +3,13 @@
 # Make sure service is running
 service rsyslog start
 
-# Make sure logging dir exists
-mkdir -p /srv/storage/audit
-
-# Touch the log file so we can tail on it
-touch /srv/storage/audit/haproxy.log
-
-# Throw the log to output
-tail -f /srv/storage/audit/haproxy.log &
-
 # Place environment variables into config
 envsubst < /usr/local/etc/haproxy/haproxy.cfg
+
+#Write pw for healthcheck subshell to work
+mkdir -p /srv/storage/haproxy/passwd
+echo $COUCHDB_USER > /srv/storage/haproxy/passwd/username
+echo $COUCHDB_PASSWORD > /srv/storage/haproxy/passwd/admin
 
 # Start haproxy
 exec /docker-entrypoint.sh "$@"

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -1,0 +1,46 @@
+# Setting `log` here with the address of 127.0.0.1 will have the effect
+# of haproxy sending the udp log messages to its own rsyslog instance
+# (which sits at `127.0.0.1`) at the `local0` facility including all
+# logs that have a priority greater or equal to the specified log level
+# log 127.0.0.1 local0 warning
+global
+  maxconn 4096
+  lua-load /usr/local/etc/haproxy/parse_basic.lua
+  lua-load /usr/local/etc/haproxy/parse_cookie.lua
+  lua-load /usr/local/etc/haproxy/replace_password.lua
+  log /dev/log len 65535 local2 info
+
+defaults
+  mode http
+  log global
+  option dontlognull
+  option http-ignore-probes
+  timeout client 150000
+  timeout server 3600000
+  timeout connect 15000
+  stats enable
+  stats refresh 30s
+  stats auth $COUCHDB_USER:$COUCHDB_PASSWORD
+  stats uri /haproxy?stats
+
+frontend http-in
+  bind  $HAPROXY_IP:$HAPROXY_PORT
+  acl has_user req.hdr(x-medic-user) -m found
+  acl has_cookie req.hdr(cookie) -m found
+  acl has_basic_auth req.hdr(authorization) -m found
+  declare capture request len 400000
+  http-request set-header x-medic-user %[lua.parseBasic] if has_basic_auth
+  http-request set-header x-medic-user %[lua.parseCookie] if !has_basic_auth !has_user has_cookie
+  http-request capture req.body id 0 # capture.req.hdr(0)
+  http-request capture req.hdr(x-medic-service) len 200 # capture.req.hdr(1)
+  http-request capture req.hdr(x-medic-user) len 200 # capture.req.hdr(2)
+  http-request capture req.hdr(user-agent) len 600 # capture.req.hdr(3)
+  capture response header Content-Length len 10 # capture.res.hdr(0)
+  log-format "%ci,%ST,%[capture.req.method],%[capture.req.uri],%[capture.req.hdr(1)],%[capture.req.hdr(2)],'%[capture.req.hdr(0),lua.replacePassword]',%B,%Tr,%[capture.res.hdr(0)],'%[capture.req.hdr(3)]'"
+  default_backend couchdb-servers
+
+backend couchdb-servers
+  balance leastconn
+  server couchdb1 $COUCHDB1_SERVER:5984 check inter 2s
+  server couchdb2 $COUCHDB2_SERVER:5984 check inter 2s
+  server couchdb3 $COUCHDB3_SERVER:5984 check inter 2s

--- a/haproxy/haproxy.cfg
+++ b/haproxy/haproxy.cfg
@@ -8,11 +8,12 @@ global
   lua-load /usr/local/etc/haproxy/parse_basic.lua
   lua-load /usr/local/etc/haproxy/parse_cookie.lua
   lua-load /usr/local/etc/haproxy/replace_password.lua
-  log /dev/log len 65535 local2 info
+  log stdout len 65535 local2 info
+  external-check
+  insecure-fork-wanted
 
 defaults
   mode http
-  log global
   option dontlognull
   option http-ignore-probes
   timeout client 150000
@@ -36,11 +37,14 @@ frontend http-in
   http-request capture req.hdr(x-medic-user) len 200 # capture.req.hdr(2)
   http-request capture req.hdr(user-agent) len 600 # capture.req.hdr(3)
   capture response header Content-Length len 10 # capture.res.hdr(0)
-  log-format "%ci,%ST,%[capture.req.method],%[capture.req.uri],%[capture.req.hdr(1)],%[capture.req.hdr(2)],'%[capture.req.hdr(0),lua.replacePassword]',%B,%Tr,%[capture.res.hdr(0)],'%[capture.req.hdr(3)]'"
+  log global
+  log-format "%ci,%s,%ST,%[capture.req.method],%[capture.req.uri],%[capture.req.hdr(1)],%[capture.req.hdr(2)],'%[capture.req.hdr(0),lua.replacePassword]',%B,%Tr,%[capture.res.hdr(0)],'%[capture.req.hdr(3)]'"
   default_backend couchdb-servers
 
 backend couchdb-servers
   balance leastconn
+  option external-check
+  external-check command /usr/local/etc/haproxy/healthcheck.sh
   server couchdb1 $COUCHDB1_SERVER:5984 check inter 2s
   server couchdb2 $COUCHDB2_SERVER:5984 check inter 2s
   server couchdb3 $COUCHDB3_SERVER:5984 check inter 2s

--- a/haproxy/haproxy.conf
+++ b/haproxy/haproxy.conf
@@ -1,0 +1,2 @@
+local2.*    /srv/storage/audit/haproxy.log
+& ~

--- a/haproxy/haproxy.conf
+++ b/haproxy/haproxy.conf
@@ -1,2 +1,0 @@
-local2.*    /srv/storage/audit/haproxy.log
-& ~

--- a/haproxy/rsyslog.conf
+++ b/haproxy/rsyslog.conf
@@ -1,0 +1,39 @@
+module(load="imuxsock") # provides support for local system logging
+module(load="imklog")   # provides kernel logging support
+
+module(load="imudp")
+input(type="imudp" port="514")
+
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+$WorkDirectory /var/spool/rsyslog
+
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+auth,authpriv.*         /var/log/auth.log
+*.*;auth,authpriv.none      -/var/log/syslog
+daemon.*            -/var/log/daemon.log
+kern.*              -/var/log/kern.log
+lpr.*               -/var/log/lpr.log
+mail.*              -/var/log/mail.log
+user.*              -/var/log/user.log
+
+mail.info           -/var/log/mail.info
+mail.warn           -/var/log/mail.warn
+mail.err            /var/log/mail.err
+
+*.=debug;\
+    auth,authpriv.none;\
+    news.none;mail.none -/var/log/debug
+*.=info;*.=notice;*.=warn;\
+    auth,authpriv.none;\
+    cron,daemon.none;\
+    mail,news.none      -/var/log/messages
+
+*.emerg             :omusrmsg:*

--- a/haproxy/rsyslog.conf
+++ b/haproxy/rsyslog.conf
@@ -1,5 +1,4 @@
 module(load="imuxsock") # provides support for local system logging
-module(load="imklog")   # provides kernel logging support
 
 module(load="imudp")
 input(type="imudp" port="514")

--- a/haproxy/scripts/healthcheck.sh
+++ b/haproxy/scripts/healthcheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# The subshell that HAProxy launches to run any external-check scripts is limited 
+# to a set of pre-defined HAProxy environment variables. For our use-case,
+# CouchDB's _membership endpoint is behind authentication, so we have to write credentials to a file,
+# for the subshell to be able to poll the endpoint and function as our healthcheck.
+# External Checks are bad practice, we should move this function to a separate Agent container.
+
+USERNAME_FILE=/srv/storage/haproxy/passwd/username
+PASSWORD_FILE=/srv/storage/haproxy/passwd/admin
+CHECK_MEMBERSHIP=`/usr/bin/curl -s http://$(/bin/cat /srv/storage/haproxy/passwd/username):$(/bin/cat /srv/storage/haproxy/passwd/admin)@$HAPROXY_SERVER_ADDR:5984/_membership`
+HEALTHCHECK=`echo $CHECK_MEMBERSHIP | /usr/bin/jq '.all_nodes == .cluster_nodes'`
+CHECK_FOR_NULL=`echo $CHECK_MEMBERSHIP | /usr/bin/jq .'all_nodes'`
+
+if [[ ! -z $CHECK_FOR_NULL ]] && [[ $HEALTHCHECK == true ]]
+then
+    exit 0
+else
+    echo "_Membership endpoint shows all nodes are not part of cluster."
+    exit 1
+fi

--- a/haproxy/scripts/parse_basic.lua
+++ b/haproxy/scripts/parse_basic.lua
@@ -1,0 +1,34 @@
+core.Alert("parseBasic loaded")
+
+-- character table string
+local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+-- decoding
+function dec(data)
+    data = string.gsub(data, '[^'..b..'=]', '')
+    return (data:gsub('.', function(x)
+        if (x == '=') then return '' end
+        local r,f='',(b:find(x)-1)
+        for i=6,1,-1 do r=r..(f%2^i-f%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end):gsub('%d%d%d?%d?%d?%d?%d?%d?', function(x)
+        if (#x ~= 8) then return '' end
+        local c=0
+        for i=1,8 do c=c+(x:sub(i,i)=='1' and 2^(8-i) or 0) end
+        return string.char(c)
+    end))
+end
+
+function parseBasic(txn)
+  local hdr = txn.http:req_get_headers()
+  local authorization = hdr["authorization"][0]
+  local userpass_b64 = authorization:match("Basic%s+(.*)")
+  if userpass_b64 then
+    local userpass = dec(userpass_b64)
+    local username, password = userpass:match("([^:]*):(.*)")
+    return username
+  end
+  return '-'
+end
+
+core.register_fetches("parseBasic", parseBasic)

--- a/haproxy/scripts/parse_cookie.lua
+++ b/haproxy/scripts/parse_cookie.lua
@@ -1,0 +1,20 @@
+core.Alert("parseCookie loaded")
+
+local hex_to_char = function(x)
+  return string.char(tonumber(x, 16))
+end
+
+local unescape = function(url)
+  return url:gsub("%%(%x%x)", hex_to_char)
+end
+
+local user = function(cookie)
+  return string.match(unescape(cookie), "userCtx={\"name\":\"(.-)\",\"roles\":")
+end
+
+function parseCookie(txn)
+  local hdr = txn.http:req_get_headers()
+  return user(hdr["cookie"][0])
+end
+
+core.register_fetches("parseCookie", parseCookie)

--- a/haproxy/scripts/replace_password.lua
+++ b/haproxy/scripts/replace_password.lua
@@ -1,0 +1,10 @@
+core.Alert("replacePassword loaded")
+
+function replacePassword(body)
+    if body then
+        local result = (body):gsub("(password[^:]*:%s*\")[^\"]*", "%1***")
+        return result
+    end
+end
+
+core.register_converters("replacePassword", replacePassword)


### PR DESCRIPTION
# Description

We wanted to move our HAProxy configuration and build files into CHT-Core.

Note: This PR doesn't contain any CI/CD. I'm hoping we can add that in a later release, and left it out of this MVP. We shouldn't need to build this image often, and allowing this to be merged without tests/CI/CD will unblock other tasks as someone can build out those in parallel. 

We bumped HAproxy from verison 1.8.14 to 2.3.19, which is supported. We could not bump up through 2.4+ because the container has switched to using non-root user (a good thing!), but that is interfering with our extra config dependencies (rsyslog + lua). There should be a way through forward, but this large of jump in versions to a supported version is plenty for an MVP. The other future task I wanted to note is moving this image to alpine as its fairly large.
