### PR TITLE
Fix `npm ci` hanging

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1828,8 +1828,8 @@
       }
     },
     "openrosa-formlist": {
-      "version": "github:medic/openrosa-formlist#3ce85a8678411f7cefb09227f5e7ac07829ab233",
-      "from": "github:medic/openrosa-formlist#sax",
+      "version": "https://github.com/medic/openrosa-formlist.git#3ce85a8678411f7cefb09227f5e7ac07829ab233",
+      "from": "openrosa-formlist@https://github.com/medic/openrosa-formlist#sax",
       "requires": {
         "async": "^2.6.1",
         "concat-stream": "^1.4.7",

--- a/api/package.json
+++ b/api/package.json
@@ -34,7 +34,7 @@
     "mustache": "^4.2.0",
     "node-cache": "^5.1.2",
     "object-path": "^0.11.8",
-    "openrosa-formlist": "github:medic/openrosa-formlist#sax",
+    "openrosa-formlist": "https://github.com/medic/openrosa-formlist#sax",
     "pass-stream": "^1.0.0",
     "pouchdb-adapter-http": "^7.2.2",
     "pouchdb-core": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15314,7 +15314,7 @@
       }
     },
     "grunt-contrib-watch": {
-      "version": "git+ssh://git@github.com/scdf/grunt-contrib-watch.git#896dba3fed7874ed85074f787a5baf60db80d12f",
+      "version": "https://github.com/scdf/grunt-contrib-watch.git#896dba3fed7874ed85074f787a5baf60db80d12f",
       "from": "grunt-contrib-watch@https://github.com/scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15314,8 +15314,8 @@
       }
     },
     "grunt-contrib-watch": {
-      "version": "github:scdf/grunt-contrib-watch#896dba3fed7874ed85074f787a5baf60db80d12f",
-      "from": "github:scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
+      "version": "https://github.com/scdf/grunt-contrib-watch#896dba3fed7874ed85074f787a5baf60db80d12f",
+      "from": "https://github.com/scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
       "dev": true,
       "requires": {
         "async": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15314,8 +15314,8 @@
       }
     },
     "grunt-contrib-watch": {
-      "version": "https://github.com/scdf/grunt-contrib-watch#896dba3fed7874ed85074f787a5baf60db80d12f",
-      "from": "https://github.com/scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
+      "version": "git+ssh://git@github.com/scdf/grunt-contrib-watch.git#896dba3fed7874ed85074f787a5baf60db80d12f",
+      "from": "grunt-contrib-watch@https://github.com/scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
       "dev": true,
       "requires": {
         "async": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "grunt-contrib-cssmin": "^4.0.0",
     "grunt-contrib-less": "^3.0.0",
     "grunt-contrib-uglify-es": "^3.3.0",
-    "grunt-contrib-watch": "github:scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
+    "grunt-contrib-watch": "https://github.com/scdf/grunt-contrib-watch#v1.0.0-fix_dirs_firing",
     "grunt-couch": "^1.5.1",
     "grunt-env": "^1.0.1",
     "grunt-exec": "^3.0.0",

--- a/webapp/src/ts/main.ts
+++ b/webapp/src/ts/main.ts
@@ -43,6 +43,7 @@ bootstrapper(POUCHDB_OPTIONS, (err) => {
       // retry initial replication automatically after one minute
       window.location.reload(false);
     }, 60 * 1000);
+
     return;
   }
 


### PR DESCRIPTION
# Description

`npm ci` hangs when installing `grunt-contrib-watch` because it's trying to fetch the remote heads and tags of the project's github repository
```
npm sill pacote Retrying git command: ls-remote -h -t git://github.com/scdf/grunt-contrib-watch.git attempt # 2
```

For an unknown reason, `git ls-remote -h -t git://github.com/scdf/grunt-contrib-watch.git` times out whereas `git ls-remote -h -t https://github.com/scdf/grunt-contrib-watch.git` works normally.

This change makes npm install `grunt-contrib-watch` and `openrosa-formlist` from github over https to avoid running into that timeout error.  
We should maybe raise an issue to @github

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.