### PR TITLE
83-automate cht-conf

### DIFF
--- a/tests/cht-conf/cht-conf-actions.spec.js
+++ b/tests/cht-conf/cht-conf-actions.spec.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 
 const { runCommand } = require('../cht-conf-utils');
+const utils = require('../utils');
 
 //Not all actions tested here due to missing forms and config
 //[convert-collect-forms , upload-collect-form, upload-branding, upload-partners, upload-privacy-policies]
@@ -19,15 +20,36 @@ const actions = [
 const configPath = 'config/default';
 
 describe('cht-conf actions tests', () => {
+  before(async () => {
+    const settings = await utils.getDoc('settings');
+    expect(settings._rev.startsWith('1-')).to.be.true;
+    expect(settings.settings.roles).to.not.include.any.keys('program_officer', 'chw_supervisor', 'chw');
+  });
+
+  after(async () => await utils.revertSettings(true));
+  
   it('should execute  upload-app-settings', async () => {
     const result = await runCommand('upload-app-settings', configPath);
     expect(result).to.contain(`INFO Settings updated successfully`);
+    const settings = await utils.getDoc('settings');
+    expect(settings._rev.startsWith('2-')).to.be.true;
+    expect(settings.settings.roles).to.include.all.keys('program_officer', 'chw_supervisor', 'chw');
   });
 
-  for (const action of actions) {
-    it(`should execute ${action}`, async () => {
-      const result = await runCommand(action, configPath);
-      expect(result).to.contain(`INFO ${action} complete.`);
-    });
-  }
+  // for (const action of actions) {
+  //   it(`should execute ${action}`, async () => {
+  //     const result = await runCommand(action, configPath);
+  //     expect(result).to.contain(`INFO ${action} complete.`);
+  //   });
+  // }
+// before gets settings
+  //compile settings
+  //upload-settings
+  //upload contact forms
+  //upload app forms
+  //upload resources
+  //upload-branding
+  //upload-partners
+  //upload-privacy-policies
+  //upload-collect-form
 });

--- a/tests/cht-conf/cht-conf-actions.spec.js
+++ b/tests/cht-conf/cht-conf-actions.spec.js
@@ -14,6 +14,7 @@ const actions = [
   'upload-contact-forms',
   'upload-resources',
   'upload-custom-translations',
+  'convert-collect-forms', 'upload-collect-form', 'upload-branding', 'upload-partners', 'upload-privacy-policies'
 ];
 const configPath = 'config/default';
 

--- a/tests/cht-conf/cht-conf-actions.spec.js
+++ b/tests/cht-conf/cht-conf-actions.spec.js
@@ -15,7 +15,7 @@ const actions = [
   'upload-contact-forms',
   'upload-resources',
   'upload-custom-translations',
-  'convert-collect-forms', 'upload-collect-form', 'upload-branding', 'upload-partners', 'upload-privacy-policies'
+  'upload-branding', 'upload-partners'
 ];
 const configPath = 'config/default';
 
@@ -27,7 +27,7 @@ describe('cht-conf actions tests', () => {
   });
 
   after(async () => await utils.revertSettings(true));
-  
+
   it('should execute  upload-app-settings', async () => {
     const result = await runCommand('upload-app-settings', configPath);
     expect(result).to.contain(`INFO Settings updated successfully`);
@@ -36,20 +36,275 @@ describe('cht-conf actions tests', () => {
     expect(settings.settings.roles).to.include.all.keys('program_officer', 'chw_supervisor', 'chw');
   });
 
-  // for (const action of actions) {
-  //   it(`should execute ${action}`, async () => {
-  //     const result = await runCommand(action, configPath);
-  //     expect(result).to.contain(`INFO ${action} complete.`);
-  //   });
-  // }
-// before gets settings
-  //compile settings
-  //upload-settings
-  //upload contact forms
-  //upload app forms
-  //upload resources
-  //upload-branding
-  //upload-partners
-  //upload-privacy-policies
-  //upload-collect-form
+  for (const action of actions) {
+    it(`should execute ${action}`, async () => {
+      const result = await runCommand(action, configPath);
+      expect(result).to.contain(`INFO ${action} complete.`);
+    });
+  }
+
+  it('should upload  branding', async () => {
+    const branding = await utils.getDoc('branding').catch(error => {
+      if(error){
+        console.log(error);
+      }
+    });
+    expect(branding.title).to.equal('Medic');
+  });
+
+  it('should uploadload  forms', async () => {
+    const forms = await utils.request({
+      path: '/api/v1/forms',
+      method: 'GET'
+    }).catch(error => {
+      if(error){
+        console.log(error);
+      }
+    });
+    expect(forms).to.deep.equal([
+      'contact:clinic:create.xml',
+      'contact:clinic:edit.xml',
+      'contact:district_hospital:create.xml',
+      'contact:district_hospital:edit.xml',
+      'contact:health_center:create.xml',
+      'contact:health_center:edit.xml',
+      'contact:person:create.xml',
+      'contact:person:edit.xml',
+      'death_report.xml',
+      'delivery.xml',
+      'pnc_danger_sign_follow_up_baby.xml',
+      'pnc_danger_sign_follow_up_mother.xml',
+      'pregnancy.xml',
+      'pregnancy_danger_sign.xml',
+      'pregnancy_danger_sign_follow_up.xml',
+      'pregnancy_facility_visit_reminder.xml',
+      'pregnancy_home_visit.xml',
+      'undo_death_report.xml'
+    ]);
+  });
+
+  it('should upload  resources', async () => {
+    const resources = await utils.getDoc('resources').catch(error => {
+      if(error){
+        console.log(error);
+      }
+    });
+    console.log(resources);
+    expect(resources.resources).to.deep.equal({
+      'icon-area': 'icon-places-CHW-area@2x.png',
+      'icon-branch': 'icon-places-clinic@2x.png',
+      'icon-calendar': 'icon-calendar.png',
+      'icon-child': 'icon-people-child@2x.png',
+      'icon-children': 'icon-people-children@2x.png',
+      'icon-clinic': 'icon-places-clinic@2x.png',
+      'icon-death-general': 'icon-death-general.png',
+      'icon-death-maternal': 'icon-death-maternal.png',
+      'icon-death-neonatal': 'icon-death-neonatal.png',
+      'icon-family': 'icon-people-family@2x.png',
+      'icon-follow-up': 'icon-followup-general@2x.png',
+      'icon-healthcare': 'Icon-healthcare-generic@2x.png',
+      'icon-household': 'icon-people-family@2x.png',
+      'icon-immunization': 'icon-healthcare-immunization@2x.png',
+      'icon-infant': 'icon-people-baby@2x.png',
+      'icon-mother-child': 'icon-people-woman-baby@2x.png',
+      'icon-new-person': 'icon-people-person-general@2x.png',
+      'icon-nurse': 'icon-people-nurse-crop@2x.png',
+      'icon-off': 'icon-messages-off@2x.png',
+      'icon-on': 'icon-messages-on@2x.png',
+      'icon-person': 'icon-people-person-general@2x.png',
+      'icon-pregnancy': 'icon-people-woman-pregnant@2x.png',
+      'icon-pregnancy-danger': 'icon-ANC-danger-sign@2x.png',
+      'icon-risk': 'icon-healthcare-warning@2x.png',
+      'icon-treatment': 'icon-healthcare-medicine@2x.png',
+      'medic-clinic': 'medic-family.svg',
+      'medic-district-hospital': 'medic-health-center.svg',
+      'medic-health-center': 'medic-chw-area.svg',
+      'medic-person': 'medic-person.svg'
+    });
+
+    expect(resources._attachments).to.deep.equal({
+      'Icon-healthcare-generic@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-x+vjoMsPBe8JcrcxM8qU6w==',
+        length: 690,
+        stub: true
+      },
+      'icon-ANC-danger-sign@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-B1hE//00k0/1ucAxX0dY+w==',
+        length: 1168,
+        stub: true
+      },
+      'icon-calendar.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-VeHPwrHAh540f9pH8aZcyg==',
+        length: 1313,
+        stub: true
+      },
+      'icon-death-general.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-44sZ9ttrLxPz2RlWCA3Dnw==',
+        length: 411,
+        stub: true
+      },
+      'icon-death-maternal.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-aW6f+dRG+NfXESUeTbSKkQ==',
+        length: 638,
+        stub: true
+      },
+      'icon-death-neonatal.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-ejce8OxOczRoKBWvXhuZmA==',
+        length: 712,
+        stub: true
+      },
+      'icon-followup-general@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-vH6PiFI89+HjrbnscXFCxA==',
+        length: 1289,
+        stub: true
+      },
+      'icon-healthcare-immunization@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-GT9Fuf1XNFyq5Ew5+QTSIA==',
+        length: 889,
+        stub: true
+      },
+      'icon-healthcare-medicine@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-MQshm84Jkdc+/9VlekIO/A==',
+        length: 1073,
+        stub: true
+      },
+      'icon-healthcare-warning@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-VUxpfDqkYkMNwIQjrKvkSg==',
+        length: 870,
+        stub: true
+      },
+      'icon-messages-off@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-IrxXsdKwTUIoHLttuJLt2w==',
+        length: 1314,
+        stub: true
+      },
+      'icon-messages-on@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-HYXvDWZgffEOpCJZKwGXSA==',
+        length: 449,
+        stub: true
+      },
+      'icon-people-baby@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-EY7c/5YMOevZEnSNNpSMOg==',
+        length: 997,
+        stub: true
+      },
+      'icon-people-child@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-oIKDpoiD1r3EgVM0Cz2Hfw==',
+        length: 829,
+        stub: true
+      },
+      'icon-people-children@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-1X2qRRh1fgFi9W7QF+f0+g==',
+        length: 1215,
+        stub: true
+      },
+      'icon-people-family@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-ib3By5zqFubosC90QRK5Qg==',
+        length: 1393,
+        stub: true
+      },
+      'icon-people-nurse-crop@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-+X46qt+78/4xG7HlCOmZFA==',
+        length: 1105,
+        stub: true
+      },
+      'icon-people-person-general@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-158qdmymTnrPCtECE4aGlQ==',
+        length: 749,
+        stub: true
+      },
+      'icon-people-woman-baby@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-4dGUiG8KGGTWvnF/WlNBIg==',
+        length: 937,
+        stub: true
+      },
+      'icon-people-woman-pregnant@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-TYwCWVE0rAuKmo+DETOVhg==',
+        length: 878,
+        stub: true
+      },
+      'icon-places-CHW-area@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-IhS7x0SpIlMYXdgweJCrNA==',
+        length: 1224,
+        stub: true
+      },
+      'icon-places-clinic@2x.png': {
+        content_type: 'image/png',
+        revpos: 3,
+        digest: 'md5-9zkj2JJH1rgQEdjB+RwOGg==',
+        length: 681,
+        stub: true
+      },
+      'medic-chw-area.svg': {
+        content_type: 'image/svg+xml',
+        revpos: 3,
+        digest: 'md5-70oHopHsHzRVOcClV5FYTw==',
+        length: 1145,
+        stub: true
+      },
+      'medic-family.svg': {
+        content_type: 'image/svg+xml',
+        revpos: 3,
+        digest: 'md5-Q0gO1YOmJ4C7w6OCCVB3zw==',
+        length: 1654,
+        stub: true
+      },
+      'medic-health-center.svg': {
+        content_type: 'image/svg+xml',
+        revpos: 3,
+        digest: 'md5-xtvZAXNBODZNz3AsX1+btg==',
+        length: 357,
+        stub: true
+      },
+      'medic-person.svg': {
+        content_type: 'image/svg+xml',
+        revpos: 3,
+        digest: 'md5-8HoRGS0ihs2qwbg+N4Gmiw==',
+        length: 435,
+        stub: true
+      }
+    });
+  });
 });

--- a/tests/conf.js
+++ b/tests/conf.js
@@ -22,8 +22,7 @@ const baseConfig = {
   suites: {
     web: [
       'e2e/!(cht)/**/*.js',
-      'e2e/**/*.js',
-      'cht-conf/**/*.js'
+      'e2e/**/*.js'
     ],
     cht: [
       'e2e/cht/*.spec.js'

--- a/tests/integration/.mocharc.js
+++ b/tests/integration/.mocharc.js
@@ -9,6 +9,7 @@ module.exports={
     'tests/integration/**/*.js',
     'tests/e2e/sentinel/**/*.js',
     'tests/e2e/transitions/**/*.js',
+    'tests/cht-conf/**/*.js'
   ],
   timeout: 135 * 1000, //API takes a little long to start up
   reporter: 'spec',


### PR DESCRIPTION
# Description

Automating cht-conf actions

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
