### PR TITLE
Support login by SMS in bulk user upload

### DIFF
--- a/api/src/services/token-login.js
+++ b/api/src/services/token-login.js
@@ -225,7 +225,7 @@ const generateTokenLoginDoc = (user, userSettings, token, appUrl) => {
   });
 };
 
-const shouldEnableTokenLogin = data => isTokenLoginEnabled() && data.token_login;
+const shouldEnableTokenLogin = data => isTokenLoginEnabled() && data.token_login === true;
 const shouldDisableTokenLogin = data => data.token_login === false;
 
 const isTokenLoginEnabled = () => {

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -663,7 +663,6 @@ const parseCsv = async (csv, logId) => {
 
   progress.status = BULK_UPLOAD_PROGRESS_STATUSES.PARSED;
   await bulkUploadLog.updateLog(logId, progress, logData);
-  console.log("users", users[0]);
   return { users, ignoredUsers };
 };
 

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -569,7 +569,18 @@ const assignCsvCellValue = (data, attribute, value) => {
   if (!attribute.length || attribute.toLowerCase().indexOf(':excluded') > 0) {
     return;
   }
-  data[attribute] = typeof value === 'string' ? value.replace(/^"|"$/g, '').trim() : value;
+
+  if (typeof value !== 'string') {
+    data[attribute] = value;
+    return;
+  }
+
+  data[attribute] = value.replace(/^"|"$/g, '').trim();
+
+  if (['TRUE', 'FALSE'].includes(data[attribute])) {
+    // converts the "TRUE" or "FALSE" string to boolean
+    data[attribute] = eval(data[attribute].toLowerCase());
+  }
 };
 
 const parseCsvRow = (data, header, value, valueIdx) => {
@@ -652,6 +663,7 @@ const parseCsv = async (csv, logId) => {
 
   progress.status = BULK_UPLOAD_PROGRESS_STATUSES.PARSED;
   await bulkUploadLog.updateLog(logId, progress, logData);
+  console.log("users", users[0]);
   return { users, ignoredUsers };
 };
 

--- a/api/tests/mocha/services/token-login.spec.js
+++ b/api/tests/mocha/services/token-login.spec.js
@@ -45,7 +45,7 @@ describe('TokenLogin service', () => {
 
     it('should return falsey when data does not request token_login to be enabled', () => {
       sinon.stub(config, 'get').withArgs('token_login').returns({ enabled: true, message: 'message' });
-      chai.expect(service.shouldEnableTokenLogin({})).to.equal(undefined);
+      chai.expect(service.shouldEnableTokenLogin({})).to.equal(false);
     });
 
     it('should return true when configured and requested', () => {

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -2604,7 +2604,7 @@ describe('Users service', () => {
       ]);
     });
 
-    it.only('should parse csv, trim spaces and not split strings with commas inside', async () => {
+    i('should parse csv, trim spaces and not split strings with commas inside', async () => {
       /* eslint-disable max-len */
       const csv = 'password,username,type,place,token_login,contact.name,contact.phone,contact.address\n' +
         ',mary,person,498a394e-f98b-4e48-8c50-f12aeb018fcc,TRUE,mary,2652527222,"1 King ST, Kent Town, 55555"\n' +

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -2604,7 +2604,7 @@ describe('Users service', () => {
       ]);
     });
 
-    i('should parse csv, trim spaces and not split strings with commas inside', async () => {
+    it('should parse csv, trim spaces and not split strings with commas inside', async () => {
       /* eslint-disable max-len */
       const csv = 'password,username,type,place,token_login,contact.name,contact.phone,contact.address\n' +
         ',mary,person,498a394e-f98b-4e48-8c50-f12aeb018fcc,TRUE,mary,2652527222,"1 King ST, Kent Town, 55555"\n' +

--- a/api/tests/mocha/services/users.spec.js
+++ b/api/tests/mocha/services/users.spec.js
@@ -2609,6 +2609,7 @@ describe('Users service', () => {
       const csv = 'password,username,type,place,token_login,contact.name,contact.phone,contact.address\n' +
         ',mary,person,498a394e-f98b-4e48-8c50-f12aeb018fcc,TRUE,mary,2652527222,"1 King ST, Kent Town, 55555"\n' +
         'Secret9876,devi,person,498a394e-f98b-4e48-8c50-f12aeb018fcc,truthy mistake,devi,265252,"12 King ST, Kent Town, 55555"\n' +
+        'Secret1144,jeff,person,498a394e-f98b-4e48-8c50-f12aeb018fcc,,jeff,26599102,"27 King ST, Kent Town, 55555"\n' +
         'Secret5678, peter ,person,498a394e-f98b-4e48-8c50-f12aeb018fcc,FALSE,Peter, 2652279,"15 King ST, Kent Town, 55555 "';
       /* eslint-enable max-len */
       sinon.stub(db.medicLogs, 'get').resolves({ progress: {} });
@@ -2632,6 +2633,14 @@ describe('Users service', () => {
           place: '498a394e-f98b-4e48-8c50-f12aeb018fcc',
           contact: { name: 'devi', phone: '265252', address: '12 King ST, Kent Town, 55555' },
           token_login: 'truthy mistake',
+        },
+        {
+          password: 'Secret1144',
+          username: 'jeff',
+          type: 'person',
+          place: '498a394e-f98b-4e48-8c50-f12aeb018fcc',
+          contact: { name: 'jeff', phone: '26599102', address: '27 King ST, Kent Town, 55555' },
+          token_login: '',
         },
         {
           password: 'Secret5678',


### PR DESCRIPTION
# Description

I've also made a few edits to the [spreadsheet](https://docs.google.com/spreadsheets/d/13f5Tj6to8FK2uy1bC9ibfAxzuYQHCtzG7FOxpr92NpE/edit?usp=sharing) that adds a `token_login` field, validates its value (`TRUE`/`FALSE` only) and make the password generation dependent on this field.

medic/cht-core#7634

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
