### PR TITLE
Title test too long for mobile 340px view port width - Apply ellipsis text overflow

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1307,7 +1307,14 @@ a.fa:hover {
       }
     }
     h2 {
-      display: initial;
+      display: inline-block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      width: 100%;
+      :hover {
+        overflow: visible;
+      }
     }
     .dropdown,
     .navigation .mm-button {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1307,14 +1307,14 @@ a.fa:hover {
       }
     }
     h2 {
+      display: initial;
+    }
+    .ellipsis-title {
       display: inline-block;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
       width: 100%;
-      :hover {
-        overflow: visible;
-      }
     }
     .dropdown,
     .navigation .mm-button {

--- a/webapp/src/ts/components/navigation/navigation.component.html
+++ b/webapp/src/ts/components/navigation/navigation.component.html
@@ -5,5 +5,5 @@
   <a *ngIf="!cancelCallback" (click)="navigateBack()" class="filter-bar-back">
     <span class="fa fa-chevron-left" translate [title]="'Back' | translate"></span>
   </a>
-  <h2>{{title}}</h2>
+  <h2 class="ellipsis-title">{{title}}</h2>
 </div>


### PR DESCRIPTION
# Title test too long for mobile 340px view port width 

This PR fix the issue 6028, clipping the the header of Task, Contact and Report tabs when the title is too long for mobile view.

# To test this PR
1.  Use a mobile device, browser developer tools, then toggle device to mobile, or set view port width to 340px(more or less)
2.  Go to Task, Contact and/or Report tab
3.  Check if the overflow text of too long titles is replaced by ellipsis (...)

medic/cht-core#6028

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
