### PR TITLE
Update immunization visit form - pneumococcal vaccine

### DIFF
--- a/config/standard/forms/app/immunization_visit.xml
+++ b/config/standard/forms/app/immunization_visit.xml
@@ -5892,10 +5892,10 @@ ID: <output value=" /immunization_visit/group_review/r_patient_id "/>&quot;</val
       <bind nodeset="/immunization_visit/group_review/r_penta_3" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pentavalent/g_pentavalent ,'DT3')"/>
       <bind nodeset="/immunization_visit/group_review/r_dpt_4" readonly="true()" type="string" relevant="selected( /immunization_visit/group_dpt/g_dpt ,'DPT4')"/>
       <bind nodeset="/immunization_visit/group_review/r_dpt_5" readonly="true()" type="string" relevant="selected( /immunization_visit/group_dpt/g_dpt ,'DPT5')"/>
-      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_1" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'MN1')"/>
-      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_2" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'MN2')"/>
-      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_3" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'MN3')"/>
-      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_4" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'MN4')"/>
+      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_1" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'PCV1')"/>
+      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_2" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'PCV2')"/>
+      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_3" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'PCV3')"/>
+      <bind nodeset="/immunization_visit/group_review/r_pneumococcal_4" readonly="true()" type="string" relevant="selected( /immunization_visit/group_pneumococcal/g_pneumococcal ,'PCV4')"/>
       <bind nodeset="/immunization_visit/group_review/r_rotavirus_1" readonly="true()" type="string" relevant="selected( /immunization_visit/group_rotavirus/g_rotavirus ,'RV1')"/>
       <bind nodeset="/immunization_visit/group_review/r_rotavirus_2" readonly="true()" type="string" relevant="selected( /immunization_visit/group_rotavirus/g_rotavirus ,'RV2')"/>
       <bind nodeset="/immunization_visit/group_review/r_rotavirus_3" readonly="true()" type="string" relevant="selected( /immunization_visit/group_rotavirus/g_rotavirus ,'RV3')"/>


### PR DESCRIPTION
### Pneumococcal Pneumonia vaccines are not shown in the summary section

When an immunization visit is created and the `Pneumococcal Pneumonia` is selected, the related vaccines were not shown in the summary section of the form.

cc: @jonathanvq 


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
