### PR TITLE
Set contact as primary contact of a place with bulk user upload

### DIFF
--- a/admin/tests/unit/controllers/multiple-user.spec.js
+++ b/admin/tests/unit/controllers/multiple-user.spec.js
@@ -46,7 +46,7 @@ describe('MultipleUserCtrl controller', () => {
           $rootScope: $rootScope,
           $q: Q,
           $uibModalInstance: uibModalInstance,
-        }); 
+        });
       };
       mockMultipleUserUpload = () => {
         createController();

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -246,8 +246,7 @@ module.exports = {
           users,
           getAppUrl(req),
           ignoredUsers,
-          logId,
-          true
+          logId
         );
         res.json(response);
       } catch (error) {

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -551,8 +551,25 @@ const validateUserContact = (data, user, userSettings) => {
   }
 };
 
+/* eslint-disable max-len */
+/**
+ * @param {Object} data
+ * @param {string} data.username Identifier used for authentication
+ * @param {string[]} data.roles
+ * @param {(Object|string)=} data.place Place identifier string (UUID) or object this user resides in. Required if the roles contain an offline role.
+ * @param {(Object|string)=} data.contact A person identifier string (UUID) or object based on the form configured in the app. Required if the roles contain an offline role.
+ * @param {string=} data.password Password string used for authentication. Only allowed to be set, not retrieved. Required if token_login is not enabled for the user.
+ * @param {string=} data.phone Valid phone number. Required if token_login is enabled for the user.
+ * @param {Boolean=} data.token_login A boolean representing whether or not the Login by SMS should be enabled for this user.
+ * @param {string=} data.fullname Full name
+ * @param {string=} data.email Email address
+ * @param {Boolean=} data.known Boolean to define if the user has logged in before. Used mainly to determine whether or not to start a tour on first login.
+ * @param {string=} data.type Deprecated. Used to infer user's roles
+ * @param {string} appUrl request protocol://hostname
+ */
+/* eslint-enable max-len */
 const createUserEntities = async (data, appUrl) => {
-  // preserve the place's primary contact only if it's an existing one
+  // Preserve the place's primary contact, if data.place already exists in the DB.
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
   const preservePrimaryContact = _.isObject(data.place) && !data.place._rev;
 
@@ -707,14 +724,27 @@ module.exports = {
         return mapUsers(users, settings, facilities);
       });
   },
-  /*
+  /* eslint-disable max-len */
+  /**
    * Take the request data and create valid user, user-settings and contact
    * objects. Returns the response body in the callback.
    *
-   * @param {Object} data - request body
-   * @param {String} appUrl - request protocol://hostname
+   * @param {Object} data
+   * @param {string} data.username Identifier used for authentication
+   * @param {string[]} data.roles
+   * @param {(Object|string)=} data.place Place identifier string (UUID) or object this user resides in. Required if the roles contain an offline role.
+   * @param {(Object|string)=} data.contact A person identifier string (UUID) or object based on the form configured in the app. Required if the roles contain an offline role.
+   * @param {string=} data.password Password string used for authentication. Only allowed to be set, not retrieved. Required if token_login is not enabled for the user.
+   * @param {string=} data.phone Valid phone number. Required if token_login is enabled for the user.
+   * @param {Boolean=} data.token_login A boolean representing whether or not the Login by SMS should be enabled for this user.
+   * @param {string=} data.fullname Full name
+   * @param {string=} data.email Email address
+   * @param {Boolean=} data.known Boolean to define if the user has logged in before. Used mainly to determine whether or not to start a tour on first login.
+   * @param {string=} data.type Deprecated. Used to infer user's roles
+   * @param {string} appUrl request protocol://hostname
    * @api public
    */
+  /* eslint-enable max-len */
   createUser: async (data, appUrl) => {
     const missing = missingFields(data);
     if (missing.length > 0) {
@@ -737,19 +767,26 @@ module.exports = {
     return await createUserEntities(data, appUrl);
   },
 
+  /* eslint-disable max-len */
   /**
    * Take the request data and create valid users, user-settings and contacts
    * objects. Returns the response body in the callback.
-   * @param {Object|Object[]} users
-   * @param {string} users[].username
-   * @param {string=} users[].phone Not required if the password is provided.
-   * @param {string=} users[].password Not required if the phone number is provided.
+   *
+   * @param {Object|Object[]} users[]
+   * @param {string} users[].username Identifier used for authentication
    * @param {string[]} users[].roles
-   * @param {(Object|string)=} users[].place Can either be a place object or an existing place id.
-   * @param {(Object|string)=} users[].contact Can either be a contact object or an existing place id.
+   * @param {(Object|string)=} users[].place Place identifier string (UUID) or object this user resides in. Required if the roles contain an offline role.
+   * @param {(Object|string)=} users[].contact A person identifier string (UUID) or object based on the form configured in the app. Required if the roles contain an offline role.
+   * @param {string=} users[].password Password string used for authentication. Only allowed to be set, not retrieved. Required if token_login is not enabled for the user.
+   * @param {string=} users[].phone Valid phone number. Required if token_login is enabled for the user.
+   * @param {Boolean=} users[].token_login A boolean representing whether or not the Login by SMS should be enabled for this user.
+   * @param {string=} users[].fullname Full name
+   * @param {string=} users[].email Email address
+   * @param {Boolean=} users[].known Boolean to define if the user has logged in before. Used mainly to determine whether or not to start a tour on first login.
    * @param {string=} users[].type Deprecated. Used to infer user's roles
    * @param {string} appUrl request protocol://hostname
    */
+  /* eslint-enable max-len */
   async createUsers(users, appUrl, ignoredUsers, logId) {
     if (!Array.isArray(users)) {
       return module.exports.createUser(users, appUrl);

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -554,8 +554,7 @@ const validateUserContact = (data, user, userSettings) => {
 const createUserEntities = async (data, appUrl) => {
   // preserve the place's primary contact only if it's an existing one
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
-  const isCreatingNewPlace = !_.isUndefined(data.place) && !_.isNull(data.place) && _.isUndefined(data.place._id);
-  const preservePrimaryContact = !isCreatingNewPlace;
+  const preservePrimaryContact = _.isObject(data.place) && !data.place._rev;
 
   const response = {};
   await validateNewUsername(data.username);

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -554,9 +554,7 @@ const validateUserContact = (data, user, userSettings) => {
 const createUserEntities = async (user, appUrl) => {
   // preserve the place's primary contact only if it's an existing one
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
-  const isCreatingNewPlace = typeof user.place !== 'undefined' &&
-    typeof user.place === 'object' &&
-    ['type', 'contact_type', 'name'].every(property => property in user.place);
+  const isCreatingNewPlace = typeof user.place === 'object' && typeof user.place._id === 'undefined';
   const preservePrimaryContact = !isCreatingNewPlace;
 
   const response = {};
@@ -802,6 +800,7 @@ module.exports = {
         progress.saving.successful++;
         logData.push(createRecordBulkLog(user, BULK_UPLOAD_STATUSES.IMPORTED));
       } catch(error) {
+        console.log("error", error);
         response = { error: error.message };
         progress.saving.failed++;
         logData.push(createRecordBulkLog(user, BULK_UPLOAD_STATUSES.ERROR, error));

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -571,7 +571,7 @@ const validateUserContact = (data, user, userSettings) => {
 const createUserEntities = async (data, appUrl) => {
   // Preserve the place's primary contact, if data.place already exists in the DB.
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
-  const preservePrimaryContact = _.isObject(data.place) && !data.place._rev;
+  const preservePrimaryContact = !(_.isObject(data.place) && !data.place._rev);
 
   const response = {};
   await validateNewUsername(data.username);

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -554,7 +554,7 @@ const validateUserContact = (data, user, userSettings) => {
 const createUserEntities = async (user, appUrl) => {
   // preserve the place's primary contact only if it's an existing one
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
-  const isCreatingNewPlace = typeof user.place === 'object' && typeof user.place._id === 'undefined';
+  const isCreatingNewPlace = !_.isNull(user.place) && typeof user.place._id === 'undefined';
   const preservePrimaryContact = !isCreatingNewPlace;
 
   const response = {};

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -800,7 +800,6 @@ module.exports = {
         progress.saving.successful++;
         logData.push(createRecordBulkLog(user, BULK_UPLOAD_STATUSES.IMPORTED));
       } catch(error) {
-        console.log("error", error);
         response = { error: error.message };
         progress.saving.failed++;
         logData.push(createRecordBulkLog(user, BULK_UPLOAD_STATUSES.ERROR, error));

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -554,7 +554,7 @@ const validateUserContact = (data, user, userSettings) => {
 const createUserEntities = async (data, appUrl) => {
   // preserve the place's primary contact only if it's an existing one
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
-  const isCreatingNewPlace = !_.isNull(data.place) && typeof data.place._id === 'undefined';
+  const isCreatingNewPlace = !_.isUndefined(data.place) && !_.isNull(data.place) && _.isUndefined(data.place._id);
   const preservePrimaryContact = !isCreatingNewPlace;
 
   const response = {};

--- a/api/src/services/users.js
+++ b/api/src/services/users.js
@@ -551,21 +551,21 @@ const validateUserContact = (data, user, userSettings) => {
   }
 };
 
-const createUserEntities = async (user, appUrl) => {
+const createUserEntities = async (data, appUrl) => {
   // preserve the place's primary contact only if it's an existing one
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
-  const isCreatingNewPlace = !_.isNull(user.place) && typeof user.place._id === 'undefined';
+  const isCreatingNewPlace = !_.isNull(data.place) && typeof data.place._id === 'undefined';
   const preservePrimaryContact = !isCreatingNewPlace;
 
   const response = {};
-  await validateNewUsername(user.username);
-  await createPlace(user);
-  await setContactParent(user);
-  await createContact(user, response);
-  await storeUpdatedPlace(user, preservePrimaryContact);
-  await createUser(user, response);
-  await createUserSettings(user, response);
-  await tokenLogin.manageTokenLogin(user, appUrl, response);
+  await validateNewUsername(data.username);
+  await createPlace(data);
+  await setContactParent(data);
+  await createContact(data, response);
+  await storeUpdatedPlace(data, preservePrimaryContact);
+  await createUser(data, response);
+  await createUserSettings(data, response);
+  await tokenLogin.manageTokenLogin(data, appUrl, response);
   return response;
 };
 


### PR DESCRIPTION
# Description

Assign the newly created contact as primary contact of a place only if we're also creating the place

You can test this PR by:
- creating a user, its contact and its place all at once with the bulk user upload feature ([docs PR](https://github.com/medic/cht-docs/pull/727))
- making sure the newly created place has the newly created user's contact as primary contact

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
