### PR TITLE
change the login font family to Noto sans serif

### DIFF
--- a/api/src/public/login/style.css
+++ b/api/src/public/login/style.css
@@ -1,3 +1,11 @@
+@font-face {
+  font-family: 'Noto';
+  src: url(/fonts/NotoSans-Regular.ttf) format("truetype");
+  font-weight: normal;
+}
+body, input {
+  font-family: Noto, sans-serif;
+}
 body {
   background-color: #323232;
   color: #FFFFFF;
@@ -5,9 +13,6 @@ body {
   height: 100%;
   padding: 0;
   margin: 0;
-}
-body, input {
-  font-family: Noto, sans-serif;
 }
 .logo {
   width: 14.2em;

--- a/api/src/public/login/style.css
+++ b/api/src/public/login/style.css
@@ -7,7 +7,7 @@ body {
   margin: 0;
 }
 body, input {
-  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-family: Noto, sans-serif;
 }
 .logo {
   width: 14.2em;


### PR DESCRIPTION
# Description

Switch the font family of the login page from "Helvetica Neue",Helvetica,Arial,sans-serif" to "Noto, sans-serif".

medic/cht-core#6382

# To test this PR
- [ ] Go to the login page
- [ ] Make sure the font-family "Noto, sans serif" is correctly loaded and is the font used on the page.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
