### PR TITLE
Leave invisible characters in string fields

### DIFF
--- a/api/src/services/records.js
+++ b/api/src/services/records.js
@@ -173,7 +173,7 @@ const createByForm = (data, { locale }={}) => {
 
   let formCode = smsparser.getFormCode(data.message);
   let formDefinition = getForm(formCode);
-  if (!formDefinition) {
+  if (formCode && !formDefinition) {
     // try again, this time without invisible characters
     const cleaned = formCode.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
     formDefinition = getForm(cleaned);

--- a/api/src/services/records.js
+++ b/api/src/services/records.js
@@ -171,6 +171,7 @@ const createByForm = (data, { locale }={}) => {
     throw new PublicError('Missing required field: message');
   }
 
+  const rawMessage = data.message;
   let formCode = smsparser.getFormCode(data.message);
   let formDefinition = getForm(formCode);
   if (formCode && !formDefinition) {
@@ -197,6 +198,7 @@ const createByForm = (data, { locale }={}) => {
   if (content.form && formDefinition) {
     formData = smsparser.parse(formDefinition, data);
   }
+  content.message = rawMessage; // reset this to the original message now that parsing is complete
   return getDataRecord(formData, content);
 };
 

--- a/api/src/services/report/smsparser.js
+++ b/api/src/services/report/smsparser.js
@@ -47,6 +47,13 @@ const regexEscape = s => {
   return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
 };
 
+const stripInvisibleCharacters = s => {
+  if (typeof s !== 'string') {
+    return s;
+  }
+  return s.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
+};
+
 // Remove the form code from the beginning of the message since it does
 // not belong to the TextForms format but is just a convention to
 // identify the message.
@@ -148,7 +155,7 @@ const fieldParsers = {
     // store list value since it has more meaning.
     // TODO we don't have locale data inside this function so calling
     // translate does not resolve locale.
-    const cleaned = String(raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, ''));
+    const cleaned = stripInvisibleCharacters(String(raw));
     if (field.list) {
       const item = field.list.find(item => String(item[0]) === cleaned);
       if (!item) {
@@ -163,7 +170,7 @@ const fieldParsers = {
   },
   string: (raw, field) => {
     if (field.list) {
-      const cleaned = raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
+      const cleaned = stripInvisibleCharacters(raw);
       for (const i of field.list) {
         const item = field.list[i];
         if (item[0] === cleaned) {
@@ -177,17 +184,16 @@ const fieldParsers = {
   date: (raw) => {
     // YYYY-MM-DD assume muvuku format for now
     // store in milliseconds since Epoch
-    const value = raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
-    return moment(value).valueOf();
+    return moment(stripInvisibleCharacters(raw)).valueOf();
   },
   bsDate: (raw) => {
-    const cleaned = raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
+    const cleaned = stripInvisibleCharacters(raw);
     const separator = cleaned[cleaned.search(/[^0-9]/)];//non-numeric character
     const dateParts = cleaned.split(separator);
     return bsToEpoch(...dateParts);
   },
   boolean: (raw) => {
-    const val = parseNum(raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, ''));
+    const val = parseNum(stripInvisibleCharacters(raw));
     if (val === 1) {
       return true;
     }
@@ -199,7 +205,7 @@ const fieldParsers = {
   },
   month: (raw) => {
     // keep months integers, not their list value.
-    return parseNum(raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, ''));
+    return parseNum(stripInvisibleCharacters(raw));
   }
 };
 

--- a/api/src/services/report/smsparser.js
+++ b/api/src/services/report/smsparser.js
@@ -10,6 +10,9 @@ const moment = require('moment');
 const bs = require('bikram-sambat');
 
 const MUVUKU_REGEX = /^\s*([A-Za-z]?\d)!.+!.+/;
+// matches invisible characters that can mess up our parsing
+// specifically: u200B, u200C, u200D, uFEFF
+const ZERO_WIDTH_UNICODE_CHARACTERS = /[\u200B-\u200D\uFEFF]/g;
 
 // Devanagari
 const T_TABLE = {
@@ -140,14 +143,14 @@ const getFieldByType = (def, type) => {
 
 const lower = str => (str && str.toLowerCase ? str.toLowerCase() : str);
 
-exports.parseField = (field, raw) => {
-  switch (field.type) {
-  case 'integer':
+const fieldParsers = {
+  integer: (raw, field) => {
     // store list value since it has more meaning.
     // TODO we don't have locale data inside this function so calling
     // translate does not resolve locale.
+    const cleaned = String(raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, ''));
     if (field.list) {
-      const item = field.list.find(item => String(item[0]) === String(raw));
+      const item = field.list.find(item => String(item[0]) === cleaned);
       if (!item) {
         logger.warn(
           `Option not available for ${JSON.stringify(raw)} in list.`
@@ -156,44 +159,35 @@ exports.parseField = (field, raw) => {
       }
       return config.translate(item[1]);
     }
-    return parseNum(raw);
-  case 'string':
-    if (raw === undefined) {
-      return;
-    }
-    if (raw === '') {
-      return null;
-    }
+    return parseNum(cleaned);
+  },
+  string: (raw, field) => {
     if (field.list) {
+      const cleaned = raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
       for (const i of field.list) {
         const item = field.list[i];
-        if (item[0] === raw) {
+        if (item[0] === cleaned) {
           return item[1];
         }
       }
       logger.warn(`Option not available for ${raw} in list.`);
     }
     return raw;
-  case 'date':
-    if (!raw) {
-      return null;
-    }
+  },
+  date: (raw) => {
     // YYYY-MM-DD assume muvuku format for now
     // store in milliseconds since Epoch
-    return moment(raw).valueOf();
-  case 'bsDate': {
-    if (!raw) {
-      return null;
-    }
-    const separator = raw[raw.search(/[^0-9]/)];//non-numeric character
-    const dateParts = raw.split(separator);
+    const value = raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
+    return moment(value).valueOf();
+  },
+  bsDate: (raw) => {
+    const cleaned = raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, '');
+    const separator = cleaned[cleaned.search(/[^0-9]/)];//non-numeric character
+    const dateParts = cleaned.split(separator);
     return bsToEpoch(...dateParts);
-  }
-  case 'boolean': {
-    if (raw === undefined) {
-      return;
-    }
-    const val = parseNum(raw);
+  },
+  boolean: (raw) => {
+    const val = parseNum(raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, ''));
     if (val === 1) {
       return true;
     }
@@ -202,14 +196,26 @@ exports.parseField = (field, raw) => {
     }
     // if we can't parse a number then return null
     return null;
-  }
-  case 'month':
+  },
+  month: (raw) => {
     // keep months integers, not their list value.
-    return parseNum(raw);
-  default:
+    return parseNum(raw.replace(ZERO_WIDTH_UNICODE_CHARACTERS, ''));
+  }
+};
+
+exports.parseField = (field, raw) => {
+  const parser = fieldParsers[field.type];
+  if (!parser) {
     logger.warn(`Unknown field type: ${field.type}`);
     return raw;
   }
+  if (raw === undefined) {
+    return;
+  }
+  if (raw === '') {
+    return null;
+  }
+  return parser(raw, field);
 };
 
 /**

--- a/api/tests/mocha/services/report/smsparser.spec.js
+++ b/api/tests/mocha/services/report/smsparser.spec.js
@@ -1000,7 +1000,7 @@ describe('sms parser', () => {
     chai.expect(actual).to.deep.equal({
       facility_id: 'fa\\cility#2#3',
       year: undefined,
-      month: null,
+      month: undefined,
       misoprostol_administered: undefined,
       quantity_dispensed: {
         la_6x1: undefined,


### PR DESCRIPTION
# Description

This is a further improvement to stripping invisible characters. Instead of always
removing invisible unicode characters, now they're only removed from non-string
fields so we don't modify values where the character may be desired.

medic/cht-core#7676

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
