### PR TITLE
7721 - Display labels in action buttons when device is small

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1545,10 +1545,7 @@ a.fa:hover {
   .action-container .actions {
     min-height: 50px;
     p {
-      display: none;
-    }
-    .fa-stack {
-      height: 20px;
+      font-size: @font-extra-extra-small;
     }
     .mm-icon {
       min-height: 50px;


### PR DESCRIPTION
# Description

This PR:
- Enables action's button labels in small font size (same as tab's label)
- Fixes `fa-stack` icon positioning by making it same height as the other icons in the action bar.

https://github.com/medic/cht-core/issues/7721

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
