### PR TITLE
Always end errored requests

### DIFF
--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -6,14 +6,12 @@ const logger = require('./logger');
 const MEDIC_BASIC_AUTH = 'Basic realm="Medic Web Services"';
 const cookie = require('./services/cookie');
 
-const APP_JSON = 'application/json';
-
-const wantsJSON = req => req.get('Accept') === APP_JSON;
+const wantsJSON = req => req.accepts('json');
 
 const writeJSON = (res, code, error, details) => {
   if (!res.headersSent) {
     res.status(code);
-    res.setHeader('Content-Type', APP_JSON);
+    res.type('json');
   }
   // using res.json would also automatically try to set the Content-Type header, which fails if headers are sent
   res.end(JSON.stringify({ code, error, details }));

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -6,13 +6,17 @@ const logger = require('./logger');
 const MEDIC_BASIC_AUTH = 'Basic realm="Medic Web Services"';
 const cookie = require('./services/cookie');
 
-const wantsJSON = req => req.get('Accept') === 'application/json';
+const APP_JSON = 'application/json';
+
+const wantsJSON = req => req.get('Accept') === APP_JSON;
 
 const writeJSON = (res, code, error, details) => {
-  if (!res.headersSent && !res.ended) {
+  if (!res.headersSent) {
     res.status(code);
-    res.json({ code, error, details });
+    res.setHeader('Content-Type', APP_JSON);
   }
+  // using res.json would also automatically try to set the Content-Type header, which fails if headers are sent
+  res.end(JSON.stringify({ code, error, details }));
 };
 
 const respond = (req, res, code, message, details) => {

--- a/api/src/server-utils.js
+++ b/api/src/server-utils.js
@@ -6,7 +6,7 @@ const logger = require('./logger');
 const MEDIC_BASIC_AUTH = 'Basic realm="Medic Web Services"';
 const cookie = require('./services/cookie');
 
-const wantsJSON = req => req.accepts('json');
+const wantsJSON = req => req.get('Accept') === 'application/json';
 
 const writeJSON = (res, code, error, details) => {
   if (!res.headersSent) {

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -186,7 +186,7 @@ describe('Server utils', () => {
 
     it('responds with JSON if requested', () => {
       const status = sinon.stub(res, 'status');
-      const json = sinon.stub(res, 'json');
+      const end = sinon.stub(res, 'end');
       const get = sinon.stub(req, 'get');
       get.returns('application/json');
       sinon.stub(res, 'setHeader');
@@ -195,12 +195,12 @@ describe('Server utils', () => {
       chai.expect(get.args[0][0]).to.equal('Accept');
       chai.expect(status.callCount).to.equal(1);
       chai.expect(status.args[0][0]).to.equal(401);
-      chai.expect(json.callCount).to.equal(1);
-      chai.expect(json.args[0][0].error).to.equal('unauthorized');
-      chai.expect(json.args[0][0].code).to.equal(401);
+      chai.expect(end.callCount).to.equal(1);
+      chai.expect(end.args[0][0]).to.equal(JSON.stringify({ code: 401, error: 'unauthorized' }));
 
-      chai.expect(res.setHeader.callCount).to.equal(1);
+      chai.expect(res.setHeader.callCount).to.equal(2);
       chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
+      chai.expect(res.setHeader.args[1]).to.deep.equal(['Content-Type', 'application/json']);
     });
 
   });
@@ -231,7 +231,7 @@ describe('Server utils', () => {
 
     it('responds with JSON', () => {
       const status = sinon.stub(res, 'status');
-      const json = sinon.stub(res, 'json');
+      const end = sinon.stub(res, 'end');
       const get = sinon.stub(req, 'get');
       get.returns('application/json');
       serverUtils.serverError({ foo: 'bar' }, req, res);
@@ -239,14 +239,13 @@ describe('Server utils', () => {
       chai.expect(get.args[0][0]).to.equal('Accept');
       chai.expect(status.callCount).to.equal(1);
       chai.expect(status.args[0][0]).to.equal(500);
-      chai.expect(json.callCount).to.equal(1);
-      chai.expect(json.args[0][0].code).to.equal(500);
-      chai.expect(json.args[0][0].error).to.equal('Server error');
+      chai.expect(end.callCount).to.equal(1);
+      chai.expect(end.args[0][0]).to.equal(JSON.stringify({ code: 500, error: 'Server error' }));
     });
 
     it('handles uncaught payload size exceptions', () => {
       const status = sinon.stub(res, 'status');
-      const json = sinon.stub(res, 'json');
+      const end = sinon.stub(res, 'end');
       const get = sinon.stub(req, 'get');
       get.returns('application/json');
       serverUtils.serverError({ foo: 'bar', type: 'entity.too.large' }, req, res);
@@ -254,9 +253,8 @@ describe('Server utils', () => {
       chai.expect(get.args[0][0]).to.equal('Accept');
       chai.expect(status.callCount).to.equal(1);
       chai.expect(status.args[0][0]).to.equal(413);
-      chai.expect(json.callCount).to.equal(1);
-      chai.expect(json.args[0][0].code).to.equal(413);
-      chai.expect(json.args[0][0].error).to.equal('Payload Too Large');
+      chai.expect(end.callCount).to.equal(1);
+      chai.expect(end.args[0][0]).to.equal(JSON.stringify({ code: 413, error: 'Payload Too Large' }));
     });
 
   });

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -4,24 +4,26 @@ const environment = require('../../src/environment');
 const serverUtils = require('../../src/server-utils');
 const cookie = require('../../src/services/cookie');
 
-const req = {
-  url: '',
-  get: () => {}
-};
-const res = {
-  writeHead: () => {},
-  end: () => {},
-  json: () => {},
-  redirect: () => {},
-  status: () => {},
-  setHeader: () => {},
-};
-
+let req;
+let res;
 let originalDb;
 
 describe('Server utils', () => {
 
   beforeEach(() => {
+    req = {
+      url: '',
+      accepts: sinon.stub(),
+    };
+    res = {
+      writeHead: sinon.stub(),
+      end: sinon.stub(),
+      json: sinon.stub(),
+      redirect: sinon.stub(),
+      status: sinon.stub(),
+      type: sinon.stub(),
+      setHeader: sinon.stub(),
+    };
     originalDb = environment.db;
     environment.db = 'medic';
   });
@@ -50,7 +52,6 @@ describe('Server utils', () => {
     it('calls notLoggedIn when given 401 error', () => {
       sinon.stub(serverUtils, 'notLoggedIn');
       sinon.spy(serverUtils, 'serverError');
-      sinon.stub(res, 'end');
       serverUtils.error({ code: 401 }, req, res);
       chai.expect(serverUtils.notLoggedIn.callCount).to.equal(1);
       chai.expect(serverUtils.notLoggedIn.args[0]).to.deep.equal([req, res, undefined]);
@@ -59,8 +60,6 @@ describe('Server utils', () => {
     });
 
     it('function handles 503 errors - #3821', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      const end = sinon.stub(res, 'end');
       // an example error thrown by the `request` library
       const error = {
         code: 503,
@@ -78,59 +77,51 @@ describe('Server utils', () => {
         }
       };
       serverUtils.error(error, req, res);
-      chai.expect(writeHead.callCount).to.equal(1);
-      chai.expect(writeHead.args[0][0]).to.equal(500);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal('Server error');
+      chai.expect(res.writeHead.callCount).to.equal(1);
+      chai.expect(res.writeHead.args[0][0]).to.equal(500);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal('Server error');
     });
 
     it('handles unknown errors', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      const end = sinon.stub(res, 'end');
       serverUtils.error({ foo: 'bar' }, req, res);
-      chai.expect(writeHead.callCount).to.equal(1);
-      chai.expect(writeHead.args[0][0]).to.equal(500);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal('Server error');
+      chai.expect(res.writeHead.callCount).to.equal(1);
+      chai.expect(res.writeHead.args[0][0]).to.equal(500);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal('Server error');
     });
 
     it('500 for any non-numeric error code', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
       serverUtils.error({ code: '100' }, req, res);
-      chai.expect(writeHead.callCount).to.eq(1);
-      chai.expect(writeHead.args[0][0]).to.eq(500);
+      chai.expect(res.writeHead.callCount).to.eq(1);
+      chai.expect(res.writeHead.args[0][0]).to.eq(500);
     });
 
     it('500 for unparseable non-numeric error code', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
       serverUtils.error({ code: 'foo' }, req, res);
-      chai.expect(writeHead.callCount).to.eq(1);
-      chai.expect(writeHead.args[0][0]).to.eq(500);
+      chai.expect(res.writeHead.callCount).to.eq(1);
+      chai.expect(res.writeHead.args[0][0]).to.eq(500);
     });
 
     it('handles err.message being an object - #5809', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      const end = sinon.stub(res, 'end');
       const message = { bar: 'foo' };
       serverUtils.error({ code: 400, message: message }, req, res);
-      chai.expect(writeHead.callCount).to.eq(1);
-      chai.expect(writeHead.args[0][0]).to.eq(400);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal(JSON.stringify(message));
+      chai.expect(res.writeHead.callCount).to.eq(1);
+      chai.expect(res.writeHead.args[0][0]).to.eq(400);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal(JSON.stringify(message));
     });
 
     it('handles err.message being an object with a "message" property - #5809', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      const end = sinon.stub(res, 'end');
       serverUtils.error({ code: 400, message: { message: 'foo' } }, req, res);
-      chai.expect(writeHead.callCount).to.eq(1);
-      chai.expect(writeHead.args[0][0]).to.eq(400);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal('foo');
+      chai.expect(res.writeHead.callCount).to.eq(1);
+      chai.expect(res.writeHead.args[0][0]).to.eq(400);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal('foo');
     });
 
   });
@@ -138,17 +129,15 @@ describe('Server utils', () => {
   describe('notLoggedIn', () => {
 
     it('redirects to login page for human user', () => {
-      const redirect = sinon.stub(res, 'redirect');
       const setForceLoginStub = sinon.stub(cookie, 'setForceLogin');
-      sinon.stub(res, 'setHeader');
       req.url = 'someurl';
       req.headers = { 'user-agent': 'Mozilla/1.0' };
 
       serverUtils.notLoggedIn(req, res);
 
-      chai.expect(redirect.callCount).to.equal(1);
-      chai.expect(redirect.args[0][0]).to.equal(302);
-      chai.expect(redirect.args[0][1]).to.equal('/medic/login?redirect=someurl');
+      chai.expect(res.redirect.callCount).to.equal(1);
+      chai.expect(res.redirect.args[0][0]).to.equal(302);
+      chai.expect(res.redirect.args[0][1]).to.equal('/medic/login?redirect=someurl');
       chai.expect(res.setHeader.callCount).to.equal(1);
       chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
       chai.expect(setForceLoginStub.calledOnce);
@@ -156,51 +145,43 @@ describe('Server utils', () => {
     });
 
     it('returns 401 for medic-collect', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      sinon.stub(res, 'setHeader');
       req.url = 'someurl';
       req.headers = { 'user-agent': null };
       serverUtils.notLoggedIn(req, res);
-      chai.expect(writeHead.callCount).to.equal(1);
-      chai.expect(writeHead.args[0][0]).to.equal(401);
+      chai.expect(res.writeHead.callCount).to.equal(1);
+      chai.expect(res.writeHead.args[0][0]).to.equal(401);
 
       chai.expect(res.setHeader.callCount).to.equal(1);
       chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
     });
 
     it('shows prompt if requested', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      sinon.stub(res, 'setHeader');
-      const end = sinon.stub(res, 'end');
       serverUtils.notLoggedIn(req, res, true);
-      chai.expect(writeHead.callCount).to.equal(1);
-      chai.expect(writeHead.args[0][0]).to.equal(401);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(writeHead.args[0][1]['WWW-Authenticate']).to.equal('Basic realm="Medic Web Services"');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal('not logged in');
+      chai.expect(res.writeHead.callCount).to.equal(1);
+      chai.expect(res.writeHead.args[0][0]).to.equal(401);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.writeHead.args[0][1]['WWW-Authenticate']).to.equal('Basic realm="Medic Web Services"');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal('not logged in');
 
       chai.expect(res.setHeader.callCount).to.equal(1);
       chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
     });
 
     it('responds with JSON if requested', () => {
-      const status = sinon.stub(res, 'status');
-      const end = sinon.stub(res, 'end');
-      const get = sinon.stub(req, 'get');
-      get.returns('application/json');
-      sinon.stub(res, 'setHeader');
+      req.accepts.returns(true);
       serverUtils.notLoggedIn(req, res);
-      chai.expect(get.callCount).to.equal(1);
-      chai.expect(get.args[0][0]).to.equal('Accept');
-      chai.expect(status.callCount).to.equal(1);
-      chai.expect(status.args[0][0]).to.equal(401);
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal(JSON.stringify({ code: 401, error: 'unauthorized' }));
+      chai.expect(req.accepts.callCount).to.equal(1);
+      chai.expect(req.accepts.args[0][0]).to.equal('json');
+      chai.expect(res.status.callCount).to.equal(1);
+      chai.expect(res.status.args[0][0]).to.equal(401);
+      chai.expect(res.type.callCount).to.equal(1);
+      chai.expect(res.type.args[0]).to.deep.equal(['json']);
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal(JSON.stringify({ code: 401, error: 'unauthorized' }));
 
-      chai.expect(res.setHeader.callCount).to.equal(2);
+      chai.expect(res.setHeader.callCount).to.equal(1);
       chai.expect(res.setHeader.args[0]).to.deep.equal(['logout-authorization', 'CHT-Core API']);
-      chai.expect(res.setHeader.args[1]).to.deep.equal(['Content-Type', 'application/json']);
     });
 
   });
@@ -208,53 +189,43 @@ describe('Server utils', () => {
   describe('serverError', () => {
 
     it('does not leak errors information to the client', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      const end = sinon.stub(res, 'end');
       serverUtils.serverError('boom', req, res);
-      chai.expect(writeHead.callCount, 1);
-      chai.expect(writeHead.args[0][0]).to.equal(500);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal('Server error');
+      chai.expect(res.writeHead.callCount, 1);
+      chai.expect(res.writeHead.args[0][0]).to.equal(500);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal('Server error');
     });
 
     it('shares public information with the client', () => {
-      const writeHead = sinon.stub(res, 'writeHead');
-      const end = sinon.stub(res, 'end');
       serverUtils.serverError({ publicMessage: 'explanation' }, req, res);
-      chai.expect(writeHead.callCount).to.equal(1);
-      chai.expect(writeHead.args[0][0]).to.equal(500);
-      chai.expect(writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal('Server error: "explanation"');
+      chai.expect(res.writeHead.callCount).to.equal(1);
+      chai.expect(res.writeHead.args[0][0]).to.equal(500);
+      chai.expect(res.writeHead.args[0][1]['Content-Type']).to.equal('text/plain');
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal('Server error: "explanation"');
     });
 
     it('responds with JSON', () => {
-      const status = sinon.stub(res, 'status');
-      const end = sinon.stub(res, 'end');
-      const get = sinon.stub(req, 'get');
-      get.returns('application/json');
+      req.accepts.withArgs('json').returns(true);
       serverUtils.serverError({ foo: 'bar' }, req, res);
-      chai.expect(get.callCount).to.equal(1);
-      chai.expect(get.args[0][0]).to.equal('Accept');
-      chai.expect(status.callCount).to.equal(1);
-      chai.expect(status.args[0][0]).to.equal(500);
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal(JSON.stringify({ code: 500, error: 'Server error' }));
+      chai.expect(req.accepts.callCount).to.equal(1);
+      chai.expect(req.accepts.args[0][0]).to.equal('json');
+      chai.expect(res.status.callCount).to.equal(1);
+      chai.expect(res.status.args[0][0]).to.equal(500);
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal(JSON.stringify({ code: 500, error: 'Server error' }));
     });
 
     it('handles uncaught payload size exceptions', () => {
-      const status = sinon.stub(res, 'status');
-      const end = sinon.stub(res, 'end');
-      const get = sinon.stub(req, 'get');
-      get.returns('application/json');
+      req.accepts.withArgs('json').returns(true);
       serverUtils.serverError({ foo: 'bar', type: 'entity.too.large' }, req, res);
-      chai.expect(get.callCount).to.equal(1);
-      chai.expect(get.args[0][0]).to.equal('Accept');
-      chai.expect(status.callCount).to.equal(1);
-      chai.expect(status.args[0][0]).to.equal(413);
-      chai.expect(end.callCount).to.equal(1);
-      chai.expect(end.args[0][0]).to.equal(JSON.stringify({ code: 413, error: 'Payload Too Large' }));
+      chai.expect(req.accepts.callCount).to.equal(1);
+      chai.expect(req.accepts.args[0][0]).to.equal('json');
+      chai.expect(res.status.callCount).to.equal(1);
+      chai.expect(res.status.args[0][0]).to.equal(413);
+      chai.expect(res.end.callCount).to.equal(1);
+      chai.expect(res.end.args[0][0]).to.equal(JSON.stringify({ code: 413, error: 'Payload Too Large' }));
     });
 
   });

--- a/api/tests/mocha/server-utils.spec.js
+++ b/api/tests/mocha/server-utils.spec.js
@@ -13,7 +13,7 @@ describe('Server utils', () => {
   beforeEach(() => {
     req = {
       url: '',
-      accepts: sinon.stub(),
+      get: sinon.stub(),
     };
     res = {
       writeHead: sinon.stub(),
@@ -169,10 +169,10 @@ describe('Server utils', () => {
     });
 
     it('responds with JSON if requested', () => {
-      req.accepts.returns(true);
+      req.get.returns('application/json');
       serverUtils.notLoggedIn(req, res);
-      chai.expect(req.accepts.callCount).to.equal(1);
-      chai.expect(req.accepts.args[0][0]).to.equal('json');
+      chai.expect(req.get.callCount).to.equal(1);
+      chai.expect(req.get.args[0][0]).to.equal('Accept');
       chai.expect(res.status.callCount).to.equal(1);
       chai.expect(res.status.args[0][0]).to.equal(401);
       chai.expect(res.type.callCount).to.equal(1);
@@ -207,10 +207,10 @@ describe('Server utils', () => {
     });
 
     it('responds with JSON', () => {
-      req.accepts.withArgs('json').returns(true);
+      req.get.withArgs('Accept').returns('application/json');
       serverUtils.serverError({ foo: 'bar' }, req, res);
-      chai.expect(req.accepts.callCount).to.equal(1);
-      chai.expect(req.accepts.args[0][0]).to.equal('json');
+      chai.expect(req.get.callCount).to.equal(1);
+      chai.expect(req.get.args[0][0]).to.equal('Accept');
       chai.expect(res.status.callCount).to.equal(1);
       chai.expect(res.status.args[0][0]).to.equal(500);
       chai.expect(res.end.callCount).to.equal(1);
@@ -218,10 +218,10 @@ describe('Server utils', () => {
     });
 
     it('handles uncaught payload size exceptions', () => {
-      req.accepts.withArgs('json').returns(true);
+      req.get.withArgs('Accept').returns('application/json');
       serverUtils.serverError({ foo: 'bar', type: 'entity.too.large' }, req, res);
-      chai.expect(req.accepts.callCount).to.equal(1);
-      chai.expect(req.accepts.args[0][0]).to.equal('json');
+      chai.expect(req.get.callCount).to.equal(1);
+      chai.expect(req.get.args[0][0]).to.equal('Accept');
       chai.expect(res.status.callCount).to.equal(1);
       chai.expect(res.status.args[0][0]).to.equal(413);
       chai.expect(res.end.callCount).to.equal(1);

--- a/tests/mobile/common/common.specs.js
+++ b/tests/mobile/common/common.specs.js
@@ -99,7 +99,7 @@ describe('Navigation tests : ', () => {
     afterAll(async () => {
       jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
       await utils.deleteUsers([user]);
-      await utils.revertSettings();
+      await utils.revertSettings(true);
       await commonElements.goToLoginPageNative();
       await loginPage.loginNative(constants.USERNAME, constants.PASSWORD);
       await commonElements.waitForLoaderToDisappear();

--- a/webapp/src/ts/constants.ts
+++ b/webapp/src/ts/constants.ts
@@ -6,6 +6,25 @@
 // go and if it's still too long then API will respond with a 413.
 const BODY_LENGTH_LIMIT = 32000000; // 32 million
 
+// To keep long _changes requests open, API sends a heartbeat (a new line) every 10 seconds, starting on the 10sh
+// second. Sending data through automatically adds a success 200 status, even though the results of the request is
+// not known, and it can still fail.
+// PouchDb only checks the request status to determine whether the request is successful or not. \
+// In order to enable a retry, and not incorrectly communicate success to the client, validate _changes request
+// responses and update the respons object accordingly before passing it to PouchDb for processing.
+const processChangesResponse = (response) => {
+  return response.json().then(json => {
+    const validChangesResponse = json.results && !json.error;
+    if (validChangesResponse) {
+      return response;
+    }
+
+    response.ok = false;
+    response.status = json.code || 500;
+    return response;
+  });
+};
+
 export const POUCHDB_OPTIONS = {
   local: { auto_compaction: true, skip_setup: false },
   remote: {
@@ -26,7 +45,10 @@ export const POUCHDB_OPTIONS = {
         opts.headers.set(header, POUCHDB_OPTIONS.remote_headers[header]);
       });
       opts.credentials = 'same-origin';
-      return window.PouchDB.fetch(url, opts);
+      const isChangesRequest = parsedUrl.pathname.startsWith('/_changes');
+      return window.PouchDB
+        .fetch(url, opts)
+        .then(response => isChangesRequest ? processChangesResponse(response) : response);
     },
   },
   remote_headers: {


### PR DESCRIPTION
# Description

Always ends errored requests. Updates client fetch to treat case where unsuccessful changes request has 200 status. 

medic/cht-core#7759
# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
