### PR TITLE
Archv3 export all container tags

### DIFF
--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -144,16 +144,10 @@ const saveDockerComposeFiles = () => {
 };
 
 const saveServiceTags = () => {
-  const tags = [
-    {
-      container_name: 'cht-api',
-      image: versions.getImageTag('api', undefined, true),
-    },
-    {
-      container_name: 'cht-sentinel',
-      image: versions.getImageTag('sentinel', undefined, true),
-    },
-  ];
+  const tags = [...versions.SERVICES, ...versions.INFRASTRUCTURE].map(service => ({
+    container_name: `cht-${service}`,
+    image: versions.getImageTag(service, undefined, true),
+  }));
   const tagsFilePath = path.resolve(stagingPath, 'tags.json');
   fs.writeFileSync(tagsFilePath, JSON.stringify(tags));
 };

--- a/tests/wdio-upgrade.conf.js
+++ b/tests/wdio-upgrade.conf.js
@@ -20,6 +20,7 @@ utils.CONTAINER_NAMES.sentinel = 'cht-sentinel';
 
 const DOCKER_COMPOSE_FOLDER = fs.mkdtempSync(path.join(os.tmpdir(), 'upgrade-service-'));
 const CHT_DOCKER_COMPOSE_FOLDER = fs.mkdtempSync(path.join(os.tmpdir(), 'cht-'));
+const CHT_DATA_FOLDER = fs.mkdtempSync(path.join(os.tmpdir(), 'cht-'));
 const UPGRADE_SERVICE_DC = path.join(DOCKER_COMPOSE_FOLDER, 'cht-upgrade-service.yml');
 const mainBranch = 'medic:medic:archv3-with-different-name';
 
@@ -50,7 +51,7 @@ const dockerComposeCmd = (...params) => {
     COUCHDB_USER: auth.username,
     COUCHDB_PASSWORD: auth.password,
     DOCKER_CONFIG_PATH: path.join(os.homedir(), '.docker'),
-    COUCHDB_DATA: CHT_DOCKER_COMPOSE_FOLDER,
+    COUCHDB_DATA: CHT_DATA_FOLDER,
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
# Description

- export all container tags
- change e2e upgrade folder structure so docker doesn't report folder access errros

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
