### PR TITLE
7768 - Fix unit tests for multimedia forms

### DIFF
--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -340,8 +340,10 @@ export class EnketoService {
           .then(valid => {
             if (valid) {
               const currentIndex = form.pages._getCurrentIndex();
-              window.history.pushState({ enketo_page_number: currentIndex }, '');
-              this.setupNavButtons($wrapper, currentIndex);
+              if (currentIndex !== undefined) {
+                window.history.pushState({ enketo_page_number: currentIndex }, '');
+                this.setupNavButtons($wrapper, currentIndex);
+              }
               this.pauseMultimedia($wrapper);
             }
             this.forceRecalculate(form);
@@ -353,10 +355,13 @@ export class EnketoService {
       .find('.btn.previous-page')
       .off('.pagemode')
       .on('click.pagemode', () => {
-        window.history.back();
-        this.setupNavButtons($wrapper, form.pages._getCurrentIndex() - 1);
-        this.forceRecalculate(form);
+        const currentIndex = form.pages._getCurrentIndex();
+        if (currentIndex !== undefined) {
+          window.history.back();
+          this.setupNavButtons($wrapper, currentIndex - 1);
+        }
         this.pauseMultimedia($wrapper);
+        this.forceRecalculate(form);
         return false;
       });
   }

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -340,10 +340,8 @@ export class EnketoService {
           .then(valid => {
             if (valid) {
               const currentIndex = form.pages._getCurrentIndex();
-              if (currentIndex !== undefined) {
-                window.history.pushState({ enketo_page_number: currentIndex }, '');
-                this.setupNavButtons($wrapper, currentIndex);
-              }
+              window.history.pushState({ enketo_page_number: currentIndex }, '');
+              this.setupNavButtons($wrapper, currentIndex);
               this.pauseMultimedia($wrapper);
             }
             this.forceRecalculate(form);
@@ -355,13 +353,10 @@ export class EnketoService {
       .find('.btn.previous-page')
       .off('.pagemode')
       .on('click.pagemode', () => {
-        const currentIndex = form.pages._getCurrentIndex();
-        if (currentIndex !== undefined) {
-          window.history.back();
-          this.setupNavButtons($wrapper, currentIndex - 1);
-        }
-        this.pauseMultimedia($wrapper);
+        window.history.back();
+        this.setupNavButtons($wrapper, form.pages._getCurrentIndex() - 1);
         this.forceRecalculate(form);
+        this.pauseMultimedia($wrapper);
         return false;
       });
   }

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1921,6 +1921,7 @@ describe('Enketo service', () => {
       $form.prepend('<span>no media here</span>');
       overrideNavigationButtonsStub.call(service, form, $form);
 
+      $prevBtn.trigger('click.pagemode');
       $nextBtn.trigger('click.pagemode');
       flush();
 

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1916,12 +1916,11 @@ describe('Enketo service', () => {
       expect(pauseStubs.audio).to.be.undefined;
     }));
 
-    it('should not call pause function when there isnt video and audio in the form wrapper', fakeAsync(() => {
+    it('should not call pause function when there is not video and audio in the form wrapper', fakeAsync(() => {
       form.pages._next.resolves(true);
       $form.prepend('<span>no media here</span>');
       overrideNavigationButtonsStub.call(service, form, $form);
 
-      $prevBtn.trigger('click.pagemode');
       $nextBtn.trigger('click.pagemode');
       flush();
 

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1877,7 +1877,7 @@ describe('Enketo service', () => {
 
     after(() => $.fn.find = originalJQueryFind);
 
-    xit('should pause the multimedia when going to the previous page', fakeAsync(() => {
+    it('should pause the multimedia when going to the previous page', fakeAsync(() => {
       $form.prepend('<video id="video"></video><audio id="audio"></audio>');
       overrideNavigationButtonsStub.call(service, form, $form);
 
@@ -1890,7 +1890,7 @@ describe('Enketo service', () => {
       expect(pauseStubs.audio.calledOnce).to.be.true;
     }));
 
-    xit('should pause the multimedia when going to the next page', fakeAsync(() => {
+    it('should pause the multimedia when going to the next page', fakeAsync(() => {
       form.pages._next.resolves(true);
       $form.prepend('<video id="video"></video><audio id="audio"></audio>');
       overrideNavigationButtonsStub.call(service, form, $form);
@@ -1904,7 +1904,7 @@ describe('Enketo service', () => {
       expect(pauseStubs.audio.calledOnce).to.be.true;
     }));
 
-    xit('should not pause the multimedia when trying to go to the next page and form is invalid', fakeAsync(() => {
+    it('should not pause the multimedia when trying to go to the next page and form is invalid', fakeAsync(() => {
       form.pages._next.resolves(false);
       $form.prepend('<video id="video"></video><audio id="audio"></audio>');
       overrideNavigationButtonsStub.call(service, form, $form);
@@ -1916,10 +1916,11 @@ describe('Enketo service', () => {
       expect(pauseStubs.audio).to.be.undefined;
     }));
 
-    xit('should not call pause function when there isnt video and audio in the form wrapper', fakeAsync(() => {
+    it('should not call pause function when there isnt video and audio in the form wrapper', fakeAsync(() => {
+      form.pages._next.resolves(true);
+      $form.prepend('<span>no media here</span>');
       overrideNavigationButtonsStub.call(service, form, $form);
 
-      $prevBtn.trigger('click.pagemode');
       $nextBtn.trigger('click.pagemode');
       flush();
 


### PR DESCRIPTION
# Description

This PR fixes unit tests for multimedia forms.
- Adds validation to prevent navigation when using `windows.history` and `form.pages._getCurrentIndex()` returns undefined. This mainly because we want to test the feature and karma doesn't do well on navigation. Also, we can't mock `windows.history` because it's ready only. 
- Enables unit tests that were breaking karma

https://github.com/medic/cht-core/issues/7768

![Screen Shot 2022-09-12 at 3 12 19 pm](https://user-images.githubusercontent.com/66472237/189604759-8d7bf5e8-6495-4cc1-a822-ba4ede1ebef4.png)


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
