### PR TITLE
Add client-side transition for offline user replace

### DIFF
--- a/shared-libs/transitions/package-lock.json
+++ b/shared-libs/transitions/package-lock.json
@@ -880,11 +880,7 @@
       }
     },
     "@medic/search": {
-      "version": "file:../search",
-      "requires": {
-        "lodash": "4.17.19",
-        "moment": "^2.29.1"
-      }
+      "version": "file:../search"
     },
     "@medic/settings": {
       "version": "file:../settings",

--- a/shared-libs/transitions/package-lock.json
+++ b/shared-libs/transitions/package-lock.json
@@ -17,7 +17,6 @@
         "@medic/outbound": "file:../outbound",
         "@medic/phone-number": "file:../phone-number",
         "@medic/registration-utils": "file:../registration-utils",
-        "@medic/search": "file:../search",
         "@medic/settings": "file:../settings",
         "@medic/task-utils": "file:../task-utils",
         "@medic/user-management": "file:../user-management",
@@ -45,6 +44,7 @@
       "license": "Apache-2.0"
     },
     "../contacts": {
+      "name": "@medic/contacts",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -120,7 +120,9 @@
       }
     },
     "../search": {
+      "name": "@medic/search",
       "version": "1.1.1",
+      "extraneous": true,
       "license": "Apache-2.0",
       "dependencies": {
         "lodash": "4.17.19",
@@ -142,6 +144,7 @@
       "license": "Apache-2.0"
     },
     "../user-management": {
+      "name": "@medic/user-management",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -204,10 +207,6 @@
     },
     "node_modules/@medic/registration-utils": {
       "resolved": "../registration-utils",
-      "link": true
-    },
-    "node_modules/@medic/search": {
-      "resolved": "../search",
       "link": true
     },
     "node_modules/@medic/settings": {
@@ -878,9 +877,6 @@
       "requires": {
         "lodash": "^4.17.19"
       }
-    },
-    "@medic/search": {
-      "version": "file:../search"
     },
     "@medic/settings": {
       "version": "file:../settings",

--- a/shared-libs/transitions/package.json
+++ b/shared-libs/transitions/package.json
@@ -19,7 +19,6 @@
     "@medic/outbound": "file:../outbound",
     "@medic/phone-number": "file:../phone-number",
     "@medic/registration-utils": "file:../registration-utils",
-    "@medic/search": "file:../search",
     "@medic/settings": "file:../settings",
     "@medic/task-utils": "file:../task-utils",
     "@medic/user-management": "file:../user-management",

--- a/shared-libs/transitions/src/lib/search.js
+++ b/shared-libs/transitions/src/lib/search.js
@@ -1,6 +1,0 @@
-const db = require('../db');
-const search = require('@medic/search');
-
-module.exports = {
-  execute: (type, filters, options, extensions) => search(Promise, db.medic)(type, filters, options, extensions),
-};

--- a/shared-libs/transitions/src/transitions/user_replace.js
+++ b/shared-libs/transitions/src/transitions/user_replace.js
@@ -1,40 +1,17 @@
 const config = require('../config');
 const db = require('../db');
 const environment = require('../environment');
-const search = require('../lib/search');
-const transitionUtils = require('./utils');
+const contactTypeUtils = require('@medic/contact-types-utils');
 const { people } = require('@medic/contacts')(config, db);
 const { users } = require('@medic/user-management')(config, db);
 
 const NAME = 'user_replace';
-const REPARENT_BATCH_SIZE = 100;
 
-const validateReplaceUserDoc = ({ reported_date, fields: { original_contact_uuid, new_contact_uuid } }) => {
-  if (!reported_date) {
-    throw new Error('The reported_date field must be populated on the replace_user report.');
+const getNewContact = (contactId) => {
+  if(!contactId) {
+    throw new Error('No id was provided for the new replacement contact.');
   }
-  if (!original_contact_uuid) {
-    throw new Error('The original_contact_uuid field must be populated on the replace_user report.');
-  }
-  if (!new_contact_uuid) {
-    throw new Error('The new_contact_uuid field must be populated on the replace_user report.');
-  }
-};
-
-const validateContact = (contact) => {
-  if (!contact.parent || !contact.parent._id) {
-    throw new Error(`Contact [${contact._id}] does not have a parent.`);
-  }
-  return contact;
-};
-
-const getContact = (contactId) => people.getOrCreatePerson(contactId)
-  .then(contact => validateContact(contact));
-
-const validateContactParents = (originalContact, newContact) => {
-  if (originalContact.parent._id !== newContact.parent._id) {
-    throw new Error(`The replacement contact must have the same parent as the original contact.`);
-  }
+  return people.getOrCreatePerson(contactId);
 };
 
 const generateUsername = (contactName) => {
@@ -88,65 +65,19 @@ const createNewUser = ({ roles }, { _id, name, phone, parent }) => {
     });
 };
 
-const getReportIdsToReparent = (contactId, timestamp, docsReparented) => {
-  const filters = {
-    date: { from: timestamp + 1, },
-    contact: contactId,
-  };
-  const options = {
-    limit: REPARENT_BATCH_SIZE,
-    skip: docsReparented,
-  };
-  return search.execute('reports', filters, options).then(({ docIds }) => docIds);
-};
-
-const getReports = (keys) => db.medic.allDocs({ keys, include_docs: true })
-  .then(({ rows }) => rows.map(({ doc }) => doc));
-
-const reparentReports = (newContactId, reports) => {
-  if(!reports.length) {
-    return;
-  }
-  reports.forEach(report => report.contact._id = newContactId);
-  return db.medic.bulkDocs(reports);
-};
-
-const reparentReportsFromReplacedUser = (replaceUserDoc, docsReparented = 0) => {
-  const {
-    reported_date,
-    fields: { original_contact_uuid, new_contact_uuid }
-  } = replaceUserDoc;
-  return getReportIdsToReparent(original_contact_uuid, reported_date, docsReparented)
-    .then(reportIds => {
-      if(!reportIds.length) {
-        return;
-      }
-      return getReports(reportIds)
-        .then(reports => reparentReports(new_contact_uuid, reports))
-        .then(() => {
-          if (reportIds.length === REPARENT_BATCH_SIZE) {
-            return reparentReportsFromReplacedUser(replaceUserDoc, docsReparented + REPARENT_BATCH_SIZE);
-          }
-        });
-    });
-};
-
-const replaceUser = (replaceUserDoc) => {
+const replaceUser = (originalContact) => {
   return Promise.resolve()
-    .then(() => validateReplaceUserDoc(replaceUserDoc))
     .then(() => {
-      const { original_contact_uuid, new_contact_uuid } = replaceUserDoc.fields;
+      const { _id, replaced: { by } } = originalContact;
       return  Promise
         .all([
-          getContact(original_contact_uuid),
-          getContact(new_contact_uuid),
-          users.getUserSettings({ contact_id: original_contact_uuid }),
+          getNewContact(by),
+          users.getUserSettings({ contact_id: _id }),
         ])
-        .then(([originalContact, newContact, originalUserSettings]) => {
-          validateContactParents(originalContact, newContact);
+        .then(([newContact, originalUserSettings]) => {
           return createNewUser(originalUserSettings, newContact)
-            .then(() => reparentReportsFromReplacedUser(replaceUserDoc))
-            .then(() => users.deleteUser(originalUserSettings.name));
+            .then(() => users.deleteUser(originalUserSettings.name))
+            .then(() => originalContact.replaced.status = 'COMPLETE');
         });
     });
 };
@@ -162,9 +93,13 @@ module.exports = {
       throw new Error(`Configuration error. Token login must be enabled to use the user_replace transition.`);
     }
   },
-  filter: (doc, info = {}) => {
-    return doc.form === 'replace_user'
-      && !transitionUtils.hasRun(info, NAME);
+  filter: (doc) => {
+    const contactType = contactTypeUtils.getContactType(config.getAll(), doc);
+    if (!contactType || !contactTypeUtils.isPersonType(contactType)) {
+      return false;
+    }
+
+    return doc.replaced && doc.replaced.status === 'READY';
   },
   onMatch: change => {
     return replaceUser(change.doc)
@@ -172,6 +107,7 @@ module.exports = {
         return true;
       })
       .catch(err => {
+        change.doc.replaced.status = 'ERROR';
         err.changed = true;
         throw err;
       });

--- a/tests/e2e/default/enketo/forms/basic_form.xml
+++ b/tests/e2e/default/enketo/forms/basic_form.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms">
+    <h:head>
+        <h:title>Basic Form</h:title>
+        <model>
+            <itext>
+                <translation lang="en">
+                    <text id="/basic_form/intro:label">
+                        <value>This is a basic form with no questions</value>
+                    </text>
+                </translation>
+            </itext>
+            <instance>
+                <basic_form id="basic_form" prefix="J1!basic_form!" delimiter="#" version="2022-09-22 00:00:00">
+                    <intro/>
+                    <meta tag="hidden">
+                        <instanceID/>
+                    </meta>
+                </basic_form>
+            </instance>
+            <instance id="contact-summary"/>
+            <bind nodeset="/basic_form/intro" readonly="true()" type="string"/>
+            <bind nodeset="/basic_form/meta/instanceID" type="string" readonly="true()" calculate="concat('uuid:', uuid())"/>
+        </model>
+    </h:head>
+    <h:body class="pages">
+        <input ref="/basic_form/intro">
+            <label ref="jr:itext('/basic_form/intro:label')"/>
+        </input>
+    </h:body>
+</h:html>

--- a/tests/e2e/protractor/forms/user_replace.wdio-spec.js
+++ b/tests/e2e/protractor/forms/user_replace.wdio-spec.js
@@ -91,11 +91,13 @@ describe('user_replace transition', () => {
     // Submit several forms to be re-parented
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formActionsLink('basic_form')).click();
+    await (await genericForm.submitButton()).waitForDisplayed();
     await (await genericForm.submitButton()).click();
     await commonPage.waitForPageLoaded();
     const basicReportId0 = await reportsPage.getCurrentReportId();
     await (await reportsPage.submitReportButton()).click();
     await (await reportsPage.formActionsLink('basic_form')).click();
+    await (await genericForm.submitButton()).waitForDisplayed();
     await (await genericForm.submitButton()).click();
     await commonPage.waitForPageLoaded();
     const basicReportId1 = await reportsPage.getCurrentReportId();

--- a/tests/e2e/protractor/forms/user_replace.wdio-spec.js
+++ b/tests/e2e/protractor/forms/user_replace.wdio-spec.js
@@ -15,8 +15,6 @@ const dobUnknownField = () => $('input[name="/replace_user/new_contact/ephemeral
 const yearsField = () => $('input[name="/replace_user/new_contact/ephemeral_dob/age_years"]');
 const femaleField = () => $('input[name="/replace_user/new_contact/sex"][value="female"]');
 
-const redirectToLoginBtn = () => $('#session-expired .btn.submit.btn-primary');
-
 const DISTRICT = {
   _id: 'fixture:district',
   type: 'district_hospital',
@@ -81,7 +79,7 @@ describe('user_replace transition', () => {
 
     await commonElements.openHamburgerMenu();
     await (await commonElements.syncButton()).click();
-    await (await redirectToLoginBtn()).click();
+    // await (await redirectToLoginBtn()).click();
     await (await loginPage.loginButton()).waitForDisplayed();
 
     await loginPage.cookieLogin();
@@ -94,8 +92,8 @@ describe('user_replace transition', () => {
     const newContact = await utils.getDoc(new_contact_uuid);
     expect(newContact.phone).to.equal(ORIGINAL_USER.phone);
 
-    await sentinelUtils.waitForSentinel(reportId);
-    const { transitions } = await sentinelUtils.getInfoDoc(reportId);
+    await sentinelUtils.waitForSentinel(original_contact_uuid);
+    const { transitions } = await sentinelUtils.getInfoDoc(original_contact_uuid);
 
     // Transition successful
     expect(transitions.user_replace.ok).to.be.true;

--- a/tests/integration/sentinel/transitions/user_replace.spec.js
+++ b/tests/integration/sentinel/transitions/user_replace.spec.js
@@ -1,5 +1,5 @@
 const utils = require('../../../utils');
-const sentinelUtils = require('../utils');
+const sentinelUtils = require('../../../utils/sentinel');
 const { expect } = require('chai');
 
 const CLINIC = {

--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -13,7 +13,6 @@ import { CheckDateService } from '@mm-services/check-date.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { GlobalActions } from '@mm-actions/global';
 import { TranslateService } from '@mm-services/translate.service';
-import { UserSettingsService } from '@mm-services/user-settings.service';
 
 const READ_ONLY_TYPES = ['form', 'translations'];
 const READ_ONLY_IDS = ['resources', 'branding', 'service-worker-meta', 'zscore-charts', 'settings', 'partners'];
@@ -77,7 +76,6 @@ export class DBSyncService {
     private store:Store,
     private translateService:TranslateService,
     private purgeService:PurgeService,
-    private userSettingsService:UserSettingsService,
   ) {
     this.globalActions = new GlobalActions(store);
   }
@@ -229,17 +227,8 @@ export class DBSyncService {
           }
           this.sendUpdate(syncState);
         })
-        .finally(async () => {
+        .finally(() => {
           this.inProgressSync = undefined;
-
-          const userSettings: { shouldLogoutNextSync?: boolean } = await this.userSettingsService.get();
-          if (userSettings.shouldLogoutNextSync) {
-            const nextUserSettings = Object.assign({}, userSettings);
-            delete nextUserSettings.shouldLogoutNextSync;
-            await this.dbService.get({ remote: true }).put(nextUserSettings);
-
-            return this.sessionService.logout();
-          }
         });
     }
 

--- a/webapp/src/ts/services/transitions.service.ts
+++ b/webapp/src/ts/services/transitions.service.ts
@@ -4,6 +4,7 @@ import { cloneDeep } from 'lodash-es';
 import { SettingsService } from '@mm-services/settings.service';
 import { ValidationService } from '@mm-services/validation.service';
 import { MutingTransition } from '@mm-services/transitions/muting.transition';
+import { UserReplaceTransition } from '@mm-services/transitions/user-replace.transition';
 
 @Injectable({
   providedIn: 'root'
@@ -13,11 +14,13 @@ export class TransitionsService {
     private settingsService:SettingsService,
     private validationService:ValidationService,
     private mutingTransition:MutingTransition,
+    private userReplaceTransition:UserReplaceTransition,
   ) {
   }
 
   private readonly AVAILABLE_TRANSITIONS = [
-    { name: 'muting', transition: this.mutingTransition }
+    { name: this.mutingTransition.name, transition: this.mutingTransition },
+    { name: this.userReplaceTransition.name, transition: this.userReplaceTransition },
   ];
 
   private loadedTransitions = [];

--- a/webapp/src/ts/services/transitions.service.ts
+++ b/webapp/src/ts/services/transitions.service.ts
@@ -19,8 +19,8 @@ export class TransitionsService {
   }
 
   private readonly AVAILABLE_TRANSITIONS = [
-    { name: 'muting', transition: this.mutingTransition },
-    { name: 'user_replace', transition: this.userReplaceTransition },
+    this.mutingTransition,
+    this.userReplaceTransition,
   ];
 
   private loadedTransitions = [];
@@ -44,8 +44,8 @@ export class TransitionsService {
       await this.loadSettings();
       await this.validationService.init();
 
-      this.AVAILABLE_TRANSITIONS.forEach(({ name, transition }) => {
-        if (!this.isEnabled(name)) {
+      this.AVAILABLE_TRANSITIONS.forEach((transition) => {
+        if (!this.isEnabled(transition.name)) {
           return;
         }
 
@@ -53,7 +53,7 @@ export class TransitionsService {
           return;
         }
 
-        this.loadedTransitions.push({ name, transition });
+        this.loadedTransitions.push(transition);
       });
     } catch (err) {
       console.error('Error loading transitions', err);
@@ -84,12 +84,12 @@ export class TransitionsService {
 
     for (const loadedTransition of this.loadedTransitions) {
       try {
-        if (!loadedTransition.transition.filter(docs)) {
+        if (!loadedTransition.filter(docs)) {
           console.debug('transition', loadedTransition.name, 'filter failed');
           continue;
         }
 
-        docs = await loadedTransition.transition.run(docs);
+        docs = await loadedTransition.run(docs);
       } catch (err) {
         console.error('Error while running transitions', err);
         // don't run partial transitions

--- a/webapp/src/ts/services/transitions.service.ts
+++ b/webapp/src/ts/services/transitions.service.ts
@@ -19,8 +19,8 @@ export class TransitionsService {
   }
 
   private readonly AVAILABLE_TRANSITIONS = [
-    { name: this.mutingTransition.name, transition: this.mutingTransition },
-    { name: this.userReplaceTransition.name, transition: this.userReplaceTransition },
+    { name: 'muting', transition: this.mutingTransition },
+    { name: 'user_replace', transition: this.userReplaceTransition },
   ];
 
   private loadedTransitions = [];

--- a/webapp/src/ts/services/transitions/muting.transition.ts
+++ b/webapp/src/ts/services/transitions/muting.transition.ts
@@ -4,7 +4,7 @@ import { DbService } from '@mm-services/db.service';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
 import { ContactMutedService } from '@mm-services/contact-muted.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
-import { Transition } from '@mm-services/transitions/transition';
+import { Transition, Doc } from '@mm-services/transitions/transition';
 import { ValidationService } from '@mm-services/validation.service';
 
 @Injectable({
@@ -437,10 +437,4 @@ interface MutingContext {
 
 interface HydratedDocs {
   [uuid:string]:Doc;
-}
-
-interface Doc {
-  _id:string;
-  type:string;
-  [other:string]:unknown;
 }

--- a/webapp/src/ts/services/transitions/transition.ts
+++ b/webapp/src/ts/services/transitions/transition.ts
@@ -1,8 +1,8 @@
 export abstract class Transition {
   abstract name:string;
   abstract init(Object):void;
-  abstract filter(Object):boolean;
-  abstract run(Object):Promise<any>;
+  abstract filter(docs: Doc[]):boolean;
+  abstract run(docs: Doc[]):Promise<any>;
 
   CLIENT_SIDE_TRANSITIONS = 'client_side_transitions';
 
@@ -10,4 +10,10 @@ export abstract class Transition {
     doc[this.CLIENT_SIDE_TRANSITIONS] = doc[this.CLIENT_SIDE_TRANSITIONS] || {};
     doc[this.CLIENT_SIDE_TRANSITIONS][this.name] = true;
   }
+}
+
+export interface Doc {
+  _id:string;
+  type:string;
+  [other:string]:unknown;
 }

--- a/webapp/src/ts/services/transitions/user-replace.transition.ts
+++ b/webapp/src/ts/services/transitions/user-replace.transition.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+
+import { DbService } from '@mm-services/db.service';
+import { Transition } from '@mm-services/transitions/transition';
+import { UserContactService } from '@mm-services/user-contact.service';
+import { UserSettingsService } from '@mm-services/user-settings.service';
+import { UserReplaceService } from '@mm-services/user-replace.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserReplaceTransition extends Transition {
+  constructor(
+    private dbService:DbService,
+    private userSettingsService:UserSettingsService,
+    private userContactService: UserContactService,
+    private userReplaceService: UserReplaceService,
+  ) {
+    super();
+  }
+
+  readonly name = 'user_replace';
+
+  init() { //settings
+    return true;
+  }
+
+  /**
+   * @param {Array<Doc>} docs - docs to be saved
+   * @return {Boolean} - whether any of the docs from the batch should be processed
+   */
+  filter(docs) {
+    return docs.filter(doc => doc.type === 'data_record').length;
+  }
+
+  /**
+   * @param {Array<Doc>} docs - docs to run the transition over
+   * @returns {Promise<Array<Doc>>} - updated docs (may include additional docs)
+   */
+  async run(docs) {
+    const originalContact = await this.userContactService.get();
+    if (!originalContact) {
+      return docs;
+    }
+
+    const userReplaceDoc = docs.find(doc => doc.form === 'replace_user');
+    if(userReplaceDoc) {
+      return this.replaceUser(docs, userReplaceDoc, originalContact);
+    }
+    if(this.userReplaceService.isReplaced(originalContact)) {
+      this.reparentReports(docs, originalContact);
+    }
+
+    return docs;
+  }
+
+  private async replaceUser(docs, userReplaceDoc, originalContact) {
+    const { original_contact_uuid, new_contact_uuid } = userReplaceDoc.fields;
+    if (originalContact._id !== original_contact_uuid) {
+      throw new Error('The only the contact associated with the currently logged in user can be replaced.');
+    }
+    const newContact = await this.getNewContact(docs, new_contact_uuid);
+
+    this.userReplaceService.setReplaced(originalContact, newContact);
+    return [...docs, originalContact];
+  }
+
+  private async getNewContact(docs, newContactId:string) {
+    const newContact = docs.find(doc => doc._id === newContactId);
+    if (newContact) {
+      return newContact;
+    }
+    return this.dbService.get().get(newContactId);
+  }
+
+  private reparentReports(docs, originalContact) {
+    const replacedById = this.userReplaceService.getReplacedBy(originalContact);
+    docs
+      .filter(doc => doc.type === 'data_record')
+      .filter(doc => doc.contact?._id === originalContact._id)
+      .forEach(doc => doc.contact._id = replacedById);
+  }
+}

--- a/webapp/src/ts/services/transitions/user-replace.transition.ts
+++ b/webapp/src/ts/services/transitions/user-replace.transition.ts
@@ -34,7 +34,7 @@ export class UserReplaceTransition extends Transition {
    * @param {Array<Doc>} docs - docs to run the transition over
    * @returns {Promise<Array<Doc>>} - updated docs (may include additional docs)
    */
-  async run(docs: Doc[]): Promise<Doc[]> {
+  async run(docs: Doc[]) {
     const originalContact = await this.userReplaceService.getUserContact();
     if (!originalContact) {
       return docs;
@@ -51,11 +51,11 @@ export class UserReplaceTransition extends Transition {
     return docs;
   }
 
-  private getUserReplaceDoc(docs: Doc[]): UserReplaceDoc {
+  private getUserReplaceDoc(docs: Doc[]) {
     return docs.find(doc => doc.form === 'replace_user') as UserReplaceDoc;
   }
 
-  private async replaceUser(docs: Doc[], userReplaceDoc: UserReplaceDoc, originalContact: Doc): Promise<Doc[]> {
+  private async replaceUser(docs: Doc[], userReplaceDoc: UserReplaceDoc, originalContact: Doc) {
     const { original_contact_uuid, new_contact_uuid } = userReplaceDoc.fields;
     if (originalContact._id !== original_contact_uuid) {
       throw new Error('The only the contact associated with the currently logged in user can be replaced.');

--- a/webapp/src/ts/services/user-replace.service.ts
+++ b/webapp/src/ts/services/user-replace.service.ts
@@ -33,9 +33,9 @@ export class UserReplaceService {
       throw new Error('The original contact could not be found when replacing the user.');
     }
     if (!newContact) {
-      throw new Error('The new contact could not be found when replacing a user.');
+      throw new Error('The new contact could not be found when replacing the user.');
     }
-    if (originalContact.parent._id !== newContact.parent._id) {
+    if (!originalContact.parent?._id || originalContact.parent._id !== newContact.parent._id) {
       throw new Error('The new contact must have the same parent as the original contact when replacing a user.');
     }
     // TODO Currently the transitions are not run for online users so this is not used.
@@ -48,7 +48,7 @@ export class UserReplaceService {
   }
 
   getReplacedBy(contact): string {
-    return contact.replaced.by;
+    return contact.replaced?.by;
   }
 
   private getStatus(contact): ReplaceStatus {
@@ -65,8 +65,7 @@ export class UserReplaceService {
     dbSyncService: DBSyncService,
     sessionService: SessionService
   ) {
-    return async({ state, to, from }) => {
-      console.log(from + state);
+    return async({ to, from }) => {
       if (to !== SyncStatus.Success || from !== SyncStatus.Success) {
         return;
       }

--- a/webapp/src/ts/services/user-replace.service.ts
+++ b/webapp/src/ts/services/user-replace.service.ts
@@ -59,8 +59,8 @@ export class UserReplaceService {
     originalContact.replaced = { status, by: newContact._id };
   }
 
-  isReplaced(contact): boolean {
-    return contact.replaced;
+  isReplaced(contact) {
+    return !!contact.replaced;
   }
 
   getReplacedBy(contact): string {

--- a/webapp/src/ts/services/user-replace.service.ts
+++ b/webapp/src/ts/services/user-replace.service.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@angular/core';
+import { UserContactService } from '@mm-services/user-contact.service';
+import { DbService } from '@mm-services/db.service';
+import { DBSyncService, SyncStatus } from '@mm-services/db-sync.service';
+import { SessionService } from '@mm-services/session.service';
+import { SettingsService } from '@mm-services/settings.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserReplaceService {
+  constructor(
+    private settingsService:SettingsService,
+    private userContactService: UserContactService,
+    private dbService: DbService,
+    private dbSyncService: DBSyncService,
+    private sessionService: SessionService,
+  ) {
+    this.settingsService.get().then(settings => {
+      if(settings?.transitions?.user_replace) {
+        this.dbSyncService.subscribe(this.syncStatusChanged(
+          this.userContactService,
+          this.dbService,
+          this.dbSyncService,
+          this.sessionService
+        ));
+      }
+    });
+  }
+
+  setReplaced(originalContact, newContact) {
+    if (!originalContact) {
+      throw new Error('The original contact could not be found when replacing the user.');
+    }
+    if (!newContact) {
+      throw new Error('The new contact could not be found when replacing a user.');
+    }
+    if (originalContact.parent._id !== newContact.parent._id) {
+      throw new Error('The new contact must have the same parent as the original contact when replacing a user.');
+    }
+    // TODO Currently the transitions are not run for online users so this is not used.
+    const status = this.sessionService.isOnlineOnly() ? ReplaceStatus.READY : ReplaceStatus.PENDING;
+    originalContact.replaced = { status, by: newContact._id };
+  }
+
+  isReplaced(contact): boolean {
+    return contact.replaced;
+  }
+
+  getReplacedBy(contact): string {
+    return contact.replaced.by;
+  }
+
+  private getStatus(contact): ReplaceStatus {
+    return ReplaceStatus[contact.replaced.status];
+  }
+
+  private setStatus(contact, status: ReplaceStatus) {
+    contact.replaced.status = status;
+  }
+
+  private syncStatusChanged(
+    userContactService: UserContactService,
+    dbService: DbService,
+    dbSyncService: DBSyncService,
+    sessionService: SessionService
+  ) {
+    return async({ state, to, from }) => {
+      console.log(from + state);
+      if (to !== SyncStatus.Success || from !== SyncStatus.Success) {
+        return;
+      }
+
+      const contact = await userContactService.get();
+      if (!contact || !this.isReplaced(contact)) {
+        return;
+      }
+
+      const status = this.getStatus(contact);
+      if (status !== ReplaceStatus.PENDING) {
+        return;
+      }
+      // After a user is replaced, the original contact will have status of PENDING.
+      // Set to READY to trigger Sentinel to create a new user (now that all docs are synced).
+      this.setStatus(contact, ReplaceStatus.READY);
+      await dbService.get().put(contact);
+      // Make sure there is not an ongoing sync before pushing changes to contact
+      if(dbSyncService.isSyncInProgress()) {
+        await dbSyncService.sync();
+      }
+      await dbSyncService.sync(true);
+      await sessionService.logout();
+    };
+  }
+}
+
+enum ReplaceStatus {
+  PENDING = 'PENDING', // Waiting on sync to complete
+  READY = 'READY' // Ready to be replaced
+  // COMPLETE - Set by Sentinel when the new user has been created
+  // ERROR - Set by Sentinel if a new user could not be created
+}

--- a/webapp/tests/karma/ts/services/transitions.service.spec.ts
+++ b/webapp/tests/karma/ts/services/transitions.service.spec.ts
@@ -7,6 +7,7 @@ import { TransitionsService } from '@mm-services/transitions.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { MutingTransition } from '@mm-services/transitions/muting.transition';
 import { ValidationService } from '@mm-services/validation.service';
+import { UserReplaceTransition } from '@mm-services/transitions/user-replace.transition';
 
 describe('Transitions Service', () => {
   let settingsService;
@@ -27,6 +28,7 @@ describe('Transitions Service', () => {
       providers: [
         { provide: SettingsService, useValue: settingsService },
         { provide: MutingTransition, useValue: mutingTransition },
+        { provide: UserReplaceTransition, useValue: { } },
         { provide: ValidationService, useValue: validationService },
       ]
     });

--- a/webapp/tests/karma/ts/services/transitions.service.spec.ts
+++ b/webapp/tests/karma/ts/services/transitions.service.spec.ts
@@ -18,6 +18,7 @@ describe('Transitions Service', () => {
   beforeEach(() => {
     settingsService = { get: sinon.stub() };
     mutingTransition = {
+      name: 'muting',
       init: sinon.stub(),
       filter: sinon.stub(),
       run: sinon.stub(),
@@ -28,7 +29,7 @@ describe('Transitions Service', () => {
       providers: [
         { provide: SettingsService, useValue: settingsService },
         { provide: MutingTransition, useValue: mutingTransition },
-        { provide: UserReplaceTransition, useValue: { } },
+        { provide: UserReplaceTransition, useValue: { name: 'user_replace' } },
         { provide: ValidationService, useValue: validationService },
       ]
     });

--- a/webapp/tests/karma/ts/services/transitions/user-replace.transition.spec.ts
+++ b/webapp/tests/karma/ts/services/transitions/user-replace.transition.spec.ts
@@ -1,0 +1,263 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DbService } from '@mm-services/db.service';
+import { UserReplaceService } from '@mm-services/user-replace.service';
+import { UserReplaceTransition } from '@mm-services/transitions/user-replace.transition';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+const ORIGINAL_CONTACT = {
+  _id: 'original-contact',
+  parent: {
+    _id: 'parent-contact'
+  },
+};
+
+const NEW_CONTACT = {
+  _id: 'new-contact',
+  parent: {
+    _id: 'parent-contact'
+  },
+  contact: {
+    _id: 'some-other-user'
+  }
+};
+
+const REPLACE_USER_DOC = {
+  type: 'data_record',
+  form: 'replace_user',
+  fields: {
+    original_contact_uuid: ORIGINAL_CONTACT._id,
+    new_contact_uuid: NEW_CONTACT._id,
+  }
+};
+
+const getDataRecord = (contact = { _id: ORIGINAL_CONTACT._id}) => ({
+  type: 'data_record',
+  form: 'other',
+  contact
+});
+
+describe('User Replace Transition', () => {
+  let medicDb;
+  let dbService;
+  let userReplaceService;
+  let transition;
+
+  beforeEach(() => {
+    medicDb = { get: sinon.stub() };
+    dbService = { get: sinon.stub().returns(medicDb) };
+    userReplaceService = {
+      getUserContact: sinon.stub(),
+      isReplaced: sinon.stub(),
+      setReplaced: sinon.stub(),
+      getReplacedBy: sinon.stub(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore(),
+        { provide: DbService, useValue: dbService },
+        { provide: UserReplaceService, useValue: userReplaceService },
+      ]
+    });
+
+    transition = TestBed.inject(UserReplaceTransition);
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('init', () => {
+    it('returns true', () => {
+      expect(transition.init()).to.be.true;
+    });
+  });
+
+  describe('filter', () => {
+    it('returns true when given a report', () => {
+      expect(transition.filter([{ type: 'data_record' }])).to.satisfy(keep => keep);
+    });
+
+    it('returns false when no documents are provided', () => {
+      expect(transition.filter([])).to.be.satisfy(keep => !keep);
+    });
+
+    it('returns false when given documents that are not data records', () => {
+      const docs = [
+        { type: 'person' },
+        { type: 'user-settings' },
+        { type: 'something_else' },
+      ];
+
+      expect(transition.filter(docs)).to.be.satisfy(keep => !keep);
+    });
+  });
+
+  describe('run', () => {
+    it('does nothing when the user is not associated with a contact', async () => {
+      userReplaceService.getUserContact.resolves(null);
+
+      const docs = await transition.run([REPLACE_USER_DOC]);
+
+      expect(docs).to.deep.equal([REPLACE_USER_DOC]);
+      expect(userReplaceService.getUserContact.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(0);
+      expect(medicDb.get.callCount).to.equal(0);
+      expect(userReplaceService.setReplaced.callCount).to.equal(0);
+      expect(userReplaceService.isReplaced.callCount).to.equal(0);
+    });
+
+    it('does nothing when the user is not being replaced or is not already replaced', async () => {
+      userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+      userReplaceService.isReplaced.resolves(false);
+      const submittedDocs = [getDataRecord(), getDataRecord(), NEW_CONTACT];
+
+      const docs = await transition.run(submittedDocs);
+
+      expect(docs).to.deep.equal(submittedDocs);
+      expect(userReplaceService.getUserContact.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(0);
+      expect(medicDb.get.callCount).to.equal(0);
+      expect(userReplaceService.setReplaced.callCount).to.equal(0);
+      expect(userReplaceService.isReplaced.callCount).to.equal(1);
+      expect(userReplaceService.isReplaced.args[0]).to.deep.equal([ORIGINAL_CONTACT]);
+    });
+
+    describe(`when the reports submitted include a replace user report`, () => {
+      // Function from the re-parent reports flow should not be called
+      afterEach(() => expect(userReplaceService.isReplaced.callCount).to.equal(0));
+
+      it('sets the contact as replaced when the new contact is existing', async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+        medicDb.get.resolves(NEW_CONTACT);
+
+        const docs = await transition.run([REPLACE_USER_DOC]);
+
+        expect(docs).to.deep.equal([REPLACE_USER_DOC, ORIGINAL_CONTACT]);
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(dbService.get.callCount).to.equal(1);
+        expect(medicDb.get.callCount).to.equal(1);
+        expect(medicDb.get.args[0]).to.deep.equal([NEW_CONTACT._id]);
+        expect(userReplaceService.setReplaced.callCount).to.equal(1);
+        expect(userReplaceService.setReplaced.args[0]).to.deep.equal([ORIGINAL_CONTACT, NEW_CONTACT]);
+      });
+
+      it('sets the contact as replaced when the new contact is also being submitted', async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+
+        const docs = await transition.run([NEW_CONTACT, REPLACE_USER_DOC]);
+
+        expect(docs).to.deep.equal([NEW_CONTACT, REPLACE_USER_DOC, ORIGINAL_CONTACT]);
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(dbService.get.callCount).to.equal(0);
+        expect(medicDb.get.callCount).to.equal(0);
+        expect(userReplaceService.setReplaced.callCount).to.equal(1);
+        expect(userReplaceService.setReplaced.args[0]).to.deep.equal([ORIGINAL_CONTACT, NEW_CONTACT]);
+      });
+
+      it(`throws an error if the original contact being replaced does not match the user's contact`, async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+        const replaceUserDoc = Object.assign(
+          {},
+          REPLACE_USER_DOC,
+          { fields: { original_contact_uuid: 'different_contact' } }
+        );
+
+        try {
+          await transition.run([replaceUserDoc]);
+          expect.fail('should have thrown an error');
+        } catch (err) {
+          expect(err.message).to
+            .equal('The only the contact associated with the currently logged in user can be replaced.');
+        }
+
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(dbService.get.callCount).to.equal(0);
+        expect(medicDb.get.callCount).to.equal(0);
+        expect(userReplaceService.setReplaced.callCount).to.equal(0);
+      });
+
+      it(`throws an error if the new contact cannot be found`, async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+        medicDb.get.rejects({ status: 404 });
+
+        try {
+          await transition.run([REPLACE_USER_DOC]);
+          expect.fail('should have thrown an error');
+        } catch (err) {
+          expect(err.message).to
+            .equal(`The new contact could not be found [${NEW_CONTACT._id}].`);
+        }
+
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(dbService.get.callCount).to.equal(1);
+        expect(medicDb.get.callCount).to.equal(1);
+        expect(medicDb.get.args[0]).to.deep.equal([NEW_CONTACT._id]);
+        expect(userReplaceService.setReplaced.callCount).to.equal(0);
+      });
+
+      it(`throws an error if an error is encountered getting the new contact`, async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+        medicDb.get.rejects({ message: 'Server Error' });
+
+        try {
+          await transition.run([REPLACE_USER_DOC]);
+          expect.fail('should have thrown an error');
+        } catch (err) {
+          expect(err.message).to.equal(`Server Error`);
+        }
+
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(dbService.get.callCount).to.equal(1);
+        expect(medicDb.get.callCount).to.equal(1);
+        expect(medicDb.get.args[0]).to.deep.equal([NEW_CONTACT._id]);
+        expect(userReplaceService.setReplaced.callCount).to.equal(0);
+      });
+    });
+
+    describe(`when the reports submitted do not include a replace user report, but the user is replaced`, () => {
+      afterEach(() => {
+        // Functions from the user replace flow should not be called
+        expect(dbService.get.callCount).to.equal(0);
+        expect(medicDb.get.callCount).to.equal(0);
+        expect(userReplaceService.setReplaced.callCount).to.equal(0);
+      });
+
+      it('re-parents the given reports to the new contact', async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+        userReplaceService.isReplaced.resolves(true);
+        userReplaceService.getReplacedBy.resolves(NEW_CONTACT._id);
+        const submittedDocs: any = [
+          getDataRecord(),
+          getDataRecord({ _id: undefined }),
+          getDataRecord({ _id: 'different_contact' }),
+          getDataRecord(),
+          NEW_CONTACT
+        ];
+
+        const docs = await transition.run(submittedDocs);
+
+        submittedDocs[0].contact._id = NEW_CONTACT._id;
+        submittedDocs[3].contact._id = NEW_CONTACT._id;
+        expect(docs).to.deep.equal(submittedDocs);
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(userReplaceService.getReplacedBy.callCount).to.equal(1);
+        expect(userReplaceService.getReplacedBy.args[0]).to.deep.equal([ORIGINAL_CONTACT]);
+      });
+
+      it('does nothing if there is no replaced by id', async () => {
+        userReplaceService.getUserContact.resolves(ORIGINAL_CONTACT);
+        userReplaceService.isReplaced.resolves(true);
+        userReplaceService.getReplacedBy.resolves(null);
+        const submittedDocs: any = [getDataRecord()];
+
+        const docs = await transition.run(submittedDocs);
+
+        expect(docs).to.deep.equal(submittedDocs);
+        expect(userReplaceService.getUserContact.callCount).to.equal(1);
+        expect(userReplaceService.getReplacedBy.callCount).to.equal(1);
+        expect(userReplaceService.getReplacedBy.args[0]).to.deep.equal([ORIGINAL_CONTACT]);
+      });
+    });
+  });
+});

--- a/webapp/tests/karma/ts/services/user-replace.service.spec.ts
+++ b/webapp/tests/karma/ts/services/user-replace.service.spec.ts
@@ -1,0 +1,265 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { UserReplaceService } from '@mm-services/user-replace.service';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { SettingsService } from '@mm-services/settings.service';
+import { UserContactService } from '@mm-services/user-contact.service';
+import { DbService } from '@mm-services/db.service';
+import { DBSyncService, SyncStatus } from '@mm-services/db-sync.service';
+import { SessionService } from '@mm-services/session.service';
+
+const ORIGINAL_CONTACT = {
+  _id: 'original-contact',
+  parent: {
+    _id: 'parent-contact'
+  },
+  replaced: undefined
+};
+
+const NEW_CONTACT = {
+  _id: 'new-contact',
+  parent: {
+    _id: 'parent-contact'
+  }
+};
+
+const getContactWithStatus = (status: string) => ({
+  _id: 'status-contact',
+  parent: {
+    _id: 'parent-contact'
+  },
+  replaced: {
+    status: status,
+    by: NEW_CONTACT._id
+  }
+});
+
+describe('User Replace service', () => {
+  let settingsService;
+  let userContactService;
+  let medicDb;
+  let dbService;
+  let dbSyncService;
+  let sessionService;
+  let service;
+
+  beforeEach(() => {
+    settingsService = { get: sinon.stub().resolves({ transitions: { user_replace: true } }) };
+    userContactService = { get: sinon.stub() };
+    medicDb = { put: sinon.stub() };
+    dbService = { get: sinon.stub().returns(medicDb) };
+    dbSyncService = {
+      subscribe: sinon.stub(),
+      isSyncInProgress: sinon.stub().returns(false),
+      sync: sinon.stub().resolves(),
+    };
+    sessionService = {
+      isOnlineOnly: sinon.stub().returns(false),
+      logout: sinon.stub(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideMockStore(),
+        { provide: SettingsService, useValue: settingsService },
+        { provide: UserContactService, useValue: userContactService },
+        { provide: DbService, useValue: dbService },
+        { provide: DBSyncService, useValue: dbSyncService },
+        { provide: SessionService, useValue: sessionService },
+      ]
+    });
+
+    service = TestBed.inject(UserReplaceService);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const assertContactNotUpdated = () => {
+    expect(dbService.get.callCount).to.equal(0);
+    expect(medicDb.put.callCount).to.equal(0);
+    expect(dbSyncService.isSyncInProgress.callCount).to.equal(0);
+    expect(dbSyncService.sync.callCount).to.equal(0);
+    expect(sessionService.logout.callCount).to.equal(0);
+  };
+
+  describe('setReplaced', () => {
+    it('should set the given new contact and a status of PENDING when the user is offline', () => {
+      const originalContact = Object.assign({}, ORIGINAL_CONTACT);
+
+      service.setReplaced(originalContact, NEW_CONTACT);
+
+      expect(originalContact.replaced).to.deep.equal({
+        status: 'PENDING',
+        by: NEW_CONTACT._id
+      });
+    });
+
+    it('should set the given new contact and a status of READY when the user is online', () => {
+      const originalContact = Object.assign({}, ORIGINAL_CONTACT);
+      sessionService.isOnlineOnly.returns(true);
+
+      service.setReplaced(originalContact, NEW_CONTACT);
+
+      expect(originalContact.replaced).to.deep.equal({
+        status: 'READY',
+        by: NEW_CONTACT._id
+      });
+    });
+
+    it('should throw an error when no original contact is provided', () => {
+      expect(() => service.setReplaced(null, NEW_CONTACT))
+        .to.throw('The original contact could not be found when replacing the user.');
+    });
+
+    it('should throw an error when no new contact is provided', () => {
+      expect(() => service.setReplaced(ORIGINAL_CONTACT, null))
+        .to.throw('The new contact could not be found when replacing the user.');
+    });
+
+    it('should throw an error when the original contact and the new contact do not have the same parent', () => {
+      const originalContact = Object.assign({}, ORIGINAL_CONTACT, { parent: { _id: 'different-parent' } });
+
+      expect(() => service.setReplaced(originalContact, NEW_CONTACT))
+        .to.throw('The new contact must have the same parent as the original contact when replacing a user.');
+    });
+
+    it('should throw an error when the original contact does not have a parent', () => {
+      const originalContact = Object.assign({}, ORIGINAL_CONTACT, { parent: undefined });
+
+      expect(() => service.setReplaced(originalContact, NEW_CONTACT))
+        .to.throw('The new contact must have the same parent as the original contact when replacing a user.');
+    });
+
+    it('should throw an error when the new contact does not have a parent', () => {
+      const newContact = Object.assign({}, NEW_CONTACT, { parent: {} });
+
+      expect(() => service.setReplaced(ORIGINAL_CONTACT, newContact))
+        .to.throw('The new contact must have the same parent as the original contact when replacing a user.');
+    });
+  });
+
+  describe('isReplaced', () => {
+    it('should return true when the given contact is replaced', () => {
+      const pendingContact = getContactWithStatus('PENDING');
+      expect(service.isReplaced(pendingContact)).to.satisfy(replaced => replaced);
+    });
+
+    it('should return false when the given contact is not replaced', () => {
+      expect(service.isReplaced(ORIGINAL_CONTACT)).to.satisfy(replaced => !replaced);
+    });
+  });
+
+  describe('getReplacedBy', () => {
+    it('should return the new contact when the given contact is replaced', () => {
+      const pendingContact = getContactWithStatus('PENDING');
+      expect(service.getReplacedBy(pendingContact)).to.equal(NEW_CONTACT._id);
+    });
+
+    it('should return undefined when the given contact is not replaced', () => {
+      expect(service.getReplacedBy(ORIGINAL_CONTACT)).to.equal(undefined);
+    });
+  });
+
+  describe('syncStatusChanged', () => {
+    const SYNC_STATUS = { to: SyncStatus.Success, from: SyncStatus.Success };
+
+    it('should update contact with PENDING status to READY and log out the user', async() => {
+      const pendingContact = getContactWithStatus('PENDING');
+      userContactService.get.resolves(pendingContact);
+
+      expect(dbSyncService.subscribe.callCount).to.equal(1);
+      const syncStatusChanged = dbSyncService.subscribe.args[0][0];
+      await syncStatusChanged(SYNC_STATUS);
+
+      expect(userContactService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.put.callCount).to.equal(1);
+      const updatedContact = Object.assign({}, pendingContact, { replaced: { by: NEW_CONTACT._id, status: 'READY' } });
+      expect(medicDb.put.args[0]).to.deep.equal([updatedContact]);
+      expect(dbSyncService.isSyncInProgress.callCount).to.equal(1);
+      expect(dbSyncService.sync.callCount).to.equal(1);
+      expect(dbSyncService.sync.args[0]).to.deep.equal([true]);
+      expect(sessionService.logout.callCount).to.equal(1);
+    });
+
+    [
+      { to: SyncStatus.Success, from: SyncStatus.InProgress },
+      { to: SyncStatus.InProgress, from: SyncStatus.Success },
+      { from: SyncStatus.Success },
+      { to: SyncStatus.Success },
+      {}
+    ].forEach(syncStatus => {
+      it(`should do nothing when the sync status is: ${JSON.stringify(syncStatus)}`, async() => {
+        const pendingContact = getContactWithStatus('PENDING');
+        userContactService.get.resolves(pendingContact);
+
+        expect(dbSyncService.subscribe.callCount).to.equal(1);
+        const syncStatusChanged = dbSyncService.subscribe.args[0][0];
+        await syncStatusChanged(syncStatus);
+
+        expect(userContactService.get.callCount).to.equal(0);
+        assertContactNotUpdated();
+      });
+    });
+
+    it('should not update contact that is not being replaced', async() => {
+      userContactService.get.resolves(ORIGINAL_CONTACT);
+
+      expect(dbSyncService.subscribe.callCount).to.equal(1);
+      const syncStatusChanged = dbSyncService.subscribe.args[0][0];
+      await syncStatusChanged(SYNC_STATUS);
+
+      expect(userContactService.get.callCount).to.equal(1);
+      expect(ORIGINAL_CONTACT.replaced).to.be.undefined;
+      assertContactNotUpdated();
+    });
+
+    it('should do nothing when there is no contact associated with the user', async() => {
+      userContactService.get.resolves(null);
+
+      expect(dbSyncService.subscribe.callCount).to.equal(1);
+      const syncStatusChanged = dbSyncService.subscribe.args[0][0];
+      await syncStatusChanged(SYNC_STATUS);
+
+      expect(userContactService.get.callCount).to.equal(1);
+      assertContactNotUpdated();
+    });
+
+    it('should not update replaced contact that is not PENDING', async() => {
+      const completeContact = getContactWithStatus('COMPLETE');
+      userContactService.get.resolves(completeContact);
+
+      expect(dbSyncService.subscribe.callCount).to.equal(1);
+      const syncStatusChanged = dbSyncService.subscribe.args[0][0];
+      await syncStatusChanged(SYNC_STATUS);
+
+      expect(userContactService.get.callCount).to.equal(1);
+      expect(completeContact.replaced.status).to.equal('COMPLETE');
+      assertContactNotUpdated();
+    });
+
+    it('should wait for sync in progress to finish before syncing updated contact', async() => {
+      const pendingContact = getContactWithStatus('PENDING');
+      userContactService.get.resolves(pendingContact);
+      dbSyncService.isSyncInProgress.resolves(true);
+
+      expect(dbSyncService.subscribe.callCount).to.equal(1);
+      const syncStatusChanged = dbSyncService.subscribe.args[0][0];
+      await syncStatusChanged(SYNC_STATUS);
+
+      expect(userContactService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.put.callCount).to.equal(1);
+      const updatedContact = Object.assign({}, pendingContact, { replaced: { by: NEW_CONTACT._id, status: 'READY' } });
+      expect(medicDb.put.args[0]).to.deep.equal([updatedContact]);
+      expect(dbSyncService.isSyncInProgress.callCount).to.equal(1);
+      expect(dbSyncService.sync.callCount).to.equal(2);
+      expect(dbSyncService.sync.args[0]).to.deep.equal([]);
+      expect(dbSyncService.sync.args[1]).to.deep.equal([true]);
+      expect(sessionService.logout.callCount).to.equal(1);
+    });
+  });
+});

--- a/webapp/tests/karma/ts/services/user-replace.service.spec.ts
+++ b/webapp/tests/karma/ts/services/user-replace.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
-import { UserReplaceService } from '@mm-services/user-replace.service';
-import sinon from 'sinon';
 import { expect } from 'chai';
+import sinon from 'sinon';
+import { UserReplaceService } from '@mm-services/user-replace.service';
 import { SettingsService } from '@mm-services/settings.service';
-import { UserContactService } from '@mm-services/user-contact.service';
 import { DbService } from '@mm-services/db.service';
 import { DBSyncService, SyncStatus } from '@mm-services/db-sync.service';
 import { SessionService } from '@mm-services/session.service';
+import { UserSettingsService } from '@mm-services/user-settings.service';
 
 const ORIGINAL_CONTACT = {
   _id: 'original-contact',
@@ -37,7 +37,7 @@ const getContactWithStatus = (status: string) => ({
 
 describe('User Replace service', () => {
   let settingsService;
-  let userContactService;
+  let userSettingsService;
   let medicDb;
   let dbService;
   let dbSyncService;
@@ -46,8 +46,8 @@ describe('User Replace service', () => {
 
   beforeEach(() => {
     settingsService = { get: sinon.stub().resolves({ transitions: { user_replace: true } }) };
-    userContactService = { get: sinon.stub() };
-    medicDb = { put: sinon.stub() };
+    userSettingsService = { get: sinon.stub().resolves({}) };
+    medicDb = { get: sinon.stub(), put: sinon.stub() };
     dbService = { get: sinon.stub().returns(medicDb) };
     dbSyncService = {
       subscribe: sinon.stub(),
@@ -63,7 +63,7 @@ describe('User Replace service', () => {
       providers: [
         provideMockStore(),
         { provide: SettingsService, useValue: settingsService },
-        { provide: UserContactService, useValue: userContactService },
+        { provide: UserSettingsService, useValue: userSettingsService },
         { provide: DbService, useValue: dbService },
         { provide: DBSyncService, useValue: dbSyncService },
         { provide: SessionService, useValue: sessionService },
@@ -73,20 +73,73 @@ describe('User Replace service', () => {
     service = TestBed.inject(UserReplaceService);
   });
 
-  afterEach(() => {
-    sinon.restore();
-  });
+  afterEach(() => sinon.restore());
 
   const assertContactNotUpdated = () => {
-    expect(dbService.get.callCount).to.equal(0);
     expect(medicDb.put.callCount).to.equal(0);
     expect(dbSyncService.isSyncInProgress.callCount).to.equal(0);
     expect(dbSyncService.sync.callCount).to.equal(0);
     expect(sessionService.logout.callCount).to.equal(0);
   };
 
+  describe('getUserContact', () => {
+    it('returns the user contact', async () => {
+      userSettingsService.get.resolves({ contact_id: ORIGINAL_CONTACT._id });
+      medicDb.get.withArgs(ORIGINAL_CONTACT._id).resolves(ORIGINAL_CONTACT);
+
+      const userContact = await service.getUserContact();
+
+      expect(userContact).to.equal(ORIGINAL_CONTACT);
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([ORIGINAL_CONTACT._id]);
+    });
+
+    it('returns undefined if the user has no contact id', async () => {
+      userSettingsService.get.resolves({ });
+
+      const userContact = await service.getUserContact();
+
+      expect(userContact).to.be.undefined;
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(0);
+      expect(medicDb.get.callCount).to.equal(0);
+    });
+
+    it(`returns undefined if the user's contact id is not associated with any document`, async () => {
+      userSettingsService.get.resolves({ contact_id: ORIGINAL_CONTACT._id });
+      medicDb.get.withArgs(ORIGINAL_CONTACT._id).rejects({ status: 404 });
+
+      const userContact = await service.getUserContact();
+
+      expect(userContact).to.be.undefined;
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([ORIGINAL_CONTACT._id]);
+    });
+
+    it(`throws an error is an error is encountered getting the user's contact`, async () => {
+      userSettingsService.get.resolves({ contact_id: ORIGINAL_CONTACT._id });
+      medicDb.get.withArgs(ORIGINAL_CONTACT._id).rejects({ message: 'Server Error' });
+
+      try {
+        await service.getUserContact();
+        expect.fail('should have thrown an error');
+      } catch (err) {
+        expect(err.message).to.equal('Server Error');
+      }
+
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([ORIGINAL_CONTACT._id]);
+    });
+  });
+
   describe('setReplaced', () => {
-    it('should set the given new contact and a status of PENDING when the user is offline', () => {
+    it('sets the given new contact and a status of PENDING when the user is offline', () => {
       const originalContact = Object.assign({}, ORIGINAL_CONTACT);
 
       service.setReplaced(originalContact, NEW_CONTACT);
@@ -97,7 +150,7 @@ describe('User Replace service', () => {
       });
     });
 
-    it('should set the given new contact and a status of READY when the user is online', () => {
+    it('sets the given new contact and a status of READY when the user is online', () => {
       const originalContact = Object.assign({}, ORIGINAL_CONTACT);
       sessionService.isOnlineOnly.returns(true);
 
@@ -109,31 +162,31 @@ describe('User Replace service', () => {
       });
     });
 
-    it('should throw an error when no original contact is provided', () => {
+    it('throws an error when no original contact is provided', () => {
       expect(() => service.setReplaced(null, NEW_CONTACT))
         .to.throw('The original contact could not be found when replacing the user.');
     });
 
-    it('should throw an error when no new contact is provided', () => {
+    it('throws an error when no new contact is provided', () => {
       expect(() => service.setReplaced(ORIGINAL_CONTACT, null))
         .to.throw('The new contact could not be found when replacing the user.');
     });
 
-    it('should throw an error when the original contact and the new contact do not have the same parent', () => {
+    it('throws an error when the original contact and the new contact do not have the same parent', () => {
       const originalContact = Object.assign({}, ORIGINAL_CONTACT, { parent: { _id: 'different-parent' } });
 
       expect(() => service.setReplaced(originalContact, NEW_CONTACT))
         .to.throw('The new contact must have the same parent as the original contact when replacing a user.');
     });
 
-    it('should throw an error when the original contact does not have a parent', () => {
+    it('throws an error when the original contact does not have a parent', () => {
       const originalContact = Object.assign({}, ORIGINAL_CONTACT, { parent: undefined });
 
       expect(() => service.setReplaced(originalContact, NEW_CONTACT))
         .to.throw('The new contact must have the same parent as the original contact when replacing a user.');
     });
 
-    it('should throw an error when the new contact does not have a parent', () => {
+    it('throws an error when the new contact does not have a parent', () => {
       const newContact = Object.assign({}, NEW_CONTACT, { parent: {} });
 
       expect(() => service.setReplaced(ORIGINAL_CONTACT, newContact))
@@ -142,23 +195,23 @@ describe('User Replace service', () => {
   });
 
   describe('isReplaced', () => {
-    it('should return true when the given contact is replaced', () => {
+    it('returns true when the given contact is replaced', () => {
       const pendingContact = getContactWithStatus('PENDING');
       expect(service.isReplaced(pendingContact)).to.satisfy(replaced => replaced);
     });
 
-    it('should return false when the given contact is not replaced', () => {
+    it('returns false when the given contact is not replaced', () => {
       expect(service.isReplaced(ORIGINAL_CONTACT)).to.satisfy(replaced => !replaced);
     });
   });
 
   describe('getReplacedBy', () => {
-    it('should return the new contact when the given contact is replaced', () => {
+    it('returns the new contact when the given contact is replaced', () => {
       const pendingContact = getContactWithStatus('PENDING');
       expect(service.getReplacedBy(pendingContact)).to.equal(NEW_CONTACT._id);
     });
 
-    it('should return undefined when the given contact is not replaced', () => {
+    it('returns undefined when the given contact is not replaced', () => {
       expect(service.getReplacedBy(ORIGINAL_CONTACT)).to.equal(undefined);
     });
   });
@@ -166,16 +219,20 @@ describe('User Replace service', () => {
   describe('syncStatusChanged', () => {
     const SYNC_STATUS = { to: SyncStatus.Success, from: SyncStatus.Success };
 
-    it('should update contact with PENDING status to READY and log out the user', async() => {
+    it('updates contact with PENDING status to READY and logs out the user', async() => {
       const pendingContact = getContactWithStatus('PENDING');
-      userContactService.get.resolves(pendingContact);
+      userSettingsService.get.resolves({ contact_id: pendingContact._id });
+      medicDb.get.withArgs(pendingContact._id).resolves(pendingContact);
+
 
       expect(dbSyncService.subscribe.callCount).to.equal(1);
       const syncStatusChanged = dbSyncService.subscribe.args[0][0];
       await syncStatusChanged(SYNC_STATUS);
 
-      expect(userContactService.get.callCount).to.equal(1);
-      expect(dbService.get.callCount).to.equal(1);
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(2);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([pendingContact._id]);
       expect(medicDb.put.callCount).to.equal(1);
       const updatedContact = Object.assign({}, pendingContact, { replaced: { by: NEW_CONTACT._id, status: 'READY' } });
       expect(medicDb.put.args[0]).to.deep.equal([updatedContact]);
@@ -192,66 +249,77 @@ describe('User Replace service', () => {
       { to: SyncStatus.Success },
       {}
     ].forEach(syncStatus => {
-      it(`should do nothing when the sync status is: ${JSON.stringify(syncStatus)}`, async() => {
-        const pendingContact = getContactWithStatus('PENDING');
-        userContactService.get.resolves(pendingContact);
-
+      it(`does nothing when the sync status is: ${JSON.stringify(syncStatus)}`, async() => {
         expect(dbSyncService.subscribe.callCount).to.equal(1);
         const syncStatusChanged = dbSyncService.subscribe.args[0][0];
         await syncStatusChanged(syncStatus);
 
-        expect(userContactService.get.callCount).to.equal(0);
+        expect(userSettingsService.get.callCount).to.equal(0);
+        expect(dbService.get.callCount).to.equal(0);
         assertContactNotUpdated();
       });
     });
 
-    it('should not update contact that is not being replaced', async() => {
-      userContactService.get.resolves(ORIGINAL_CONTACT);
+    it('does not update contact that is not being replaced', async() => {
+      userSettingsService.get.resolves({ contact_id: ORIGINAL_CONTACT._id });
+      medicDb.get.withArgs(ORIGINAL_CONTACT._id).resolves(ORIGINAL_CONTACT);
 
       expect(dbSyncService.subscribe.callCount).to.equal(1);
       const syncStatusChanged = dbSyncService.subscribe.args[0][0];
       await syncStatusChanged(SYNC_STATUS);
 
-      expect(userContactService.get.callCount).to.equal(1);
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([ORIGINAL_CONTACT._id]);
       expect(ORIGINAL_CONTACT.replaced).to.be.undefined;
       assertContactNotUpdated();
     });
 
-    it('should do nothing when there is no contact associated with the user', async() => {
-      userContactService.get.resolves(null);
+    it('does nothing when there is no contact associated with the user', async() => {
+      userSettingsService.get.resolves({});
 
       expect(dbSyncService.subscribe.callCount).to.equal(1);
       const syncStatusChanged = dbSyncService.subscribe.args[0][0];
       await syncStatusChanged(SYNC_STATUS);
 
-      expect(userContactService.get.callCount).to.equal(1);
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(0);
+      expect(medicDb.get.callCount).to.equal(0);
       assertContactNotUpdated();
     });
 
-    it('should not update replaced contact that is not PENDING', async() => {
+    it('does not update replaced contact that is not PENDING', async() => {
       const completeContact = getContactWithStatus('COMPLETE');
-      userContactService.get.resolves(completeContact);
+      userSettingsService.get.resolves({ contact_id: completeContact._id });
+      medicDb.get.withArgs(completeContact._id).resolves(completeContact);
 
       expect(dbSyncService.subscribe.callCount).to.equal(1);
       const syncStatusChanged = dbSyncService.subscribe.args[0][0];
       await syncStatusChanged(SYNC_STATUS);
 
-      expect(userContactService.get.callCount).to.equal(1);
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(1);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([completeContact._id]);
       expect(completeContact.replaced.status).to.equal('COMPLETE');
       assertContactNotUpdated();
     });
 
-    it('should wait for sync in progress to finish before syncing updated contact', async() => {
+    it('waits for sync in progress to finish before syncing updated contact', async() => {
       const pendingContact = getContactWithStatus('PENDING');
-      userContactService.get.resolves(pendingContact);
+      userSettingsService.get.resolves({ contact_id: pendingContact._id });
+      medicDb.get.withArgs(pendingContact._id).resolves(pendingContact);
       dbSyncService.isSyncInProgress.resolves(true);
 
       expect(dbSyncService.subscribe.callCount).to.equal(1);
       const syncStatusChanged = dbSyncService.subscribe.args[0][0];
       await syncStatusChanged(SYNC_STATUS);
 
-      expect(userContactService.get.callCount).to.equal(1);
-      expect(dbService.get.callCount).to.equal(1);
+      expect(userSettingsService.get.callCount).to.equal(1);
+      expect(dbService.get.callCount).to.equal(2);
+      expect(medicDb.get.callCount).to.equal(1);
+      expect(medicDb.get.args[0]).to.deep.equal([pendingContact._id]);
       expect(medicDb.put.callCount).to.equal(1);
       const updatedContact = Object.assign({}, pendingContact, { replaced: { by: NEW_CONTACT._id, status: 'READY' } });
       expect(medicDb.put.args[0]).to.deep.equal([updatedContact]);


### PR DESCRIPTION
# Description

Overview of logic flow:

- CLIENT (in `webapp`)
	- `replace_user` form submitted  
	- Triggers _client-side_ `user-replace.transition` to set `replaced` properties on user's _current_ contact
	    - `replaced.by` = `_id` of new contact
	    - `replaced.status` = "PENDING"
	- Any additional reports submitted after the user is replaced (but before the client syncs) will be automatically re-parented by the client-side transition
	- Client syncs.
		- When syncing completes successfully, the `syncStatusChanged` function in the `user-replace.service` is triggered
		    - If the user has been replaced, and the status is set to "PENDING", then we know everything has now synced successfully (since that is what triggered `syncStatusChanged` in the first place
		    - Set the status on the original contact to "READY" and sync again
		    - When the next sync completes, automatically log out the user
- SERVER  
	- Server's `user_replace` transition  is triggered by updated contact with `replaced.status=READY`  
		- Creates new user  
		- Deletes existing user  
		- Sets original contact `replaced.status=COMPLETE` 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
