### PR TITLE
Remove `server_name` from nginx config

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,7 +16,6 @@ http {
 
     server {
         listen         80;
-        server_name    _;
         location / {
             return 301 https://$host$request_uri;
         }
@@ -24,7 +23,6 @@ http {
 
     server {
         listen       443 ssl;
-        server_name  _;
 
         gzip                on;
         gzip_disable        "msie6";

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -894,4 +894,16 @@ describe('routing', () => {
         });
     });
   });
+
+  describe('admin access to Fauxton', () => {
+    it('should allow access with a trailing slash', async () => {
+      const response = await utils.request({ path: '/_utils/', json: false });
+      expect(response).to.include('Fauxton Release');
+    });
+
+    it('should allow access without a trailing slash', async () => {
+      const response = await utils.request({ path: '/_utils', json: false });
+      expect(response).to.include('Fauxton Release');
+    });
+  });
 });


### PR DESCRIPTION
# Description

medic/cht-core#7815

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
