### PR TITLE
Add 3.x compose file for docker helper until we fix it or remove it

### DIFF
--- a/scripts/docker-helper/cht-docker-compose.sh
+++ b/scripts/docker-helper/cht-docker-compose.sh
@@ -165,6 +165,8 @@ pull_images(){
 get_docker_compose_yml_path(){
   if [ -f docker-compose-developer.yml ]; then
     echo "docker-compose-developer.yml"
+  elif [ -f docker-compose-developer-3.x-only.yml ]; then
+    echo "docker-compose-developer-3.x-only.yml"
   elif [ -f ../../docker-compose-developer.yml ]; then
     echo "../../docker-compose-developer.yml"
   else
@@ -378,7 +380,7 @@ main (){
   # very first thing check we have valid env file, exit if not
   validEnv=$(validate_env_file "$envFile")
   if [ -n "$validEnv" ]; then
-    window "CHT Docker Helper - WARNING - Missing or invalid .env File" "red" "100%"
+    window "CHT Docker Helper - WARNING - Missing or invalid .env File  -  (USE WITH CHT 3.x ONLY!)" "red" "100%"
     append "$validEnv"
     endwin
     set -e
@@ -397,7 +399,7 @@ main (){
   # with constants set, let's ensure all the apps are present, exit if not
   appStatus=$(required_apps_installed "$APP_STRING")
   if [ -n "$appStatus" ]; then
-    window "WARNING: Missing Apps" "red" "100%"
+    window "WARNING: Missing Apps  -  (USE WITH CHT 3.x ONLY!)" "red" "100%"
     append "Install before proceeding:"
     append "$appStatus"
     endwin
@@ -454,7 +456,7 @@ main (){
 
   # display only action so this paints on bash screen. next loop we'll quit and show nothing new
   if [ "$docker_action" = "destroy" ] || [ "$docker_action" = "down" ]; then
-    window "${docker_action}ing ${COMPOSE_PROJECT_NAME} " "red" "100%"
+    window "${docker_action}ing ${COMPOSE_PROJECT_NAME}   -  (USE WITH CHT 3.x ONLY!)" "red" "100%"
     append "Please wait... "
     endwin
     exitNext=$docker_action
@@ -465,7 +467,7 @@ main (){
     exit 0
   fi
 
-  window "CHT Docker Helper: ${COMPOSE_PROJECT_NAME}" "green" "100%"
+  window "CHT Docker Helper: ${COMPOSE_PROJECT_NAME}  -  (USE WITH CHT 3.x ONLY!)" "green" "100%"
   append_tabbed "CHT Health - Version|${overAllHealth} - ${chtVersion}" 2 "|"
   append_tabbed "CHT URL|${chtUrl}" 2 "|"
   append_tabbed "FAUXTON URL|${chtUrl}/_utils/" 2 "|"
@@ -478,7 +480,7 @@ main (){
   endwin
 
   if [ -z "$dockerComposePath" ]; then
-    window "WARNING: Missing Compose File " "red" "100%"
+    window "WARNING: Missing Compose File   -  (USE WITH CHT 3.x ONLY!)" "red" "100%"
     append "Download before proceeding: "
     append "wget https://github.com/medic/cht-core/blob/master/docker-compose-developer.yml"
     endwin

--- a/scripts/docker-helper/docker-compose-developer-3.x-only.yml
+++ b/scripts/docker-helper/docker-compose-developer-3.x-only.yml
@@ -1,0 +1,51 @@
+version: '3.7'
+
+
+###########################
+######### NOTICE ##########
+###########################
+# THIS COMPOSE FILE ONLY  #
+# WORKS WITH CHT 3.X. IT  #
+# WILL NOT WORK WITH      #
+# CHT 4.X!                #
+###########################
+
+# For more information on how to use this docker compose file see our docs page:
+#   https://docs.communityhealthtoolkit.org/apps/guides/hosting/app-developer/
+
+services:
+  medic-os:
+
+    image: medicmobile/medic-os:cht-3.9.0-rc.2
+    volumes:
+      - medic-data:/srv
+    ports:
+      - "${CHT_HTTP:-80}:80"
+      - "${CHT_HTTPS:-443}:443"
+    working_dir: /srv
+    depends_on:
+      - haproxy
+    networks:
+      - medic-net
+    environment:
+      - DOCKER_NETWORK_NAME=haproxy
+      - DOCKER_COUCHDB_ADMIN_PASSWORD=${DOCKER_COUCHDB_ADMIN_PASSWORD:-password}
+
+  haproxy:
+
+    image: medicmobile/haproxy:rc-1.17
+    volumes:
+      - medic-data:/srv
+    environment:
+      - COUCHDB_HOST=medic-os
+      - HA_PASSWORD=${DOCKER_COUCHDB_ADMIN_PASSWORD:-password}
+    networks:
+      - medic-net
+
+volumes:
+  medic-data:
+
+
+networks:
+  medic-net:
+


### PR DESCRIPTION
# Description

This PR adds a compose filed called `docker-compose-developer-3.x-only.yml` and then updates the `cht-docker-compose.sh` script to know to look for that.  While this won't work for 3.x, it will unblock many developers who will still need to run 3.x instances for development for years to come.

See [docs PR  too](https://github.com/medic/cht-docs/pull/801)

# Code review checklist
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
