### PR TITLE
Fix bringing own certs 

### DIFF
--- a/scripts/build/cht-core.yml.template
+++ b/scripts/build/cht-core.yml.template
@@ -81,7 +81,7 @@ services:
       - "${NGINX_HTTP_PORT:-80}:80"
       - "${NGINX_HTTPS_PORT:-443}:443"
     volumes:
-      - cht-ssl:/root/.acme.sh/
+      - cht-ssl:"${SSL_VOLUME_MOUNT_PATH:-/root/.acme.sh/}"
     environment:
       - "CERTIFICATE_MODE=${CERTIFICATE_MODE:-SELF_SIGNED}"
       - "SSL_CERT_FILE_PATH=${SSL_CERT_FILE_PATH:-/etc/nginx/private/cert.pem}"

--- a/scripts/build/cht-core.yml.template
+++ b/scripts/build/cht-core.yml.template
@@ -81,7 +81,7 @@ services:
       - "${NGINX_HTTP_PORT:-80}:80"
       - "${NGINX_HTTPS_PORT:-443}:443"
     volumes:
-      - cht-ssl:"${SSL_VOLUME_MOUNT_PATH:-/root/.acme.sh/}"
+      - cht-ssl:${SSL_VOLUME_MOUNT_PATH:-/root/.acme.sh/}
     environment:
       - "CERTIFICATE_MODE=${CERTIFICATE_MODE:-SELF_SIGNED}"
       - "SSL_CERT_FILE_PATH=${SSL_CERT_FILE_PATH:-/etc/nginx/private/cert.pem}"


### PR DESCRIPTION
# Description

1 line fix to allow passing in an env var to set the path for the mount point for `cht-nginx` service

medic/cht-core#7832

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
