### PR TITLE
Allow for short CouchDb Secret

### DIFF
--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -41,7 +41,16 @@ const getKey = () => {
   const url = `${getCouchConfigUrl()}/couch_httpd_auth/secret`;
   return request
     .get(url, { json: true })
-    .then(key => Buffer.from(key).slice(0, KEY_LENGTH));
+    .then(key => {
+      let buffer = Buffer.from(key);
+      if (buffer.length < KEY_LENGTH) {
+        const duplicateCount = Math.ceil(KEY_LENGTH / buffer.length);
+        const bufferList = Array.from({ length: duplicateCount }).map(() => buffer);
+        buffer = Buffer.concat(bufferList);
+      }
+
+      return buffer.slice(0, KEY_LENGTH);
+    });
 };
 
 const encrypt = (text) => {

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -42,6 +42,10 @@ const getKey = () => {
   return request
     .get(url, { json: true })
     .then(key => {
+      if (!key.length) {
+        throw new Error('Invalid cypher. CouchDB Secret needs to be set in order to use secure credentials.');
+      }
+
       let buffer = Buffer.from(key);
       if (buffer.length < KEY_LENGTH) {
         const duplicateCount = Math.ceil(KEY_LENGTH / buffer.length);

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -228,6 +228,20 @@ describe('Settings Shared Library', () => {
         });
     });
 
+    it('should throw an error when couch secret is empty string', () => {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.onCall(0).rejects({ message: 'missing', statusCode: 404 });
+      requestGet.onCall(1).resolves('');
+
+      return lib
+        .setCredentials('mykey', 'mypass')
+        .then(() => expect.fail('Should have thrown'))
+        .catch((err) => {
+          expect(err.message)
+            .to.equal('Invalid cypher. CouchDB Secret needs to be set in order to use secure credentials.');
+        });
+    });
+
   });
 
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -651,6 +651,7 @@ const dockerComposeCmd = (...params) => {
     DB1_DATA: db1Data,
     DB2_DATA: db2Data,
     DB3_DATA: db3Data,
+    COUCHDB_SECRET: 'monkey',
   };
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
# Description

When secret is too short, concatenate with itself until we have desired string length. 

medic/cht-core#7840

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
