### PR TITLE
Improve interaction between online webapp and api startup page

### DIFF
--- a/webapp/src/ts/constants.ts
+++ b/webapp/src/ts/constants.ts
@@ -13,6 +13,10 @@ const BODY_LENGTH_LIMIT = 32000000; // 32 million
 // In order to enable a retry, and not incorrectly communicate success to the client, validate _changes
 // responses and update the response object accordingly, before passing it to PouchDb for processing.
 const processChangesResponse = (response) => {
+  if (!response.ok) {
+    return Promise.resolve(response);
+  }
+
   const clone = response.clone();
   return clone.json().then(json => {
     const validChangesResponse = json.results && !json.error;

--- a/webapp/src/ts/services/auth.service.ts
+++ b/webapp/src/ts/services/auth.service.ts
@@ -17,6 +17,7 @@ export class AuthService {
    * Returns true if the current user's role has all the permissions passed in as arguments.
    * If a permission has a '!' prefix, resolves true only if the user doesn't have the permission.
    * DB admins automatically have all permissions.
+   * Throws error when respose has 503 status
    * @param permissions {string | string[]}
    */
   has(permissions?: string | string[]): Promise<boolean> {
@@ -33,7 +34,7 @@ export class AuthService {
         return chtApi.v1.hasPermissions(permissions, userCtx);
       })
       .catch((err) => {
-        if (err.status === 503) {
+        if (err?.status === 503) {
           throw err;
         }
         return false;

--- a/webapp/src/ts/services/auth.service.ts
+++ b/webapp/src/ts/services/auth.service.ts
@@ -17,7 +17,7 @@ export class AuthService {
    * Returns true if the current user's role has all the permissions passed in as arguments.
    * If a permission has a '!' prefix, resolves true only if the user doesn't have the permission.
    * DB admins automatically have all permissions.
-   * Throws error when respose has 503 status
+   * Throws error when response has 503 status.
    * @param permissions {string | string[]}
    */
   has(permissions?: string | string[]): Promise<boolean> {

--- a/webapp/src/ts/services/auth.service.ts
+++ b/webapp/src/ts/services/auth.service.ts
@@ -32,7 +32,12 @@ export class AuthService {
 
         return chtApi.v1.hasPermissions(permissions, userCtx);
       })
-      .catch(() => false);
+      .catch((err) => {
+        if (err.status === 503) {
+          throw err;
+        }
+        return false;
+      });
   }
 
   /**

--- a/webapp/src/ts/services/session.service.ts
+++ b/webapp/src/ts/services/session.service.ts
@@ -2,7 +2,7 @@ const COOKIE_NAME = 'userCtx';
 const ONLINE_ROLE = 'mm-online';
 import * as _ from 'lodash-es';
 import { Injectable, Inject } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { CookieService } from 'ngx-cookie-service';
 import { DOCUMENT } from '@angular/common';
 
@@ -13,6 +13,7 @@ import { LocationService } from '@mm-services/location.service';
 })
 export class SessionService {
   userCtxCookieValue = null
+  httpOptions = { headers: new HttpHeaders({ Accept:  'application/json' }) };
 
   constructor(
     private cookieService: CookieService,
@@ -38,7 +39,7 @@ export class SessionService {
 
   logout() {
     return this.http
-      .delete('/_session')
+      .delete('/_session', this.httpOptions)
       .toPromise()
       .catch(() => {
         // Set cookie to force login before using app
@@ -86,7 +87,7 @@ export class SessionService {
     }
 
     return this.http
-      .get<{ userCtx: { name:string; roles:string[] } }>('/_session', { responseType: 'json' })
+      .get<{ userCtx: { name:string; roles:string[] } }>('/_session', { responseType: 'json', ...this.httpOptions })
       .toPromise()
       .then(value => {
         const name = value && value.userCtx && value.userCtx.name;

--- a/webapp/tests/karma/ts/services/auth.service.spec.ts
+++ b/webapp/tests/karma/ts/services/auth.service.spec.ts
@@ -116,6 +116,17 @@ describe('Auth Service', () => {
       expect(result).to.be.false;
     });
 
+    it('should throw error when server is offline', async () => {
+      settingsService.get.rejects({ status: 503 });
+      chtScriptApiService.init();
+      try {
+        await service.has(['']);
+        expect.fail();
+      } catch (err) {
+        expect(err).to.deep.equal({ status: 503 });
+      }
+    });
+
     describe('unconfigured permissions', () => {
 
       // Unconfigured permissions should behave the same as having the permission

--- a/webapp/tests/karma/ts/services/session.service.spec.ts
+++ b/webapp/tests/karma/ts/services/session.service.spec.ts
@@ -96,6 +96,8 @@ describe('Session service', () => {
     $httpBackend.get.withArgs('/_session').returns(throwError({ status: 0 }));
     await service.init();
     expect(cookieDelete.callCount).to.equal(0);
+    const headers = $httpBackend.get.args[0][1].headers;
+    expect(headers.get('Accept')).to.equal('application/json');
   });
 
   it('logs out if remote userCtx inconsistent', async () => {


### PR DESCRIPTION
# Description

- Adds explicit header to webapp session request
- don't default to permission denied when api is offline

medic/cht-core#2967

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
