### PR TITLE
Fix unit tests so they also run in TZs that are < UTC

### DIFF
--- a/api/tests/mocha/services/report/smsparser-compact-textform.spec.js
+++ b/api/tests/mocha/services/report/smsparser-compact-textform.spec.js
@@ -1,5 +1,6 @@
 const smsparser = require('../../../../src/services/report/smsparser');
 const chai = require('chai');
+const moment = require('moment');
 
 const def = {
   meta: {
@@ -42,7 +43,7 @@ describe('sms parser compact', () => {
     const expectedObj = {
       name: 'sarah',
       lmp: 24,
-      somedate: 1331510400000
+      somedate: moment('2012-03-12').valueOf()
     };
 
     const obj = smsparser.parse(def, doc);
@@ -104,7 +105,7 @@ describe('sms parser compact', () => {
     const expectedObj = {
       name: 'Sarah Connor',
       lmp: 24,
-      somedate: 1331510400000
+      somedate: moment('2012-03-12').valueOf()
     };
 
     const obj = smsparser.parse(def, doc);
@@ -120,7 +121,7 @@ describe('sms parser compact', () => {
     const expectedObj = {
       name: 'Sarah "killer bee" Connor',
       lmp: 24,
-      somedate: 1331510400000
+      somedate: moment('2012-03-12').valueOf()
     };
     const obj = smsparser.parse(def, doc);
     chai.expect(obj).to.deep.equal(expectedObj);
@@ -153,7 +154,7 @@ describe('sms parser compact', () => {
     const expectedObj = {
       name: 'Sarah Connor',
       lmp: 24,
-      somedate: 1331510400000
+      somedate: moment('2012-03-12').valueOf()
     };
 
     const obj = smsparser.parse(def, doc);
@@ -207,7 +208,7 @@ describe('sms parser compact', () => {
     const expectedObj = {
       name: 'sarah',
       lmp: null,
-      somedate: 1331510400000
+      somedate: moment('2012-03-12').valueOf()
     };
 
     const obj = smsparser.parse(def, doc);

--- a/shared-libs/message-utils/test/index.js
+++ b/shared-libs/message-utils/test/index.js
@@ -1094,30 +1094,30 @@ describe('messageUtils', () => {
     describe('bikram sambat', () => {
 
       it('integer', () => {
-        const date = 1457235941000;
+        const date = new Date(2016, 2, 6);
         const expected = '२३ फाल्गुन २०७२';
         const input = '{{#bikram_sambat_date}}{{reported_date}}{{/bikram_sambat_date}}';
-        const doc = { reported_date: date };
+        const doc = { reported_date: date.getTime() };
         const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(expected);
       });
 
       it('Date object', () => {
-        const date = 1457235941000;
+        const date = new Date(2016, 2, 6);
         const expected = '२३ फाल्गुन २०७२';
         const input = '{{#bikram_sambat_date}}Date({{reported_date}}){{/bikram_sambat_date}}';
-        const doc = { reported_date: date };
+        const doc = { reported_date: date.getTime() };
         const config = { reported_date_format: 'DD-MMMM-YYYY HH:mm:ss' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(expected);
       });
 
       it('i18n has no influence', () => {
-        const date = 1457235941000;
+        const date = new Date(2016, 2, 6);
         const expected = '२३ फाल्गुन २०७२';
         const input = '{{#bikram_sambat_date}}Date({{reported_date}}){{/bikram_sambat_date}}';
-        const doc = { reported_date: date, locale: 'sw' };
+        const doc = { reported_date: date.getTime(), locale: 'sw' };
         const config = { reported_date_format: 'ddd, MMM Do, YYYY' };
         const actual = utils.template(config, null, doc, { message: input });
         expect(actual).to.equal(expected);

--- a/shared-libs/rules-engine/package.json
+++ b/shared-libs/rules-engine/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "test": "mocha test/*.spec.js test/**/*.spec.js",
+    "test": "TZ=UTC mocha test/*.spec.js test/**/*.spec.js",
     "tz": "TZ=Canada/Pacific npm test && TZ=Africa/Monrovia npm test && TZ=Pacific/Auckland npm test"
   },
   "repository": {

--- a/shared-libs/rules-engine/package.json
+++ b/shared-libs/rules-engine/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "test": "TZ=UTC mocha test/*.spec.js test/**/*.spec.js",
+    "test": "mocha test/*.spec.js test/**/*.spec.js",
     "tz": "TZ=Canada/Pacific npm test && TZ=Africa/Monrovia npm test && TZ=Pacific/Auckland npm test"
   },
   "repository": {

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -22,7 +22,7 @@ const { assert, expect } = chai;
 chai.use(chaiExclude);
 
 const rulesStateStore = RestorableRulesStateStore();
-const NOW = 50000;
+const NOW = moment([1970, 0, 1, 0, 0, 50]).valueOf();
 const DEFAULT_EXPIRE = 7 * 24 * 60 * 60 * 1000;
 
 const reportConnectedByPlace = {
@@ -267,7 +267,7 @@ describe('provider-wireup integration tests', () => {
           emission: {},
           stateHistory: [{
             state: 'Cancelled',
-            timestamp: 50000,
+            timestamp: NOW,
           }]
         }],
         userSettingsId: 'org.couchdb.user:username',


### PR DESCRIPTION
# Description

Some of the unit test fail for me when I run them locally due to timezone issues. (The TZ of my local system is CST (UTC-6)).  It appears that all the unit test (`grunt unit`) run fine in UTC or in TZs that are > UTC (such as EAT), but they fail in TZ that are < UTC.  

The goal of this PR is to correct those issues so that the unit tests work regardless of the system TZ.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
