### PR TITLE
Configurable Healthcheck service address

### DIFF
--- a/haproxy/entrypoint.sh
+++ b/haproxy/entrypoint.sh
@@ -11,7 +11,7 @@ BACKEND="/usr/local/etc/haproxy/backend.cfg"
 cp /usr/local/etc/haproxy/backend.cfg.template $BACKEND
 for COUCHDB_SERVER in ${COUCHDB_SERVERS//,/ }
 do
-  printf "  server $COUCHDB_SERVER $COUCHDB_SERVER:5984 check agent-check agent-inter 5s agent-addr healthcheck agent-port 5555\n" >> $BACKEND
+  printf "  server $COUCHDB_SERVER $COUCHDB_SERVER:5984 check agent-check agent-inter 5s agent-addr $HEALTHCHECK_ADDR agent-port 5555\n" >> $BACKEND
 done
 
 # Place environment variables into config

--- a/scripts/build/cht-core.yml.template
+++ b/scripts/build/cht-core.yml.template
@@ -11,6 +11,7 @@ services:
       - "COUCHDB_PASSWORD=${COUCHDB_PASSWORD}"
       - "COUCHDB_SERVERS=${COUCHDB_SERVERS:-{{ couchdb_servers }}}"
       - "HAPROXY_PORT=${HAPROXY_PORT:-5984}"
+      - "HEALTHCHECK_ADDR=${HEALTHCHECK_ADDR:-healthcheck}"
     logging:
       driver: "local"
       options:


### PR DESCRIPTION
Necessary for k8s hosted deploys. We need our healthcheck service address to be found on localhost and not docker service names.

# Description

[description]

medic/cht-core#[number]

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
