### PR TITLE
Change default SSL_MOUNT_PATH to match the default CERTIFICATE_MODE

### DIFF
--- a/scripts/build/cht-core.yml.template
+++ b/scripts/build/cht-core.yml.template
@@ -77,7 +77,7 @@ services:
       - "${NGINX_HTTP_PORT:-80}:80"
       - "${NGINX_HTTPS_PORT:-443}:443"
     volumes:
-      - cht-ssl:${SSL_VOLUME_MOUNT_PATH:-/root/.acme.sh/}
+      - cht-ssl:${SSL_VOLUME_MOUNT_PATH:-/etc/nginx/private/}
     environment:
       - API_HOST=api
       - API_PORT=${API_PORT:-5988}


### PR DESCRIPTION
# Description

Since default `CERTIFICATE_MODE` is `OWN_CERT`, updates default `SSL_MOUNT_PATH` to match the folder where the self signed certificates are stored, and avoid generating them every time nginx container is recreated. 
When using other values for `CERTIFICATE_MODE`, this value must be changed to reflect the cert path in the container, if persistence is desired. 

medic/cht-core#7855

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
