### PR TITLE
Update template so PR submitters add compose URLs manually 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,16 @@ medic/cht-core#[number]
 - [ ] Internationalised: All user facing text
 - [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
 
+# Compose URLs:
+<!-- After CI passes, PR submitter should manually replace these placeholders with deep links to staging. Makes for easier testing! -->
+<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-core.yml  -->
+<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb.yml   -->
+<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb-clustered.yml  -->
+
+* CHT Core: CHT_CORE_COMPOSE_URL
+* CouchDB Single: COUCH_SINGLE_COMPOSE_URL
+* CouchDB Cluster: COUCH_CLUSTER_COMPOSE_URL
+ 
 # License
 
 The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.


### PR DESCRIPTION
# Description

While we want to automate having the compose URLs added, we can manually add them until automation is put in place.  Further, automation will need the exact same change made before it will work, so this is a good first step to take regardless. 

medic/cht-core#7848

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
