### PR TITLE
Log error when no compose files were overwritten on upgrade complete

### DIFF
--- a/api/src/services/setup/upgrade-steps.js
+++ b/api/src/services/setup/upgrade-steps.js
@@ -116,12 +116,9 @@ const complete = async (buildInfo) => {
   const stagingDoc = await upgradeUtils.getStagingDoc(buildInfo);
   const payload = upgradeUtils.getUpgradeServicePayload(stagingDoc);
 
+  // The upgrade request will initiate container upgrades. If successful, the API container will stop and the execution
+  // of this code will be interrupted. 
   const response = await upgradeUtils.makeUpgradeRequest(payload);
-
-  if (!upgradeUtils.upgradeResponseSuccess(payload, response)) {
-    logger.error('No compose files were updated: %o', response);
-    throw new Error('No compose files were updated');
-  }
 
   logger.warn(
     'upgrade-service upgrade request succeeded, without CHT-API restarting. ' +

--- a/api/src/services/setup/upgrade-steps.js
+++ b/api/src/services/setup/upgrade-steps.js
@@ -116,7 +116,20 @@ const complete = async (buildInfo) => {
   const stagingDoc = await upgradeUtils.getStagingDoc(buildInfo);
   const payload = upgradeUtils.getUpgradeServicePayload(stagingDoc);
 
-  return await upgradeUtils.makeUpgradeRequest(payload);
+  const response = await upgradeUtils.makeUpgradeRequest(payload);
+
+  if (!upgradeUtils.upgradeResponseSuccess(payload, response)) {
+    logger.error('No compose files were updated: %o', response);
+    throw new Error('No compose files were updated');
+  }
+
+  logger.warn(
+    'upgrade-service upgrade request succeeded, without CHT-API restarting. ' +
+    'This can potentially indicate that the upgrade was not successful. ' +
+    'Please inspect the upgrade response to determine whether all expected compose files were upgraded: %o',
+    response
+  );
+  return response;
 };
 
 module.exports = {

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -336,7 +336,7 @@ const upgradeResponseSuccess = (payload, response) => {
   }
 
   const sucessfullyUpdatedFiles = Object.keys(payload).filter(file => response[file] && response[file].ok);
-  return sucessfullyUpdatedFiles.length;
+  return !!sucessfullyUpdatedFiles.length;
 };
 
 module.exports = {

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -330,6 +330,15 @@ const makeUpgradeRequest = (payload) => {
   return rpn.post({ url: url.toString(), json: true, body: payload });
 };
 
+const upgradeResponseSuccess = (payload, response) => {
+  if (!response) {
+    return false;
+  }
+
+  const sucessfullyUpdatedFiles = Object.keys(payload).filter(file => response[file] && response[file].ok);
+  return sucessfullyUpdatedFiles.length;
+};
+
 module.exports = {
   cleanup,
 
@@ -346,4 +355,5 @@ module.exports = {
   getStagingDoc,
   getUpgradeServicePayload,
   makeUpgradeRequest,
+  upgradeResponseSuccess,
 };

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -318,7 +318,7 @@ const getUpgradeServicePayload = (stagingDoc) => {
   };
 };
 
-const makeUpgradeRequest = (payload) => {
+const makeUpgradeRequest = async (payload) => {
   let url;
   try {
     url = new URL(UPGRADE_SERVICE_URL);
@@ -327,7 +327,14 @@ const makeUpgradeRequest = (payload) => {
     throw new Error(`Invalid UPGRADE_SERVICE_URL: ${UPGRADE_SERVICE_URL}`);
   }
 
-  return rpn.post({ url: url.toString(), json: true, body: payload });
+  const response = await rpn.post({ url: url.toString(), json: true, body: payload });
+  const success = upgradeResponseSuccess(payload, response);
+  if (!success) {
+    logger.error('No compose files were updated: %o', response);
+    throw new Error('No compose files were updated');
+  }
+
+  return response;
 };
 
 const upgradeResponseSuccess = (payload, response) => {

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -335,7 +335,9 @@ const upgradeResponseSuccess = (payload, response) => {
     return false;
   }
 
-  const sucessfullyUpdatedFiles = Object.keys(payload).filter(file => response[file] && response[file].ok);
+  const sucessfullyUpdatedFiles = Object
+    .keys(payload.docker_compose)
+    .filter(file => response[file] && response[file].ok);
   return !!sucessfullyUpdatedFiles.length;
 };
 

--- a/api/tests/mocha/services/setup/upgrade-steps.spec.js
+++ b/api/tests/mocha/services/setup/upgrade-steps.spec.js
@@ -412,33 +412,6 @@ describe('Upgrade steps', () => {
       expect(upgradeUtils.makeUpgradeRequest.args[0]).to.deep.equal([{ docker_compose: { 'doc.yml': 'payload' } }]);
     });
 
-    it('should throw error when response is invalid', async () => {
-      sinon.stub(upgradeLogService, 'setCompleting');
-      sinon.stub(upgradeUtils, 'getStagingDoc').resolves({ the: 'staging_doc' });
-      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ docker_compose: { 'doc.yml': 'payload' } });
-      sinon.stub(upgradeUtils, 'makeUpgradeRequest').resolves('this is not an object');
-
-      const buildInfo = { version: '4.0.0' };
-
-      await expect(upgradeSteps.complete({ ...buildInfo })).to.be.rejectedWith('No compose files were updated');
-    });
-
-    it('should throw error when no files were updated', async () => {
-      sinon.stub(upgradeLogService, 'setCompleting');
-      sinon.stub(upgradeUtils, 'getStagingDoc').resolves({ the: 'staging_doc' });
-      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({
-        docker_compose: { 'doc1.yml': 'payload', 'doc2.yml': 'payload' },
-      });
-      sinon.stub(upgradeUtils, 'makeUpgradeRequest').resolves({
-        'doc1.yml': { ok: false },
-        'doc2.yml': { ok: false },
-      });
-
-      const buildInfo = { version: '4.0.0' };
-
-      await expect(upgradeSteps.complete({ ...buildInfo })).to.be.rejectedWith('No compose files were updated');
-    });
-
     it('should throw missing staging doc errors', async () => {
       sinon.stub(upgradeLogService, 'setCompleting');
       sinon.stub(upgradeUtils, 'getStagingDoc').rejects({ status: 404 });

--- a/api/tests/mocha/services/setup/upgrade-steps.spec.js
+++ b/api/tests/mocha/services/setup/upgrade-steps.spec.js
@@ -396,7 +396,7 @@ describe('Upgrade steps', () => {
     it('should get staging doc, prep payload and make upgrade request', async () => {
       sinon.stub(upgradeLogService, 'setCompleting');
       sinon.stub(upgradeUtils, 'getStagingDoc').resolves({ the: 'staging_doc' });
-      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ 'doc.yml': 'payload' });
+      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ docker_compose: { 'doc.yml': 'payload' } });
       sinon.stub(upgradeUtils, 'makeUpgradeRequest').resolves({ 'doc.yml': { ok: true } });
 
       const buildInfo = { version: '4.0.0' };
@@ -409,13 +409,13 @@ describe('Upgrade steps', () => {
       expect(upgradeUtils.getUpgradeServicePayload.callCount).to.equal(1);
       expect(upgradeUtils.getUpgradeServicePayload.args[0]).to.deep.equal([{ the: 'staging_doc' }]);
       expect(upgradeUtils.makeUpgradeRequest.callCount).to.equal(1);
-      expect(upgradeUtils.makeUpgradeRequest.args[0]).to.deep.equal([{ 'doc.yml': 'payload' }]);
+      expect(upgradeUtils.makeUpgradeRequest.args[0]).to.deep.equal([{ docker_compose: { 'doc.yml': 'payload' } }]);
     });
 
     it('should throw error when response is invalid', async () => {
       sinon.stub(upgradeLogService, 'setCompleting');
       sinon.stub(upgradeUtils, 'getStagingDoc').resolves({ the: 'staging_doc' });
-      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ 'doc.yml': 'payload' });
+      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ docker_compose: { 'doc.yml': 'payload' } });
       sinon.stub(upgradeUtils, 'makeUpgradeRequest').resolves('this is not an object');
 
       const buildInfo = { version: '4.0.0' };
@@ -426,7 +426,9 @@ describe('Upgrade steps', () => {
     it('should throw error when no files were updated', async () => {
       sinon.stub(upgradeLogService, 'setCompleting');
       sinon.stub(upgradeUtils, 'getStagingDoc').resolves({ the: 'staging_doc' });
-      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({ 'doc1.yml': 'payload', 'doc2.yml': 'payload' });
+      sinon.stub(upgradeUtils, 'getUpgradeServicePayload').returns({
+        docker_compose: { 'doc1.yml': 'payload', 'doc2.yml': 'payload' },
+      });
       sinon.stub(upgradeUtils, 'makeUpgradeRequest').resolves({
         'doc1.yml': { ok: false },
         'doc2.yml': { ok: false },

--- a/api/tests/mocha/services/setup/utils.spec.js
+++ b/api/tests/mocha/services/setup/utils.spec.js
@@ -929,4 +929,22 @@ describe('Setup utils', () => {
       await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('boom');
     });
   });
+
+  describe('upgradeResponseSuccess', () => {
+    it('should return false when response is falsy', () => {
+      expect(utils.upgradeResponseSuccess({}, false)).to.equal(false);
+    });
+
+    it('should return false when there are no successful upgrades', () => {
+      const payload = { a: 'a', b: 'b', c: 'c' };
+      const response = { a: { ok: false }, b: { ok: false }, c: { ok: false } };
+      expect(utils.upgradeResponseSuccess(payload, response)).to.equal(false);
+    });
+
+    it('should return true when there is at lease one successful upgrade', () => {
+      const payload = { a: 'a', b: 'b', c: 'c' };
+      const response = { a: { ok: true }, b: { ok: false }, c: { ok: false } };
+      expect(utils.upgradeResponseSuccess(payload, response)).to.equal(true);
+    });
+  });
 });

--- a/api/tests/mocha/services/setup/utils.spec.js
+++ b/api/tests/mocha/services/setup/utils.spec.js
@@ -886,7 +886,7 @@ describe('Setup utils', () => {
 
   describe('makeUpgradeRequest', () => {
     it('should call default upgrade service url', async () => {
-      const payload = { docker_compose: { 'doc.yml': 'payload' } };
+      const payload = { docker_compose: { 'doc.yml': 'payload' }, containers: [] };
       const response = { 'doc.yml': { ok: true } };
       sinon.stub(rpn, 'post').resolves({ 'doc.yml': { ok: true } });
 
@@ -900,7 +900,7 @@ describe('Setup utils', () => {
     });
 
     it('should call env upgrade service url', async () => {
-      const payload = { tags: {}, docker_compose: { 'doc.yml': 'payload' } };
+      const payload = { containers: [], docker_compose: { 'doc.yml': 'payload' } };
       const response = { 'doc.yml': { ok: true } };
       sinon.stub(rpn, 'post').resolves(response);
       process.env.UPGRADE_SERVICE_URL = 'http://someurl';
@@ -916,7 +916,7 @@ describe('Setup utils', () => {
     });
 
     it('should throw invalid url error', async () => {
-      const payload = { tags: {}, docker_compose: {} };
+      const payload = { containers: [], docker_compose: {} };
       sinon.stub(rpn, 'post').resolves({});
       process.env.UPGRADE_SERVICE_URL = 'whatever';
       utils = rewire('../../../../src/services/setup/utils');
@@ -925,45 +925,73 @@ describe('Setup utils', () => {
     });
 
     it('should throw request errors', async () => {
-      const payload = { tags: {}, 'docker-compose': {} };
+      const payload = { containers: [], 'docker-compose': {} };
       sinon.stub(rpn, 'post').rejects(new Error('boom'));
 
       await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('boom');
     });
 
     it('should throw error when response is invalid', async () => {
-      const payload = { docker_compose: { 'doc.yml': 'payload' } };
-      sinon.stub(rpn, 'post').resolves('this is not an object');
+      const payload = { docker_compose: { 'doc.yml': 'payload' }, containers: {} };
+      sinon.stub(rpn, 'post').resolves();
 
-      await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('No compose files were updated');
+      await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('No containers were updated');
     });
 
-    it('should throw error when no files were updated', async () => {
-      const payload = { docker_compose: { 'doc1.yml': 'payload', 'doc2.yml': 'payload' } };
+    it('should throw error when no docker-compose files were updated', async () => {
+      const payload = { docker_compose: { 'doc1.yml': 'payload', 'doc2.yml': 'payload' }, containers: [] };
       sinon.stub(rpn, 'post').resolves({
         'doc1.yml': { ok: false },
         'doc2.yml': { ok: false },
       });
 
-      await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('No compose files were updated');
+      await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('No containers were updated');
+    });
+
+    it('should throw error when no containers were upgraded', async () => {
+      const payload = {
+        docker_compose: { 'd1.yml': 'p', 'd2.yml': 'p' },
+        containers: [{ container_name: 'a' }, { container_name: 'b' }]
+      };
+      sinon.stub(rpn, 'post').resolves({
+        'a': { ok: false },
+        'b': { ok: false },
+      });
+
+      await expect(utils.makeUpgradeRequest(payload)).to.be.rejectedWith('No containers were updated');
     });
   });
 
   describe('upgradeResponseSuccess', () => {
     it('should return false when response is falsy', () => {
-      expect(utils.upgradeResponseSuccess({}, false)).to.equal(false);
+      expect(utils.__get__('upgradeResponseSuccess')({}, false)).to.equal(false);
     });
 
-    it('should return false when there are no successful upgrades', () => {
-      const payload = { docker_compose: { a: 'a', b: 'b', c: 'c' } };
+    it('should return false when there are no successful docker-compose file upgrades', () => {
+      const payload = { docker_compose: { a: 'a', b: 'b', c: 'c' }, containers: [] };
       const response = { a: { ok: false }, b: { ok: false }, c: { ok: false } };
-      expect(utils.upgradeResponseSuccess(payload, response)).to.equal(false);
+      expect(utils.__get__('upgradeResponseSuccess')(payload, response)).to.equal(false);
     });
 
-    it('should return true when there is at lease one successful upgrade', () => {
-      const payload = { docker_compose: { a: 'a', b: 'b', c: 'c' } };
+    it('should return false when there are no successful k8s container upgrades', () => {
+      const payload = {
+        docker_compose: { a: 'a', b: 'b', c: 'c' },
+        containers: [{ container_name: 'c1', image: 'a' }, { container_name: 'c2', image: 'b' }]
+      };
+      const response = { c1: { ok: false }, c2: { ok: false } };
+      expect(utils.__get__('upgradeResponseSuccess')(payload, response)).to.equal(false);
+    });
+
+    it('should return true when there is at least one successful docker-compose file upgrade', () => {
+      const payload = { docker_compose: { a: 'a', b: 'b', c: 'c' }, containers: [] };
       const response = { a: { ok: true }, b: { ok: false }, c: { ok: false } };
-      expect(utils.upgradeResponseSuccess(payload, response)).to.equal(true);
+      expect(utils.__get__('upgradeResponseSuccess')(payload, response)).to.equal(true);
+    });
+
+    it('should return true when there is at least one successful container upgrade', () => {
+      const payload = { docker_compose: { a: 'a' }, containers: [{ container_name: 'aa' }, { container_name: 'bb' }] };
+      const response = { aa: { ok: true }, bb: { ok: false } };
+      expect(utils.__get__('upgradeResponseSuccess')(payload, response)).to.equal(true);
     });
   });
 });

--- a/api/tests/mocha/services/setup/utils.spec.js
+++ b/api/tests/mocha/services/setup/utils.spec.js
@@ -936,13 +936,13 @@ describe('Setup utils', () => {
     });
 
     it('should return false when there are no successful upgrades', () => {
-      const payload = { a: 'a', b: 'b', c: 'c' };
+      const payload = { docker_compose: { a: 'a', b: 'b', c: 'c' } };
       const response = { a: { ok: false }, b: { ok: false }, c: { ok: false } };
       expect(utils.upgradeResponseSuccess(payload, response)).to.equal(false);
     });
 
     it('should return true when there is at lease one successful upgrade', () => {
-      const payload = { a: 'a', b: 'b', c: 'c' };
+      const payload = { docker_compose: { a: 'a', b: 'b', c: 'c' } };
       const response = { a: { ok: true }, b: { ok: false }, c: { ok: false } };
       expect(utils.upgradeResponseSuccess(payload, response)).to.equal(true);
     });

--- a/api/tests/mocha/services/setup/utils.spec.js
+++ b/api/tests/mocha/services/setup/utils.spec.js
@@ -9,7 +9,6 @@ const upgradeLogService = require('../../../../src/services/setup/upgrade-log');
 const env = require('../../../../src/environment');
 const { DATABASES } = require('../../../../src/services/setup/databases');
 const ddocsService = require('../../../../src/services/setup/ddocs');
-const upgradeUtils = require('../../../../src/services/setup/utils');
 
 let utils;
 let clock;


### PR DESCRIPTION
# Description

medic/cht-core#7859

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs:
<!-- After CI passes, PR submitter should manually replace these placeholders with deep links to staging. Makes for easier testing! -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-core.yml  -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb.yml   -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb-clustered.yml  -->

* CHT Core: https://staging.dev.medicmobile.org/_couch/builds/medic%3Amedic%3A7859-no-doc-error/docker-compose%2Fcht-core.yml
* CouchDB Single: https://staging.dev.medicmobile.org/_couch/builds/medic%3Amedic%3A7859-no-doc-error/docker-compose%2Fcht-couchdb.yml
* CouchDB Cluster: https://staging.dev.medicmobile.org/_couch/builds/medic%3Amedic%3A7859-no-doc-error/docker-compose%2Fcht-couchdb-clustered.yml
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
