### PR TITLE
Expose couch-httpd port 5986 over docker network

### DIFF
--- a/couchdb/10-docker-default.ini
+++ b/couchdb/10-docker-default.ini
@@ -16,10 +16,11 @@ port = 5984
 bind_address = 0.0.0.0
 server_options = [{recbuf, 262144}]
 socket_options = [{sndbuf, 262144}, {nodelay, true}]
+require_valid_user = true
 
 [httpd]
 port = 5986
-bind_address = 127.0.0.1
+bind_address = 0.0.0.0
 secure_rewrites = false
 max_http_request_size = 134217728 ; 128 MiB
 WWW-Authenticate = Basic realm="Medic Mobile Web Services"
@@ -28,6 +29,7 @@ WWW-Authenticate = Basic realm="Medic Mobile Web Services"
 # timeout is set to 1 year in seconds, 31536000
 timeout = 31536000
 allow_persistent_cookies = true
+require_valid_user = true
 
 [ssl]
 verify_ssl_certificates = false
@@ -36,9 +38,3 @@ ssl_certificate_max_depth = 4
 [cluster]
 q=12
 n=1
-
-[chttpd]
-require_valid_user = true
-
-[couch_httpd_auth]
-require_valid_user = true

--- a/tests/integration/.mocharc.js
+++ b/tests/integration/.mocharc.js
@@ -1,6 +1,8 @@
 const chaiExclude = require('chai-exclude');
+const chaiAsPromised = require('chai-as-promised');
 const chai = require('chai');
 chai.use(chaiExclude);
+chai.use(chaiAsPromised);
 
 module.exports = {
   allowUncaught: false,

--- a/tests/integration/contacts/contact-edit.spec.js
+++ b/tests/integration/contacts/contact-edit.spec.js
@@ -1,3 +1,4 @@
+const { expect } = require('chai');
 const utils = require('../../utils');
 const personFactory = require('../../factories/cht/contacts/person');
 const placeFactory = require('../../factories/cht/contacts/place');

--- a/tests/integration/contacts/contact-edit.spec.js
+++ b/tests/integration/contacts/contact-edit.spec.js
@@ -1,7 +1,6 @@
 const utils = require('../../utils');
 const personFactory = require('../../factories/cht/contacts/person');
 const placeFactory = require('../../factories/cht/contacts/place');
-const {expect} = require('chai');
 
 describe('Editing contacts ', () => {
   const district = placeFactory.place().build({type:'district_hospital'});

--- a/tests/integration/couchdb/couch_chttpd.spec.js
+++ b/tests/integration/couchdb/couch_chttpd.spec.js
@@ -1,6 +1,64 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const constants = require('../../constants');
 const utils = require('../../utils');
+const { expect } = require('chai');
 
+const runDockerCommand = (command, params, env=process.env) => {
+  return new Promise((resolve, reject) => {
+    const cmd = spawn(command, params, { cwd: path.join(__dirname, 'couch_httpd_script'), env });
+    const output = [];
+    const log = (data) => output.push(data.toString().replace(/\n/g, ''));
+    cmd.on('error', reject);
+    cmd.stdout.on('data', log);
+    cmd.stderr.on('data', log);
+    cmd.on('close', () => resolve(output));
+  });
+};
 
-describe('acessing couch_httpd', () => {
+const startContainer = async (useAuthentication) => {
+  const env = { ...process.env };
+  if (useAuthentication) {
+    env.COUCH_AUTH = `${constants.USERNAME}:${constants.PASSWORD}`;
+  }
+  return await runDockerCommand('docker-compose', ['up', '--build', '--force-recreate'], env);
+};
+const getLogs = async () => {
+  const containerName = (await runDockerCommand('docker-compose', ['ps', '-q', '-a']))[0];
+  const logs = await runDockerCommand('docker', ['logs', containerName]);
+  try {
+    return logs && logs.map(log => JSON.parse(log));
+  } catch (err) {
+    console.log(logs);
+    throw err;
+  }
+};
 
+describe('accessing couch_httpd', () => {
+  it('should not be available to the host', async () => {
+    await expect(
+      utils.request({ uri: `https://localhost:5986/_dbs/${constants.DB_NAME}` })
+    ).to.be.rejectedWith('Error: connect ECONNREFUSED 127.0.0.1:5986');
+  });
+
+  it('should block unauthenticated access through docker network', async () => {
+    await startContainer();
+    const logs = await getLogs();
+    expect(logs.length).to.equal(1);
+    expect(logs[0]).to.deep.equal({ error: 'unauthorized', reason: 'Authentication required.' });
+  });
+
+  it('should allow authenticated access through docker network', async () => {
+    await startContainer(true);
+    const logs = await getLogs();
+    expect(logs.length).to.equal(1);
+    const metadata = logs[0];
+    expect(metadata._id).to.equal(constants.DB_NAME);
+    // 12 shards, evenly distributed across 3 nodes
+    expect(Object.keys(metadata.by_range).length).to.equal(12);
+    expect(metadata.by_node).to.have.keys(['couchdb@couchdb.1', 'couchdb@couchdb.2', 'couchdb@couchdb.3']);
+    expect(metadata.by_node['couchdb@couchdb.1'].length).to.equal(4);
+    expect(metadata.by_node['couchdb@couchdb.2'].length).to.equal(4);
+    expect(metadata.by_node['couchdb@couchdb.3'].length).to.equal(4);
+  });
 });

--- a/tests/integration/couchdb/couch_chttpd.spec.js
+++ b/tests/integration/couchdb/couch_chttpd.spec.js
@@ -27,7 +27,7 @@ const getLogs = async () => {
   const containerName = (await runDockerCommand('docker-compose', ['ps', '-q', '-a']))[0];
   const logs = await runDockerCommand('docker', ['logs', containerName]);
   try {
-    return logs && logs.map(log => JSON.parse(log));
+    return logs && logs.filter(log => log).map(log => JSON.parse(log));
   } catch (err) {
     console.log(logs);
     throw err;

--- a/tests/integration/couchdb/couch_chttpd.spec.js
+++ b/tests/integration/couchdb/couch_chttpd.spec.js
@@ -1,0 +1,6 @@
+const utils = require('../../utils');
+
+
+describe('acessing couch_httpd', () => {
+
+});

--- a/tests/integration/couchdb/couch_httpd_script/Dockerfile
+++ b/tests/integration/couchdb/couch_httpd_script/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:alpine
+WORKDIR /app
+COPY . .
+CMD ["node", "/app/index.js"]

--- a/tests/integration/couchdb/couch_httpd_script/docker-compose.yml
+++ b/tests/integration/couchdb/couch_httpd_script/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  chttpd_call:
+    build: .
+    networks:
+      net:
+    environment:
+      - COUCH_AUTH
+
+networks:
+  net:
+    name: cht-net-e2e

--- a/tests/integration/couchdb/couch_httpd_script/index.js
+++ b/tests/integration/couchdb/couch_httpd_script/index.js
@@ -1,2 +1,23 @@
 const http = require('node:http');
+const { COUCH_AUTH } = process.env;
 
+(() => {
+  const options = {
+    hostname: 'couchdb.1',
+    port: 5986,
+    path: '/_dbs/medic-test',
+    method: 'GET',
+    auth: COUCH_AUTH,
+    headers: {
+      'Content-Type': 'application/json',
+    }
+  };
+
+  const req = http.request(options, (res) => {
+    res.setEncoding('utf8');
+    res.on('data', console.log);
+    res.on('error', console.error);
+  });
+
+  req.end();
+})();

--- a/tests/integration/couchdb/couch_httpd_script/index.js
+++ b/tests/integration/couchdb/couch_httpd_script/index.js
@@ -1,0 +1,2 @@
+const http = require('node:http');
+

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -518,7 +518,6 @@ const waitForDockerLogs = (container, ...regex) => {
   // As a fix, watch the logs with tail=1, so we always receive one log line immediately, then proceed with next
   // steps of testing afterwards.
   const params = `logs ${container} -f --tail=1`;
-  console.log('docker', params);
   const proc = spawn('docker', params.split(' '), { stdio: ['ignore', 'pipe', 'pipe'] });
   let receivedFirstLine;
   const firstLineReceivedPromise = new Promise(resolve => receivedFirstLine = resolve);


### PR DESCRIPTION
# Description

Also adds e2e test to check:
- that the endpoints are not available on the host network
- that the endpoints require authentication over docker network
- that the sharding is correct (2x win here). 

medic/cht-core#7864

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs:
<!-- After CI passes, PR submitter should manually replace these placeholders with deep links to staging. Makes for easier testing! -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-core.yml  -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb.yml   -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb-clustered.yml  -->

* CHT Core: CHT_CORE_COMPOSE_URL
* CouchDB Single: COUCH_SINGLE_COMPOSE_URL
* CouchDB Cluster: COUCH_CLUSTER_COMPOSE_URL
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
