### PR TITLE
Recording the time spent by a user in a form before quitting

### DIFF
--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -204,8 +204,10 @@ export class TrainingCardsComponent extends MmModalAbstract implements OnInit, O
   }
 
   private recordTelemetryQuitTraining() {
+    this.telemetryData.postQuit = Date.now();
     this.telemetryService.record(
-      `enketo:${this.telemetryData.form}:${this.telemetryData.action}:quit`
+      `enketo:${this.telemetryData.form}:${this.telemetryData.action}:quit`,
+      this.telemetryData.postQuit - this.telemetryData.postRender
     );
   }
 


### PR DESCRIPTION
**Note: we need to update training cards (3.15) to latest or backport from 3.17 a fix (ubuntu upgrade) in order to merge. Pausing while we decide what to do with training cards** 

# Description

Recording the time spent by a user in a form before quitting the training card. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs:
<!-- After CI passes, PR submitter should manually replace these placeholders with deep links to staging. Makes for easier testing! -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-core.yml  -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb.yml   -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb-clustered.yml  -->

* CHT Core: CHT_CORE_COMPOSE_URL
* CouchDB Single: COUCH_SINGLE_COMPOSE_URL
* CouchDB Cluster: COUCH_CLUSTER_COMPOSE_URL
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
