### PR TITLE
Extracting non-palette color vars to a new file

### DIFF
--- a/webapp/src/css/dropdown.less
+++ b/webapp/src/css/dropdown.less
@@ -195,7 +195,7 @@
       color: @label-color;
     }
     .actions a.btn-link {
-      color: @gray-medium;
+      color: @inactive-color;
     }
   }
 }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -426,7 +426,7 @@ body {
   .mobile-freetext-filter {
     &.disabled {
       input, .btn, .mm-button-icon {
-        color: @gray-dark;
+        color: @text-secondary-color;
       }
     }
   }
@@ -1309,7 +1309,7 @@ mm-search-bar {
         box-shadow: 0 6px 12px rgb(0 0 0 / 40%);
 
         .dropdown-header {
-          color: @gray-medium;
+          color: @filter-text-color;
         }
       }
     }
@@ -1348,9 +1348,9 @@ mm-search-bar {
       }
 
       .filter-counter {
-        color: @white;
+        color: @chip-text-color;
         font-size: @font-extra-extra-small;
-        background: @blue-dark;
+        background: @chip-background-color;
         border-radius: 50%;
         padding: 1px 5px;
         vertical-align: middle;
@@ -1359,11 +1359,11 @@ mm-search-bar {
 
     .fa {
       font-size: @font-extra-large;
-      color: @black;
+      color: @filter-icon-color;
     }
 
     &.disabled .search-bar-left-icon .fa {
-      color: @gray-medium;
+      color: @inactive-color;
     }
   }
 }
@@ -1674,7 +1674,7 @@ mm-search-bar {
           position: absolute;
           top: 3px;
           right: -2px;
-          border: 1px solid @white;
+          border: 1px solid @chip-border-color;
         }
       }
 

--- a/webapp/src/css/private-vars.less
+++ b/webapp/src/css/private-vars.less
@@ -1,0 +1,29 @@
+/**
+* WARNING:
+* Don't import this file. This is only for "variable.less" usage.
+* Don't use these variables. The variable names aren't descriptive enough.
+* Instead, use the variables from "variable.less".
+*/
+@white: #FFFFFF;
+@gray-ultra-light: #F2F2F2;
+@gray-light: #E0E0E0;
+@gray-medium: #A0A0A0;
+@gray-dark: #777777;
+@gray-ultra-dark: #333333;
+@black: #000000; ///aaaaaaa
+@blue: #63A2C6;
+@periwinkle: #7193EE;
+@yellow: #E9AA22;
+@pink: #F47B63;
+@teal: #76B0B0;
+@blue-highlight: #EFF5F9;
+@periwinkle-highlight: #F0F4FD;
+@yellow-highlight: #FCF6E7;
+@pink-highlight: #FDF1EF;
+@teal-highlight: #e4efef;
+@red: #E33030;
+@yellow-dark: #C78330;
+@teal-dark: #218E7F;
+@blue-dark: #007AC0;
+@blue-ultra-dark: #23527C;
+@green: #A0BA62;

--- a/webapp/src/css/private-vars.less
+++ b/webapp/src/css/private-vars.less
@@ -10,7 +10,7 @@
 @gray-medium: #A0A0A0;
 @gray-dark: #777777;
 @gray-ultra-dark: #333333;
-@black: #000000; ///aaaaaaa
+@black: #000000;
 @blue: #63A2C6;
 @periwinkle: #7193EE;
 @yellow: #E9AA22;

--- a/webapp/src/css/sidebar-filter.less
+++ b/webapp/src/css/sidebar-filter.less
@@ -47,11 +47,11 @@
     height: 100%;
     z-index: 1030;
     overflow: hidden;
-    background-color: @white;
+    background-color: @sidebar-background-color;
     background-clip: padding-box;
     display: flex;
     flex-direction: column;
-    color: @gray-ultra-dark;
+    color: @text-normal-color;
 
     .sidebar-header,
     .sidebar-footer,
@@ -67,7 +67,7 @@
 
     .sidebar-header {
       justify-content: flex-start;
-      border-bottom: 1px solid @gray-light;
+      border-bottom: 1px solid @separator-color;
 
       .sidebar-title {
         font-size: @font-extra-large;
@@ -81,7 +81,7 @@
         margin-right: 20px;
 
         &.disabled {
-          color: @gray-medium;
+          color: @inactive-color;
           cursor: not-allowed;
         }
       }
@@ -89,7 +89,7 @@
       .sidebar-close {
         font-size: @font-large;
         font-weight: lighter;
-        color: @gray-ultra-dark;
+        color: @text-normal-color;
       }
     }
 
@@ -105,7 +105,7 @@
 
         .panel-heading .accordion-toggle {
           .btn-link {
-            color: @gray-ultra-dark;
+            color: @text-normal-color;
             font-size: @font-medium;
             font-weight: bold;
             padding: 0;
@@ -135,15 +135,15 @@
           }
 
           .chip {
-            background: @blue-dark;
-            color: @white;
+            background: @chip-background-color;
+            color: @chip-text-color;
             border-radius: 100px;
             padding: 2px 15px;
             margin-left: 10px;
             display: inline-block;
 
             &.disabled {
-              background: @gray-medium !important;
+              background: @inactive-color !important;
             }
 
             .fa {
@@ -186,8 +186,8 @@
         .mm-button {
           display: block;
           box-shadow: none;
-          border: 1px solid @gray-light;
-          background: @white;
+          border: 1px solid @button-text-inverse-color;
+          background: @button-background-inverse-color;
           border-radius: 5px;
           margin-right: 8px;
 
@@ -205,7 +205,7 @@
 
           &.group-header {
             font-size: @font-medium;
-            color: @gray-medium;
+            color: @filter-text-color;
             padding: 3px 0px;
 
             &:not(:first-child) {
@@ -220,7 +220,7 @@
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             white-space: normal;
-            color: @gray-ultra-dark;
+            color: @text-normal-color;
             font-size: @font-medium;
             padding-left: 30px;
             margin-bottom: 5px;
@@ -229,7 +229,7 @@
               content: '\f096'; // http://fontawesome.io/icon/square-o/
               font-family: FontAwesome;
               font-size: @font-extra-extra-large;
-              color: @gray-medium;
+              color: @filter-text-color;
               vertical-align: middle;
               margin: 5px 7px 5px -30px;
             }
@@ -237,12 +237,12 @@
 
           &.selected a:before {
             content: '\f14a'; // https://fontawesome.com/v4/icon/check-square
-            color: @blue-dark;
+            color: @checkbox-selected-color;
           }
 
           &.disabled *,
           &.disabled a:before {
-            color: @gray-medium !important;
+            color: @inactive-color !important;
           }
         }
 
@@ -265,7 +265,7 @@
               cursor: pointer;
               width: @accordion-chevron-width;
               font-size: @font-extra-large;
-              color: @gray-medium;
+              color: @filter-text-color;
               display: block;
               position: absolute;
               top: 0;
@@ -283,14 +283,14 @@
 
           .accordion-facility-check {
             font-size: @font-extra-extra-large;
-            color: @gray-medium;
+            color: @checkbox-border-color;
             display: block;
             position: absolute;
             top: 0;
             left: 0;
 
             &.fa-check-square {
-              color: @blue-dark;
+              color: @checkbox-selected-color;
             }
           }
         }
@@ -347,7 +347,7 @@
       overflow-x: hidden;
       overflow-y: auto;
       opacity: 0.4;
-      background-color: @black;
+      background-color: @backdrop-color;
     }
 
     .sidebar-main {

--- a/webapp/src/css/targets.less
+++ b/webapp/src/css/targets.less
@@ -140,7 +140,7 @@
 #target-aggregates-list {
   .content-row {
     &.selected {
-      background-color: @teal-highlight;
+      background-color: @analytics-highlight;
     }
 
     .aggregate-status {
@@ -165,7 +165,7 @@
         margin: 20px 0 0 0;
 
         &.placeholder {
-          background: @gray-ultra-light;
+          background: @background-color;
         }
 
         .progress-bar {
@@ -180,7 +180,7 @@
           span {
             font-size: @font-small;
             padding: 0 @radius-size-small;
-            color: @white;
+            color: @progress-bar-background-color;
           }
         }
       }

--- a/webapp/src/css/variables.less
+++ b/webapp/src/css/variables.less
@@ -1,27 +1,4 @@
-/* Basic colors. WARNING: Don't use these outside this file as the variable names are not useful */
-@white: #FFFFFF;
-@gray-ultra-light: #F2F2F2;
-@gray-light: #E0E0E0;
-@gray-medium: #A0A0A0;
-@gray-dark: #777777;
-@gray-ultra-dark: #333333;
-@black: #000000;
-@blue: #63A2C6;
-@periwinkle: #7193EE;
-@yellow: #E9AA22;
-@pink: #F47B63;
-@teal: #76B0B0;
-@blue-highlight: #EFF5F9;
-@periwinkle-highlight: #F0F4FD;
-@yellow-highlight: #FCF6E7;
-@pink-highlight: #FDF1EF;
-@teal-highlight: #e4efef;
-@red: #E33030;
-@yellow-dark: #C78330;
-@teal-dark: #218E7F;
-@blue-dark: #007AC0;
-@blue-ultra-dark: #23527C;
-@green: #A0BA62;
+@import (reference) "private-vars";
 
 /* app colors */
 @top-header-color: @gray-ultra-dark;
@@ -31,6 +8,7 @@
 @separator-color: @gray-light;
 @button-text-color: @gray-ultra-dark;
 @button-text-inverse-color: @gray-light;
+@button-background-inverse-color: @white;
 @text-normal-color: @gray-ultra-dark;
 @label-color: @gray-dark;
 @text-secondary-color: @gray-dark;
@@ -48,6 +26,16 @@
 @report-review-verified-color: @teal-dark;
 @overdue-color: @red;
 @button-color: @blue-dark;
+@checkbox-selected-color: @blue-dark;
+@checkbox-border-color: @gray-medium;
+@chip-background-color: @blue-dark;
+@chip-text-color: @white;
+@chip-border-color: @white;
+@sidebar-background-color: @white;
+@filter-icon-color: @black;
+@filter-text-color: @gray-medium;
+@progress-bar-background-color: @white;
+@backdrop-color: @black;
 
 /* tab colors */
 @messages-color: @blue;
@@ -59,6 +47,7 @@
 @reports-color: @yellow;
 @reports-highlight: @yellow-highlight;
 @analytics-color: @teal;
+@analytics-highlight: @teal-highlight;
 @admin-color: @gray-dark;
 @help-color: @gray-dark;
 


### PR DESCRIPTION
# Description
Extracting color variables to another file, the ones that are not part of the palette.
The variables in private-vars.less are still accessible anywhere that imports variable.less, so the original idea doesn't work. However having them in 2 files might help devs to understand the right way of using them

https://github.com/medic/cht-core/issues/7862

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs:
<!-- After CI passes, PR submitter should manually replace these placeholders with deep links to staging. Makes for easier testing! -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-core.yml  -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb.yml   -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb-clustered.yml  -->

* CHT Core: CHT_CORE_COMPOSE_URL
* CouchDB Single: COUCH_SINGLE_COMPOSE_URL
* CouchDB Cluster: COUCH_CLUSTER_COMPOSE_URL
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
