### PR TITLE
add missing opening quote on couch readme

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -35,12 +35,12 @@ This field identifies each CouchDB instance. If you are adding a new node to a c
 
 This is an identifier by which other nodes can access this node. This value should contain either the node's IP address or the [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) of the node. 
 
-#### COUCHDB_SERVERS
+#### CLUSTER_PEER_IPS
 
 This field should only be set on the cluster set up coordination node aka `setup-coordination-node` . In other clustered database systems this is known as the master/main node, however, CouchDB does not have the master/slave concept as any node can be master. This field should contain a comma-separated list of IP addresses or FQDNs. If you are deploying a clustered setup on a basic docker network, please ensure there is a (.) in your service names, to validate the FQDN requirements for Erlang. 
 
 ```yaml
-COUCHDB_SERVERS="couchdb.1,couchdb.2,couchdb.3"
+CLUSTER_PEER_IPS="couchdb.2,couchdb.3"
 ```
 
 #### COUCHDB_SYNC_ADMINS_NODE

--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -35,12 +35,12 @@ This field identifies each CouchDB instance. If you are adding a new node to a c
 
 This is an identifier by which other nodes can access this node. This value should contain either the node's IP address or the [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) of the node. 
 
-#### CLUSTER_PEER_IPS
+#### COUCHDB_SERVERS
 
 This field should only be set on the cluster set up coordination node aka `setup-coordination-node` . In other clustered database systems this is known as the master/main node, however, CouchDB does not have the master/slave concept as any node can be master. This field should contain a comma-separated list of IP addresses or FQDNs. If you are deploying a clustered setup on a basic docker network, please ensure there is a (.) in your service names, to validate the FQDN requirements for Erlang. 
 
 ```yaml
-CLUSTER_PEER_IPS=couchdb.2,couchdb.3"
+COUCHDB_SERVERS="couchdb.1,couchdb.2,couchdb.3"
 ```
 
 #### COUCHDB_SYNC_ADMINS_NODE


### PR DESCRIPTION
# Description

~~correct env var in couchdb readme as `CLUSTER_PEER_IPS` is deprecated in favor of `COUCHDB_SERVERS`~~ Saved for later - instead just fix missing opening quote.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs:
<!-- After CI passes, PR submitter should manually replace these placeholders with deep links to staging. Makes for easier testing! -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-core.yml  -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb.yml   -->
<!-- e.g. https://staging.dev.medicmobile.org/_couch/builds/medic:medic:<branch>/docker-compose/cht-couchdb-clustered.yml  -->

* CHT Core: CHT_CORE_COMPOSE_URL
* CouchDB Single: COUCH_SINGLE_COMPOSE_URL
* CouchDB Cluster: COUCH_CLUSTER_COMPOSE_URL
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
