### PR TITLE
add more log to XMLFormService to add precision in case form load fails

### DIFF
--- a/.github/ISSUE_TEMPLATE/z_release_major.md
+++ b/.github/ISSUE_TEMPLATE/z_release_major.md
@@ -52,7 +52,7 @@ Keep an eye on the forum for the release announcement in the next couple of week
     - An SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient
 - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another beta.
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
-- [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
+- [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds_4/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Execute the scalability testing suite on the final build and download the scalability results on S3 at medic-e2e/scalability/$TAG_NAME. Add the release `.jtl` file to `cht-core/tests/scalability/previous_results`. More info in the  [scalability documentation](https://github.com/medic/cht-core/blob/master/tests/scalability/README.md).
 - [ ] Upgrade the `demo-cht.dev` instance to this version.
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/c/product/releases/26), under the "Product - Releases" category using this template:

--- a/.github/ISSUE_TEMPLATE/z_release_patch.md
+++ b/.github/ISSUE_TEMPLATE/z_release_patch.md
@@ -36,7 +36,7 @@ Once all issues have passed acceptance testing and have been merged into `master
         - An SRE to review and confirm the documentation on upgrade instructions and breaking changes is sufficient
 - [ ] Until release testing passes, make sure regressions are fixed in `master`, cherry-pick them into the release branch, and release another beta.
 - [ ] Create a release in GitHub from the release branch so it shows up under the [Releases tab](https://github.com/medic/cht-core/releases) with the naming convention `<major>.<minor>.<patch>`. This will create the git tag automatically. Link to the release notes in the description of the release.
-- [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
+- [ ] Confirm the release build completes successfully and the new release is available on the [market](https://staging.dev.medicmobile.org/builds_4/releases). Make sure that the document has new entry with `id: medic:medic:<major>.<minor>.<patch>`
 - [ ] Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org/), under the "Product - Releases" category using this template:
 ```
 *Announcing the release of {{version}}*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   COUCH_URL: http://admin:pass@localhost:5984/medic-test
   BUILDS_SERVER: ${{ secrets.AUTH_MARKET_URL && '_couch/builds_testing' || '_couch/builds_external' }}
-  STAGING_SERVER: ${{ secrets.AUTH_MARKET_URL && '_couch/builds' || '_couch/builds_external' }}
+  STAGING_SERVER: ${{ secrets.AUTH_MARKET_URL && '_couch/builds_4' || '_couch/builds_external' }}
   MARKET_URL_READ: 'https://staging.dev.medicmobile.org'
   MARKET_URL: ${{ secrets.AUTH_MARKET_URL || 'https://staging.dev.medicmobile.org' }}
   INTERNAL_CONTRIBUTOR: ${{ secrets.AUTH_MARKET_URL && 'true' }}

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -1,4 +1,4 @@
-const BUILDS_DB = 'https://staging.dev.medicmobile.org/_couch/builds';
+const BUILDS_DB = 'https://staging.dev.medicmobile.org/_couch/builds_4';
 
 angular.module('controllers').controller('UpgradeCtrl',
   function(

--- a/api/src/environment.js
+++ b/api/src/environment.js
@@ -3,7 +3,7 @@ const url = require('url');
 const logger = require('./logger');
 
 const { UNIT_TEST_ENV, COUCH_URL, BUILDS_URL } = process.env;
-const DEFAULT_BUILDS_URL = 'https://staging.dev.medicmobile.org/_couch/builds';
+const DEFAULT_BUILDS_URL = 'https://staging.dev.medicmobile.org/_couch/builds_4';
 
 if (UNIT_TEST_ENV) {
   module.exports = {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -57,7 +57,6 @@ const adminAppReg = new RegExp(`/*${environment.db}/_design/medic-admin/_rewrite
 const serverUtils = require('./server-utils');
 const uuid = require('uuid');
 const compression = require('compression');
-const BUILDS_DB = 'https://staging.dev.medicmobile.org/_couch/builds/'; // jshint ignore:line
 const cookie = require('./services/cookie');
 const deployInfo = require('./services/deploy-info');
 const app = express.Router({ strict: true });
@@ -157,7 +156,7 @@ app.use(
         manifestSrc: [`'self'`],
         connectSrc: [
           `'self'`,
-          BUILDS_DB,
+          environment.buildsUrl + '/',
           'maps.googleapis.com' // used for enketo geopoint widget
         ],
         childSrc:  [`'self'`],

--- a/api/tests/mocha/routing.spec.js
+++ b/api/tests/mocha/routing.spec.js
@@ -1,6 +1,5 @@
 const rewire = require('rewire');
 const chai = require('chai');
-const routing = rewire('./../../src/routing');
 
 describe('Routing', () => {
   before(() => global.angular = {
@@ -12,8 +11,9 @@ describe('Routing', () => {
   after(() => delete global.angular);
 
   it('Content Security policy build url matches actual', () => {
+    const environment = rewire('./../../src/environment');
     const adminUpgrade = rewire('./../../../admin/src/js/controllers/upgrade');
-    const cspBuildDb = routing.__get__('BUILDS_DB');
+    const cspBuildDb = environment.__get__('DEFAULT_BUILDS_URL');
     const actualBuildDb = adminUpgrade.__get__('BUILDS_DB');
     chai.expect(cspBuildDb).to.not.eq(undefined);
     chai.expect(cspBuildDb).to.include(actualBuildDb);

--- a/scripts/build/cht-core.yml.template
+++ b/scripts/build/cht-core.yml.template
@@ -46,7 +46,7 @@ services:
       - "${API_PORT:-5988}"
     environment:
       - COUCH_URL=http://${COUCHDB_USER:-admin}:${COUCHDB_PASSWORD:?COUCHDB_PASSWORD must be set}@haproxy:${HAPROXY_PORT:-5984}/{{ db_name }}
-      - BUILDS_URL=${MARKET_URL_READ:-https://staging.dev.medicmobile.org}/${BUILDS_SERVER:-_couch/builds}
+      - BUILDS_URL=${MARKET_URL_READ:-https://staging.dev.medicmobile.org}/${BUILDS_SERVER:-_couch/builds_4}
       - UPGRADE_SERVICE_URL=${UPGRADE_SERVICE_URL:-http://localhost:5100}
     logging:
       driver: "local"

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -28,6 +28,7 @@ import { ServicesActions } from '@mm-actions/services';
 import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TransitionsService } from '@mm-services/transitions.service';
+import { FeedbackService } from '@mm-services/feedback.service';
 import { GlobalActions } from '@mm-actions/global';
 
 @Injectable({
@@ -54,6 +55,7 @@ export class EnketoService {
     private zScoreService: ZScoreService,
     private transitionsService: TransitionsService,
     private translateService: TranslateService,
+    private feedbackService:FeedbackService,
     private ngZone: NgZone,
   ) {
     this.inited = this.init();
@@ -441,6 +443,11 @@ export class EnketoService {
 
         window.CHTCore.debugFormModel = () => form.model.getStr();
         return form;
+      }).catch(err => {
+        const errorMessage = `Failed during the form "${formDoc.internalId}" rendering : `;
+        console.error(errorMessage, err.message);
+        this.feedbackService.submit(errorMessage + err.message, false);
+        return Promise.reject(new Error(errorMessage + err.message));
       });
   }
 

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -85,10 +85,9 @@ export class XmlFormsService {
         return docs[0];
       })
       .catch(err => {
-        const errorMessage = 'Error in XMLFormService getByView ';
-        console.error(errorMessage, err.message);
-        this.feedbackService.submit(errorMessage + err.message, false);
-        return Promise.reject(new Error(errorMessage));
+        const errorTitle = 'Error in XMLFormService : getByView : ';
+        console.error(errorTitle, err.message);
+        return Promise.reject(new Error(errorTitle + err.message));
       });
   }
 
@@ -270,7 +269,7 @@ export class XmlFormsService {
     return this
       .getById(internalId)
       .catch(err => {
-        console.warn('Error in XMLFormService getById : ', err?.message, err?.status, err);
+        console.warn('Error in XMLFormService : getById : ', err?.message, err?.status, err);
         if (err.status === 404) {
           // fallback for backwards compatibility
           return this.getByView(internalId);
@@ -279,13 +278,17 @@ export class XmlFormsService {
       })
       .then(doc => {
         if (!this.findXFormAttachmentName(doc)) {
+          const errorTitle = 'Error in XMLFormService : findXFormAttachmentName : ';
           const errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
-          this.feedbackService.submit('Error in XMLFormService findXFormAttachmentName : ' + errorMessage, false);
-          console.error('Error in XMLFormService findXFormAttachmentName : ', errorMessage);
-          return Promise.reject(new Error(errorMessage));
+          console.error(errorTitle, errorMessage);
+          return Promise.reject(new Error(errorTitle + errorMessage));
         }
         return doc;
+      }).catch(err => {
+        this.feedbackService.submit(err.message, false);
+        throw err;
       });
+
   }
 
   getDocAndFormAttachment(internalId) {
@@ -296,13 +299,14 @@ export class XmlFormsService {
           .then(blob => this.fileReaderService.utf8(blob))
           .then(xml => ({ doc, xml }))
           .catch(err => {
+            const errorTitle = 'Error in XMLFormService : getDocAndFormAttachment : ';
+            let errorMessage = `Failed to get the form "${internalId}" xform attachment`;
             if (err.status === 404) {
-              const errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
-              console.error('Error in XMLFormService getDocAndFormAttachment : ', errorMessage);
-              this.feedbackService.submit('Error in XMLFormService getDocAndFormAttachment : ' + errorMessage, false);
-              return Promise.reject(new Error(errorMessage));
+              errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
             }
-            throw err;
+            console.error(errorTitle, errorMessage);
+            this.feedbackService.submit(errorTitle + errorMessage, false);
+            return Promise.reject(new Error(errorTitle + errorMessage));
           });
       });
   }

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -68,22 +68,18 @@ export class XmlFormsService {
   }
 
   private getByView(internalId) {
-    let errorMsg = '';
     return this
       .init
       .then(docs => docs?.filter(doc => doc.internalId === internalId))
       .then(docs => {
         if (!docs.length) {
-          errorMsg = `No form found for internalId "${internalId}"`;
-          return Promise.reject(new Error(errorMsg));
+          return Promise.reject(new Error(`No form found for internalId "${internalId}"`));
         }
         if (docs.length > 1) {
-          errorMsg = `Multiple forms found for internalId: "${internalId}"`;
-          return Promise.reject(new Error(errorMsg));
+          return Promise.reject(new Error(`Multiple forms found for internalId: "${internalId}"`));
         }
         return docs[0];
-      })
-      .catch(err => console.error('Error in XMLFormService getByView : ', errorMsg, err));
+      });
   }
 
   private evaluateExpression(expression, doc, user, contactSummary) {
@@ -268,13 +264,13 @@ export class XmlFormsService {
           // fallback for backwards compatibility
           return this.getByView(internalId);
         }
-        console.error(`Error in XMLFormService getByView : the form "${internalId}" was not found`);
+        console.error('Error in XMLFormService getByView : ', err?.message, err)
         throw err;
       })
       .then(doc => {
         if (!this.findXFormAttachmentName(doc)) {
           const errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
-          console.error('Error in XMLFormService getByView : '+errorMessage);
+          console.error('Error in XMLFormService get : ' + errorMessage);
           return Promise.reject(new Error(errorMessage));
         }
         return doc;

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -73,10 +73,14 @@ export class XmlFormsService {
       .then(docs => docs?.filter(doc => doc.internalId === internalId))
       .then(docs => {
         if (!docs.length) {
-          return Promise.reject(new Error(`No form found for internalId "${internalId}"`));
+          const message = `No form found for internalId "${internalId}"`;
+          console.error('Error in XMLFormService getByView : ', message);
+          return Promise.reject(new Error(message));
         }
         if (docs.length > 1) {
-          return Promise.reject(new Error(`Multiple forms found for internalId: "${internalId}"`));
+          const message = `Multiple forms found for internalId: "${internalId}"`;
+          console.error('Error in XMLFormService getByView : ', message);
+          return Promise.reject(new Error(message));
         }
         return docs[0];
       });
@@ -260,17 +264,17 @@ export class XmlFormsService {
     return this
       .getById(internalId)
       .catch(err => {
+        console.warn('Error in XMLFormService getById, falls back to using view : ', err?.message, err);
         if (err.status === 404) {
           // fallback for backwards compatibility
           return this.getByView(internalId);
         }
-        console.error('Error in XMLFormService getByView : ', err?.message, err);
         throw err;
       })
       .then(doc => {
         if (!this.findXFormAttachmentName(doc)) {
           const errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
-          console.error('Error in XMLFormService get : ' + errorMessage);
+          console.error('Error in XMLFormService findXFormAttachmentName : ', errorMessage);
           return Promise.reject(new Error(errorMessage));
         }
         return doc;
@@ -286,7 +290,9 @@ export class XmlFormsService {
           .then(xml => ({ doc, xml }))
           .catch(err => {
             if (err.status === 404) {
-              return Promise.reject(new Error(`The form "${internalId}" doesn't have an xform attachment`));
+              const errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
+              console.error('Error in XMLFormService getDocAndFormAttachment : ', errorMessage);
+              return Promise.reject(new Error(errorMessage));
             }
             throw err;
           });

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -273,9 +273,9 @@ export class XmlFormsService {
       })
       .then(doc => {
         if (!this.findXFormAttachmentName(doc)) {
-          const errorMsg = `The form "${internalId}" doesn't have an xform attachment`;
-          console.log('Error in XMLFormService getByView : '+errorMsg);
-          return Promise.reject(new Error(errorMsg));
+          const errorMessage = `The form "${internalId}" doesn't have an xform attachment`;
+          console.error('Error in XMLFormService getByView : '+errorMessage);
+          return Promise.reject(new Error(errorMessage));
         }
         return doc;
       });

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -264,7 +264,7 @@ export class XmlFormsService {
           // fallback for backwards compatibility
           return this.getByView(internalId);
         }
-        console.error('Error in XMLFormService getByView : ', err?.message, err)
+        console.error('Error in XMLFormService getByView : ', err?.message, err);
         throw err;
       })
       .then(doc => {

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -68,18 +68,22 @@ export class XmlFormsService {
   }
 
   private getByView(internalId) {
+    let errorMsg = '';
     return this
       .init
       .then(docs => docs?.filter(doc => doc.internalId === internalId))
       .then(docs => {
         if (!docs.length) {
-          return Promise.reject(new Error(`No form found for internalId "${internalId}"`));
+          errorMsg = `No form found for internalId "${internalId}"`;
+          return Promise.reject(new Error(errorMsg));
         }
         if (docs.length > 1) {
-          return Promise.reject(new Error(`Multiple forms found for internalId: "${internalId}"`));
+          errorMsg = `Multiple forms found for internalId: "${internalId}"`;
+          return Promise.reject(new Error(errorMsg));
         }
         return docs[0];
-      });
+      })
+      .catch(err => console.error('Error in XMLFormService getByView : ', errorMsg, err));
   }
 
   private evaluateExpression(expression, doc, user, contactSummary) {
@@ -264,11 +268,14 @@ export class XmlFormsService {
           // fallback for backwards compatibility
           return this.getByView(internalId);
         }
+        console.error(`Error in XMLFormService getByView : the form "${internalId}" was not found`);
         throw err;
       })
       .then(doc => {
         if (!this.findXFormAttachmentName(doc)) {
-          return Promise.reject(new Error(`The form "${internalId}" doesn't have an xform attachment`));
+          const errorMsg = `The form "${internalId}" doesn't have an xform attachment`;
+          console.log('Error in XMLFormService getByView : '+errorMsg);
+          return Promise.reject(new Error(errorMsg));
         }
         return doc;
       });

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -270,7 +270,6 @@ export class XmlFormsService {
     return this
       .getById(internalId)
       .catch(err => {
-        this.feedbackService.submit(`Error in XMLFormService getById : "${err?.status}" ; "${err?.message}"`);
         console.warn('Error in XMLFormService getById : ', err?.message, err?.status, err);
         if (err.status === 404) {
           // fallback for backwards compatibility

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -26,6 +26,7 @@ import { ContactSummaryService } from '@mm-services/contact-summary.service';
 import { TransitionsService } from '@mm-services/transitions.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { GlobalActions } from '@mm-actions/global';
+import { FeedbackService } from '@mm-services/feedback.service';
 import * as medicXpathExtensions from '../../../../src/js/enketo/medic-xpath-extensions';
 
 describe('Enketo service', () => {
@@ -72,6 +73,8 @@ describe('Enketo service', () => {
   let zScoreService;
   let zScoreUtil;
   let globalActions;
+  let error;
+  let feedbackService;
 
   beforeEach(() => {
     enketoInit = sinon.stub();
@@ -122,6 +125,8 @@ describe('Enketo service', () => {
     zScoreService = { getScoreUtil: sinon.stub().resolves(zScoreUtil) };
     globalActions = { setSnackbarContent: sinon.stub(GlobalActions.prototype, 'setSnackbarContent') };
     setLastChangedDoc = sinon.stub(ServicesActions.prototype, 'setLastChangedDoc');
+    error = sinon.stub(console, 'error');
+    feedbackService = { submit: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
@@ -154,6 +159,7 @@ describe('Enketo service', () => {
         { provide: ZScoreService, useValue: zScoreService },
         { provide: TransitionsService, useValue: transitionsService },
         { provide: TranslateService, useValue: translateService },
+        { provide: FeedbackService, useValue: feedbackService },
       ],
     });
 
@@ -215,8 +221,10 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>my form</div>')
         .onSecondCall().resolves(VISIT_MODEL);
       EnketoPrepopulationData.resolves('<xml></xml>');
-      const expected = ['nope', 'still nope'];
-      enketoInit.returns(expected);
+      const expectedErrorTitle = `Failed during the form "myform" rendering : `;
+      const expectedErrorDetail = ['nope', 'still nope'];
+      const expectedErrorMessage = expectedErrorTitle + JSON.stringify(expectedErrorDetail);
+      enketoInit.returns(expectedErrorDetail);
       return service
         .render($('<div></div>'), mockEnketoDoc('myform'))
         .then(() => {
@@ -224,7 +232,11 @@ describe('Enketo service', () => {
         })
         .catch(actual => {
           expect(enketoInit.callCount).to.equal(1);
-          expect(actual.message).to.equal(JSON.stringify(expected));
+          expect(actual.message).to.equal(expectedErrorMessage);
+          expect(error.callCount).to.equal(1);
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(feedbackService.submit.callCount).to.equal(1);
+          expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorMessage);
         });
     });
 

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -73,7 +73,7 @@ describe('Enketo service', () => {
   let zScoreService;
   let zScoreUtil;
   let globalActions;
-  let error;
+  let consoleErrorMock;
   let feedbackService;
 
   beforeEach(() => {
@@ -125,7 +125,7 @@ describe('Enketo service', () => {
     zScoreService = { getScoreUtil: sinon.stub().resolves(zScoreUtil) };
     globalActions = { setSnackbarContent: sinon.stub(GlobalActions.prototype, 'setSnackbarContent') };
     setLastChangedDoc = sinon.stub(ServicesActions.prototype, 'setLastChangedDoc');
-    error = sinon.stub(console, 'error');
+    consoleErrorMock = sinon.stub(console, 'error');
     feedbackService = { submit: sinon.stub() };
 
     TestBed.configureTestingModule({
@@ -233,8 +233,8 @@ describe('Enketo service', () => {
         .catch(actual => {
           expect(enketoInit.callCount).to.equal(1);
           expect(actual.message).to.equal(expectedErrorMessage);
-          expect(error.callCount).to.equal(1);
-          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(consoleErrorMock.callCount).to.equal(1);
+          expect(consoleErrorMock.args[0][0]).to.equal(expectedErrorTitle);
           expect(feedbackService.submit.callCount).to.equal(1);
           expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorMessage);
         });
@@ -288,7 +288,6 @@ describe('Enketo service', () => {
     });
 
     it('leaves img wrapped and hides loader if failed to load', () => {
-      const consoleErrorMock = sinon.stub(console, 'error');
       UserContact.resolves({ contact_id: '123' });
       dbGetAttachment
         .onFirstCall().resolves('<div><img data-media-src="myimg"></div>')

--- a/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
+++ b/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
@@ -1023,12 +1023,13 @@ describe('XmlForms service', () => {
         .catch(err => {
           expect(err.name).to.equal('getById fails');
           expect(warn.callCount).to.equal(1);
-          expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
+          expect(warn.args[0][0]).to.equal('Error in XMLFormService : getById : ');
         });
     });
 
     it('returns error, logs and register feedback doc when getByView fails', () => {
       const internalId = 'birth';
+      const expectedErrorTitle = 'Error in XMLFormService : getByView : ';
       dbGet.rejects({status: 404 });
       dbQuery.rejects('getByView fails');
       const service = getService();
@@ -1037,18 +1038,20 @@ describe('XmlForms service', () => {
           assert.fail('getByView fails');
         })
         .catch(err => {
-          expect(err.message).to.equal('Error in XMLFormService getByView ');
-          expect(feedbackService.submit.callCount).to.equal(1);
-          expect(feedbackService.submit.args[0][0].startsWith('Error in XMLFormService getByView ')).to.be.true;
+          expect(err.message).to.match(new RegExp(expectedErrorTitle));
           expect(warn.callCount).to.equal(1);
-          expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
+          expect(warn.args[0][0]).to.equal('Error in XMLFormService : getById : ');
           expect(error.callCount).to.equal(1);
-          expect(error.args[0][0]).to.equal('Error in XMLFormService getByView ');
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(feedbackService.submit.callCount).to.equal(1);
+          expect(feedbackService.submit.args[0][0]).to.match(new RegExp(expectedErrorTitle));
         });
     });
 
     it('returns error when cannot find xform attachment', () => {
       const internalId = 'birth';
+      const expectedErrorTitle = 'Error in XMLFormService : findXFormAttachmentName : ';
+      const expectedErrorDetail = `The form "${internalId}" doesn't have an xform attachment`;
       const expected = {
         type: 'form',
         _attachments: { 'something.txt': { stub: true } }
@@ -1062,13 +1065,12 @@ describe('XmlForms service', () => {
           assert.fail('expected error to be thrown');
         })
         .catch(err => {
-          expect(err.message).to.equal(`The form "${internalId}" doesn't have an xform attachment`);
+          expect(err.message).to.equal(expectedErrorTitle + expectedErrorDetail);
           expect(error.callCount).to.equal(1);
-          expect(error.args[0][0]).to.equal('Error in XMLFormService findXFormAttachmentName : ');
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(error.args[0][1]).to.equal(expectedErrorDetail);
           expect(feedbackService.submit.callCount).to.equal(1);
-          expect(feedbackService.submit.args[0][0]
-            .startsWith('Error in XMLFormService findXFormAttachmentName : '))
-            .to.be.true;
+          expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorTitle + expectedErrorDetail);
         });
     });
 
@@ -1088,7 +1090,7 @@ describe('XmlForms service', () => {
       const service = getService();
       return service.get(internalId).then(actual => {
         expect(warn.callCount).to.equal(1);
-        expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
+        expect(warn.args[0][0]).to.equal('Error in XMLFormService : getById : ');
         expect(actual).to.deep.equal(expected);
         expect(dbQuery.callCount).to.equal(1);
         expect(dbQuery.args[0][0]).to.equal(`medic-client/doc_by_type`);
@@ -1100,6 +1102,8 @@ describe('XmlForms service', () => {
 
     it('query fails if multiple forms found', () => {
       const internalId = 'birth';
+      const expectedErrorTitle = 'Error in XMLFormService : getByView : ';
+      const expectedErrorDetail = `Multiple forms found for internalId : "${internalId}"`;
       const expected = {
         internalId,
         _attachments: { 'something.xml': { stub: true } }
@@ -1118,24 +1122,21 @@ describe('XmlForms service', () => {
           assert.fail('expected error to be thrown');
         })
         .catch(err => {
-          expect(err.message).to.equal('Error in XMLFormService getByView ');
+          expect(err.message).to.equal(expectedErrorTitle  + expectedErrorDetail);
           expect(warn.callCount).to.equal(1);
-          expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
+          expect(warn.args[0][0]).to.equal('Error in XMLFormService : getById : ');
           expect(error.callCount).to.equal(1);
-          expect(error.args[0][0]).to.equal('Error in XMLFormService getByView ');
-          expect(error.args[0][1]).to.equal(`Multiple forms found for internalId : "${internalId}"`);
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(error.args[0][1]).to.equal(expectedErrorDetail);
           expect(feedbackService.submit.callCount).to.equal(1);
-          expect(feedbackService.submit.args[0][0]
-            .startsWith('Error in XMLFormService getByView '))
-            .to.be.true;
-          expect(feedbackService.submit.args[0][0]
-            .includes(`Multiple forms found for internalId : "${internalId}"`))
-            .to.be.true;
+          expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorTitle + expectedErrorDetail);
         });
     });
 
     it('query fails if no forms found', () => {
       const internalId = 'birth';
+      const expectedErrorTitle = 'Error in XMLFormService : getByView : ';
+      const expectedErrorDetail = `No form found for internalId : "${internalId}"`;
       dbGet.rejects({ status: 404 });
       dbQuery.resolves({
         rows: [
@@ -1149,28 +1150,24 @@ describe('XmlForms service', () => {
           assert.fail('expected error to be thrown');
         })
         .catch(err => {
-          expect(err.message).to.equal('Error in XMLFormService getByView ');
+          expect(err.message).to.equal(expectedErrorTitle + expectedErrorDetail);
           expect(warn.callCount).to.equal(1);
-          expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
+          expect(warn.args[0][0]).to.equal('Error in XMLFormService : getById : ');
           expect(error.callCount).to.equal(1);
-          expect(error.args[0][0]).to.equal('Error in XMLFormService getByView ');
-          expect(error.args[0][1]).to.equal(`No form found for internalId : "${internalId}"`);
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(error.args[0][1]).to.equal(expectedErrorDetail);
           expect(feedbackService.submit.callCount).to.equal(1);
-          expect(feedbackService.submit.args[0][0]
-            .startsWith('Error in XMLFormService getByView '))
-            .to.be.true;
-          expect(feedbackService.submit.args[0][0]
-            .includes(`No form found for internalId : "${internalId}"`))
-            .to.be.true;
+          expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorTitle + expectedErrorDetail);
         });
     });
-
   });
 
   describe('getDocAndFormAttachment', () => {
 
     it('fails if no forms found', () => {
       const internalId = 'birth';
+      const expectedErrorTitle = 'Error in XMLFormService : getDocAndFormAttachment : ';
+      const expectedErrorDetail = `The form "${internalId}" doesn't have an xform attachment`;
       dbQuery.resolves([]);
       dbGet.resolves({
         _id: 'form:death',
@@ -1185,10 +1182,39 @@ describe('XmlForms service', () => {
           assert.fail('expected error to be thrown');
         })
         .catch(err => {
-          expect(err.message).to.equal(`The form "${internalId}" doesn't have an xform attachment`);
+          expect(err.message).to.equal(expectedErrorTitle + expectedErrorDetail);
           expect(error.callCount).to.equal(1);
-          expect(error.args[0][0]).to.equal('Error in XMLFormService getDocAndFormAttachment : ');
-          expect(error.args[0][1]).to.equal(`The form "${internalId}" doesn't have an xform attachment`);
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(error.args[0][1]).to.equal(expectedErrorDetail);
+          expect(feedbackService.submit.callCount).to.equal(1);
+          expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorTitle + expectedErrorDetail);
+        });
+    });
+
+    it('fails if failed to get forms, but not 404', () => {
+      const internalId = 'birth';
+      const expectedErrorTitle = 'Error in XMLFormService : getDocAndFormAttachment : ';
+      const expectedErrorDetail = `Failed to get the form "${internalId}" xform attachment`;
+      dbQuery.resolves([]);
+      dbGet.resolves({
+        _id: 'form:death',
+        _attachments: { 'something.xml': { stub: true } },
+        internalId: 'birth'
+      });
+      dbGetAttachment.rejects();
+      const service = getService();
+      return service
+        .getDocAndFormAttachment(internalId)
+        .then(() => {
+          assert.fail('expected error to be thrown');
+        })
+        .catch(err => {
+          expect(err.message).to.equal(expectedErrorTitle + expectedErrorDetail);
+          expect(error.callCount).to.equal(1);
+          expect(error.args[0][0]).to.equal(expectedErrorTitle);
+          expect(error.args[0][1]).to.equal(expectedErrorDetail);
+          expect(feedbackService.submit.callCount).to.equal(1);
+          expect(feedbackService.submit.args[0][0]).to.equal(expectedErrorTitle + expectedErrorDetail);
         });
     });
 

--- a/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
+++ b/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
@@ -1011,7 +1011,7 @@ describe('XmlForms service', () => {
       });
     });
 
-    it('returns error, logs and register feedback doc when getById fails', () => {
+    it('returns error, logs when getById fails', () => {
       const internalId = 'birth';
       dbGet.rejects('getById fails');
       dbQuery.rejects('getByView fails');
@@ -1022,8 +1022,6 @@ describe('XmlForms service', () => {
         })
         .catch(err => {
           expect(err.name).to.equal('getById fails');
-          expect(feedbackService.submit.callCount).to.equal(1);
-          expect(feedbackService.submit.args[0][0].startsWith('Error in XMLFormService getById : ')).to.be.true;
           expect(warn.callCount).to.equal(1);
           expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
         });
@@ -1040,9 +1038,8 @@ describe('XmlForms service', () => {
         })
         .catch(err => {
           expect(err.message).to.equal('Error in XMLFormService getByView ');
-          expect(feedbackService.submit.callCount).to.equal(2);
-          expect(feedbackService.submit.args[0][0].startsWith('Error in XMLFormService getById ')).to.be.true;
-          expect(feedbackService.submit.args[1][0].startsWith('Error in XMLFormService getByView ')).to.be.true;
+          expect(feedbackService.submit.callCount).to.equal(1);
+          expect(feedbackService.submit.args[0][0].startsWith('Error in XMLFormService getByView ')).to.be.true;
           expect(warn.callCount).to.equal(1);
           expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
           expect(error.callCount).to.equal(1);
@@ -1092,10 +1089,6 @@ describe('XmlForms service', () => {
       return service.get(internalId).then(actual => {
         expect(warn.callCount).to.equal(1);
         expect(warn.args[0][0]).to.equal('Error in XMLFormService getById : ');
-        expect(feedbackService.submit.callCount).to.equal(1);
-        expect(feedbackService.submit.args[0][0]
-          .startsWith('Error in XMLFormService getById'))
-          .to.be.true;
         expect(actual).to.deep.equal(expected);
         expect(dbQuery.callCount).to.equal(1);
         expect(dbQuery.args[0][0]).to.equal(`medic-client/doc_by_type`);
@@ -1131,14 +1124,11 @@ describe('XmlForms service', () => {
           expect(error.callCount).to.equal(1);
           expect(error.args[0][0]).to.equal('Error in XMLFormService getByView ');
           expect(error.args[0][1]).to.equal(`Multiple forms found for internalId : "${internalId}"`);
-          expect(feedbackService.submit.callCount).to.equal(2);
+          expect(feedbackService.submit.callCount).to.equal(1);
           expect(feedbackService.submit.args[0][0]
-            .startsWith('Error in XMLFormService getById : '))
-            .to.be.true;
-          expect(feedbackService.submit.args[1][0]
             .startsWith('Error in XMLFormService getByView '))
             .to.be.true;
-          expect(feedbackService.submit.args[1][0]
+          expect(feedbackService.submit.args[0][0]
             .includes(`Multiple forms found for internalId : "${internalId}"`))
             .to.be.true;
         });
@@ -1165,14 +1155,11 @@ describe('XmlForms service', () => {
           expect(error.callCount).to.equal(1);
           expect(error.args[0][0]).to.equal('Error in XMLFormService getByView ');
           expect(error.args[0][1]).to.equal(`No form found for internalId : "${internalId}"`);
-          expect(feedbackService.submit.callCount).to.equal(2);
+          expect(feedbackService.submit.callCount).to.equal(1);
           expect(feedbackService.submit.args[0][0]
-            .startsWith('Error in XMLFormService getById : '))
-            .to.be.true;
-          expect(feedbackService.submit.args[1][0]
             .startsWith('Error in XMLFormService getByView '))
             .to.be.true;
-          expect(feedbackService.submit.args[1][0]
+          expect(feedbackService.submit.args[0][0]
             .includes(`No form found for internalId : "${internalId}"`))
             .to.be.true;
         });

--- a/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
+++ b/webapp/tests/karma/ts/services/xml-forms.service.spec.ts
@@ -26,6 +26,7 @@ describe('XmlForms service', () => {
   let contextUtils;
   let pipesService;
   let error;
+  let warn;
   let fileReaderService;
 
   const mockEnketoDoc = (formInternalId?, docId?) => {
@@ -58,6 +59,7 @@ describe('XmlForms service', () => {
     getTypeId = sinon.stub().callsFake(contact => contact.type === 'contact' ? contact.contact_type : contact.type);
     contextUtils = {};
     error = sinon.stub(console, 'error');
+    warn = sinon.stub(console, 'warn');
 
     pipesService = {
       transform: sinon.stub().returnsArg(1),
@@ -1021,6 +1023,9 @@ describe('XmlForms service', () => {
         })
         .catch(err => {
           expect(err.message).to.equal(`The form "${internalId}" doesn't have an xform attachment`);
+          expect(error.callCount).to.equal(1);
+          expect(error.args[0][0]).to.equal('Error in XMLFormService findXFormAttachmentName : ');
+
         });
     });
 
@@ -1039,6 +1044,8 @@ describe('XmlForms service', () => {
       });
       const service = getService();
       return service.get(internalId).then(actual => {
+        expect(warn.callCount).to.equal(1);
+        expect(warn.args[0][0]).to.equal('Error in XMLFormService getById, falls back to using view : ');
         expect(actual).to.deep.equal(expected);
         expect(dbQuery.callCount).to.equal(1);
         expect(dbQuery.args[0][0]).to.equal(`medic-client/doc_by_type`);
@@ -1069,6 +1076,9 @@ describe('XmlForms service', () => {
         })
         .catch(err => {
           expect(err.message).to.equal(`Multiple forms found for internalId: "${internalId}"`);
+          expect(error.callCount).to.equal(1);
+          expect(error.args[0][0]).to.equal('Error in XMLFormService getByView : ');
+          expect(error.args[0][1]).to.equal(`Multiple forms found for internalId: "${internalId}"`);
         });
     });
 
@@ -1088,6 +1098,11 @@ describe('XmlForms service', () => {
         })
         .catch(err => {
           expect(err.message).to.equal(`No form found for internalId "${internalId}"`);
+          expect(warn.callCount).to.equal(1);
+          expect(warn.args[0][0]).to.equal('Error in XMLFormService getById, falls back to using view : ');
+          expect(error.callCount).to.equal(1);
+          expect(error.args[0][0]).to.equal('Error in XMLFormService getByView : ');
+          expect(error.args[0][1]).to.equal(`No form found for internalId "${internalId}"`);
         });
     });
 
@@ -1112,6 +1127,9 @@ describe('XmlForms service', () => {
         })
         .catch(err => {
           expect(err.message).to.equal(`The form "${internalId}" doesn't have an xform attachment`);
+          expect(error.callCount).to.equal(1);
+          expect(error.args[0][0]).to.equal('Error in XMLFormService getDocAndFormAttachment : ');
+          expect(error.args[0][1]).to.equal(`The form "${internalId}" doesn't have an xform attachment`);
         });
     });
 


### PR DESCRIPTION
# Description

We catch all errors that happen when forms fail to load. However we don't register feedback docs when these crashes happen.

medic/cht-core#7525

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7525-register-failing-forms-feedback-doc/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7525-register-failing-forms-feedback-doc/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7525-register-failing-forms-feedback-doc/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
