### PR TITLE
Update deep staging link: builds -> builds_4

### DIFF
--- a/.github/actions/update-staging-url-placeholders/index.js
+++ b/.github/actions/update-staging-url-placeholders/index.js
@@ -20,11 +20,11 @@ const main = async () => {
     let body = pr.body;
 
     const search_replace = {
-      __CHT_CORE_COMPOSE_URL__: '[Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:'
+      __CHT_CORE_COMPOSE_URL__: '[Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:'
         + branch + '/docker-compose/cht-core.yml)',
-      __COUCH_SINGLE_COMPOSE_URL__: '[CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:'
+      __COUCH_SINGLE_COMPOSE_URL__: '[CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:'
         + branch + '/docker-compose/cht-couchdb.yml)',
-      __COUCH_CLUSTER_COMPOSE_URL__: '[CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:'
+      __COUCH_CLUSTER_COMPOSE_URL__: '[CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:'
         + branch + '/docker-compose/cht-couchdb-clustered.yml)',
     }
 


### PR DESCRIPTION
# Description

With the change in #7879 , we need to update the deep links for the compose URLs from `builds` -> `builds_4`.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:mrjones-staging-link-update/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:mrjones-staging-link-update/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:mrjones-staging-link-update/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
