### PR TITLE
add contact link to report with  #6994

### DIFF
--- a/ddocs/medic-db/medic/views/doc_summaries_by_id/map.js
+++ b/ddocs/medic-db/medic/views/doc_summaries_by_id/map.js
@@ -34,7 +34,6 @@ function(doc) {
     var subject = {};
     var reference = doc.patient_id ||
                     (doc.fields && doc.fields.patient_id) ||
-                    doc.patient_uuid ||
                     (doc.fields && doc.fields.patient_uuid) ||
                     doc.place_id ||
                     (doc.fields && doc.fields.place_id);

--- a/ddocs/medic-db/medic/views/doc_summaries_by_id/map.js
+++ b/ddocs/medic-db/medic/views/doc_summaries_by_id/map.js
@@ -21,6 +21,7 @@ function(doc) {
     }
 
     if (error.fields.indexOf('patient_id') !== -1 ||
+      error.fields.indexOf('patient_uuid') !== -1 ||
       error.fields.indexOf('patient_name') !== -1 ||
       error.fields.indexOf('place_id') !== -1) {
       return true;
@@ -33,6 +34,8 @@ function(doc) {
     var subject = {};
     var reference = doc.patient_id ||
                     (doc.fields && doc.fields.patient_id) ||
+                    doc.patient_uuid ||
+                    (doc.fields && doc.fields.patient_uuid) ||
                     doc.place_id ||
                     (doc.fields && doc.fields.place_id);
 

--- a/webapp/src/ts/modules/reports/reports-content.component.html
+++ b/webapp/src/ts/modules/reports/reports-content.component.html
@@ -35,7 +35,7 @@
           </div>
 
           <div *ngIf="summaries[$index]?.subject?.type" class="subject">
-            <a class="name" *ngIf="summaries[$index]?.subject._id || summaries[$index].patient._id"
+            <a class="name" *ngIf="summaries[$index]?.subject._id || summaries[$index]?.patient?._id"
               [routerLink]="['/contacts', summaries[$index].subject._id || summaries[$index].patient._id]"
               [innerHTML]="(summaries[$index].subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </a>

--- a/webapp/src/ts/modules/reports/reports-content.component.html
+++ b/webapp/src/ts/modules/reports/reports-content.component.html
@@ -35,11 +35,11 @@
           </div>
 
           <div *ngIf="summaries[$index]?.subject?.type" class="subject">
-            <a class="name" *ngIf="summaries[$index]?.subject._id || summaries[$index].fields?.patient_uuid"
-              [routerLink]="['/contacts', summaries[$index].subject._id || summaries[$index].fields.patient_uuid]"
+            <a class="name" *ngIf="summaries[$index]?.subject._id || summaries[$index].patient._id"
+              [routerLink]="['/contacts', summaries[$index].subject._id || summaries[$index].patient._id]"
               [innerHTML]="(summaries[$index].subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </a>
-            <span class="name" *ngIf="!summaries[$index]?.subject._id && !summaries[$index].fields?.patient_uuid"
+            <span class="name" *ngIf="!summaries[$index]?.subject._id && !summaries[$index].patient._id"
               [innerHTML]="(summaries[$index]?.subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </span>
           </div>

--- a/webapp/src/ts/modules/reports/reports-content.component.html
+++ b/webapp/src/ts/modules/reports/reports-content.component.html
@@ -39,7 +39,7 @@
               [routerLink]="['/contacts', summaries[$index].subject._id || summaries[$index].patient._id]"
               [innerHTML]="(summaries[$index].subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </a>
-            <span class="name" *ngIf="!summaries[$index]?.subject._id && !summaries[$index].patient._id"
+            <span class="name" *ngIf="!summaries[$index]?.subject._id && !summaries[$index].patient?._id"
               [innerHTML]="(summaries[$index]?.subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </span>
           </div>

--- a/webapp/src/ts/modules/reports/reports-content.component.html
+++ b/webapp/src/ts/modules/reports/reports-content.component.html
@@ -35,11 +35,11 @@
           </div>
 
           <div *ngIf="summaries[$index]?.subject?.type" class="subject">
-            <a class="name" *ngIf="summaries[$index]?.subject._id || summaries[$index]?.patient?._id"
-              [routerLink]="['/contacts', summaries[$index].subject._id || summaries[$index].patient._id]"
+            <a class="name" *ngIf="summaries[$index]?.subject._id"
+              [routerLink]="['/contacts', summaries[$index].subject._id]"
               [innerHTML]="(summaries[$index].subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </a>
-            <span class="name" *ngIf="!summaries[$index]?.subject._id && !summaries[$index].patient?._id"
+            <span class="name" *ngIf="!summaries[$index]?.subject._id"
               [innerHTML]="(summaries[$index]?.subject.type === 'name' && summaries[$index].subject.value) || summaries[$index].subject.name || ('report.subject.unknown' | translate)">
             </span>
           </div>

--- a/webapp/src/ts/services/get-summaries.service.ts
+++ b/webapp/src/ts/services/get-summaries.service.ts
@@ -39,7 +39,6 @@ export class GetSummariesService {
     const reference =
       doc.patient_id ||
       (doc.fields && doc.fields.patient_id) ||
-      doc.patient_uuid ||
       (doc.fields && doc.fields.patient_uuid) ||
       doc.place_id ||
       (doc.fields && doc.fields.place_id);

--- a/webapp/src/ts/services/get-summaries.service.ts
+++ b/webapp/src/ts/services/get-summaries.service.ts
@@ -15,7 +15,7 @@ export class GetSummariesService {
   ) {
   }
 
-  private readonly SUBJECT_FIELDS = [ 'patient_id', 'patient_name', 'place_id' ];
+  private readonly SUBJECT_FIELDS = [ 'patient_id', 'patient_uuid', 'patient_name', 'place_id' ];
 
   private getLineage(contact) {
     const parts = [];
@@ -39,6 +39,8 @@ export class GetSummariesService {
     const reference =
       doc.patient_id ||
       (doc.fields && doc.fields.patient_id) ||
+      doc.patient_uuid ||
+      (doc.fields && doc.fields.patient_uuid) ||
       doc.place_id ||
       (doc.fields && doc.fields.place_id);
     const patientName = doc.fields && doc.fields.patient_name;

--- a/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -101,6 +101,23 @@ const postNatalVisitBis = Object.assign({}, postNatalVisit, {
   })
 });
 
+
+const postNatalVisitPatientIdNoUuid = Object.assign({}, postNatalVisit, {
+  _id: '4971a859-bde7-4ff0-a0ed-326925b83038-idnouuid',
+  fields: Object.assign({}, postNatalVisit.fields, {
+    patient_id: 'a29c933c-90cb-4cb0-9e25-36403499aee6',
+    patient_uuid: null,
+  })
+});
+
+const postNatalVisitPatientUuidNoId = Object.assign({}, postNatalVisit, {
+  _id: '4971a859-bde7-4ff0-a0ed-326925b83038-bis',
+  fields: Object.assign({}, postNatalVisit.fields, {
+    patient_id: null,
+    patient_uuid: 'a29c933c-90cb-4cb0-9e25-36403499aee7',
+  })
+});
+
 const jsonR = {
   _id: '60f2df4791ea8f83b531cdcf30003abe',
   _rev: '2-2fcc401c60fc33f91842482f0931fc27',
@@ -264,7 +281,9 @@ describe('doc_summaries_by_id view', () => {
       jsonD,
       jsonDBis,
       jsonHousehold,
-      jsonHouseholdBis
+      jsonHouseholdBis,
+      postNatalVisitPatientIdNoUuid,
+      postNatalVisitPatientUuidNoId,
     ];
 
     let emitted = true;
@@ -509,5 +528,48 @@ describe('doc_summaries_by_id view', () => {
       }
     });
 
+    assert.deepEqual(emitted[12], {
+      key: '4971a859-bde7-4ff0-a0ed-326925b83038',
+      value: {
+        _rev: '1-daf9f65652fbe6da38911d3ffd6c1d77',
+        from: undefined,
+        phone: undefined,
+        form: 'postnatal_visit',
+        read: undefined,
+        valid: true,
+        verified: true,
+        reported_date: 1517392010413,
+        contact: 'df28f38e-cd3c-475f-96b5-48080d863e34',
+        lineage: ['1a1aac55-04d6-40dc-aae2-e67a75a1496d'],
+        subject: {
+          name: 'mother',
+          type: 'reference',
+          value: 'a29c933c-90cb-4cb0-9e25-36403499aee5'
+        },
+        case_id: '12345'
+      }
+    });
+
+    assert.deepEqual(emitted[13], {
+      key: '4971a859-bde7-4ff0-a0ed-326925b83038',
+      value: {
+        _rev: '1-daf9f65652fbe6da38911d3ffd6c1d77',
+        from: undefined,
+        phone: undefined,
+        form: 'postnatal_visit',
+        read: undefined,
+        valid: true,
+        verified: true,
+        reported_date: 1517392010413,
+        contact: 'df28f38e-cd3c-475f-96b5-48080d863e34',
+        lineage: ['1a1aac55-04d6-40dc-aae2-e67a75a1496d'],
+        subject: {
+          name: 'mother',
+          type: 'reference',
+          value: 'a29c933c-90cb-4cb0-9e25-36403499aee6'
+        },
+        case_id: '12345'
+      }
+    });
   });
 });

--- a/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -111,7 +111,7 @@ const postNatalVisitPatientIdNoUuid = Object.assign({}, postNatalVisit, {
 });
 
 const postNatalVisitPatientUuidNoId = Object.assign({}, postNatalVisit, {
-  _id: '4971a859-bde7-4ff0-a0ed-326925b83038-bis',
+  _id: '4971a859-bde7-4ff0-a0ed-326925b83038-uuidnoid',
   fields: Object.assign({}, postNatalVisit.fields, {
     patient_id: null,
     patient_uuid: 'a29c933c-90cb-4cb0-9e25-36403499aee7',
@@ -529,7 +529,7 @@ describe('doc_summaries_by_id view', () => {
     });
 
     assert.deepEqual(emitted[12], {
-      key: '4971a859-bde7-4ff0-a0ed-326925b83038',
+      key: '4971a859-bde7-4ff0-a0ed-326925b83038-idnouuid',
       value: {
         _rev: '1-daf9f65652fbe6da38911d3ffd6c1d77',
         from: undefined,
@@ -551,7 +551,7 @@ describe('doc_summaries_by_id view', () => {
     });
 
     assert.deepEqual(emitted[13], {
-      key: '4971a859-bde7-4ff0-a0ed-326925b83038',
+      key: '4971a859-bde7-4ff0-a0ed-326925b83038-uuidnoid',
       value: {
         _rev: '1-daf9f65652fbe6da38911d3ffd6c1d77',
         from: undefined,

--- a/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -96,7 +96,8 @@ const postNatalVisit = {
 const postNatalVisitBis = Object.assign({}, postNatalVisit, {
   _id: '4971a859-bde7-4ff0-a0ed-326925b83038-bis',
   fields: Object.assign({}, postNatalVisit.fields, {
-    patient_id: null
+    patient_id: null,
+    patient_uuid: null,
   })
 });
 

--- a/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
+++ b/webapp/tests/mocha/unit/views/doc_summaries_by_id.spec.js
@@ -544,7 +544,7 @@ describe('doc_summaries_by_id view', () => {
         subject: {
           name: 'mother',
           type: 'reference',
-          value: 'a29c933c-90cb-4cb0-9e25-36403499aee5'
+          value: 'a29c933c-90cb-4cb0-9e25-36403499aee6'
         },
         case_id: '12345'
       }
@@ -566,7 +566,7 @@ describe('doc_summaries_by_id view', () => {
         subject: {
           name: 'mother',
           type: 'reference',
-          value: 'a29c933c-90cb-4cb0-9e25-36403499aee6'
+          value: 'a29c933c-90cb-4cb0-9e25-36403499aee7'
         },
         case_id: '12345'
       }


### PR DESCRIPTION
# Description

When a report has an empty value for their patient_id field, or lacks the field entirely, will not link to the patient contact in the UI, despite having a valid patient_uuid field.

Instructions for AT :
- before fix
Fill and submit a report form missing or empty patient_id field, but having valid patient_uuid field, you would notice there is no link to patient contact on the report detail ui.
- After fix
The report detail ui now have a link to the patient contact.

medic/cht-core#6994

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:6994-add-contact-link-to-report-ui/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:6994-add-contact-link-to-report-ui/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:6994-add-contact-link-to-report-ui/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
