### PR TITLE
Refactor privacy controller to use template service

### DIFF
--- a/api/src/controllers/privacy-policy.js
+++ b/api/src/controllers/privacy-policy.js
@@ -1,31 +1,14 @@
-const fs = require('fs');
-const { promisify } = require('util');
 const path = require('path');
-const _ = require('lodash');
 const serverUtils = require('../server-utils');
 const privacyPolicyService = require('../services/privacy-policy');
 const config = require('../config');
 const cookie = require('../services/cookie');
+const templateService = require('../services/template');
+const templateFilepath = path.join(__dirname, '..', 'templates', 'privacy-policy', 'index.html');
 
-let template;
-
-const getTemplate = () => {
-  if (template) {
-    return template;
-  }
-  const filepath = path.join(__dirname, '..', 'templates', 'privacy-policy', 'index.html');
-  template = promisify(fs.readFile)(filepath, { encoding: 'utf-8' })
-    .then(file => _.template(file));
-  return template;
-};
-
-const getHtml = (policy, showBackButton, translations) => {
-  return getTemplate()
-    .then(template => template({
-      policy,
-      showBackButton,
-      translations
-    }));
+const getHtml = async (policy, showBackButton, translations) => {
+  const template = await templateService.getTemplate(templateFilepath);
+  return template({ policy, showBackButton, translations });
 };
 
 const getLocale = (req) => {


### PR DESCRIPTION
medic/cht-core#7841

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7841-refactor-privacy-controller/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7841-refactor-privacy-controller/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7841-refactor-privacy-controller/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
