### PR TITLE
reorder hamburger menu, move sync to top

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -208,6 +208,7 @@ body {
     }
     .sync-status {
       margin-top: 10px;
+      margin-bottom: 10px;
       a {
         padding-top: 0;
         padding-bottom: 0;

--- a/webapp/src/ts/components/header/header.component.html
+++ b/webapp/src/ts/components/header/header.component.html
@@ -52,6 +52,29 @@
               <span>{{'admin.app.name' | translate}}</span>
             </a>
           </li>
+
+          <li role="presentation disabled" *ngIf="!replicationStatus.disabled" [ngClass]="{ 'disabled': replicationStatus.current?.disableSyncButton }">
+            <a role="menuitem" tabindex="-1" (click)="!replicationStatus.current?.disableSyncButton && replicate()">
+              <i class="fa fa-fw fa-refresh"></i>
+              <span>{{'sync.now' | translate}}</span>
+            </a>
+          </li>
+
+          <li role="separator" class="divider" *ngIf="!replicationStatus.disabled"></li>
+
+          <li role="presentation disabled" *ngIf="!replicationStatus.disabled" class="sync-status">
+            <a class="no-click" [ngClass]="replicationStatus.current?.className" *ngIf="replicationStatus.current">
+              <i class="fa fa-fw" [ngClass]="replicationStatus.current?.icon"></i>
+              <span>{{replicationStatus.current.key | translate}}</span>
+            </a>
+            <a class="no-click" *ngIf="replicationStatus.lastSuccessTo">
+              <span>{{'sync.last_success' | translate}}</span>
+              <span [innerHTML]="replicationStatus.lastSuccessTo | relativeDate"></span>
+            </a>
+          </li>
+
+          <li role="separator" class="divider" *ngIf="!replicationStatus.disabled"></li>
+
           <li role="presentation" mmAuth="can_configure">
             <a role="menuitem" tabindex="-1" (click)="openGuidedSetup()">
               <i class="fa fa-fw fa-list-ol"></i>
@@ -92,28 +115,6 @@
             <a role="menuitem" tabindex="-1" rel="external" (click)="logout()">
               <i class="fa fa-fw fa-power-off"></i>
               <span>{{'Log Out' | translate}}</span>
-            </a>
-          </li>
-
-          <li role="separator" class="divider" *ngIf="!replicationStatus.disabled"></li>
-
-          <li role="presentation disabled" *ngIf="!replicationStatus.disabled" [ngClass]="{ 'disabled': replicationStatus.current?.disableSyncButton }">
-            <a role="menuitem" tabindex="-1" (click)="!replicationStatus.current?.disableSyncButton && replicate()">
-              <i class="fa fa-fw fa-refresh"></i>
-              <span>{{'sync.now' | translate}}</span>
-            </a>
-          </li>
-
-          <li role="separator" class="divider" *ngIf="!replicationStatus.disabled"></li>
-
-          <li role="presentation disabled" *ngIf="!replicationStatus.disabled" class="sync-status">
-            <a class="no-click" [ngClass]="replicationStatus.current?.className" *ngIf="replicationStatus.current">
-              <i class="fa fa-fw" [ngClass]="replicationStatus.current?.icon"></i>
-              <span>{{replicationStatus.current.key | translate}}</span>
-            </a>
-            <a class="no-click" *ngIf="replicationStatus.lastSuccessTo">
-              <span>{{'sync.last_success' | translate}}</span>
-              <span [innerHTML]="replicationStatus.lastSuccessTo | relativeDate"></span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
# Description

Partners have reported that users are accidentally logging themselves out when attempting to sync and then are unable to log back in.
So we moved sync component to top.

medic/cht-core#7900

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7900-reorder-hamburger-menu/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7900-reorder-hamburger-menu/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7900-reorder-hamburger-menu/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
