### PR TITLE
add device id to feedback docs #7127

### DIFF
--- a/webapp/src/ts/services/feedback.service.ts
+++ b/webapp/src/ts/services/feedback.service.ts
@@ -7,6 +7,7 @@ import { VersionService } from '@mm-services/version.service';
 import { environment } from '@mm-environments/environment';
 import { DebugService } from '@mm-services/debug.service';
 import { LanguageService } from '@mm-services/language.service';
+import { TelemetryService } from '@mm-services/telemetry.service';
 
 @Injectable({
   providedIn: 'root'
@@ -18,6 +19,7 @@ export class FeedbackService {
     private versionService:VersionService,
     private debugService: DebugService,
     private languageService: LanguageService,
+    private telemetryService : TelemetryService,
   ) {
   }
 
@@ -102,7 +104,8 @@ export class FeedbackService {
         language,
         url: this.getUrl(),
         version,
-        source: isManual ? 'manual' : 'automatic'
+        source: isManual ? 'manual' : 'automatic',
+        deviceId : this.telemetryService.getUniqueDeviceId(),
       },
       info,
       log: this.getLog(),

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -43,7 +43,7 @@ export class TelemetryService {
     return window.PouchDB(dbName); // avoid angular-pouch as digest isn't necessary here
   }
 
-  private getUniqueDeviceId() {
+   getUniqueDeviceId() {
     let uniqueDeviceId = window.localStorage.getItem(this.DEVICE_ID_KEY);
 
     if (!uniqueDeviceId) {

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -43,7 +43,7 @@ export class TelemetryService {
     return window.PouchDB(dbName); // avoid angular-pouch as digest isn't necessary here
   }
 
-   getUniqueDeviceId() {
+  getUniqueDeviceId() {
     let uniqueDeviceId = window.localStorage.getItem(this.DEVICE_ID_KEY);
 
     if (!uniqueDeviceId) {

--- a/webapp/tests/karma/ts/services/feedback.service.spec.ts
+++ b/webapp/tests/karma/ts/services/feedback.service.spec.ts
@@ -136,4 +136,27 @@ describe('Feedback service', () => {
     expect(submittedDoc.meta.version).to.equal('0.5.0');
     expect(submittedDoc.meta.time).to.equal('1970-01-01T00:00:00.000Z');
   });
+
+  it('should record device id in feedback doc', async () => {
+    post.resolves();
+    getLocal.resolves(({ version: '0.5.0' }));
+    languageService.get.resolves('en');
+    service.init();
+    service._setOptions({
+      console: mockConsole,
+      window: mockWindow,
+      document: mockDocument
+    });
+
+    await service.submit({ message: 'hello world' }, true);
+
+    expect(post.calledOnce).to.be.true;
+    const submittedDoc = post.args[0][0];
+    expect(submittedDoc.meta.source).to.equal('manual');
+    expect(submittedDoc.meta.language).to.equal('en');
+    expect(submittedDoc.meta.deviceId).to.exist;
+
+  });
+
+
 });


### PR DESCRIPTION
# Description

Add the device Id in feedback docs for debugging purposes.

Instructions for AT :
- Before fix : feedback docs do not include the device id
- After fix : feedback docs now include the device id
- How to test : Perform any action that would trigger feedback docs registration, then check if the doc contains a `deviceId` field

medic/cht-core#7127

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7127-record-device-id-in-feedback-docs/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7127-record-device-id-in-feedback-docs/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7127-record-device-id-in-feedback-docs/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
