### PR TITLE
Gracefully handle decryption error

### DIFF
--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -79,6 +79,9 @@ const decrypt = (text) => {
       const start = decipher.update(encryptedText);
       const final = decipher.final();
       return Buffer.concat([ start, final ]).toString();
+    })
+    .catch(() => {
+      throw new Error('Error decrypting credential. Try setting the credential again.');
     });
 };
 

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -242,6 +242,24 @@ describe('Settings Shared Library', () => {
         });
     });
 
+    it('should handle error gracefully when secret is changed', () => {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.onCall(0).rejects({ message: 'missing', statusCode: 404 });
+      requestGet.onCall(1).resolves('oldsecret');
+      sinon.stub(request, 'put').resolves();
+      return lib
+        .setCredentials('mykey', 'mypass')
+        .then(() => {
+          const doc = request.put.args[0][1].body;
+          requestGet.onCall(2).resolves(doc);
+          requestGet.onCall(3).resolves('newsecret');
+          return lib.getCredentials('mykey');
+        })
+        .catch(err => {
+          expect(err.message).to.equal('Error decrypting credential. Try setting the credential again.');
+        });
+    });
+
   });
 
 

--- a/shared-libs/settings/test/index.spec.js
+++ b/shared-libs/settings/test/index.spec.js
@@ -255,6 +255,7 @@ describe('Settings Shared Library', () => {
           requestGet.onCall(3).resolves('newsecret');
           return lib.getCredentials('mykey');
         })
+        .then(() => expect.fail('Should have thrown'))
         .catch(err => {
           expect(err.message).to.equal('Error decrypting credential. Try setting the credential again.');
         });


### PR DESCRIPTION
medic/cht-core#7926

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7926-better-decryption-message/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7926-better-decryption-message/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7926-better-decryption-message/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
