### PR TITLE
Fix deprecated-transitions endpoint blocking transitions from executing in API

### DIFF
--- a/api/src/services/settings.js
+++ b/api/src/services/settings.js
@@ -4,6 +4,7 @@ const path = require('path');
 const db = require('../db');
 const environment = require('../environment');
 const { info } = require('../logger');
+const config = require('../config');
 
 const isObject = obj => obj === Object(obj) && !Array.isArray(obj);
 
@@ -32,18 +33,20 @@ const doExtend = (target, source) => {
 };
 
 const getDeprecatedTransitions = () => {
-  const transitions = require('@medic/transitions')();
+  const transitions = config.getTransitionsLib();
+
+  if (!transitions) {
+    return [];
+  }
 
   return transitions
     .getDeprecatedTransitions()
-    .map(transition => {
-      return {
-        name: transition.name,
-        deprecated: transition.deprecated,
-        deprecatedIn: transition.deprecatedIn,
-        deprecationMessage: transition.getDeprecationMessage ? transition.getDeprecationMessage() : ''
-      };
-    });
+    .map(transition => ({
+      name: transition.name,
+      deprecated: transition.deprecated,
+      deprecatedIn: transition.deprecatedIn,
+      deprecationMessage: transition.getDeprecationMessage ? transition.getDeprecationMessage() : ''
+    }));
 };
 
 module.exports = {

--- a/api/tests/mocha/services/settings.spec.js
+++ b/api/tests/mocha/services/settings.spec.js
@@ -1,11 +1,13 @@
 const sinon = require('sinon');
 const path = require('path');
-require('chai').should();
+const { should, expect } = require('chai');
+should();
 
 const service = require('../../../src/services/settings');
 const db = require('../../../src/db');
 const environment = require('../../../src/environment');
 const defaults = require('../../../build/default-docs/settings.doc.json');
+const config = require('../../../src/config');
 
 let settings;
 let replace;
@@ -161,6 +163,31 @@ describe('settings service', () => {
           update.callCount.should.equal(1);
           update.args[0][0].settings.should.deep.equal(newSettings);
         });
+    });
+  });
+
+  describe('getDeprecatedTransitions', () => {
+    it('should return deprecated transitions', () => {
+      const getDeprecatedTransitions = sinon.stub().returns([
+        { name: 't1', deprecated: true, deprecatedIn: 1 },
+        { name: 't2', deprecated: true, deprecatedIn: 2, getDeprecationMessage: sinon.stub().returns('a') },
+        { name: 't3', deprecated: false, deprecatedIn: 3 },
+        { name: 't4', deprecated: true, deprecatedIn: 4, getDeprecationMessage: sinon.stub().returns('b') },
+      ]);
+      sinon.stub(config, 'getTransitionsLib').returns({ getDeprecatedTransitions });
+
+      expect(service.getDeprecatedTransitions()).to.deep.equal([
+        { name: 't1', deprecated: true, deprecatedIn: 1, deprecationMessage: '' },
+        { name: 't2', deprecated: true, deprecatedIn: 2, deprecationMessage: 'a' },
+        { name: 't3', deprecated: false, deprecatedIn: 3, deprecationMessage: '' },
+        { name: 't4', deprecated: true, deprecatedIn: 4, deprecationMessage: 'b' },
+      ]);
+      expect(config.getTransitionsLib.args).to.deep.equal([[]]);
+    });
+
+    it('should return empty array if transitions lib is not initialized', () => {
+      sinon.stub(config, 'getTransitionsLib').returns();
+      expect(service.getDeprecatedTransitions()).to.deep.equal([]);
     });
   });
 });

--- a/shared-libs/.eslintrc
+++ b/shared-libs/.eslintrc
@@ -3,6 +3,6 @@
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 8
+    "ecmaVersion": 2018
   }
 }

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -267,11 +267,14 @@ const saveDoc = (change, callback) => {
  * change/write.
  */
 const applyTransition = ({ key, change, transition, force }, callback) => {
-  if (!force && !canRun({ key, change, transition })) {
-    logger.debug(
-      `canRun test failed on transition ${key} for doc ${change.id} seq ${change.seq}`
-    );
-    return callback();
+  try {
+    if (!force && !canRun({ key, change, transition })) {
+      logger.debug(`canRun test failed on transition ${key} for doc ${change.id} seq ${change.seq}`);
+      return callback();
+    }
+  } catch (err) {
+    logger.error(`canRun test errored on transition ${key} for doc ${change.id}: %o`, err);
+    return callback(null, false);
   }
 
   logger.debug(

--- a/shared-libs/transitions/test/unit/transitions.js
+++ b/shared-libs/transitions/test/unit/transitions.js
@@ -1,8 +1,11 @@
 const sinon = require('sinon');
-const assert = require('chai').assert;
+const { assert, expect, ...chai } = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
 const transitions = require('../../src/transitions');
 const config = require('../../src/config');
 const _ = require('lodash');
+const infodoc = require('@medic/infodoc');
 
 const requiredFunctions = {
   onMatch: 1,
@@ -333,5 +336,186 @@ describe('transitions', () => {
     assert.isDefined(deprecatedTransitions);
     assert.equal(deprecatedTransitions.length, 2);
   });
+
+  describe('applyTransition',  () => {
+    it('should apply transition with change', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub().returns(true),
+        onMatch: sinon.stub().resolves(true),
+      };
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(true);
+      expect(transition.filter.args).to.deep.equal([[change.doc, change.info]]);
+      expect(transition.onMatch.args).to.deep.equal([[change]]);
+      expect(infodoc.updateTransition.args).to.deep.equal([[change, transition.key, true]]);
+    });
+
+    it('should apply transition without change', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub().returns(true),
+        onMatch: sinon.stub().resolves(false),
+      };
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(false);
+      expect(transition.filter.args).to.deep.equal([[change.doc, change.info]]);
+      expect(transition.onMatch.args).to.deep.equal([[change]]);
+      expect(infodoc.updateTransition.called).to.equal(false);
+    });
+
+    it('should skip transitions that dont pass filter', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub().returns(false),
+        onMatch: sinon.stub(),
+      };
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(undefined);
+      expect(transition.filter.args).to.deep.equal([[change.doc, change.info]]);
+      expect(transition.onMatch.called).to.equal(false);
+      expect(infodoc.updateTransition.called).to.equal(false);
+    });
+
+    it('should skip transitions that cant run', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub(),
+        onMatch: sinon.stub(),
+      };
+
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { deleted: true, doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(undefined);
+      expect(transition.filter.called).to.equal(false);
+      expect(transition.onMatch.called).to.equal(false);
+      expect(infodoc.updateTransition.called).to.equal(false);
+    });
+
+    it('should force running a transition', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub(),
+        onMatch: sinon.stub().resolves(true),
+      };
+
+      sinon.stub(transitions, 'canRun').returns(false);
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition, force: true },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(true);
+      expect(transitions.canRun.called).to.equal(false);
+      expect(transition.onMatch.args).to.deep.equal([[change]]);
+      expect(infodoc.updateTransition.args).to.deep.equal([[change, transition.key, true]]);
+    });
+
+    it('should catch transition filter errors', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub().throws(new Error('boom')),
+        onMatch: sinon.stub(),
+      };
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+      expect(result).to.equal(false);
+      expect(transition.filter.args).to.deep.equal([[change.doc, change.info]]);
+      expect(transition.onMatch.called).to.equal(false);
+      expect(infodoc.updateTransition.called).to.equal(false);
+    });
+
+    it('should catch transition onMatch errors without changes', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub().returns(true),
+        onMatch: sinon.stub().rejects(new Error('and its gone')),
+      };
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(false);
+      expect(transition.filter.args).to.deep.equal([[change.doc, change.info]]);
+      expect(transition.onMatch.called).to.equal(true);
+      expect(infodoc.updateTransition.called).to.equal(false);
+    });
+
+    it('should catch transition onMatch errors with changes', async () => {
+      const transition = {
+        key: 'mytransition',
+        filter: sinon.stub().returns(true),
+        onMatch: sinon.stub().rejects({ changed: true }),
+      };
+      sinon.stub(infodoc, 'updateTransition');
+      const change = { doc: {}, info: {} };
+
+      const result = await new Promise((resolve, reject) => {
+        transitions.applyTransition(
+          { key: transition.key, change, transition },
+          (err, result) => err ? reject(err) : resolve(result)
+        );
+      });
+
+      expect(result).to.equal(true);
+      expect(transition.filter.args).to.deep.equal([[change.doc, change.info]]);
+      expect(transition.onMatch.called).to.equal(true);
+      expect(infodoc.updateTransition.args).to.deep.equal([[change, transition.key, false]]);
+    });
+  });
+
 });
 


### PR DESCRIPTION
# Description


- fixes transition filter errors causing processing transitions to hang (forever)
- deprecated-transitions not gets transitionsLib from config
- adds unit test coverage for deprecated-transitions
- adds e2e test

#7912

(cherry picked from commit 8be4b33697b59098f969725b07ef9d0001119fee)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7912-deprecated-transitions-4.0.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7912-deprecated-transitions-4.0.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds/medic:medic:7912-deprecated-transitions-4.0.x/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
