### PR TITLE
Always return some form definition 3.17.x

### DIFF
--- a/api/src/services/report/smsparser.js
+++ b/api/src/services/report/smsparser.js
@@ -284,12 +284,11 @@ exports.parse = (def, doc) => {
       }
     }
 
-    if(!bsYear) {      
+    if (bsYear) {
+      formData[aggregateBSDateField] = bsToEpoch(bsYear, bsMonth, bsDay);
+    } else {
       logger.error('Can not aggregate bsAggreDate without bsYear');
-      return;
     }
-    
-    formData[aggregateBSDateField] = bsToEpoch(bsYear, bsMonth, bsDay);
   }
 
   // pass along some system generated fields

--- a/api/tests/mocha/services/report/smsparser.spec.js
+++ b/api/tests/mocha/services/report/smsparser.spec.js
@@ -634,7 +634,7 @@ describe('sms parser', () => {
       lmp_date: moment('2012-03-12').valueOf()
     });
   });
-  
+
 
   it('BS date parts with invalid bsYear yyys: compact textforms', () => {
     const doc = { message: 'YYYS 12345 123 11 29' };
@@ -646,6 +646,16 @@ describe('sms parser', () => {
       lmp_date: null
     });
   });
+
+  it('BS date parts with missing bsYear yyys: compact textforms', () => {
+    const doc = { message: 'YYYS 12345' };
+    const def = definitions.forms.YYYS;
+    const data = smsparser.parse(def, doc);
+    chai.expect(data).to.deep.equal({
+      patient_id: '12345',
+    });
+  });
+
 
   it('BS date parts without bsMonth & bsDay yyyr: compact textforms', () => {
     const doc = { message: 'YYYR 12345 2068' };
@@ -1474,7 +1484,7 @@ describe('sms parser', () => {
           type: 'string',
           labels: {
             tiny: 'ch'
-          } 
+          }
         }
       }
     };


### PR DESCRIPTION
# Description

#7933

(cherry picked from commit a0bcf5b6e83fe7b2af755d2a08a0dfb1987c0635)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* __CHT_CORE_COMPOSE_URL__
* __COUCH_SINGLE_COMPOSE_URL__
* __COUCH_CLUSTER_COMPOSE_URL__
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
