### PR TITLE
Fixes webpack analyzer output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tests/cht-couchdb-test.yml
 tests/cht-couchdb-cluster-test.yml
 couchdb/srv*
 tests/scalability/jmeter/
+webapp/analyzer.report.html

--- a/webapp/custom-webpack.config.js
+++ b/webapp/custom-webpack.config.js
@@ -53,7 +53,7 @@ module.exports = {
     }),
     new BundleAnalyzerPlugin({
       analyzerMode: 'static',
-      reportFilename: '../../../analyzer.report.html',
+      reportFilename: __dirname + '/analyzer.report.html',
       openAnalyzer: false,
     }),
   ]


### PR DESCRIPTION
For some reason this file was ending up in API but it's only relevant to webapp. Moved to proper location.
Also added it to gitignore because there's no need to commit it.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-analyzer-output-dir/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-analyzer-output-dir/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-analyzer-output-dir/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
