### PR TITLE
Handle when branding doc is missing attachment

### DIFF
--- a/api/src/controllers/favicon.js
+++ b/api/src/controllers/favicon.js
@@ -1,0 +1,18 @@
+const branding = require('../services/branding');
+
+const CACHE_MAX_AGE = 7 * 24 * 60 * 60; // one week in seconds
+
+module.exports = {
+  get: async (req, res) => {
+    // Cache for a week. Normally we don't interfere with couch headers, but
+    // due to Chrome (including Android WebView) aggressively requesting
+    // favicons on every page change and window.history update
+    // ( https://github.com/medic/medic/issues/1913 ), we have to
+    // stage an intervention
+    
+    const icon = await branding.getFavicon();
+    res.setHeader('Cache-Control', `public, max-age=${CACHE_MAX_AGE}`);
+    res.set('Content-Type', icon.contentType);
+    res.send(icon.data);
+  }
+};

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -43,6 +43,7 @@ const createUserDb = require('./controllers/create-user-db');
 const purgedDocsController = require('./controllers/purged-docs');
 const privacyPolicyController = require('./controllers/privacy-policy');
 const couchConfigController = require('./controllers/couch-config');
+const faviconController = require('./controllers/favicon');
 const replicationLimitLogController = require('./controllers/replication-limit-log');
 const connectedUserLog = require('./middleware/connected-user-log').log;
 const getLocale = require('./middleware/locale').getLocale;
@@ -237,22 +238,7 @@ app.all('/+medic(/*)?', (req, res, next) => {
   next();
 });
 
-app.get('/favicon.ico', (req, res) => {
-  // Cache for a week. Normally we don't interfere with couch headers, but
-  // due to Chrome (including Android WebView) aggressively requesting
-  // favicons on every page change and window.history update
-  // ( https://github.com/medic/medic/issues/1913 ), we have to
-  // stage an intervention
-  writeHeaders(req, res, [['Cache-Control', 'public, max-age=604800']]);
-  db.medic.get('branding').then(doc => {
-    db.medic.getAttachment(doc._id, doc.resources.favicon).then(blob => {
-      res.send(blob);
-    });
-  }).catch(err => {
-    res.sendFile('resources/ico/favicon.ico', { root : __dirname });
-    logger.warn('Branding doc or/and favicon missing: %o', err);
-  });
-});
+app.get('/favicon.ico', faviconController.get);
 
 // saves CouchDB _session information as `userCtx` in the `req` object
 app.use(authorization.getUserCtx);

--- a/api/src/services/branding.js
+++ b/api/src/services/branding.js
@@ -6,8 +6,9 @@ const db = require('../db');
 const logger = require('../logger');
 
 const DEFAULT_LOGO_PATH = path.join(__dirname, '..', 'resources', 'logo', 'medic-logo-light-full.svg');
+const DEFAULT_FAVICON_PATH = path.join(__dirname, '..', 'resources', 'ico', 'favicon.ico');
 
-const getInlineImage = (data, contentType) => `data:${contentType};base64,${data}`;
+const getInlineImage = ({ data, contentType }) => `data:${contentType};base64,${data}`;
 
 const getBrandingDoc = async () => {
   try {
@@ -20,20 +21,34 @@ const getBrandingDoc = async () => {
 
 const getName = (doc) => (doc && doc.title) || 'CHT';
 
-const getLogo = async (doc) => {
-  let data;
-  let contentType;
-  const name = doc && doc.resources && doc.resources.logo;
+const readImageFile = async (path) => {
+  const data = await promisify(fs.readFile)(path, {});
+  return Buffer.from(data);
+};
+
+const loadImageAttachment = (doc, prop) => {
+  const name = doc && doc.resources && doc.resources[prop];
   if (name) {
     const image = doc._attachments[name];
-    data = image.data;
-    contentType = image.content_type;
-  } else {
-    const logo = await promisify(fs.readFile)(DEFAULT_LOGO_PATH, {});
-    data = Buffer.from(logo).toString('base64');
-    contentType = 'image/svg+xml';
+    if (image) {
+      return {
+        data: image.data,
+        contentType: image.content_type
+      };
+    }
   }
-  return getInlineImage(data, contentType);
+};
+
+const getLogo = async (doc) => {
+  let image = loadImageAttachment(doc, 'logo');
+  if (!image) {
+    const data = await readImageFile(DEFAULT_LOGO_PATH);
+    image = {
+      data: data.toString('base64'),
+      contentType: 'image/svg+xml'
+    };
+  }
+  return getInlineImage(image);
 };
 
 const getIcon = (doc) => (doc && doc.resources && doc.resources.icon) || 'icon.png';
@@ -49,4 +64,21 @@ const getBranding = async () => {
   };
 };
 
-module.exports.get = getBranding;
+const getFavicon = async () => {
+  const doc = await getBrandingDoc();
+  const image = loadImageAttachment(doc, 'favicon');
+  if (image) {
+    image.data = Buffer.from(image.data, 'base64');
+    return image;
+  }
+  const data = await readImageFile(DEFAULT_FAVICON_PATH);
+  return {
+    data,
+    contentType: 'image/x-icon'
+  };
+};
+
+module.exports = {
+  get: getBranding,
+  getFavicon: getFavicon
+};

--- a/api/tests/mocha/services/branding.spec.js
+++ b/api/tests/mocha/services/branding.spec.js
@@ -15,43 +15,136 @@ describe('branding service', () => {
     sinon.restore();
   });
 
-  it('returns default when missing doc', async () => {
-    const get = sinon.stub(db, 'get').rejects({});
-    const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, 'zyx');
-    const result = await service.get();
-    chai.expect(get.callCount).to.equal(1);
-    chai.expect(get.args[0][0]).to.equal('branding');
-    chai.expect(get.args[0][1].attachments).to.equal(true);
-    chai.expect(readFile.callCount).to.equal(1);
-    chai.expect(readFile.args[0][0]).to.equal(baseDir + '/resources/logo/medic-logo-light-full.svg');
-    chai.expect(result.name).to.equal('CHT');
-    chai.expect(result.logo).to.equal('data:image/svg+xml;base64,enl4');
-    chai.expect(result.icon).to.equal('icon.png');
+  describe('get', async() => {
+
+    it('returns default when missing doc', async () => {
+      const get = sinon.stub(db, 'get').rejects({});
+      const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, 'zyx');
+      const result = await service.get();
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(get.args[0][0]).to.equal('branding');
+      chai.expect(get.args[0][1].attachments).to.equal(true);
+      chai.expect(readFile.callCount).to.equal(1);
+      chai.expect(readFile.args[0][0]).to.equal(baseDir + '/resources/logo/medic-logo-light-full.svg');
+      chai.expect(result.name).to.equal('CHT');
+      chai.expect(result.logo).to.equal('data:image/svg+xml;base64,enl4');
+      chai.expect(result.icon).to.equal('icon.png');
+    });
+
+    it('returns default when missing attachment', async () => {
+      const doc = {
+        title: 'some name',
+        resources: {
+          logo: 'DOES_NOT_MATCH.png',
+          icon: 'MISSING.ico'
+        },
+        _attachments: {
+          'somelogo.png': {
+            data: 'base64data',
+            content_type: 'image/png'
+          }
+        }
+      };
+      const get = sinon.stub(db, 'get').resolves(doc);
+      const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, 'zyx');
+      const result = await service.get();
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(get.args[0][0]).to.equal('branding');
+      chai.expect(get.args[0][1].attachments).to.equal(true);
+      chai.expect(readFile.callCount).to.equal(1);
+      chai.expect(readFile.args[0][0]).to.equal(baseDir + '/resources/logo/medic-logo-light-full.svg');
+      chai.expect(result.name).to.equal('some name');
+      chai.expect(result.logo).to.equal('data:image/svg+xml;base64,enl4');
+    });
+
+    it('returns configured branding', async () => {
+      const doc = {
+        title: 'some name',
+        resources: {
+          logo: 'somelogo.png',
+          icon: 'leastfavicon.ico'
+        },
+        _attachments: {
+          'somelogo.png': {
+            data: 'base64data',
+            content_type: 'image/png'
+          }
+        }
+      };
+      const get = sinon.stub(db, 'get').resolves(doc);
+      const readFile = sinon.stub(fs, 'readFile');
+      const result = await service.get();
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(readFile.callCount).to.equal(0);
+      chai.expect(result.name).to.equal('some name');
+      chai.expect(result.logo).to.equal('data:image/png;base64,base64data');
+      chai.expect(result.icon).to.equal('leastfavicon.ico');
+      chai.expect(result.doc).to.equal(doc);
+    });
+
   });
 
-  it('returns configured branding', async () => {
-    const doc = {
-      title: 'some name',
-      resources: {
-        logo: 'somelogo.png',
-        icon: 'leastfavicon.ico'
-      },
-      _attachments: {
-        'somelogo.png': {
-          data: 'base64data',
-          content_type: 'image/png'
+  describe('getFavicon', async() => {
+
+    it('returns default when missing doc', async () => {
+      const get = sinon.stub(db, 'get').rejects({});
+      const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, 'zyx');
+      const result = await service.getFavicon();
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(get.args[0][0]).to.equal('branding');
+      chai.expect(get.args[0][1].attachments).to.equal(true);
+      chai.expect(readFile.callCount).to.equal(1);
+      chai.expect(readFile.args[0][0]).to.equal(baseDir + '/resources/ico/favicon.ico');
+      chai.expect(Buffer.from(result.data).toString()).to.equal('zyx');
+      chai.expect(result.contentType).to.equal('image/x-icon');
+    });
+
+    it('returns default when missing attachment', async () => {
+      const doc = {
+        resources: {
+          favcon: 'DOES_NOT_MATCH.ico'
+        },
+        _attachments: {
+          'some.ico': {
+            data: 'base64data',
+            content_type: 'image/png'
+          }
         }
-      }
-    };
-    const get = sinon.stub(db, 'get').resolves(doc);
-    const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, 'zyx');
-    const result = await service.get();
-    chai.expect(get.callCount).to.equal(1);
-    chai.expect(readFile.callCount).to.equal(0);
-    chai.expect(result.name).to.equal('some name');
-    chai.expect(result.logo).to.equal('data:image/png;base64,base64data');
-    chai.expect(result.icon).to.equal('leastfavicon.ico');
-    chai.expect(result.doc).to.equal(doc);
+      };
+      const get = sinon.stub(db, 'get').resolves(doc);
+      const readFile = sinon.stub(fs, 'readFile').callsArgWith(2, null, 'zyx');
+      const result = await service.getFavicon();
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(get.args[0][0]).to.equal('branding');
+      chai.expect(get.args[0][1].attachments).to.equal(true);
+      chai.expect(readFile.callCount).to.equal(1);
+      chai.expect(readFile.args[0][0]).to.equal(baseDir + '/resources/ico/favicon.ico');
+      chai.expect(Buffer.from(result.data).toString()).to.equal('zyx');
+      chai.expect(result.contentType).to.equal('image/x-icon');
+    });
+
+    it('returns configured favicon', async () => {
+      const doc = {
+        resources: {
+          favicon: 'some.ico'
+        },
+        _attachments: {
+          'some.ico': {
+            data: Buffer.from('base64data').toString('base64'),
+            content_type: 'image/png'
+          }
+        }
+      };
+      const get = sinon.stub(db, 'get').resolves(doc);
+      const readFile = sinon.stub(fs, 'readFile');
+      const result = await service.getFavicon();
+      chai.expect(get.callCount).to.equal(1);
+      chai.expect(readFile.callCount).to.equal(0);
+      chai.expect(Buffer.from(result.data).toString()).to.equal('base64data');
+      chai.expect(result.contentType).to.equal('image/png');
+    });
+
   });
+
 
 });


### PR DESCRIPTION
Prevents an unhandled rejection for misconfigured branding. Also refactors the code into a service to make it able to be tested.

medic/cht-core#7976

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7976-handle-missing-branding-attachment/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7976-handle-missing-branding-attachment/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7976-handle-missing-branding-attachment/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
