### PR TITLE
Default contact script:  api v2 -> v1 change, work with sparser place objects

### DIFF
--- a/scripts/set-default-contact/index.js
+++ b/scripts/set-default-contact/index.js
@@ -50,7 +50,7 @@ const getObjectFromMedicDb = async id => {
 const hasDefaultContact = async user => {
   if(typeof user.place === 'object' && typeof user.contact === 'object' &&  user.place._id  ){
     const place = await getObjectFromMedicDb(user.place._id);
-    return !((typeof place.contact === 'object' && !place.contact._id) || typeof place.contact !== 'object');
+    return place.contact && place.contact._id;
   }
   // return true for invalid users like admin or medic so we don't process them
   return true;

--- a/scripts/set-default-contact/index.js
+++ b/scripts/set-default-contact/index.js
@@ -15,7 +15,7 @@ const compileUrl = path => {
 };
 
 const getChtUsers = async () => {
-  console.log('   Using URL taken from COUCH_URL env var: ', process.env.COUCH_URL);
+  console.log('   Using COUCH_URL env var:', process.env.COUCH_URL);
   console.log('');
   //  pin  to v1 of API so it is backwards compatible with CHT 3.x
   const url = compileUrl('/api/v1/users');

--- a/scripts/set-default-contact/index.js
+++ b/scripts/set-default-contact/index.js
@@ -17,7 +17,7 @@ const compileUrl = path => {
 const getChtUsers = async () => {
   console.log('   Using URL taken from COUCH_URL env var: ', process.env.COUCH_URL);
   console.log('');
-  const url = compileUrl('/api/v2/users');
+  const url = compileUrl('/api/v1/users');
   const options = {
     uri: url.href,
     json: true
@@ -49,7 +49,7 @@ const getObjectFromMedicDb = async id => {
 const hasDefaultContact = async user => {
   if(typeof user.place === 'object' && typeof user.contact === 'object' &&  user.place._id  ){
     const place = await getObjectFromMedicDb(user.place._id);
-    return !(typeof place.contact === 'object' && !place.contact._id);
+    return !((typeof place.contact === 'object' && !place.contact._id) || typeof place.contact !== 'object');
   }
   // return true for invalid users like admin or medic so we don't process them
   return true;
@@ -70,6 +70,9 @@ const savePlace = async (placeId, contactId) => {
   const url = compileUrl('/medic/' + placeId);
   // fetch the place fresh because we need to ensure revision ID is current
   const placeObj = await getObjectFromMedicDb(placeId);
+  if(!placeObj.contact){
+    placeObj.contact = {};
+  }
   placeObj.contact._id = contactId;
   placeObj.contact.parent = {_id: placeId};
   const options = {

--- a/scripts/set-default-contact/index.js
+++ b/scripts/set-default-contact/index.js
@@ -17,6 +17,7 @@ const compileUrl = path => {
 const getChtUsers = async () => {
   console.log('   Using URL taken from COUCH_URL env var: ', process.env.COUCH_URL);
   console.log('');
+  //  pin  to v1 of API so it is backwards compatible with CHT 3.x
   const url = compileUrl('/api/v1/users');
   const options = {
     uri: url.href,

--- a/scripts/set-default-contact/readme.md
+++ b/scripts/set-default-contact/readme.md
@@ -4,16 +4,18 @@ This script goes through all users and checks if the places they're assigned to 
 
 A requirement is that each user has both a place and a contact assigned to them.
 
+This is compatible with both CHT 3.x and 4.x instances.
+
 ## Installing and running
 
 To install, `cd` into this directory and call `npm install`
 
-To run, call `COUCH_URL=https://USER:PASSWORD@CHT-URL node index.cjs`. So if your CHT URL was `127-0-0-1.my.local-ip.co:10445` and your admin user login was `medic` and password was `password`, you would call `COUCH_URL=https://medic:password@127-0-0-1.my.local-ip.co:10445 node index.cjs`.
+To run, call `COUCH_URL=https://USER:PASSWORD@CHT-URL node index.js`. So if your CHT URL was `127-0-0-1.my.local-ip.co:10445` and your admin user login was `medic` and password was `password`, you would call `COUCH_URL=https://medic:password@127-0-0-1.my.local-ip.co:10445 node index.cjs`.
 
 ### Sample output
 
 ```shell
-COUCH_URL=https://medic:password@127-0-0-1.my.local-ip.co:10445 node index.cjs
+COUCH_URL=https://medic:password@127-0-0-1.my.local-ip.co:10445 node index.js
 
 Start
 


### PR DESCRIPTION
# Description

Fixes  to #7987

* fixes readme to reference `index.js` vs `index.cjs`
* checks for  `place.contact` not being set
* downgrades use of User API from `/v2` to `/v1` so it works with earlier 3.x instances.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:set-default-contact-script/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:set-default-contact-script/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:set-default-contact-script/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
