### PR TITLE
7910 Fix issue where cancel confirm dialog not shown

### DIFF
--- a/tests/page-objects/default/enketo/generic-form.wdio.page.js
+++ b/tests/page-objects/default/enketo/generic-form.wdio.page.js
@@ -4,6 +4,7 @@ const reportsPage = require('../reports/reports.wdio.page');
 
 const REVIEW_MENU = '[test-id="report-review-menu"]';
 const submitButton = () => $('.enketo .submit');
+const cancelButton = () => $('.enketo .cancel');
 const nextButton = () => $('button.btn.btn-primary.next-page');
 const nameField = () => $('#report-form form [name="/data/name"]');
 
@@ -88,6 +89,7 @@ const submitForm = () => submitButton().click();
 
 module.exports = {
   submitButton,
+  cancelButton,
   nextPage,
   invalidateReport,
   validateReport,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -9,6 +9,7 @@ const reportBodyDetails = () => $(reportBodyDetailsSelector);
 const reportTasks = () =>  $(`${reportBodyDetailsSelector} .scheduled-tasks`);
 const REPORT_BODY = '#reports-content .report-body';
 const reportBody = () => $(REPORT_BODY);
+const noReportSelectedLabel = () => $('.empty-selection');
 const selectedCaseId = () => $(`${reportBodyDetailsSelector} > ul > li > p > span > a`);
 const selectedCaseIdLabel = () => $(`${reportBodyDetailsSelector} ul > li > label > span`);
 const submitterPlace = () => $('.position a');
@@ -357,6 +358,7 @@ const fieldByIndex = async (index) => {
 module.exports = {
   getCurrentReportId,
   getLastSubmittedReportId,
+  noReportSelectedLabel,
   reportList,
   firstReport,
   submitterName,

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -302,6 +302,8 @@ export class EnketoService {
         this.overrideNavigationButtons(this.currentForm, wrapper);
         this.addPopStateHandler(this.currentForm, wrapper);
         this.forceRecalculate(this.currentForm);
+        // forceRecalculate can cause form to be marked as edited
+        this.currentForm.editStatus = false;
         this.setupNavButtons(wrapper, 0);
         return this.currentForm;
       });

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -92,18 +92,6 @@ describe('Enketo service', () => {
     form = {
       validate: sinon.stub(),
       getDataStr: sinon.stub(),
-    };
-    AddAttachment = sinon.stub();
-    removeAttachment = sinon.stub();
-    EnketoForm = sinon.stub();
-    EnketoPrepopulationData = sinon.stub();
-    Search = sinon.stub();
-    LineageModelGenerator = { contact: sinon.stub() };
-    xmlFormGet = sinon.stub().resolves({ _id: 'abc' });
-    xmlFormGetWithAttachment = sinon.stub().resolves({ doc: { _id: 'abc', xml: '<form/>' } });
-    window.EnketoForm = EnketoForm;
-    window.URL.createObjectURL = createObjectURL;
-    EnketoForm.returns({
       view: {
         $: { on: sinon.stub() },
         html: document.createElement('div'),
@@ -115,7 +103,18 @@ describe('Enketo service', () => {
       },
       calc: { update: () => { } },
       output: { update: () => { } },
-    });
+    };
+    AddAttachment = sinon.stub();
+    removeAttachment = sinon.stub();
+    EnketoForm = sinon.stub();
+    EnketoPrepopulationData = sinon.stub();
+    Search = sinon.stub();
+    LineageModelGenerator = { contact: sinon.stub() };
+    xmlFormGet = sinon.stub().resolves({ _id: 'abc' });
+    xmlFormGetWithAttachment = sinon.stub().resolves({ doc: { _id: 'abc', xml: '<form/>' } });
+    window.EnketoForm = EnketoForm;
+    window.URL.createObjectURL = createObjectURL;
+    EnketoForm.returns(form);
     transitionsService = { applyTransitions: sinon.stub().resolvesArg(0) };
     translateService = {
       instant: sinon.stub().returnsArg(0),
@@ -241,6 +240,7 @@ describe('Enketo service', () => {
     });
 
     it('return form when everything works', () => {
+      expect(form.editStatus).to.be.undefined;
       UserContact.resolves({ contact_id: '123' });
       dbGetAttachment
         .onFirstCall().resolves('<div>my form</div>')
@@ -255,6 +255,7 @@ describe('Enketo service', () => {
         expect(FileReader.utf8.args[0][0]).to.equal('<div>my form</div>');
         expect(FileReader.utf8.args[1][0]).to.equal(VISIT_MODEL);
         expect(enketoInit.callCount).to.equal(1);
+        expect(form.editStatus).to.equal(false);
         expect(dbGetAttachment.callCount).to.equal(2);
         expect(dbGetAttachment.args[0][0]).to.equal('form:myform');
         expect(dbGetAttachment.args[0][1]).to.equal('form.html');


### PR DESCRIPTION
# Description

Manually set the `editStatus` of an Enketo form to `false` before rendering the form. During the form initialization, the re-evaluation of some `calculate`s can cause the form to be marked as edited before receiving any input from the user.  

Resetting the `editStatus` prevents this behavior from affecting the cancel confirmation dialog behavior.  After this change, the cancel confirmation dialog should always be shown when the user has input data into the form (regardless of what calculations are done while initing the form).

Closes https://github.com/medic/cht-core/issues/7910

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7910_cancel_dialog/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7910_cancel_dialog/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7910_cancel_dialog/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
