### PR TITLE
Separate base version from build in admin app upgrade page

### DIFF
--- a/admin/src/js/filters/build-version.js
+++ b/admin/src/js/filters/build-version.js
@@ -4,7 +4,7 @@ angular.module('filters').filter('buildVersion',
     'use strict';
     'ngInject';
 
-    return function(buildInfo, displayBaseVersion {
+    return function(buildInfo, displayBaseVersion) {
       if (buildInfo) {
         if (buildInfo.version === buildInfo.base_version || !buildInfo.base_version) {
           return buildInfo.version;

--- a/admin/src/js/filters/build-version.js
+++ b/admin/src/js/filters/build-version.js
@@ -4,10 +4,12 @@ angular.module('filters').filter('buildVersion',
     'use strict';
     'ngInject';
 
-    return function(buildInfo) {
+    return function(buildInfo, displayBaseVersion {
       if (buildInfo) {
         if (buildInfo.version === buildInfo.base_version || !buildInfo.base_version) {
           return buildInfo.version;
+        } else if (displayBaseVersion) {
+          return buildInfo.base_version;
         } else {
           return buildInfo.version + ' (~' + buildInfo.base_version + ')';
         }

--- a/admin/src/js/filters/build-version.js
+++ b/admin/src/js/filters/build-version.js
@@ -4,12 +4,10 @@ angular.module('filters').filter('buildVersion',
     'use strict';
     'ngInject';
 
-    return function(buildInfo, displayBaseVersion) {
+    return function(buildInfo) {
       if (buildInfo) {
         if (buildInfo.version === buildInfo.base_version || !buildInfo.base_version) {
           return buildInfo.version;
-        } else if (displayBaseVersion) {
-          return buildInfo.base_version;
         } else {
           return buildInfo.version + ' (~' + buildInfo.base_version + ')';
         }

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -58,6 +58,8 @@
       <p ng-hide="currentDeploy" translate>instance.upgrade.no_details</p>
       <dl ng-show="currentDeploy" class="horizontal">
         <dt translate>instance.upgrade.version</dt>
+        <dd>{{currentDeploy | buildVersion:true}}</dd>
+        <dt translate>instance.upgrade.build.version</dt>
         <dd>{{currentDeploy | buildVersion}}</dd>
         <dt translate>instance.upgrade.deployed_by</dt>
         <dd>{{currentDeploy.user}}</dd>

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -60,7 +60,7 @@
         <dt translate>instance.upgrade.version</dt>
         <dd>{{currentDeploy | buildVersion:true}}</dd>
         <dt translate>instance.upgrade.build.version</dt>
-        <dd>{{currentDeploy | buildVersion}}</dd>
+        <dd id="build_version">{{currentDeploy | buildVersion}}</dd>
         <dt translate>instance.upgrade.deployed_by</dt>
         <dd>{{currentDeploy.user}}</dd>
         <dt translate>instance.upgrade.at</dt>

--- a/admin/src/templates/upgrade.html
+++ b/admin/src/templates/upgrade.html
@@ -58,9 +58,9 @@
       <p ng-hide="currentDeploy" translate>instance.upgrade.no_details</p>
       <dl ng-show="currentDeploy" class="horizontal">
         <dt translate>instance.upgrade.version</dt>
-        <dd>{{currentDeploy | buildVersion:true}}</dd>
+        <dd>{{currentDeploy.base_version}}</dd>
         <dt translate>instance.upgrade.build.version</dt>
-        <dd id="build_version">{{currentDeploy | buildVersion}}</dd>
+        <dd>{{currentDeploy.version}}</dd>
         <dt translate>instance.upgrade.deployed_by</dt>
         <dd>{{currentDeploy.user}}</dd>
         <dt translate>instance.upgrade.at</dt>

--- a/api/resources/translations/messages-en.properties
+++ b/api/resources/translations/messages-en.properties
@@ -753,6 +753,7 @@ instance.upgrade = Upgrades
 instance.upgrade.at = On
 instance.upgrade.betas = Betas
 instance.upgrade.branches = Branches
+instance.upgrade.build.version = Build
 instance.upgrade.cancel = Cancel upgrade
 instance.upgrade.cancelling = Cancelling upgrade
 instance.upgrade.cancel.note = Cancelling will stop the current upgrade and reset any staging progress made so far.

--- a/api/src/services/deploy-info.js
+++ b/api/src/services/deploy-info.js
@@ -12,7 +12,7 @@ const getDeployInfo = async () => {
 
   try {
     const ddoc = await db.medic.get(ddocs.getId(environment.ddoc));
-    deployInfoCache = Object.assign({}, ddoc.deploy_info, { version: ddoc.version });
+    deployInfoCache = Object.assign({}, ddoc.build_info, ddoc.deploy_info, { version: ddoc.version });
 
     return deployInfoCache;
   } catch (err) {

--- a/api/tests/mocha/services/deploy-info.spec.js
+++ b/api/tests/mocha/services/deploy-info.spec.js
@@ -24,6 +24,12 @@ describe('deploy info', () => {
           timestamp: 1000,
           user: 'my user',
         },
+        build_info: {
+          base_version: '3.14.0',
+          build: '3.14.0-56437856378453',
+          time: 'human readable',
+          version: 'aaa',
+        },
         version: '3.14.0-dev.547839573',
       };
 
@@ -36,6 +42,9 @@ describe('deploy info', () => {
         timestamp: 1000,
         user: 'my user',
         version: '3.14.0-dev.547839573',
+        base_version: '3.14.0',
+        build: '3.14.0-56437856378453',
+        time: 'human readable',
       });
 
       expect(db.medic.get.args).to.deep.equal([['_design/medic']]);
@@ -71,7 +80,7 @@ describe('deploy info', () => {
       expect(db.medic.get.callCount).to.equal(1);
     });
 
-    it('should work with undefined deploy info', async () => {
+    it('should work with undefined deploy info and build info', async () => {
       const ddoc = {
         _id: '_design/medic',
         version: '20000',

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -43,11 +43,15 @@ describe('Performing an upgrade', () => {
     const currentVersion = await upgradePage.getCurrentVersion();
     expect(currentVersion).to.include(version.getVersion());
 
+    await browser.refresh(); // load updated code of admin app
+    await upgradePage.goToUpgradePage();
+    const currentBuild = await upgradePage.getBuild();
+
     // there should be no staged ddocs
     const ddocs = await getDdocs();
     const staged = ddocs.filter(ddoc => ddoc._id.includes('staged'));
     expect(staged.length).to.equal(0);
 
-    ddocs.forEach(ddoc => expect(ddoc.version).to.equal(currentVersion));
+    ddocs.forEach(ddoc => expect(ddoc.version).to.equal(currentBuild));
   });
 });

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -235,7 +235,7 @@ describe('routing', () => {
         utils.request(Object.assign({ path: '/api/deploy-info' }, offlineRequestOptions)),
         utils.requestOnTestDb('/_design/medic-client')
       ]).then(([ deployInfoOnline, deployInfoOffline, ddoc ]) => {
-        const deployInfo = Object.assign(ddoc.deploy_info, { version: ddoc.version });
+        const deployInfo = Object.assign(ddoc.deploy_info, ddoc.build_info, { version: ddoc.version });
         expect(deployInfoOnline).to.deep.equal(deployInfo);
         expect(deployInfoOffline).to.deep.equal(deployInfo);
       });

--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -31,11 +31,13 @@ const upgradeModalConfirm = async () => {
 };
 
 const getCurrentVersion = async () => {
-  const version = async () => {
-    const ddRows = await $$('dl.horizontal dd');
-    const idx = ddRows.length > 3 ? 1 : 0;
-    return (await $$('dl.horizontal dd'))[idx];
-  };
+  const version = () => $('dl.horizontal dd');
+  await browser.waitUntil(async () => await (await version()).getText());
+  return await (await version()).getText();
+};
+
+const getBuild = async () => {
+  const version = () => $('dl.horizontal dd:nth-child(4)');
   await browser.waitUntil(async () => await (await version()).getText());
   return await (await version()).getText();
 };
@@ -49,4 +51,5 @@ module.exports = {
   goToUpgradePage,
   expandPreReleasesAccordion,
   upgradeModalConfirm,
+  getBuild,
 };

--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -31,7 +31,7 @@ const upgradeModalConfirm = async () => {
 };
 
 const getCurrentVersion = async () => {
-  const version = () => $('dl.horizontal dd');
+  const version = () => $('dl.horizontal dd#build_version');
   await browser.waitUntil(async () => await (await version()).getText());
   return await (await version()).getText();
 };

--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -31,7 +31,11 @@ const upgradeModalConfirm = async () => {
 };
 
 const getCurrentVersion = async () => {
-  const version = () => $('dl.horizontal dd#build_version');
+  const version = async () => {
+    const ddRows = await $$('dl.horizontal dd');
+    const idx = ddRows.length > 3 ? 1 : 0;
+    return (await $$('dl.horizontal dd'))[idx];
+  };
   await browser.waitUntil(async () => await (await version()).getText());
   return await (await version()).getText();
 };


### PR DESCRIPTION
# Description

Changes `version` field to display `base_version` (like `4.2.0`) and adds a separate field that displays the full build version (which helps differentiate builds for the same branch from one another). 

![image](https://user-images.githubusercontent.com/35681649/212139131-1a630b1d-1fa4-44d0-b128-0f980b921d06.png)


medic/cht-core#8009

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8009-separate-admin-build-and-version/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8009-separate-admin-build-and-version/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8009-separate-admin-build-and-version/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
