### PR TITLE
Fix report date in reports e2e tests

### DIFF
--- a/tests/e2e/default-mobile/reports/delete.wdio-spec.js
+++ b/tests/e2e/default-mobile/reports/delete.wdio-spec.js
@@ -14,14 +14,20 @@ describe('Delete Reports', () => {
   const healthCenter = places.get('health_center');
   const onlineUser = userFactory.build({ place: healthCenter._id, roles: ['program_officer'] });
   const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
+
   const today = moment();
+  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
+  reportDate1.subtract(4, 'month');
+  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
+  reportDate2.subtract(1, 'month');
+
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: moment([today.year(), today.month() - 4, 1, 23, 30]).valueOf() },
+      { form: 'P', reported_date: reportDate1.valueOf() },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 3, 2022' } },
     ),
     reportFactory.build(
-      { form: 'P', reported_date: moment([today.year(), today.month() - 1, 16, 0, 30]).valueOf() },
+      { form: 'P', reported_date: reportDate2.valueOf() },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 16, 2022' } },
     ),
   ];

--- a/tests/e2e/default-mobile/reports/delete.wdio-spec.js
+++ b/tests/e2e/default-mobile/reports/delete.wdio-spec.js
@@ -16,18 +16,19 @@ describe('Delete Reports', () => {
   const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
 
   const today = moment();
-  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
-  reportDate1.subtract(4, 'month');
-  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
-  reportDate2.subtract(1, 'month');
-
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: reportDate1.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf()
+      },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 3, 2022' } },
     ),
     reportFactory.build(
-      { form: 'P', reported_date: reportDate2.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 12, 10, 30]).subtract(1, 'month').valueOf()
+      },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 16, 2022' } },
     ),
   ];

--- a/tests/e2e/default/login/renew-token.wdio-spec.js
+++ b/tests/e2e/default/login/renew-token.wdio-spec.js
@@ -15,15 +15,15 @@ describe('should renew token', async () => {
     await commonPage.waitForPageLoaded();
 
     for (let counter = 0; counter < 3; counter++) {
-      const beforPageLoadTime = moment();
+      const beforePageLoadTime = moment();
       await browser.refresh();
       await commonPage.waitForPageLoaded();
       const afterPageLoadTime = moment();
       const ctxExpiry = await getCtxCookieExpiry();
 
       chai.expect(
-        ctxExpiry.isBetween(beforPageLoadTime.add(1, 'year'), afterPageLoadTime.add(1, 'year')),
-        `Failed for counter = ${counter}, ${ctxExpiry.toISOString()} ${beforPageLoadTime.toISOString()}`
+        ctxExpiry.isBetween(beforePageLoadTime.add(1, 'year'), afterPageLoadTime.add(1, 'year')),
+        `Failed for counter = ${counter}, ${ctxExpiry.toISOString()} ${beforePageLoadTime.toISOString()}`
       ).to.be.true;
     }
   });

--- a/tests/e2e/default/reports/breadcrumbs.wdio-spec.js
+++ b/tests/e2e/default/reports/breadcrumbs.wdio-spec.js
@@ -10,7 +10,6 @@ const personFactory = require('../../../factories/cht/contacts/person');
 const reportFactory = require('../../../factories/cht/reports/generic-report');
 
 describe('Reports tab breadcrumbs', () => {
-  const today = moment();
   const places = placeFactory.generateHierarchy();
   const clinic = places.get('clinic');
   const health_center = places.get('health_center');
@@ -52,15 +51,22 @@ describe('Reports tab breadcrumbs', () => {
     _id: 'patient1',
     parent: { _id: clinic._id, parent: { _id: health_center._id, parent: { _id: district_hospital._id }}}
   });
+
+  const today = moment();
+  const reportDate = moment([today.year(), today.month(), 1, 23, 30]);
+  reportDate.subtract(4, 'month');
+
   const reports = [
     reportFactory.build(
       {
         form: 'P',
-        reported_date: moment([ today.year(), today.month() - 4, 1, 23, 30 ]).valueOf(),
+        reported_date: reportDate.valueOf(),
         patient_id: 'patient1',
       },
       {
-        patient, submitter: offlineUser.contact, fields: { lmp_date: 'Feb 3, 2022', patient_id: 'patient1' },
+        patient,
+        submitter: offlineUser.contact,
+        fields: { lmp_date: 'Feb 3, 2022', patient_id: 'patient1' },
       },
     ),
   ];

--- a/tests/e2e/default/reports/breadcrumbs.wdio-spec.js
+++ b/tests/e2e/default/reports/breadcrumbs.wdio-spec.js
@@ -53,14 +53,11 @@ describe('Reports tab breadcrumbs', () => {
   });
 
   const today = moment();
-  const reportDate = moment([today.year(), today.month(), 1, 23, 30]);
-  reportDate.subtract(4, 'month');
-
   const reports = [
     reportFactory.build(
       {
         form: 'P',
-        reported_date: reportDate.valueOf(),
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf(),
         patient_id: 'patient1',
       },
       {

--- a/tests/e2e/default/reports/date-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/date-filter.wdio-spec.js
@@ -19,23 +19,23 @@ describe('Report Filter', () => {
     // one registration half an hour before the start date
     reportFactory.build(
       { form: 'P', reported_date: moment([2016, 4, 15, 23, 30]).valueOf() },
-      { patient, submitter: user.contact, fields: { lmp_date: 'Feb 3, 2016' },
-      }),
+      { patient, submitter: user.contact, fields: { lmp_date: 'Feb 3, 2016' } }
+    ),
     // one registration half an hour after the start date
     reportFactory.build(
       { form: 'P', reported_date: moment([2016, 4, 16, 0, 30]).valueOf() },
-      { patient, submitter: user.contact, fields: { lmp_date: 'Feb 15, 2016' },
-      }),
+      { patient, submitter: user.contact, fields: { lmp_date: 'Feb 15, 2016' } }
+    ),
     // one visit half an hour after the end date
     reportFactory.build(
       { form: 'V', reported_date: moment([2016, 4, 18, 0, 30]).valueOf() },
-      { patient, submitter: user.contact, fields: { ok: 'Yes!' },
-      }),
+      { patient, submitter: user.contact, fields: { ok: 'Yes!' } }
+    ),
     // one visit half an hour before the end date
     reportFactory.build(
       { form: 'V', reported_date: moment([2016, 4, 17, 23, 30]).valueOf() },
-      { patient, submitter: user.contact, fields: { ok: 'Yes!' },
-      }),
+      { patient, submitter: user.contact, fields: { ok: 'Yes!' } }
+    ),
   ];
 
   beforeEach(async () => {

--- a/tests/e2e/default/reports/delete.wdio-spec.js
+++ b/tests/e2e/default/reports/delete.wdio-spec.js
@@ -14,14 +14,20 @@ describe('Delete Reports', () => {
   const healthCenter = places.get('health_center');
   const onlineUser = userFactory.build({ place: healthCenter._id, roles: ['program_officer'] });
   const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
+
   const today = moment();
+  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
+  reportDate1.subtract(4, 'month');
+  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
+  reportDate2.subtract(1, 'month');
+
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: moment([today.year(), today.month() - 4, 1, 23, 30]).valueOf() },
+      { form: 'P', reported_date: reportDate1.valueOf() },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 3, 2022' } },
     ),
     reportFactory.build(
-      { form: 'P', reported_date: moment([today.year(), today.month() - 1, 16, 0, 30]).valueOf() },
+      { form: 'P', reported_date: reportDate2.valueOf() },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 16, 2022' } },
     ),
   ];

--- a/tests/e2e/default/reports/delete.wdio-spec.js
+++ b/tests/e2e/default/reports/delete.wdio-spec.js
@@ -16,18 +16,19 @@ describe('Delete Reports', () => {
   const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
 
   const today = moment();
-  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
-  reportDate1.subtract(4, 'month');
-  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
-  reportDate2.subtract(1, 'month');
-
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: reportDate1.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf()
+      },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 3, 2022' } },
     ),
     reportFactory.build(
-      { form: 'P', reported_date: reportDate2.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 12, 10, 30]).subtract(1, 'month').valueOf()
+      },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 16, 2022' } },
     ),
   ];

--- a/tests/e2e/default/reports/export.wdio-spec.js
+++ b/tests/e2e/default/reports/export.wdio-spec.js
@@ -15,14 +15,20 @@ describe('Export Reports', () => {
   const healthCenter = places.get('health_center');
   const onlineUser = userFactory.build({ place: healthCenter._id, roles: [ 'program_officer' ] });
   const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
+
   const today = moment();
+  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
+  reportDate1.subtract(4, 'month');
+  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
+  reportDate2.subtract(1, 'month');
+
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: moment([today.year(), today.month() - 4, 1, 23, 30]).valueOf() },
+      { form: 'P', reported_date: reportDate1.valueOf() },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 3, 2022' } },
     ),
     reportFactory.build(
-      { form: 'P', reported_date: moment([today.year(), today.month() - 1, 16, 0, 30]).valueOf() },
+      { form: 'P', reported_date: reportDate2.valueOf() },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 16, 2022' } },
     ),
   ];

--- a/tests/e2e/default/reports/export.wdio-spec.js
+++ b/tests/e2e/default/reports/export.wdio-spec.js
@@ -17,18 +17,19 @@ describe('Export Reports', () => {
   const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
 
   const today = moment();
-  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
-  reportDate1.subtract(4, 'month');
-  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
-  reportDate2.subtract(1, 'month');
-
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: reportDate1.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf()
+      },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 3, 2022' } },
     ),
     reportFactory.build(
-      { form: 'P', reported_date: reportDate2.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 12, 10, 30]).subtract(1, 'month').valueOf()
+      },
       { patient, submitter: onlineUser.contact, fields: { lmp_date: 'Feb 16, 2022' } },
     ),
   ];

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -16,30 +16,33 @@ describe('Reports Sidebar Filter', () => {
   const patient = personFactory.build({ parent: { _id: user.place._id, parent: { _id: parent._id } } });
 
   const today = moment();
-  const reportDate1 = moment([today.year(), today.month(), 1, 23, 30]);
-  reportDate1.subtract(4, 'month');
-  const reportDate2 = moment([today.year(), today.month(), 12, 10, 30]);
-  reportDate2.subtract(1, 'month');
-  const reportDate3 = moment([today.year(), today.month(), 15, 0, 30]);
-  reportDate3.subtract(5, 'month');
-  const reportDate4 = moment([today.year(), today.month(), 16, 9, 10]);
-  reportDate4.subtract(1, 'month');
-
   const reports = [
     reportFactory.build(
-      { form: 'P', reported_date: reportDate1.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf()
+      },
       { patient, submitter: user.contact, fields: { lmp_date: 'Feb 3, 2022' }}
     ),
     reportFactory.build(
-      { form: 'P', reported_date: reportDate2.valueOf() },
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 12, 10, 30]).subtract(1, 'month').valueOf()
+      },
       { patient, submitter: user.contact, fields: { lmp_date: 'Feb 16, 2022' }}
     ),
     reportFactory.build(
-      { form: 'V', reported_date: reportDate3.valueOf() },
+      {
+        form: 'V',
+        reported_date: moment([today.year(), today.month(), 15, 0, 30]).subtract(5, 'month').valueOf()
+      },
       { patient, submitter: user.contact, fields: { ok: 'Yes!' }}
     ),
     reportFactory.build(
-      { form: 'V', reported_date: reportDate4.valueOf() },
+      {
+        form: 'V',
+        reported_date: moment([today.year(), today.month(), 16, 9, 10]).subtract(1, 'month').valueOf()
+      },
       { patient, submitter: user.contact, fields: { ok: 'Yes!' }}
     ),
   ];


### PR DESCRIPTION
# Description

This work focuses on e2e only. The code validation to prevent saving reports without `reported_date` will be done later after the teams prioritize work. 

- Fixes typos and format in e2e
- Fixes report_date property when creating reports.

https://github.com/medic/cht-core/issues/8030

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-reported-date-in-reports-e2e-tests/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-reported-date-in-reports-e2e-tests/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-reported-date-in-reports-e2e-tests/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
