### PR TITLE
add LAN IP to Docker Helper 4.x

### DIFF
--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -110,7 +110,7 @@ get_lan_ip() {
   else
     subnet=$(netstat -rn| grep default | awk '{print $2}'|grep -Ev '^[a-f]' |cut -f1,2,3 -d'.')
     ifconfig_line=$(ifconfig|grep inet|grep "$subnet" | cut -d' ' -f 2)
-    echo ifconfig_line
+    lanAddress=$ifconfig_line
   fi
 
   # always fall back to localhost if lanAddress wasn't set
@@ -120,7 +120,7 @@ get_lan_ip() {
   echo "$lanAddress"
 }
 
-get_local_ip(){
+get_local_ip_url(){
   lanIp=$1
   cookedLanAddress=$(echo "$lanIp" | tr . -)
   url="https://${cookedLanAddress}.my.local-ip.co:${NGINX_HTTPS_PORT}"
@@ -288,6 +288,8 @@ fi
 # shellcheck disable=SC1090
 source "./$projectFile"
 
+projectURL=$(get_local_ip_url "$(get_lan_ip)")
+
 echo ""
 docker-compose --env-file "./$projectFile" --file "$homeDir/upgrade-service.yml" up --detach
 
@@ -322,8 +324,6 @@ docker exec -it "$nginxContainerId" bash -c "curl -s -o chain.pem http://local-i
 docker exec -it "$nginxContainerId" bash -c "cat server.pem chain.pem > /etc/nginx/private/cert.pem"
 docker exec -it "$nginxContainerId" bash -c "curl -s -o /etc/nginx/private/key.pem http://local-ip.co/cert/server.key"
 docker restart "$nginxContainerId" 1>/dev/null
-
-projectURL=$(get_local_ip "$(get_lan_ip)")
 
 echo ""
 echo ""

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -139,6 +139,22 @@ required_apps_installed(){
   echo "${error}"
 }
 
+get_nginx_container_id() {
+	docker ps --all --filter "publish=${NGINX_HTTPS_PORT}" --filter "name=${projectName}" --quiet
+}
+
+get_is_container_running() {
+	containerId=$1
+	docker inspect --format="{{.State.Running}}" "$containerId" 2>/dev/null
+}
+
+if [ -n "$(required_apps_installed "docker-compose")" ];then
+  echo ""
+  echo -e "${red}\"docker-compose\" is not installed or could not be found. Please install and try again!${noColor}"
+  show_help_existing_stop_and_destroy
+  exit 0
+fi
+
 # can pass a project .env file as argument
 if [[ -n "${1-}" ]]; then
 	if [[ "$1" == "--help" ]] || [[  "$1" == "-h" ]]; then
@@ -278,15 +294,6 @@ docker-compose --env-file "./$projectFile" --file "$homeDir/upgrade-service.yml"
 set +e
 echo "Starting project \"${projectName}\". First run takes a while. Will try for up to five minutes..." | tr -d '\n'
 
-get_nginx_container_id() {
-	docker ps --all --filter "publish=${NGINX_HTTPS_PORT}" --filter "name=${projectName}" --quiet
-}
-
-get_is_container_running() {
-	containerId=$1
-	docker inspect --format="{{.State.Running}}" "$containerId" 2>/dev/null
-}
-
 nginxContainerId=$(get_nginx_container_id)
 isNginxRunning=$(get_is_container_running "$nginxContainerId")
 i=0
@@ -324,8 +331,8 @@ echo " -------------------------------------------------------- "
 echo ""
 echo "  Success! \"${projectName}\" is set up:"
 echo ""
-echo "    ${projectURL} (CHT)"
-echo "    ${projectURL}_utils/ (Fauxton)"
+echo "    ${projectURL}/ (CHT)"
+echo "    ${projectURL}/_utils/ (Fauxton)"
 echo ""
 echo "    Login: ${COUCHDB_USER}"
 echo "    Password: ${COUCHDB_PASSWORD}"


### PR DESCRIPTION
# Description

adds check for `docker-compose` in path and also shows actual LAN IP to Docker Helper 4.x and this should support too.

IP change means that instead of this with the `127` IP:

```
  Success! "supervisor_chw_create" is set up:

    https://127-0-0-1.my.local-ip.co:10446/ (CHT)
    https://127-0-0-1.my.local-ip.co:10446/_utils/ (Fauxton)
```

We show the hosts actual `192` LAN IP:

```
  Success! "supervisor_chw_create" is set up:

    https://192-168-68-26.my.local-ip.co:10446 (CHT)
    https://192-168-68-26.my.local-ip.co:10446/_utils/ (Fauxton)
```

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:add-lan-ip-to-docker-helper/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:add-lan-ip-to-docker-helper/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:add-lan-ip-to-docker-helper/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
