### PR TITLE
fix couchdb entry point script 

### DIFF
--- a/couchdb/docker-entrypoint.sh
+++ b/couchdb/docker-entrypoint.sh
@@ -35,7 +35,7 @@ setSecret() {
     COUCHDB_SECRET=$(cat /proc/sys/kernel/random/uuid)
   fi
   # Set secret only if not already present
-  if [ -z $(grep -Pzoqr "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini)]; then
+  if [ -z $(grep -Pzor "\[couch_httpd_auth\]\nsecret =" /opt/couchdb/etc/local.d/*.ini)]; then
     printf "\n[couch_httpd_auth]\nsecret = %s\n" "$COUCHDB_SECRET" >> $CLUSTER_CREDENTIALS
   fi
 }
@@ -45,7 +45,7 @@ setUuid() {
     COUCHDB_UUID=$(cat /proc/sys/kernel/random/uuid)
   fi
   # Set uuid only if not already present
-  if [ -z $(grep -Pzoqr "\[couchdb\]\nuuid =" /opt/couchdb/etc/local.d/*.ini)]; then
+  if [ -z $(grep -Pzor "\[couchdb\]\nuuid =" /opt/couchdb/etc/local.d/*.ini)]; then
     printf "\n[couchdb]\nuuid = %s\n" "$COUCHDB_UUID" >> $CLUSTER_CREDENTIALS
   fi
 }


### PR DESCRIPTION
# Description

makes `grep` more chatty to fix entry point script in couchdb 

medic/cht-core#8067

To test:
* download the couchdb compose file from this branch
* start up a couchdb instance using the compose file you just downloaded
* get the line count of the credentials file: `wc -l /opt/couchdb/etc/local.d/cluster-credentials.ini`
* restart the container
* re-run the `wc` command above and ensure the line count is unchanged and that the couchdb service still works

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* __CHT_CORE_COMPOSE_URL__
* __COUCH_SINGLE_COMPOSE_URL__
* __COUCH_CLUSTER_COMPOSE_URL__
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
