### PR TITLE
Use _all_docs to get forms on API startup.

### DIFF
--- a/api/src/controllers/forms.js
+++ b/api/src/controllers/forms.js
@@ -95,7 +95,8 @@ module.exports = {
       };
       return serverUtils.error(error, req, res);
     }
-    return formsService.getFormDocs()
+    return formsService
+      .getFormDocs()
       .then(docs => docs.find(doc => doc.internalId === form))
       .then(doc => formsService.getXFormAttachment(doc))
       .then(attachment => {

--- a/api/src/services/forms.js
+++ b/api/src/services/forms.js
@@ -2,6 +2,8 @@
  * @module forms
  */
 const db = require('../db');
+const FORM_DOC_ID_PREFIX = 'form:';
+const DOC_TYPE = 'form';
 
 module.exports = {
 
@@ -21,15 +23,18 @@ module.exports = {
    *   with a valid xform attachment.
    */
   getFormDocs: () => {
-    const options = {
-      key: ['form'],
-      include_docs: true,
-      attachments: true,
-      binary: true,
-    };
-    return db.medic.query('medic-client/doc_by_type', options)
-      .then(response => response.rows.filter(row => module.exports.getXFormAttachment(row.doc)))
-      .then(rows => rows.map(row => row.doc));
-  }
-
+    return db.medic
+      .allDocs({
+        startkey: FORM_DOC_ID_PREFIX,
+        endkey: `${FORM_DOC_ID_PREFIX}\ufff0`,
+        include_docs: true,
+        attachments: true,
+        binary: true,
+      })
+      .then(response => {
+        return response.rows
+          .map(row => row.doc)
+          .filter(doc => doc && doc.type === DOC_TYPE && module.exports.getXFormAttachment(doc));
+      });
+  },
 };

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -241,7 +241,8 @@ module.exports = {
    * Updates the model and form attachments for all forms if necessary.
    */
   updateAll: () => {
-    return formsService.getFormDocs()
+    return formsService
+      .getFormDocs()
       .then(docs => {
         if (!docs.length) {
           return [];

--- a/api/tests/mocha/controllers/forms.spec.js
+++ b/api/tests/mocha/controllers/forms.spec.js
@@ -42,10 +42,10 @@ describe('forms controller', () => {
         params: { form: 'a.xml' },
         userCtx: { name: 'formuser' }
       };
-      sinon.stub(db.medic, 'allDocs').rejects('icky');
+      sinon.stub(db.medic, 'allDocs').rejects({ error: 'icky' });
       sinon.stub(serverUtils, 'error');
       return controller.get(req, res).then(() => {
-        chai.expect(serverUtils.error.args[0][0].name).to.deep.equal('icky');
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal({ error: 'icky' });
         chai.expect(db.medic.allDocs.callCount).to.equal(1);
       });
     });
@@ -92,10 +92,10 @@ describe('forms controller', () => {
       const req = {
         userCtx: { name: 'formuser' }
       };
-      sinon.stub(db.medic, 'allDocs').rejects('icky');
+      sinon.stub(db.medic, 'allDocs').rejects({ error: 'icky' });
       sinon.stub(serverUtils, 'error');
       return controller.list(req, res).then(() => {
-        chai.expect(serverUtils.error.args[0][0].name).to.equal('icky');
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal({ error: 'icky' });
         chai.expect(db.medic.allDocs.callCount).to.equal(1);
       });
     });

--- a/api/tests/mocha/services/config-watcher.spec.js
+++ b/api/tests/mocha/services/config-watcher.spec.js
@@ -25,7 +25,6 @@ describe('Configuration', () => {
 
     sinon.stub(db, 'createVault');
     sinon.stub(db.medic, 'get');
-    sinon.stub(db.medic, 'query');
     sinon.stub(db.medic, 'changes').returns({ on });
     sinon.stub(viewMapUtils, 'loadViewMaps');
     sinon.stub(translations, 'run');

--- a/api/tests/mocha/services/forms.spec.js
+++ b/api/tests/mocha/services/forms.spec.js
@@ -38,26 +38,41 @@ describe('forms service', () => {
 
     it('returns an empty array when no docs found', () => {
       const given = [];
-      sinon.stub(db.medic, 'query').resolves({ rows: given });
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: given });
       return service.getFormDocs().then(actual => {
         expect(actual).to.deep.equal([]);
+        expect(db.medic.allDocs.args).to.deep.equal([[{
+          startkey: 'form:',
+          endkey: 'form:\ufff0',
+          include_docs: true,
+          attachments: true,
+          binary: true,
+        }]]);
       });
     });
 
     it('returns an empty array when no xform docs found', () => {
       const given = [ { doc: {} } ];
-      sinon.stub(db.medic, 'query').resolves({ rows: given });
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: given });
       return service.getFormDocs().then(actual => {
         expect(actual).to.deep.equal([]);
+        expect(db.medic.allDocs.args).to.deep.equal([[{
+          startkey: 'form:',
+          endkey: 'form:\ufff0',
+          include_docs: true,
+          attachments: true,
+          binary: true,
+        }]]);
       });
     });
 
-    it('returns doc with "xml" attachment', () => {
+    it('returns doc with form type and "xml" attachment', () => {
       const given = [
-        { doc: { _id: 'form:a', _attachments: { xml: '<myxml/>' } } },
-        { doc: { _id: 'form:b', _attachments: { xsl: '<myxsl/>' } } }
+        { doc: { _id: 'form:a', type: 'form', _attachments: { xml: '<myxml/>' } } },
+        { doc: { _id: 'form:b', type: 'form', _attachments: { xsl: '<myxsl/>' } } },
+        { doc: { _id: 'form:c', _attachments: { xml: '<myxml/>' } } },
       ];
-      sinon.stub(db.medic, 'query').resolves({ rows: given });
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: given });
       return service.getFormDocs().then(actual => {
         expect(actual.length).to.equal(1);
         expect(actual[0]._id).to.equal('form:a');

--- a/api/tests/mocha/services/forms.spec.js
+++ b/api/tests/mocha/services/forms.spec.js
@@ -71,6 +71,7 @@ describe('forms service', () => {
         { doc: { _id: 'form:a', type: 'form', _attachments: { xml: '<myxml/>' } } },
         { doc: { _id: 'form:b', type: 'form', _attachments: { xsl: '<myxsl/>' } } },
         { doc: { _id: 'form:c', _attachments: { xml: '<myxml/>' } } },
+        { doc: { _id: 'form:d', type: 'not_form', _attachments: { xml: '<myxml/>' } } },
       ];
       sinon.stub(db.medic, 'allDocs').resolves({ rows: given });
       return service.getFormDocs().then(actual => {

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -339,33 +339,34 @@ describe('generate-xform service', () => {
       doc: {
         _id: 'b',
         _attachments: { xml: {} },
-        context: { collect: true }
+        context: { collect: true },
+        type: 'form',
       }
     };
 
     it('should handle no forms', () => {
-      sinon.stub(db.medic, 'query').resolves({ rows: [] });
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: [] });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
-        expect(db.medic.query.callCount).to.equal(1);
+        expect(db.medic.allDocs.callCount).to.equal(1);
         expect(db.medic.bulkDocs.callCount).to.equal(0);
       });
     });
 
     it('should ignore json forms', () => {
-      sinon.stub(db.medic, 'query').resolves({ rows: [ JSON_FORM_ROW ] });
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: [ JSON_FORM_ROW ] });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
-        expect(db.medic.query.callCount).to.equal(1);
+        expect(db.medic.allDocs.callCount).to.equal(1);
         expect(db.medic.bulkDocs.callCount).to.equal(0);
       });
     });
 
     it('should ignore collect forms', () => {
-      sinon.stub(db.medic, 'query').resolves({ rows: [ COLLECT_FORM_ROW ] });
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: [ COLLECT_FORM_ROW ] });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
-        expect(db.medic.query.callCount).to.equal(1);
+        expect(db.medic.allDocs.callCount).to.equal(1);
         expect(db.medic.bulkDocs.callCount).to.equal(0);
       });
     });
@@ -374,17 +375,20 @@ describe('generate-xform service', () => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const currentModel = '<xml/>';
-      sinon.stub(db.medic, 'query').resolves({ rows: [ {
-        doc: { _attachments: {
-          'xform.xml': { data: Buffer.from(formXml) },
-          'form.html': { data: Buffer.from(currentForm) },
-          'model.xml': { data: Buffer.from(currentModel) }
-        } }
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: [ {
+        doc: {
+          type: 'form',
+          _attachments: {
+            'xform.xml': { data: Buffer.from(formXml) },
+            'form.html': { data: Buffer.from(currentForm) },
+            'model.xml': { data: Buffer.from(currentModel) }
+          }
+        }
       } ] });
       sinon.stub(service, 'generate').resolves({ form: currentForm, model: currentModel });
       sinon.stub(db.medic, 'bulkDocs');
       return service.updateAll().then(() => {
-        expect(db.medic.query.callCount).to.equal(1);
+        expect(db.medic.allDocs.callCount).to.equal(1);
         expect(db.medic.bulkDocs.callCount).to.equal(0);
       });
     });
@@ -395,10 +399,11 @@ describe('generate-xform service', () => {
       const newForm = '<html><title>Hello</title></html>';
       const currentModel = '<xml/>';
       const newModel = '<instance><multimedia/></instance>';
-      sinon.stub(db.medic, 'query').resolves({ rows: [
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: [
         {
           doc: {
             _id: 'd',
+            type: 'form',
             _attachments: {
               'xform.xml': { data: Buffer.from(formXml) },
               'form.html': { data: Buffer.from(currentForm) },
@@ -423,12 +428,13 @@ describe('generate-xform service', () => {
       const newForm = '<html><title>Hello</title></html>';
       const currentModel = '<xml/>';
       const newModel = '<instance><multimedia/></instance>';
-      sinon.stub(db.medic, 'query').resolves({ rows: [
+      sinon.stub(db.medic, 'allDocs').resolves({ rows: [
         JSON_FORM_ROW,
         COLLECT_FORM_ROW,
         {
           doc: {
             _id: 'c',
+            type: 'form',
             _attachments: {
               'xform.xml': { data: Buffer.from(formXml) },
               'form.html': { data: Buffer.from(currentForm) },
@@ -439,6 +445,7 @@ describe('generate-xform service', () => {
         {
           doc: {
             _id: 'd',
+            type: 'form',
             _attachments: {
               'xform.xml': { data: Buffer.from(formXml) },
               'form.html': { data: Buffer.from(currentForm) },
@@ -452,7 +459,7 @@ describe('generate-xform service', () => {
         .onCall(1).resolves({ form: newForm, model: newModel });
       sinon.stub(db.medic, 'bulkDocs').resolves([ { ok: true } ]);
       return service.updateAll().then(() => {
-        expect(db.medic.query.callCount).to.equal(1);
+        expect(db.medic.allDocs.callCount).to.equal(1);
         expect(db.medic.bulkDocs.callCount).to.equal(1);
         expect(db.medic.bulkDocs.args[0][0].length).to.equal(1);
         expect(db.medic.bulkDocs.args[0][0][0]._id).to.equal('d');


### PR DESCRIPTION
# Description

Leverages the fact that all forms' doc ids are prefixed with `form:` (source: https://github.com/medic/cht-conf/blob/ba6155395ee2f198fb847e3ce8e3dd2c28f3d1d8/src/lib/upload-forms.js#L73) , which makes it possible to use `_all_docs` to get a list of forms to update. 

medic/cht-core#7964

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7964-no-api-startup-query/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7964-no-api-startup-query/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7964-no-api-startup-query/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
