### PR TITLE
Update haproxy to latest LTS

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -2,6 +2,8 @@ FROM haproxy:2.6
 
 USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext jq curl -y
+USER haproxy
+
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,8 +1,10 @@
-FROM haproxy:2.3.19
+FROM haproxy:2.6
 
+USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext jq curl -y
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
+USER 1001
 
 ADD default_frontend.cfg /usr/local/etc/haproxy
 ADD backend.cfg.template /usr/local/etc/haproxy

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -2,10 +2,9 @@ FROM haproxy:2.6
 
 USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext jq curl -y
-USER haproxy
-
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
+USER haproxy
 
 ADD default_frontend.cfg /usr/local/etc/haproxy
 ADD backend.cfg.template /usr/local/etc/haproxy

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -4,7 +4,6 @@ USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext jq curl -y
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-USER haproxy
 
 ADD default_frontend.cfg /usr/local/etc/haproxy
 ADD backend.cfg.template /usr/local/etc/haproxy

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -12,4 +12,4 @@ ADD rsyslog.conf /etc/rsyslog.conf
 COPY scripts /usr/local/etc/haproxy/
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["-f", "/usr/local/etc/haproxy/default_frontend.cfg", "-f", "/usr/local/etc/haproxy/backend.cfg"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/default_frontend.cfg", "-f", "/usr/local/etc/haproxy/backend.cfg"]

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -10,5 +10,5 @@ ADD backend.cfg.template /usr/local/etc/haproxy
 ADD rsyslog.conf /etc/rsyslog.conf
 COPY scripts /usr/local/etc/haproxy/
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/default_frontend.cfg", "-f", "/usr/local/etc/haproxy/backend.cfg"]

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -4,7 +4,6 @@ USER root
 RUN apt-get update && apt-get install rsyslog luarocks gettext jq curl -y
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh
-USER 1001
 
 ADD default_frontend.cfg /usr/local/etc/haproxy
 ADD backend.cfg.template /usr/local/etc/haproxy

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -10,5 +10,5 @@ ADD backend.cfg.template /usr/local/etc/haproxy
 ADD rsyslog.conf /etc/rsyslog.conf
 COPY scripts /usr/local/etc/haproxy/
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["haproxy", "-f", "/usr/local/etc/haproxy/default_frontend.cfg", "-f", "/usr/local/etc/haproxy/backend.cfg"]

--- a/haproxy/entrypoint.sh
+++ b/haproxy/entrypoint.sh
@@ -24,4 +24,4 @@ echo $COUCHDB_USER > /srv/storage/haproxy/passwd/username
 echo $COUCHDB_PASSWORD > /srv/storage/haproxy/passwd/admin
 
 # Start haproxy
-exec /docker-entrypoint.sh "$@"
+exec /usr/local/bin/docker-entrypoint.sh "$@"


### PR DESCRIPTION
# Description

Upgrades haproxy from an unmaintained version to the most recent LTS including a recent security patch.

medic/cht-core#8076

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8076-update-haproxy/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8076-update-haproxy/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8076-update-haproxy/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
