### PR TITLE
fix(#8130): haproxy lua lock up

### DIFF
--- a/haproxy/default_frontend.cfg
+++ b/haproxy/default_frontend.cfg
@@ -6,9 +6,9 @@
 global
   maxconn 150000
   spread-checks 5
-  lua-load /usr/local/etc/haproxy/parse_basic.lua
-  lua-load /usr/local/etc/haproxy/parse_cookie.lua
-  lua-load /usr/local/etc/haproxy/replace_password.lua
+  lua-load-per-thread /usr/local/etc/haproxy/parse_basic.lua
+  lua-load-per-thread /usr/local/etc/haproxy/parse_cookie.lua
+  lua-load-per-thread /usr/local/etc/haproxy/replace_password.lua
   log stdout len 65535 local2 debug
   tune.bufsize 1638400
   tune.http.maxhdr 1010


### PR DESCRIPTION
# Description

medic/cht-core#8130

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8130-haproxy-lua-lock/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8130-haproxy-lua-lock/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8130-haproxy-lua-lock/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
