### PR TITLE
feat(#8136): Add current timestamp into feedback document logs

### DIFF
--- a/webapp/src/ts/services/feedback.service.ts
+++ b/webapp/src/ts/services/feedback.service.ts
@@ -32,12 +32,13 @@ export class FeedbackService {
   private logIdx = 0;
   private readonly LEVELS = ['error', 'warn', 'log', 'info'];
   private readonly LOG_LENGTH = 20;
-  private readonly logs = new Array(this.LOG_LENGTH);
+  private readonly logCircularBuffer = new Array(this.LOG_LENGTH);
 
-  // Flips and reverses log into a clean latest first array for logging out
+  // converts the logCircularBuffer into an ordered array of log events
   private getLog() {
-    // [oldest + newest] -> reversed -> filter empty
-    return (this.logs.slice(this.logIdx, this.LOG_LENGTH).concat(this.logs.slice(0, this.logIdx)))
+    const olderLogEvents = this.logCircularBuffer.slice(this.logIdx, this.LOG_LENGTH);
+    const newerLogEvents = this.logCircularBuffer.slice(0, this.logIdx);
+    return [...olderLogEvents, ...newerLogEvents]
       .reverse()
       .filter(i => !!i);
   }
@@ -69,8 +70,14 @@ export class FeedbackService {
     this.LEVELS.forEach(level => {
       const original = this.options.console[level];
       this.options.console[level] = (...args) => {
-        // push the error onto the stack
-        this.logs[this.logIdx++] = { level, arguments: JSON.stringify(args, getCircularReplacer()) };
+        const logEvent = {
+          level,
+          arguments: JSON.stringify(args, getCircularReplacer()),
+          time: new Date().toISOString(),
+        };
+
+        // push the log event onto the circular buffer
+        this.logCircularBuffer[this.logIdx++] = logEvent;
         if (this.logIdx === this.LOG_LENGTH) {
           this.logIdx = 0;
         }


### PR DESCRIPTION
# Description

#8136 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8136-feedback-log-timestamp/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8136-feedback-log-timestamp/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8136-feedback-log-timestamp/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
