### PR TITLE
chore: Update PR template to instruct about semantic PR titles / commit messages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,9 @@ feat(#1234): add hat wobble
 |     |      |
 |     |      + - > subject
 |     |
-|     + ------- > issue number
+|     + -------- > issue number
 |
-+ ------------- > type: chore, feat, fix, perf, style, test, etc.
++ -------------- > type: chore, feat, fix, perf, style, test, etc.
 
 https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 Please use semantic PR Titles
 Format: <type>(#<issue number>): <subject>
 
+Quick example:
+
 feat(#1234): add hat wobble
 ^--^ (#^--^) ^------------^
 |      |     |
@@ -18,6 +20,8 @@ chore: updating grunt tasks etc; no production code change
 test: adding missing tests, refactoring tests; no production code change
 style: formatting, missing semi colons, etc; no production code change
 refactor: refactoring production code, eg. renaming a variable
+
+https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
 -->
 
 # Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,25 @@
+<!--
+Please use semantic PR Titles
+Format: <type>(#<issue number>): <subject>
+
+feat(#1234): add hat wobble
+^--^ (#^--^) ^------------^
+|      |     |
+|      |     + - > subject
+|      |
+|      + ------- > issue number
+|
++ -------------- > type: chore, feat, fix, perf, refactor, style, or test.
+
+feat: new feature for the user, not a new feature for build script
+fix: bug fix for the user, not a fix to a build script
+perf: optimizing for performance
+chore: updating grunt tasks etc; no production code change
+test: adding missing tests, refactoring tests; no production code change
+style: formatting, missing semi colons, etc; no production code change
+refactor: refactoring production code, eg. renaming a variable
+-->
+
 # Description
 
 [description]
@@ -19,8 +41,8 @@ If Build CI hasn't passed, these may 404:
 * __CHT_CORE_COMPOSE_URL__
 * __COUCH_SINGLE_COMPOSE_URL__
 * __COUCH_CLUSTER_COMPOSE_URL__
- 
+
 # License
 
 The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
- 
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,9 @@ Please use semantic PR titles that respect this format:
 Quick example:
 
 feat(#1234): add hat wobble
-^--^(#^--^) ^------------^
-|     |     |
-|     |     + - > subject
+^--^(#^--^): ^------------^
+|     |      |
+|     |      + - > subject
 |     |
 |     + ------- > issue number
 |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,18 @@
 <!--
-Please use semantic PR Titles
-Format: <type>(#<issue number>): <subject>
+Please use semantic PR titles that respect this format:
+
+<type>(#<issue number>): <subject>
 
 Quick example:
 
 feat(#1234): add hat wobble
-^--^ (#^--^) ^------------^
-|      |     |
-|      |     + - > subject
-|      |
-|      + ------- > issue number
+^--^(#^--^) ^------------^
+|     |     |
+|     |     + - > subject
+|     |
+|     + ------- > issue number
 |
-+ -------------- > type: chore, feat, fix, perf, refactor, style, or test.
-
-feat: new feature for the user, not a new feature for build script
-fix: bug fix for the user, not a fix to a build script
-perf: optimizing for performance
-chore: updating grunt tasks etc; no production code change
-test: adding missing tests, refactoring tests; no production code change
-style: formatting, missing semi colons, etc; no production code change
-refactor: refactoring production code, eg. renaming a variable
++ ------------- > type: chore, feat, fix, perf, style, test, etc.
 
 https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
 -->


### PR DESCRIPTION
# Description

I find I sometimes have to look these up. I think having an example directly in the PR template will help adopting and correct use of semantic commit messages. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:semantic-pr-title-template/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:semantic-pr-title-template/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:semantic-pr-title-template/docker-compose/cht-couchdb-clustered.yml)
 
# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
 
