### PR TITLE
fix(#7363): Create feedback documents from crashes in Tasks/Targets

### DIFF
--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -171,11 +171,11 @@ export class TasksComponent implements OnInit, OnDestroy {
       this.telemetryService.record(telemetryEntryName, telemetryData.end - telemetryData.start);
 
     } catch (exception) {
-      console.error('Error getting tasks for all contacts', exception);
       this.error = true;
       this.loading = false;
       this.hasTasks = false;
       this.tasksActions.setTasksList([]);
+      throw `Error getting tasks for all contacts: ${exception}`;
     }
   }
 


### PR DESCRIPTION
# Description

Throwing the error from the try/catch clause is enough for our custom exception handler to catch it and submit a feedback doc for it.

medic/cht-core#7363

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7363-create-feedback-docs-from-tasks-errors/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7363-create-feedback-docs-from-tasks-errors/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:7363-create-feedback-docs-from-tasks-errors/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

