### PR TITLE
chore(#6505): prevent opening unauthorized forms by url

### DIFF
--- a/api/resources/translations/messages-en.properties
+++ b/api/resources/translations/messages-en.properties
@@ -666,6 +666,7 @@ error.general.description = Error. Try again.
 error.general.title = Error
 error.loading.form = Error loading form. Please try again or check with an administrator.
 error.loading.form.no_contact = Error loading form. Your user does not have an associated contact, or does not have access to the associated contact. Talk to your administrator to correct this.
+error.loading.form.no_authorized = Error loading form. Your user is not authorized to access this form.
 error.report.save = Error saving report
 error.settings.loading = Error loading settings, please try again.
 expected_date = Expected date

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -12,8 +12,8 @@ import { ContactSaveService } from '@mm-services/contact-save.service';
 import { Selectors } from '@mm-selectors/index';
 import { GlobalActions } from '@mm-actions/global';
 import { ContactsActions } from '@mm-actions/contacts';
+import { XmlFormsService } from '@mm-services/xml-forms.service';
 import { TranslateService } from '@mm-services/translate.service';
-
 
 @Component({
   templateUrl: './contacts-edit.component.html'
@@ -28,6 +28,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     private contactTypesService:ContactTypesService,
     private dbService:DbService,
     private contactSaveService:ContactSaveService,
+    private xmlFormsService:XmlFormsService,
     private translateService:TranslateService,
   ) {
     this.globalActions = new GlobalActions(store);
@@ -241,6 +242,11 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private async renderForm(formId: string, titleKey: string) {
     const formDoc = await this.dbService.get().get(formId);
+
+    if (!await this.xmlFormsService.canAccessForm(formDoc)) {
+      return Promise.reject({ translationKey: 'error.loading.form.no_authorized' });
+    }
+
     this.xmlVersion = formDoc.xmlVersion;
     const instanceData = this.getFormInstanceData();
     const markFormEdited = this.markFormEdited.bind(this);

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -152,7 +152,7 @@ export class XmlFormsService {
   }
 
   private checkFormExpression(form, doc, user, contactSummary) {
-    if (!form.context.expression) {
+    if (!form.context?.expression) {
       return true;
     }
 
@@ -170,7 +170,7 @@ export class XmlFormsService {
   }
 
   private checkFormPermissions(form) {
-    if (!form.context.permission) {
+    if (!form.context?.permission) {
       return true;
     }
 


### PR DESCRIPTION
# Description

Adds checks to verify that reports and contact forms can't be access by URL if the `context.permission` and `context.expression` doesn't match.

[medic/cht-core#[number]](https://github.com/medic/cht-core/issues/6505)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* __CHT_CORE_COMPOSE_URL__
* __COUCH_SINGLE_COMPOSE_URL__
* __COUCH_CLUSTER_COMPOSE_URL__

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

