### PR TITLE
prototype - enable monitoring of nginx via nginx-lua-prometheus

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,11 +1,17 @@
 # base build
-FROM nginx:1.19.6-alpine as base_nginx
+
+FROM nginx:1.24.0-alpine as base_nginx
 RUN apk add --update --no-cache \
     curl \
     socat \
     sed \
     bash \
     openssl
+RUN apk add nginx-mod-http-lua=1.24.0-r2 --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
+
+# install nginx-lua-prometheus
+RUN curl -Lo /nginx-lua-prometheus.tar.gz https://github.com/knyar/nginx-lua-prometheus/archive/0.20221218.tar.gz
+RUN tar -C / -xvzf /nginx-lua-prometheus.tar.gz
 
 COPY ssl-install.sh /docker-entrypoint.d
 RUN chmod 755 /docker-entrypoint.d/ssl-install.sh

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,9 +1,31 @@
+load_module modules/ndk_http_module.so;
+load_module modules/ngx_http_lua_module.so;
+
 user nginx;
 worker_processes auto;
 
 events {
     worker_connections 10240;
 }
+
+# lua_shared_dict prometheus_metrics 10M;
+# lua_package_path "/nginx-lua-prometheus-0.20221218/prometheus.lua";
+
+# init_worker_by_lua_block {
+#   prometheus = require("prometheus").init("prometheus_metrics")
+
+#   metric_requests = prometheus:counter(
+#     "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
+#   metric_latency = prometheus:histogram(
+#     "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
+#   metric_connections = prometheus:gauge(
+#     "nginx_http_connections", "Number of HTTP connections", {"state"})
+# }
+
+# log_by_lua_block {
+#   metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
+#   metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.server_name})
+# }
 
 http {
     include       /etc/nginx/mime.types;
@@ -56,6 +78,7 @@ http {
         #   <iframes>s, we should probably switch this back to DENY.
 
         add_header X-Frame-Options  SAMEORIGIN;
+
 
         include /etc/nginx/conf.d/server.conf;
     }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -8,25 +8,6 @@ events {
     worker_connections 10240;
 }
 
-# lua_shared_dict prometheus_metrics 10M;
-# lua_package_path "/nginx-lua-prometheus-0.20221218/prometheus.lua";
-
-# init_worker_by_lua_block {
-#   prometheus = require("prometheus").init("prometheus_metrics")
-
-#   metric_requests = prometheus:counter(
-#     "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
-#   metric_latency = prometheus:histogram(
-#     "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
-#   metric_connections = prometheus:gauge(
-#     "nginx_http_connections", "Number of HTTP connections", {"state"})
-# }
-
-# log_by_lua_block {
-#   metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
-#   metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.server_name})
-# }
-
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
@@ -35,6 +16,25 @@ http {
     keepalive_timeout     300;
     proxy_read_timeout    600;
     client_max_body_size  32M;
+
+    lua_shared_dict prometheus_metrics 10M;
+    lua_package_path "/nginx-lua-prometheus-0.20221218/prometheus.lua";
+
+    init_worker_by_lua_block {
+        prometheus = require("prometheus").init("prometheus_metrics")
+
+        metric_requests = prometheus:counter(
+            "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
+        metric_latency = prometheus:histogram(
+            "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
+        metric_connections = prometheus:gauge(
+            "nginx_http_connections", "Number of HTTP connections", {"state"})
+    }
+
+    log_by_lua_block {
+        metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
+        metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.server_name})
+    }
 
     server {
         listen         80;
@@ -79,6 +79,14 @@ http {
 
         add_header X-Frame-Options  SAMEORIGIN;
 
+        location /metrics {
+            content_by_lua_block {
+                metric_connections:set(ngx.var.connections_reading, {"reading"})
+                metric_connections:set(ngx.var.connections_waiting, {"waiting"})
+                metric_connections:set(ngx.var.connections_writing, {"writing"})
+                prometheus:collect()
+            }
+        }
 
         include /etc/nginx/conf.d/server.conf;
     }


### PR DESCRIPTION
# Description

Attempted to enable https://github.com/knyar/nginx-lua-prometheus for endpoint monitoring via Prometheus. Blocked and I requested some help here by https://github.com/knyar/nginx-lua-prometheus/issues/156

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:nginx-lua-prometheu/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:nginx-lua-prometheu/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:nginx-lua-prometheu/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

