### PR TITLE
chore(#8244): Fix upgrade e2e test when pushing a beta

### DIFF
--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -6,7 +6,11 @@ const deploymentInProgress = () => $('legend*=Deployment in progress');
 const deploymentComplete = () => $('div*=Deployment complete');
 
 const getInstallButton = async (branch, tag) => {
-  const element = tag ? await $(`span=${tag}`) : await $(`span*=${branch} (`);
+  let selector = `span*=${branch} (`;
+  if (tag) {
+    selector = tag.includes('beta') ? `span*=${tag}` : `span=${tag}`;
+  }
+  const element = await $(selector);
   const parent = await (await element.parentElement()).parentElement();
   return await parent.$('.btn-primary');
 };


### PR DESCRIPTION
# Description
Cherry-picked from https://github.com/medic/cht-core/commit/536e72f16b79d73ac049562e47980bdb2111b6ca

medic/cht-core#8244

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cherry-pick-8244-flexible-upgrade-beta-span/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cherry-pick-8244-flexible-upgrade-beta-span/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cherry-pick-8244-flexible-upgrade-beta-span/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

