### PR TITLE
feat (cht-android/issues/310) enable nginx to serve android app links

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -20,6 +20,10 @@ http {
             default_type "text/plain";
             root /etc/nginx/private/certbot;
         }
+        location = /.well-known/assetlinks.json {
+            default_type "application/json";
+            alias /etc/nginx/private/android/assetlinks.json;
+        }
         location / {
             return 301 https://$host$request_uri;
         }
@@ -57,6 +61,10 @@ http {
 
         add_header X-Frame-Options  SAMEORIGIN;
 
+        location = /.well-known/assetlinks.json {
+            default_type "application/json";
+            alias /etc/nginx/private/android/assetlinks.json;
+        }
         include /etc/nginx/conf.d/server.conf;
     }
 }

--- a/nginx/ssl-install.sh
+++ b/nginx/ssl-install.sh
@@ -130,8 +130,13 @@ EOF
   echo "nginx configured to work with certbot"
 }
 
+prepare_android_assetlink(){
+  mkdir -p /etc/nginx/private/android
+}
+
 main (){
   welcome_message
+  prepare_android_assetlink
   select_ssl_certificate_mode
   echo "Launching Nginx" >&2
 }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Initial PR to enable `nginx` container to serve static JSON files for [android asset links](https://developer.android.com/training/app-links/verify-android-applinks#multi-subdomain):

See [cht-android/issues/308](https://github.com/medic/cht-android/issues/308)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cht-android-310-android-assetlink/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cht-android-310-android-assetlink/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cht-android-310-android-assetlink/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

