### PR TITLE
Nginx change - use more modern cipher

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -47,7 +47,7 @@ http {
         ssl_session_timeout         10m;
         ssl_session_cache           shared:SSL:10m;
         ssl_protocols               TLSv1.2 TLSv1.3;
-        ssl_ciphers                 "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_ciphers                 "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:!EXP:!ADH:!aNULL";
         ssl_ecdh_curve              secp384r1;
         ssl_session_tickets         off;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -29,7 +29,6 @@ http {
         listen       443 ssl;
 
         gzip                on;
-        gzip_disable        "msie6";
         gzip_vary           on;
         gzip_proxied        any;
         gzip_comp_level     6;
@@ -43,11 +42,11 @@ http {
 
         ssl_certificate             /etc/nginx/private/cert.pem;
         ssl_certificate_key         /etc/nginx/private/key.pem;
-        ssl_prefer_server_ciphers   on;
+        ssl_prefer_server_ciphers   off;
         ssl_session_timeout         10m;
         ssl_session_cache           shared:SSL:10m;
         ssl_protocols               TLSv1.2 TLSv1.3;
-        ssl_ciphers                 "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:!EXP:!ADH:!aNULL";
+        ssl_ciphers                 ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
         ssl_ecdh_curve              secp384r1;
         ssl_session_tickets         off;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,10 +44,12 @@ http {
         ssl_certificate             /etc/nginx/private/cert.pem;
         ssl_certificate_key         /etc/nginx/private/key.pem;
         ssl_prefer_server_ciphers   on;
-        ssl_session_timeout         30m;
-        ssl_session_cache           shared:SSL:5m;
-        ssl_protocols               TLSv1.2 TLSv1.1 TLSv1;
-        ssl_ciphers                 ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:DHE-RSA-AES128-SHA:DES-CBC3-SHA:!EXP:!ADH:!aNULL;
+        ssl_session_timeout         10m;
+        ssl_session_cache           shared:SSL:10m;
+        ssl_protocols               TLSv1.2 TLSv1.3;
+        ssl_ciphers                 "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_ecdh_curve              secp384r1;
+        ssl_session_tickets         off;
 
         # Prevent "clickjacking" attacks:
         #   This disallows external sites from embedding any of our pages in


### PR DESCRIPTION
# Description

#8335

The list of ciphers in the nginx config are outdated. This PR updates them.

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:nginx-cipher-fix/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:nginx-cipher-fix/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:nginx-cipher-fix/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

