### PR TITLE
chore: move CouchDB's view test

### DIFF
--- a/tests/integration/couchdb/views/docs-by-replication-key.spec.js
+++ b/tests/integration/couchdb/views/docs-by-replication-key.spec.js
@@ -1,4 +1,5 @@
 const utils = require('@utils');
+const { expect } = require('chai');
 
 describe('docs_by_replication_key', () => {
   let docByPlaceIds;
@@ -314,99 +315,99 @@ describe('docs_by_replication_key', () => {
   }, 5 * 60 * 1000);
 
   it('should not return the ddoc', () => {
-    expect(docByPlaceIds).not.toContain('_design/medic');
+    expect(docByPlaceIds).to.not.have.string('_design/medic');
   });
 
   it('should always return forms', () => {
-    expect(docByPlaceIds).toContain('form:doc_by_place_test_form');
+    expect(docByPlaceIds).to.have.string('form:doc_by_place_test_form');
   });
 
   it('should always return form deletes', () => {
-    expect(docByPlaceIds).toContain('form:some_deleted_form____tombstone');
+    expect(docByPlaceIds).to.have.string('form:some_deleted_form____tombstone');
   });
 
   describe('Documents associated with the person id', () => {
     it('should return clinics if a recursive parent is the user', () => {
-      expect(docByPlaceIds).toContain('report_about_patient');
-      expect(docByPlaceIds).toContain('report_about_patient_deleted____tombstone');
+      expect(docByPlaceIds).to.have.string('report_about_patient');
+      expect(docByPlaceIds).to.have.string('report_about_patient_deleted____tombstone');
     });
 
     it('should return district_hospitals if the recursive parent is the user', () => {
-      expect(docByPlaceIds).toContain('report_about_patient_2');
-      expect(docByPlaceIds).toContain('report_about_patient_2_deleted____tombstone');
+      expect(docByPlaceIds).to.have.string('report_about_patient_2');
+      expect(docByPlaceIds).to.have.string('report_about_patient_2_deleted____tombstone');
     });
 
     it('should return health_centers if the recursive parent is the user', () => {
-      expect(docByPlaceIds).toContain('report_about_place');
+      expect(docByPlaceIds).to.have.string('report_about_place');
     });
 
     it('should check the contact of the first message of the first task in kujua messages', () => {
-      expect(docByPlaceIds).toContain('test_kujua_message');
-      expect(docByPlaceIds).not.toContain('test_not_assigned_kujua_message');
+      expect(docByPlaceIds).to.have.string('test_kujua_message');
+      expect(docByPlaceIds).to.not.have.string('test_not_assigned_kujua_message');
     });
 
     it('should check the contact of data records', () => {
-      expect(docByPlaceIds).toContain('report_with_contact');
-      expect(docByPlaceIds).not.toContain('test_data_record_wrong_user');
+      expect(docByPlaceIds).to.have.string('report_with_contact');
+      expect(docByPlaceIds).to.not.have.string('test_data_record_wrong_user');
 
-      expect(docByPlaceIds).toContain('report_with_contact_deleted____tombstone');
-      expect(docByPlaceIds).not.toContain('test_data_record_wrong_user_deleted____tombstone');
+      expect(docByPlaceIds).to.have.string('report_with_contact_deleted____tombstone');
+      expect(docByPlaceIds).to.not.have.string('test_data_record_wrong_user_deleted____tombstone');
     });
 
     it('should fall back to contact id when unknown patient', () => {
-      expect(docByPlaceIds).toContain('report_with_unknown_patient_id');
+      expect(docByPlaceIds).to.have.string('report_with_unknown_patient_id');
     });
 
     it('should check for patient_uuid', () => {
-      expect(docByPlaceIds).toContain('report_with_patient_uuid');
-      expect(docByPlaceIds).not.toContain('report_with_patient_uuid_other_patient');
+      expect(docByPlaceIds).to.have.string('report_with_patient_uuid');
+      expect(docByPlaceIds).to.not.have.string('report_with_patient_uuid_other_patient');
     });
 
     it('should fall back to contact id when invalid patient', () => {
-      expect(docByPlaceIds).toContain('report_with_invalid_patient_id');
+      expect(docByPlaceIds).to.have.string('report_with_invalid_patient_id');
     });
 
     it('should return data_records with needs_signoff from same branch', () => {
-      expect(docByPlaceIds).toContain('needs_signoff_within_branch');
-      expect(docByPlaceIds).not.toContain('needs_signoff_within_branch_falsy');
-      expect(docByPlaceIds).not.toContain('needs_signoff_outside_branch');
+      expect(docByPlaceIds).to.have.string('needs_signoff_within_branch');
+      expect(docByPlaceIds).to.not.have.string('needs_signoff_within_branch_falsy');
+      expect(docByPlaceIds).to.not.have.string('needs_signoff_outside_branch');
     });
 
     it('should return target docs', () => {
-      expect(docByPlaceIds).toContain('target_created_by_user');
-      expect(docByPlaceIds).not.toContain('target_created_by_other_user');
+      expect(docByPlaceIds).to.have.string('target_created_by_user');
+      expect(docByPlaceIds).to.not.have.string('target_created_by_other_user');
     });
   });
 
   describe('Documents associated with user id', () => {
     it('should return task docs', () => {
-      expect(docByPlaceIds).toContain('task_created_by_user');
-      expect(docByPlaceIds).not.toContain('task_created_by_other_user');
+      expect(docByPlaceIds).to.have.string('task_created_by_user');
+      expect(docByPlaceIds).to.not.have.string('task_created_by_other_user');
     });
   });
 
   describe('Documents that only pass when unassigned == true', () => {
     it('should pass when no tasks', () => {
-      expect(docByPlaceIds_unassigned).toContain('test_kujua_message_no_tasks');
-      expect(docByPlaceIds).not.toContain('test_kujua_message_no_tasks');
+      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_no_tasks');
+      expect(docByPlaceIds).to.not.have.string('test_kujua_message_no_tasks');
 
-      expect(docByPlaceIds_unassigned).toContain('test_kujua_message_no_tasks_deleted____tombstone');
-      expect(docByPlaceIds).not.toContain('test_kujua_message_no_tasks_deleted____tombstone');
+      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_no_tasks_deleted____tombstone');
+      expect(docByPlaceIds).to.not.have.string('test_kujua_message_no_tasks_deleted____tombstone');
     });
 
     it('should pass when empty tasks', () => {
-      expect(docByPlaceIds_unassigned).toContain('test_kujua_message_empty_tasks');
-      expect(docByPlaceIds).not.toContain('test_kujua_message_empty_tasks');
+      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_empty_tasks');
+      expect(docByPlaceIds).to.not.have.string('test_kujua_message_empty_tasks');
     });
 
     it('should pass when no contact', () => {
-      expect(docByPlaceIds_unassigned).toContain('test_kujua_message_no_contact');
-      expect(docByPlaceIds).not.toContain('test_kujua_message_no_contact');
+      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_no_contact');
+      expect(docByPlaceIds).to.not.have.string('test_kujua_message_no_contact');
     });
 
     it('should pass when no contact (incoming)', () => {
-      expect(docByPlaceIds_unassigned).toContain('test_kujua_message_incoming_no_contact');
-      expect(docByPlaceIds).not.toContain('test_kujua_message_incoming_no_contact');
+      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_incoming_no_contact');
+      expect(docByPlaceIds).to.not.have.string('test_kujua_message_incoming_no_contact');
     });
   });
 });

--- a/tests/integration/couchdb/views/docs-by-replication-key.spec.js
+++ b/tests/integration/couchdb/views/docs-by-replication-key.spec.js
@@ -1,46 +1,46 @@
-const utils = require('../utils');
+const utils = require('@utils');
 
-describe('view docs_by_replication_key', () => {
-
-  'use strict';
+describe('docs_by_replication_key', () => {
+  let docByPlaceIds;
+  let docByPlaceIds_unassigned;
 
   const documentsToReturn = [
     {
       _id: 'form:doc_by_place_test_form',
       reported_date: 1,
-      type: 'form'
+      type: 'form',
     },
     {
       _id: 'report_about_patient',
       reported_date: 1,
       form: 'V',
       type: 'data_record',
-      patient_id: 'testpatient'
+      patient_id: 'testpatient',
     },
     {
       _id: 'report_about_patient_2',
       reported_date: 1,
       form: 'V',
       type: 'data_record',
-      fields: { patient_id: 'testpatient' }
+      fields: { patient_id: 'testpatient' },
     },
     {
       _id: 'report_about_place',
       reported_date: 1,
       form: 'V',
       type: 'data_record',
-      place_id: 'testplace'
+      place_id: 'testplace',
     },
     {
       _id: 'testuser',
       reported_date: 1,
       type: 'person',
-      parent: { _id: 'testuserplace' }
+      parent: { _id: 'testuserplace' },
     },
     {
       _id: 'testuserplace',
       reported_date: 1,
-      type: 'clinic'
+      type: 'clinic',
     },
     {
       _id: 'test_kujua_message',
@@ -48,25 +48,15 @@ describe('view docs_by_replication_key', () => {
       type: 'data_record',
       kujua_message: true,
       tasks: [
-        {
-          messages: [
-            {
-              contact: {
-                _id: 'testuser'
-              }
-            }
-          ]
-        }
-      ]
+        { messages: [ { contact: { _id: 'testuser' } } ] },
+      ],
     },
     {
       _id: 'report_with_contact',
       reported_date: 1,
       form: 'V',
       type: 'data_record',
-      contact: {
-        _id: 'testuser'
-      }
+      contact: { _id: 'testuser' },
     },
     {
       _id: 'report_with_unknown_patient_id',
@@ -74,10 +64,8 @@ describe('view docs_by_replication_key', () => {
       form: 'V',
       type: 'data_record',
       patient_id: 'unknown_patient',
-      contact: {
-        _id: 'testuser'
-      },
-      errors: [ { code: 'registration_not_found' } ]
+      contact: { _id: 'testuser' },
+      errors: [ { code: 'registration_not_found' } ],
     },
     {
       _id: 'report_with_invalid_patient_id',
@@ -85,10 +73,8 @@ describe('view docs_by_replication_key', () => {
       form: 'V',
       type: 'data_record',
       patient_id: 'invalid_patient',
-      contact: {
-        _id: 'testuser'
-      },
-      errors: [ { code: 'invalid_patient_id' } ]
+      contact: { _id: 'testuser' },
+      errors: [ { code: 'invalid_patient_id' } ],
     },
     {
       _id: 'form:some_deleted_form____tombstone',
@@ -97,7 +83,7 @@ describe('view docs_by_replication_key', () => {
         _id: 'form:some_deleted_form',
         reported_date: 1,
         type: 'form',
-        _deleted: true
+        _deleted: true,
       },
     },
     {
@@ -109,7 +95,7 @@ describe('view docs_by_replication_key', () => {
         form: 'V',
         type: 'data_record',
         patient_id: 'testpatient',
-        _deleted: true
+        _deleted: true,
       },
     },
     {
@@ -121,7 +107,7 @@ describe('view docs_by_replication_key', () => {
         form: 'V',
         type: 'data_record',
         fields: { patient_id: 'testpatient' },
-        _deleted: true
+        _deleted: true,
       },
     },
     {
@@ -132,14 +118,12 @@ describe('view docs_by_replication_key', () => {
         reported_date: 1,
         form: 'V',
         type: 'data_record',
-        contact: {
-          _id: 'testuser'
-        }
+        contact: { _id: 'testuser' },
       },
     }, {
       _id: 'needs_signoff_within_branch',
       type: 'data_record',
-      contact: { _id: 'user1', parent: { _id: 'parent1', parent: { _id: 'testuserplace' }}},
+      contact: { _id: 'user1', parent: { _id: 'parent1', parent: { _id: 'testuserplace' } } },
       fields: { patient_id: 'somepatient', needs_signoff: true },
     },
     {
@@ -147,7 +131,7 @@ describe('view docs_by_replication_key', () => {
       type: 'data_record',
       form: 'V',
       contact: { _id: 'someuser' },
-      fields: { patient_uuid: 'testpatient' }
+      fields: { patient_uuid: 'testpatient' },
     },
     {
       _id: 'task_created_by_user',
@@ -168,7 +152,7 @@ describe('view docs_by_replication_key', () => {
     {
       _id: 'fakedoctype',
       reported_date: 1,
-      type: 'fakedoctype'
+      type: 'fakedoctype',
     },
     {
       _id: 'not_the_testuser',
@@ -181,20 +165,14 @@ describe('view docs_by_replication_key', () => {
       type: 'data_record',
       kujua_message: true,
       tasks: [
-        {
-          messages: [
-            {
-              contact: 'not_the_testuser'
-            }
-          ]
-        }
-      ]
+        { messages: [ { contact: 'not_the_testuser' } ] },
+      ],
     },
     {
       _id: 'test_data_record_wrong_user',
       reported_date: 1,
       type: 'data_record',
-      contact: 'not_the_testuser'
+      contact: 'not_the_testuser',
     },
     {
       _id: 'fakedoctype_deleted____tombstone',
@@ -203,7 +181,7 @@ describe('view docs_by_replication_key', () => {
         _id: 'fakedoctype_deleted',
         reported_date: 1,
         type: 'fakedoctype',
-        _deleted: true
+        _deleted: true,
       }
     },
     {
@@ -213,7 +191,7 @@ describe('view docs_by_replication_key', () => {
         _id: 'not_the_testuser_deleted',
         reported_date: 1,
         type: 'person',
-        _deleted: true
+        _deleted: true,
       },
     },
     {
@@ -224,7 +202,7 @@ describe('view docs_by_replication_key', () => {
         reported_date: 1,
         type: 'data_record',
         contact: 'not_the_testuser',
-        _deleted: true
+        _deleted: true,
       },
     },
     {
@@ -243,7 +221,7 @@ describe('view docs_by_replication_key', () => {
       _id: 'report_with_patient_uuid_other_patient',
       type: 'data_record',
       contact: { _id: 'someuser' },
-      fields: { patient_uuid: 'not_the_testpatient' }
+      fields: { patient_uuid: 'not_the_testpatient' },
     },
     {
       _id: 'task_created_by_other_user',
@@ -266,30 +244,26 @@ describe('view docs_by_replication_key', () => {
       _id: 'test_kujua_message_no_tasks',
       reported_date: 1,
       type: 'data_record',
-      kujua_message: true
+      kujua_message: true,
     },
     {
       _id: 'test_kujua_message_empty_tasks',
       reported_date: 1,
       type: 'data_record',
       kujua_message: true,
-      tasks: []
+      tasks: [],
     },
     {
       _id: 'test_kujua_message_no_contact',
       reported_date: 1,
       type: 'data_record',
       kujua_message: true,
-      tasks: [
-        {
-          messages: []
-        }
-      ]
+      tasks: [ { messages: [] } ],
     },
     {
       _id: 'test_kujua_message_incoming_no_contact',
       reported_date: 1,
-      type: 'data_record'
+      type: 'data_record',
     },
     {
       _id: 'test_kujua_message_no_tasks_deleted____tombstone',
@@ -299,59 +273,51 @@ describe('view docs_by_replication_key', () => {
         reported_date: 1,
         type: 'data_record',
         kujua_message: true,
-        _deleted: true
+        _deleted: true,
       }
     }
   ];
 
-  // TODO: consider removing this and just pulling ids from the two arrays above
-  let docByPlaceIds;
-  let docByPlaceIds_unassigned;
+  const getChanges = async (keys) => {
+    console.log('Requesting changes, please be patient…');
 
-  before( async () => {
+    return await utils
+      .requestOnTestDb({
+        path: '/_design/medic/_view/docs_by_replication_key?keys=' + JSON.stringify(keys),
+        method: 'GET',
+      })
+      .then(response => {
+        console.log('Got changes', response);
+        return response.rows.map(doc => doc.id);
+      })
+      .catch(err => console.log('Error requesting changes', err));
+  };
+
+  before(async () => {
     const alldocs = documentsToReturn.concat(documentsToIgnore, documentsToIgnoreSometimes);
 
-    const getChanges = async (keys) => {
-      console.log('Requesting changes, please be patient…');
-
-      return await utils.requestOnTestDb({
-        path: '/_design/medic/_view/docs_by_replication_key?keys=' + JSON.stringify(keys),
-        method: 'GET'
-      }).then(response => {
-        console.log('…got changes', response);
-        return response.rows.map(doc => {
-          return doc.id;
-        });
-      })
-        .catch(err => {
-          console.log('Error requesting changes', err);
-        });
-    };
-
-    console.log(`Pushing ${alldocs.length} documents for testing…`);
-    return await utils.saveDocs(alldocs)
+    console.log(`Pushing ${alldocs.length} documents for testing`);
+    return await utils
+      .saveDocs(alldocs)
       .then(() => {
-        return getChanges(
-          ['_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username']
-        );
+        const keys = [ '_all', 'testuser', 'testplace', 'testpatient', 'testuserplace', 'org.couchdb.user:username' ];
+        return getChanges(keys);
       })
       .then((docs) => {
         docByPlaceIds = docs;
         return getChanges(['_all', '_unassigned', 'testuser', 'testplace', 'testpatient', 'testuserplace' ]);
       })
-      .then((docs) => {
-        docByPlaceIds_unassigned = docs;
-      })
+      .then((docs) => docByPlaceIds_unassigned = docs)
       .catch(err => {
         throw err;
       });
   }, 5 * 60 * 1000);
 
-  it('Does not return the ddoc', () => {
+  it('should not return the ddoc', () => {
     expect(docByPlaceIds).not.toContain('_design/medic');
   });
 
-  it('Should always return forms', () => {
+  it('should always return forms', () => {
     expect(docByPlaceIds).toContain('form:doc_by_place_test_form');
   });
 
@@ -360,26 +326,26 @@ describe('view docs_by_replication_key', () => {
   });
 
   describe('Documents associated with the person id', () => {
-    it('Should return clinics if a recursive parent is the user', () => {
+    it('should return clinics if a recursive parent is the user', () => {
       expect(docByPlaceIds).toContain('report_about_patient');
       expect(docByPlaceIds).toContain('report_about_patient_deleted____tombstone');
     });
 
-    it('Should return district_hospitals if the recursive parent is the user', () => {
+    it('should return district_hospitals if the recursive parent is the user', () => {
       expect(docByPlaceIds).toContain('report_about_patient_2');
       expect(docByPlaceIds).toContain('report_about_patient_2_deleted____tombstone');
     });
 
-    it('Should return health_centers if the recursive parent is the user', () => {
+    it('should return health_centers if the recursive parent is the user', () => {
       expect(docByPlaceIds).toContain('report_about_place');
     });
 
-    it('Should check the contact of the first message of the first task in kujua messages', () => {
+    it('should check the contact of the first message of the first task in kujua messages', () => {
       expect(docByPlaceIds).toContain('test_kujua_message');
       expect(docByPlaceIds).not.toContain('test_not_assigned_kujua_message');
     });
 
-    it('Should check the contact of data records', () => {
+    it('should check the contact of data records', () => {
       expect(docByPlaceIds).toContain('report_with_contact');
       expect(docByPlaceIds).not.toContain('test_data_record_wrong_user');
 
@@ -387,7 +353,7 @@ describe('view docs_by_replication_key', () => {
       expect(docByPlaceIds).not.toContain('test_data_record_wrong_user_deleted____tombstone');
     });
 
-    it('Falls back to contact id when unknown patient', () => {
+    it('should fall back to contact id when unknown patient', () => {
       expect(docByPlaceIds).toContain('report_with_unknown_patient_id');
     });
 
@@ -396,7 +362,7 @@ describe('view docs_by_replication_key', () => {
       expect(docByPlaceIds).not.toContain('report_with_patient_uuid_other_patient');
     });
 
-    it('Falls back to contact id when invalid patient', () => {
+    it('should fall back to contact id when invalid patient', () => {
       expect(docByPlaceIds).toContain('report_with_invalid_patient_id');
     });
 
@@ -420,7 +386,7 @@ describe('view docs_by_replication_key', () => {
   });
 
   describe('Documents that only pass when unassigned == true', () => {
-    it('Should pass when no tasks', () => {
+    it('should pass when no tasks', () => {
       expect(docByPlaceIds_unassigned).toContain('test_kujua_message_no_tasks');
       expect(docByPlaceIds).not.toContain('test_kujua_message_no_tasks');
 
@@ -428,22 +394,19 @@ describe('view docs_by_replication_key', () => {
       expect(docByPlaceIds).not.toContain('test_kujua_message_no_tasks_deleted____tombstone');
     });
 
-    it('Should pass when empty tasks', () => {
+    it('should pass when empty tasks', () => {
       expect(docByPlaceIds_unassigned).toContain('test_kujua_message_empty_tasks');
       expect(docByPlaceIds).not.toContain('test_kujua_message_empty_tasks');
     });
 
-    it('Should pass when no contact', () => {
+    it('should pass when no contact', () => {
       expect(docByPlaceIds_unassigned).toContain('test_kujua_message_no_contact');
       expect(docByPlaceIds).not.toContain('test_kujua_message_no_contact');
     });
 
-    it('Should pass when no contact (incoming)', () => {
+    it('should pass when no contact (incoming)', () => {
       expect(docByPlaceIds_unassigned).toContain('test_kujua_message_incoming_no_contact');
       expect(docByPlaceIds).not.toContain('test_kujua_message_incoming_no_contact');
     });
   });
-
-  // TODO: test these branches:
-  //  - OK() no query id
 });

--- a/tests/integration/couchdb/views/docs-by-replication-key.spec.js
+++ b/tests/integration/couchdb/views/docs-by-replication-key.spec.js
@@ -315,99 +315,99 @@ describe('docs_by_replication_key', () => {
   }, 5 * 60 * 1000);
 
   it('should not return the ddoc', () => {
-    expect(docByPlaceIds).to.not.have.string('_design/medic');
+    expect(docByPlaceIds).to.not.include('_design/medic');
   });
 
   it('should always return forms', () => {
-    expect(docByPlaceIds).to.have.string('form:doc_by_place_test_form');
+    expect(docByPlaceIds).to.have.include('form:doc_by_place_test_form');
   });
 
   it('should always return form deletes', () => {
-    expect(docByPlaceIds).to.have.string('form:some_deleted_form____tombstone');
+    expect(docByPlaceIds).to.have.include('form:some_deleted_form____tombstone');
   });
 
   describe('Documents associated with the person id', () => {
     it('should return clinics if a recursive parent is the user', () => {
-      expect(docByPlaceIds).to.have.string('report_about_patient');
-      expect(docByPlaceIds).to.have.string('report_about_patient_deleted____tombstone');
+      expect(docByPlaceIds).to.have.include('report_about_patient');
+      expect(docByPlaceIds).to.have.include('report_about_patient_deleted____tombstone');
     });
 
     it('should return district_hospitals if the recursive parent is the user', () => {
-      expect(docByPlaceIds).to.have.string('report_about_patient_2');
-      expect(docByPlaceIds).to.have.string('report_about_patient_2_deleted____tombstone');
+      expect(docByPlaceIds).to.have.include('report_about_patient_2');
+      expect(docByPlaceIds).to.have.include('report_about_patient_2_deleted____tombstone');
     });
 
     it('should return health_centers if the recursive parent is the user', () => {
-      expect(docByPlaceIds).to.have.string('report_about_place');
+      expect(docByPlaceIds).to.have.include('report_about_place');
     });
 
     it('should check the contact of the first message of the first task in kujua messages', () => {
-      expect(docByPlaceIds).to.have.string('test_kujua_message');
-      expect(docByPlaceIds).to.not.have.string('test_not_assigned_kujua_message');
+      expect(docByPlaceIds).to.have.include('test_kujua_message');
+      expect(docByPlaceIds).to.not.have.include('test_not_assigned_kujua_message');
     });
 
     it('should check the contact of data records', () => {
-      expect(docByPlaceIds).to.have.string('report_with_contact');
-      expect(docByPlaceIds).to.not.have.string('test_data_record_wrong_user');
+      expect(docByPlaceIds).to.have.include('report_with_contact');
+      expect(docByPlaceIds).to.not.have.include('test_data_record_wrong_user');
 
-      expect(docByPlaceIds).to.have.string('report_with_contact_deleted____tombstone');
-      expect(docByPlaceIds).to.not.have.string('test_data_record_wrong_user_deleted____tombstone');
+      expect(docByPlaceIds).to.have.include('report_with_contact_deleted____tombstone');
+      expect(docByPlaceIds).to.not.have.include('test_data_record_wrong_user_deleted____tombstone');
     });
 
     it('should fall back to contact id when unknown patient', () => {
-      expect(docByPlaceIds).to.have.string('report_with_unknown_patient_id');
+      expect(docByPlaceIds).to.have.include('report_with_unknown_patient_id');
     });
 
     it('should check for patient_uuid', () => {
-      expect(docByPlaceIds).to.have.string('report_with_patient_uuid');
-      expect(docByPlaceIds).to.not.have.string('report_with_patient_uuid_other_patient');
+      expect(docByPlaceIds).to.have.include('report_with_patient_uuid');
+      expect(docByPlaceIds).to.not.have.include('report_with_patient_uuid_other_patient');
     });
 
     it('should fall back to contact id when invalid patient', () => {
-      expect(docByPlaceIds).to.have.string('report_with_invalid_patient_id');
+      expect(docByPlaceIds).to.have.include('report_with_invalid_patient_id');
     });
 
     it('should return data_records with needs_signoff from same branch', () => {
-      expect(docByPlaceIds).to.have.string('needs_signoff_within_branch');
-      expect(docByPlaceIds).to.not.have.string('needs_signoff_within_branch_falsy');
-      expect(docByPlaceIds).to.not.have.string('needs_signoff_outside_branch');
+      expect(docByPlaceIds).to.have.include('needs_signoff_within_branch');
+      expect(docByPlaceIds).to.not.have.include('needs_signoff_within_branch_falsy');
+      expect(docByPlaceIds).to.not.have.include('needs_signoff_outside_branch');
     });
 
     it('should return target docs', () => {
-      expect(docByPlaceIds).to.have.string('target_created_by_user');
-      expect(docByPlaceIds).to.not.have.string('target_created_by_other_user');
+      expect(docByPlaceIds).to.have.include('target_created_by_user');
+      expect(docByPlaceIds).to.not.have.include('target_created_by_other_user');
     });
   });
 
   describe('Documents associated with user id', () => {
     it('should return task docs', () => {
-      expect(docByPlaceIds).to.have.string('task_created_by_user');
-      expect(docByPlaceIds).to.not.have.string('task_created_by_other_user');
+      expect(docByPlaceIds).to.have.include('task_created_by_user');
+      expect(docByPlaceIds).to.not.have.include('task_created_by_other_user');
     });
   });
 
   describe('Documents that only pass when unassigned == true', () => {
     it('should pass when no tasks', () => {
-      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_no_tasks');
-      expect(docByPlaceIds).to.not.have.string('test_kujua_message_no_tasks');
+      expect(docByPlaceIds_unassigned).to.have.include('test_kujua_message_no_tasks');
+      expect(docByPlaceIds).to.not.have.include('test_kujua_message_no_tasks');
 
-      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_no_tasks_deleted____tombstone');
-      expect(docByPlaceIds).to.not.have.string('test_kujua_message_no_tasks_deleted____tombstone');
+      expect(docByPlaceIds_unassigned).to.have.include('test_kujua_message_no_tasks_deleted____tombstone');
+      expect(docByPlaceIds).to.not.have.include('test_kujua_message_no_tasks_deleted____tombstone');
     });
 
     it('should pass when empty tasks', () => {
-      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_empty_tasks');
-      expect(docByPlaceIds).to.not.have.string('test_kujua_message_empty_tasks');
+      expect(docByPlaceIds_unassigned).to.have.include('test_kujua_message_empty_tasks');
+      expect(docByPlaceIds).to.not.have.include('test_kujua_message_empty_tasks');
     });
 
     it('should pass when no contact', () => {
-      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_no_contact');
-      expect(docByPlaceIds).to.not.have.string('test_kujua_message_no_contact');
+      expect(docByPlaceIds_unassigned).to.have.include('test_kujua_message_no_contact');
+      expect(docByPlaceIds).to.not.have.include('test_kujua_message_no_contact');
     });
 
     it('should pass when no contact (incoming)', () => {
-      expect(docByPlaceIds_unassigned).to.have.string('test_kujua_message_incoming_no_contact');
-      expect(docByPlaceIds).to.not.have.string('test_kujua_message_incoming_no_contact');
+      expect(docByPlaceIds_unassigned).to.have.include('test_kujua_message_incoming_no_contact');
+      expect(docByPlaceIds).to.not.have.include('test_kujua_message_incoming_no_contact');
     });
   });
 });


### PR DESCRIPTION
# Description

Moves test to integration folder and makes it work with mocha and chai.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:chore_couch_view_test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:chore_couch_view_test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:chore_couch_view_test/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

