### PR TITLE
chore(#8254): skip should remove the primary contact from the clinic when the contact is deleted

### DIFF
--- a/tests/e2e/default/about/about.wdio-spec.js
+++ b/tests/e2e/default/about/about.wdio-spec.js
@@ -31,6 +31,7 @@ describe('About page', async () => {
 
     await utils.saveDoc(partnersDoc);
     await commonPage.goToAboutPage();
+    await (await aboutPage.partners()).waitForDisplayed();
 
     const image1 = await aboutPage.getPartnerImage('image1');
     expect(image1).to.equal(`data:image/png;base64,${partnerData[0].data}`);

--- a/tests/e2e/default/contacts/edit.wdio-spec.js
+++ b/tests/e2e/default/contacts/edit.wdio-spec.js
@@ -39,7 +39,7 @@ describe('Edit contacts with the default config. ', () => {
     expect(primaryContactName).to.equal(CONTACT_UPDATED_NAME);
   });
 
-  it('should remove the primary contact from the clinic when the contact is deleted', async () => {
+  xit('should remove the primary contact from the clinic when the contact is deleted', async () => {
     await commonPage.goToPeople();
     await commonPage.waitForPageLoaded();
 

--- a/tests/e2e/default/enketo/add-family.wdio-spec.js
+++ b/tests/e2e/default/enketo/add-family.wdio-spec.js
@@ -8,7 +8,7 @@ const userData = require('@page-objects/default/users/user.data');
 const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
 const { cookieLogin } = require('@page-objects/default/login/login.wdio.page');
 
-describe('Family form', () => {
+xdescribe('Family form', () => {
   const contactId = userData.contactId;
   const userDocs = userData.docs;
   const formXML = fs.readFileSync(`${__dirname}/forms/add-family-multiple-repeats.xml`, 'utf8');

--- a/tests/page-objects/default/about/about.wdio.page.js
+++ b/tests/page-objects/default/about/about.wdio.page.js
@@ -11,5 +11,6 @@ const getPartnerImage = async (name) => {
 
 module.exports = {
   userName,
+  partners,
   getPartnerImage,
 };


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Also disables entire suite that had a single disabled test and was sometimes failing the `onBefore` call. 

medic/cht-core#8254

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8254-disable-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8254-disable-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8254-disable-test/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

