### PR TITLE
fix(#8355): fix header in new modal

### DIFF
--- a/webapp/src/ts/components/fast-action-button/fast-action-button.component.html
+++ b/webapp/src/ts/components/fast-action-button/fast-action-button.component.html
@@ -27,7 +27,7 @@
 <ng-template #contentWrapper>
   <section class="fast-action-content-wrapper">
 
-    <mm-panel-header [title]="config?.title || 'fast_action_button.title'" (onClose)="closeAll()"></mm-panel-header>
+    <mm-panel-header [headerTitle]="config?.title || 'fast_action_button.title'" (onClose)="closeAll()"></mm-panel-header>
 
     <mat-list class="fast-action-body">
       <mat-list-item *ngFor="let action of fastActions; trackBy: trackById">

--- a/webapp/src/ts/components/panel-header/panel-header.component.html
+++ b/webapp/src/ts/components/panel-header/panel-header.component.html
@@ -1,5 +1,5 @@
 <div class="panel-header">
-  <p class="panel-header-title">{{ title | translate }}</p>
+  <p class="panel-header-title">{{ headerTitle | translate }}</p>
   <a class="panel-header-close" (click)="onClose.next(true)">
     <mat-icon fontIcon="fa-times"></mat-icon>
   </a>

--- a/webapp/src/ts/components/panel-header/panel-header.component.ts
+++ b/webapp/src/ts/components/panel-header/panel-header.component.ts
@@ -5,6 +5,6 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   templateUrl: './panel-header.component.html',
 })
 export class PanelHeaderComponent {
-  @Input() title;
+  @Input() headerTitle;
   @Output() onClose = new EventEmitter<boolean>();
 }

--- a/webapp/src/ts/modules/reports/reports-more-menu.component.html
+++ b/webapp/src/ts/modules/reports/reports-more-menu.component.html
@@ -33,7 +33,7 @@
 
 <ng-template #verifyReportWrapper>
   <section class="verify-report-options-wrapper">
-    <mm-panel-header title="reports.verify" (onClose)="closeVerifyReportComponents()"></mm-panel-header>
+    <mm-panel-header headerTitle="reports.verify" (onClose)="closeVerifyReportComponents()"></mm-panel-header>
     <div class="verify-report-options-body">
       <button mat-flat-button class="invalid-option" [class.active-option]="selectedReportDoc?.verified === false" (click)="isReportCorrect(false)">
         <report-verify-invalid-icon class="verify-icon"></report-verify-invalid-icon>


### PR DESCRIPTION
# Description

The tooltip's style overrides this component, so I changed the component's input name to be different from the HTML's title attribute. 

https://github.com/medic/cht-core/issues/8355

Test recording:

https://github.com/medic/cht-core/assets/66472237/0767ff81-de7e-40da-888f-9f9213c5aeaa

https://github.com/medic/cht-core/assets/66472237/54ccf1ef-7f8c-4f90-a58d-d47e3190aaa6


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8355_fix_review_title/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8355_fix_review_title/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8355_fix_review_title/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

