### PR TITLE
chore(#8357): Stabilize or disable languages flaky test

### DIFF
--- a/tests/page-objects/default/admin/admin.wdio.page.js
+++ b/tests/page-objects/default/admin/admin.wdio.page.js
@@ -11,6 +11,7 @@ const toggleLanguage = async (locale, shouldEnable) => {
   await (await localePanelHeader(locale)).click();
   const languageAccordion = await localePanelBody(locale);
   await languageAccordion.waitForDisplayed();
+  await utils.delayPromise(500); // wait for animation to complete
   const buttonLabel = shouldEnable ? 'Enable' : 'Disable';
   const button = languageAccordion.$(`span=${buttonLabel}`);
   await button.waitForClickable();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

My hunch is this test was failing because the click landed on a different element. 
Looking at the screenshot capture, where the click was supposed to enable the language, it appears as if the click landed on `download` instead. 
Mu guess is that the accordion was still in animation when the click was issued. Adding a timeout to delay the click. 
![image](https://github.com/medic/cht-core/assets/35681649/79536c0f-2474-4e66-8adc-d84a73f48fe5)


medic/cht-core#8357

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8357-disable-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8357-disable-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8357-disable-test/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

