### PR TITLE
fix(#8161): get telemetry app version from correct place.

### DIFF
--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -33,7 +33,7 @@ const getApiUrl = (pathname = '') => {
   return apiUrl.toString();
 };
 
-const releaseName = TAG || BRANCH || 'local-development';
+const releaseName = TAG || BRANCH || `${packageJson.version}-local-development`;
 
 const setBuildInfo = () => {
   const buildInfoPath = path.resolve(ddocsBuildPath, 'medic-db', 'medic', 'build_info');

--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -6,6 +6,7 @@ const placeFactory = require('@factories/cht/contacts/place');
 const personFactory = require('@factories/cht/contacts/person');
 const { faker: Faker } = require('@faker-js/faker');
 const userFactory = require('@factories/cht/users/users');
+const { BRANCH, TAG } = process.env;
 
 const setupUser = () => {
   const places = placeFactory.generateHierarchy();
@@ -73,6 +74,7 @@ describe('Telemetry', () => {
       'metadata.user': user.username,
       'metadata.versions.app': clientDdoc.build_info.version,
     });
-    expect(clientDdoc.build_info.version).to.include(clientDdoc.build_info.base_version);
+    const ciBuild = TAG || BRANCH;
+    expect(clientDdoc.build_info.version).to.include(ciBuild || clientDdoc.build_info.base_version);
   });
 });

--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -1,0 +1,77 @@
+const commonPage = require('@page-objects/default/common/common.wdio.page');
+const utils = require('@utils');
+const moment = require('moment');
+const loginPage = require('@page-objects/default/login/login.wdio.page');
+const placeFactory = require('@factories/cht/contacts/place');
+const personFactory = require('@factories/cht/contacts/person');
+const { faker: Faker } = require('@faker-js/faker');
+const userFactory = require('@factories/cht/users/users');
+
+const setupUser = () => {
+  const places = placeFactory.generateHierarchy();
+  const districtHospital = places.get('district_hospital');
+  const contact = personFactory.build({
+    name: Faker.name.firstName(),
+    parent: { _id: districtHospital._id },
+  });
+  const user = userFactory.build({
+    username: Faker.internet.userName().toLowerCase().replace(/[^0-9a-zA-Z_]/g, ''),
+    password: 'Secret_1',
+    place: districtHospital._id,
+    contact: contact._id,
+    known: true,
+  });
+
+  return {
+    docs: [
+      ...places.values(),
+      contact,
+    ],
+    user,
+  };
+};
+
+const setOldTelemetryDate = async (user) => {
+  const yesterday = moment().subtract(1, 'day').valueOf();
+  const telemetryDateStorageKey = `medic-${user.username}-telemetry-date`;
+  await browser.execute((telemetryDateStorageKey, yesterday) => {
+    // eslint-disable-next-line no-undef
+    window.localStorage.setItem(telemetryDateStorageKey, yesterday);
+  }, telemetryDateStorageKey, yesterday);
+};
+
+describe('Telemetry', () => {
+  let user;
+  let docs;
+
+  before(async () => {
+    ({ docs, user } = setupUser());
+    await utils.saveDocs(docs);
+    await utils.createUsers([user]);
+    await loginPage.login(user);
+  });
+
+  it('should record telemetry', async () => {
+    await commonPage.goToReports();
+    await commonPage.goToPeople();
+    await setOldTelemetryDate(user);
+
+    // generate telemetry aggregate
+    await commonPage.goToReports();
+    await commonPage.sync();
+
+    const clientDdoc = await utils.getDoc('_design/medic-client');
+
+    const options = { auth: { username: user.username, password: user.password }, userName: user.username };
+    const metaDocs = await utils.requestOnTestMetaDb({ ...options, path: '/_all_docs?include_docs=true' });
+
+    const telemetryEntry = metaDocs.rows.find(row => row.id.startsWith('telemetry'));
+    expect(telemetryEntry.doc).to.deep.nested.include({
+      'metadata.year': moment().year(),
+      'metadata.month': moment().month() + 1,
+      'metadata.day': moment().day() + 1,
+      'metadata.user': user.username,
+      'metadata.versions.app': clientDdoc.build_info.version,
+    });
+  });
+});

--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -73,5 +73,6 @@ describe('Telemetry', () => {
       'metadata.user': user.username,
       'metadata.versions.app': clientDdoc.build_info.version,
     });
+    expect(clientDdoc.build_info.version).to.include(clientDdoc.build_info.base_version);
   });
 });

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -124,7 +124,7 @@ export class TelemetryService {
       ])
       .then(([ddoc, formResults, settingsResults]) => {
         const date = this.getFirstAggregatedDate();
-        const version = (ddoc.deploy_info && ddoc.deploy_info.version) || 'unknown';
+        const version = ddoc?.build_info?.version || 'unknown';
         const forms = formResults.rows.reduce((keyToVersion, row) => {
           keyToVersion[row.doc.internalId] = row.doc._rev;
 

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -181,7 +181,7 @@ describe('TelemetryService', () => {
         .withArgs('_design/medic-client')
         .resolves({
           _id: '_design/medic-client',
-          deploy_info: { version: '3.0.0' }
+          build_info: { version: '3.0.0' }
         });
       medicDb.query.resolves({
         rows: [
@@ -384,7 +384,7 @@ describe('TelemetryService', () => {
       metaDb.put.onSecondCall().resolves();
       medicDb.get.withArgs('_design/medic-client').resolves({
         _id: '_design/medic-client',
-        deploy_info: {
+        build_info: {
           version: '3.0.0'
         }
       });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

medic/cht-core#8161

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8161-fix-telemetry-app-version/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8161-fix-telemetry-app-version/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8161-fix-telemetry-app-version/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

