### PR TITLE
fix(#8367): adds postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "default-wdio-mobile": "wdio run ./tests/e2e/default-mobile/wdio.conf.js",
     "local-images": "export VERSION=$(node ./scripts/build/get-version.js) && grunt build-service-images && grunt create-local-docker-compose-files",
     "prepare": "husky install",
-    "fresh-start": "npm ci && cd webapp && ng cache clean && echo \"The fresh-start process has completed!\""
+    "fresh-start": "npm ci && cd webapp && ng cache clean && cd .. && echo \"The fresh-start process has completed!\""
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "default-wdio-mobile": "wdio run ./tests/e2e/default-mobile/wdio.conf.js",
     "local-images": "export VERSION=$(node ./scripts/build/get-version.js) && grunt build-service-images && grunt create-local-docker-compose-files",
     "prepare": "husky install",
-    "postinstall": "cd webapp && ng cache clean && cd ..",
-    "dev-install": "npm ci && npm run postinstall"
+    "postinstall": "cd webapp && ng cache clean && cd .."
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "default-wdio-mobile": "wdio run ./tests/e2e/default-mobile/wdio.conf.js",
     "local-images": "export VERSION=$(node ./scripts/build/get-version.js) && grunt build-service-images && grunt create-local-docker-compose-files",
     "prepare": "husky install",
-    "fresh-start": "npm ci && cd webapp && ng cache clean && cd .. && echo \"The fresh-start process has completed!\""
+    "postinstall": "cd webapp && ng cache clean && cd ..",
+    "dev-install": "npm ci && npm run postinstall"
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "standard-wdio": "wdio run ./tests/e2e/standard/wdio.conf.js",
     "default-wdio-mobile": "wdio run ./tests/e2e/default-mobile/wdio.conf.js",
     "local-images": "export VERSION=$(node ./scripts/build/get-version.js) && grunt build-service-images && grunt create-local-docker-compose-files",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "fresh-start": "npm ci && cd webapp && ng cache clean && echo \"The fresh-start process has completed!\""
   },
   "devDependencies": {
     "@angular-builders/custom-webpack": "^15.0.0",


### PR DESCRIPTION
# Description

Adds `postinstall` script. 

medic/cht-core#8367

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8367_fresh_start_helper/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8367_fresh_start_helper/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8367_fresh_start_helper/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

