### PR TITLE
perf(#8372): Set API timeout to 60 minutes

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -54,7 +54,7 @@ process
   const server = app.listen(apiPort, () => {
     logger.info('API listening on port ' + apiPort);
   });
-  server.setTimeout(0);
+  server.setTimeout(216000000 /* 1hour */);
 
   const checkInstall = require('./src/services/setup/check-install');
   const configWatcher = require('./src/services/config-watcher');

--- a/api/server.js
+++ b/api/server.js
@@ -54,7 +54,7 @@ process
   const server = app.listen(apiPort, () => {
     logger.info('API listening on port ' + apiPort);
   });
-  server.setTimeout(216000000 /* 1hour */);
+  server.setTimeout(3600000 /* 1hour */);
 
   const checkInstall = require('./src/services/setup/check-install');
   const configWatcher = require('./src/services/config-watcher');


### PR DESCRIPTION
# Description

#8372

Based on API log analysis, some requests spend much longer than 1 hour within the API service. 
Given nginx and ELB have a 60 minute timeout: The response is doomed; API's efforts are futile; painless termination is prudent. 
Enable Express's timeout after 60 minutes. 

https://github.com/medic/cht-core/pull/7190

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

