### PR TITLE
fix(#8385): Adds login's images to service worker's cache

### DIFF
--- a/api/src/generate-service-worker.js
+++ b/api/src/generate-service-worker.js
@@ -93,6 +93,7 @@ const writeServiceWorkerFile = async () => {
       path.join(webappDirectoryPath, 'fonts', 'NotoSans-Bold.ttf'),
       path.join(webappDirectoryPath, 'fonts', 'NotoSans-Regular.ttf'),
       path.join(staticDirectoryPath, 'login', '*.{css,js}'),
+      path.join(staticDirectoryPath, 'login', 'images', '*.svg'),
     ],
     dynamicUrlToDependencies: {
       '/': [path.join(webappDirectoryPath, 'index.html')], // Webapp's entry point

--- a/api/tests/mocha/generate-service-worker.spec.js
+++ b/api/tests/mocha/generate-service-worker.spec.js
@@ -73,6 +73,7 @@ describe('generate service worker', () => {
             '/absolute/path/to/build/static/webapp/fonts/NotoSans-Bold.ttf',
             '/absolute/path/to/build/static/webapp/fonts/NotoSans-Regular.ttf',
             '/absolute/path/to/build/static/login/*.{css,js}',
+            '/absolute/path/to/build/static/login/images/*.svg',
             '/extension-libs',
             '/extension-libs/bar.js',
           ],
@@ -197,6 +198,7 @@ describe('generate service worker', () => {
             '/absolute/path/to/build/static/webapp/fonts/NotoSans-Bold.ttf',
             '/absolute/path/to/build/static/webapp/fonts/NotoSans-Regular.ttf',
             '/absolute/path/to/build/static/login/*.{css,js}',
+            '/absolute/path/to/build/static/login/images/*.svg',
             '/extension-libs',
           ],
           dynamicUrlToDependencies: {

--- a/tests/e2e/default/service-worker/service-worker.wdio-spec.js
+++ b/tests/e2e/default/service-worker/service-worker.wdio-spec.js
@@ -124,6 +124,8 @@ describe('Service worker cache', () => {
       '/login/lib-bowser.js',
       '/login/script.js',
       '/login/style.css',
+      '/login/images/hide-password.svg',
+      '/login/images/show-password.svg',
       '/main.js',
       '/manifest.json',
       '/medic/_design/medic/_rewrite/',


### PR DESCRIPTION
# Description

Adds login's images to service worker's cache.

medic/cht-core#8385

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8385_cache_login_img_service_worker/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8385_cache_login_img_service_worker/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8385_cache_login_img_service_worker/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

