### PR TITLE
chore(#8404): ignore error when test logging fails

### DIFF
--- a/tests/integration/api/server.spec.js
+++ b/tests/integration/api/server.spec.js
@@ -186,6 +186,7 @@ describe('server', () => {
       await utils.stopHaproxy(); // this will also crash API
       await utils.startHaproxy();
       await utils.listenForApi();
+      await utils.delayPromise(1000);
 
       const forms = await utils.db.allDocs({
         start_key: 'form:',

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1160,12 +1160,16 @@ const collectSentinelLogs = (...regex) => collectLogs('sentinel', ...regex);
 
 const collectApiLogs = (...regex) => collectLogs('api', ...regex);
 
+const normalizeTestName = name => name.replace(/\s/g, '_');
+
 const apiLogTestStart = (name) => {
-  return requestOnTestDb(`/?start=${name.replace(/\s/g, '_')}`);
+  return requestOnTestDb(`/?start=${normalizeTestName(name)}`)
+    .catch(() => console.warn('Error logging test start - ignoring'));
 };
 
 const apiLogTestEnd = (name) => {
-  return requestOnTestDb(`/?end=${name.replace(/\s/g, '_')}`);
+  return requestOnTestDb(`/?end=${normalizeTestName(name)}`)
+    .catch(() => console.warn('Error logging test end - ignoring'));
 };
 
 const getDockerVersion = () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

[description]

medic/cht-core#8404

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8404-ignore-logging-error/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8404-ignore-logging-error/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8404-ignore-logging-error/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

