### PR TITLE
chore: Update cht-conf version from 3.15.2 to 3.18.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-exclude": "^2.1.0",
         "chai-shallow-deep-equal": "^1.4.6",
-        "cht-conf": "^3.15.2",
+        "cht-conf": "^3.18.3",
         "clean-css-cli": "^5.6.2",
         "couchdb-compile": "^1.11.2",
         "csv-writer": "^1.6.0",
@@ -10125,9 +10125,9 @@
       }
     },
     "node_modules/cht-conf": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/cht-conf/-/cht-conf-3.15.2.tgz",
-      "integrity": "sha512-z2koEpbvcawJmSGzyikUU2rUT5nPJK42BpNRX5dVTiUViYrzalInk23DoekAvmWXnKeER4xPUO2mgf4XERqR4g==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/cht-conf/-/cht-conf-3.18.3.tgz",
+      "integrity": "sha512-gGNLEyB7mDZL4gBpMm+SFZ/I8zvIjz7CphXGD1FXz1NkeGK5XZ15Ac3zOVcjLu1GFBz1Vy7QpxgGC3+4FxD7UQ==",
       "dev": true,
       "dependencies": {
         "@hapi/joi": "^16.1.8",
@@ -41245,9 +41245,9 @@
       "dev": true
     },
     "cht-conf": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/cht-conf/-/cht-conf-3.15.2.tgz",
-      "integrity": "sha512-z2koEpbvcawJmSGzyikUU2rUT5nPJK42BpNRX5dVTiUViYrzalInk23DoekAvmWXnKeER4xPUO2mgf4XERqR4g==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/cht-conf/-/cht-conf-3.18.3.tgz",
+      "integrity": "sha512-gGNLEyB7mDZL4gBpMm+SFZ/I8zvIjz7CphXGD1FXz1NkeGK5XZ15Ac3zOVcjLu1GFBz1Vy7QpxgGC3+4FxD7UQ==",
       "dev": true,
       "requires": {
         "@hapi/joi": "^16.1.8",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.1.0",
     "chai-shallow-deep-equal": "^1.4.6",
-    "cht-conf": "^3.15.2",
+    "cht-conf": "^3.18.3",
     "clean-css-cli": "^5.6.2",
     "couchdb-compile": "^1.11.2",
     "csv-writer": "^1.6.0",


### PR DESCRIPTION
# Description

Older versions of cht-conf were [broken with Node ](https://github.com/medic/cht-conf/issues/538)17+ because Webpack 4.x [used the ](https://github.com/medic/cht-conf/pull/540/files#r1119345390)md4[ hash by default](https://github.com/medic/cht-conf/pull/540/files#r1119345390) and that has is no longer supported in Node 17.x


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-cht-conf-version/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-cht-conf-version/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-cht-conf-version/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

