### PR TITLE
fix(#8457): increase couchdb doc size and retry saving forms

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -136,6 +136,19 @@ if (UNIT_TEST_ENV) {
       });
   };
 
+  const saveDocs = async (db, docs) => {
+    try {
+      return await db.bulkDocs(docs);
+    } catch (err) {
+      if (err.status !== 413 || docs.length === 1) {
+        throw err;
+      }
+
+      const results = await Promise.all(docs.map(doc => db.put(doc)));
+      return results.flat();
+    }
+  };
+
   /**
    * @param {Database} db
    * @param {Array<DesignDocument>} docs
@@ -150,18 +163,7 @@ if (UNIT_TEST_ENV) {
       return [];
     }
 
-    let results;
-    try {
-      results = await db.bulkDocs(docs);
-    } catch (err) {
-      if (err.status !== 413 || docs.length === 1) {
-        throw err;
-      }
-
-      results = await Promise.all(docs.map(doc => db.put(doc)));
-      results = results.flat();
-    }
-
+    const results = await saveDocs(db, docs);
     const errors = results
       .filter(result => result.error)
       .map(result => `saving ${result.id} failed with ${result.error}`);

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -155,14 +155,11 @@ if (UNIT_TEST_ENV) {
     try {
       results = await db.bulkDocs(docs);
     } catch (err) {
-      const docsCount = docs.length;
-      if (err.status !== 413 || docsCount === 1) {
+      if (err.status !== 413 || docs.length === 1) {
         throw err;
       }
 
-      const batches = _.chunk(docs, docsCount / 2);
-
-      results = await Promise.all(batches.map(batch => module.exports.saveDocs(db, batch)));
+      results = await Promise.all(docs.map(doc => db.put(doc)));
       results = results.flat();
     }
 
@@ -173,8 +170,6 @@ if (UNIT_TEST_ENV) {
     if (!errors.length) {
       return results;
     }
-
-    // todo try one by one!
 
     throw new Error(`Error while saving docs: ${errors.join(', ')}`);
   };

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -2,7 +2,6 @@ const PouchDB = require('pouchdb-core');
 const logger = require('./logger');
 const environment = require('./environment');
 const rpn = require('request-promise-native');
-const _ = require('lodash');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 PouchDB.plugin(require('pouchdb-find'));
 PouchDB.plugin(require('pouchdb-mapreduce'));

--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -255,7 +255,7 @@ module.exports = {
         if (!toSave.length) {
           return;
         }
-        return db.medic.bulkDocs(toSave).then(results => {
+        return db.saveDocs(db.medic, toSave).then(results => {
           const failures = results.filter(result => !result.ok);
           if (failures.length) {
             logger.error('Bulk save failed with: %o', failures);

--- a/api/tests/mocha/db.spec.js
+++ b/api/tests/mocha/db.spec.js
@@ -79,6 +79,82 @@ describe('db', () => {
         expect(err).to.deep.equal({ some: 'err' });
       }
     });
+
+    it('should retry with half the payload if 413 is thrown', async () => {
+      sinon.stub(db.medic, 'bulkDocs')
+        .rejects({ status: 413 })
+        .onCall(1).resolves(['succ1', 'succ2'])
+        .onCall(2).resolves(['succ3', 'succ4']);
+
+      const result = await db.saveDocs(db.medic, [{ _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }]);
+      expect(result).to.deep.equal(['succ1', 'succ2', 'succ3', 'succ4']);
+      expect(db.medic.bulkDocs.args).to.deep.equal([
+        [[{ _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }]],
+        [[{ _id: 1 }, { _id: 2 }]],
+        [[{ _id: 3 }, { _id: 4 }]],
+      ]);
+    });
+
+    it('should keep retrying with half the payload', async () => {
+      sinon.stub(db.medic, 'bulkDocs')
+        .rejects({ status: 413 })
+        .onCall(3).resolves(['succ1'])
+        .onCall(4).resolves(['succ2'])
+        .onCall(5).resolves(['succ3'])
+        .onCall(6).resolves(['succ4']);
+
+      const result = await db.saveDocs(db.medic, [{ _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }]);
+      expect(result).to.deep.equal(['succ1', 'succ2', 'succ3', 'succ4']);
+      expect(db.medic.bulkDocs.args).to.deep.equal([
+        [[{ _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }]],
+        [[{ _id: 1 }, { _id: 2 }]],
+        [[{ _id: 3 }, { _id: 4 }]],
+        [[{ _id: 1 }]],
+        [[{ _id: 2 }]],
+        [[{ _id: 3 }]],
+        [[{ _id: 4 }]]
+      ]);
+    });
+
+    it('should work with uneven docs counts', async () => {
+      sinon.stub(db.medic, 'bulkDocs')
+        .rejects({ status: 413 })
+        .onCall(3).resolves(['succ1'])
+        .onCall(4).resolves(['succ2'])
+        .onCall(5).resolves(['succ3'])
+        .onCall(6).resolves(['succ4'])
+        .onCall(7).resolves(['succ5']);
+
+      const result = await db.saveDocs(db.medic, [{ _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }]);
+      expect(result).to.have.members(['succ1', 'succ2', 'succ3', 'succ4', 'succ5']);
+      expect(db.medic.bulkDocs.args).to.deep.equal([
+        [[{ _id: 1 }, { _id: 2 }, { _id: 3 }, { _id: 4 }, { _id: 5 }]],
+        [[{ _id: 1 }, { _id: 2 }]],
+        [[{ _id: 3 }, { _id: 4 }]],
+        [[{ _id: 5 }]],
+        [[{ _id: 1 }]],
+        [[{ _id: 2 }]],
+        [[{ _id: 3 }]],
+        [[{ _id: 4 }]]
+      ]);
+    });
+
+    it('should throw final error when getting a 413 with a single doc', async () => {
+      const docs = [{ _id: 1 }, { _id: 2 }];
+      sinon.stub(db.medic, 'bulkDocs').rejects({ status: 413 });
+
+      try {
+        await db.saveDocs(db.medic, docs);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).to.deep.equal( { status: 413 });
+        expect(db.medic.bulkDocs.args).to.deep.equal([
+          [[{ _id: 1 }, { _id: 2 }]],
+          [[{ _id: 1 }]],
+          [[{ _id: 2 }]],
+        ]);
+      }
+    });
   });
 
   describe('get', () => {

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -96,7 +96,7 @@ describe('generate-xform service', () => {
 
     it('should replace multimedia src elements', () => runTest('multimedia', spawned));
 
-    it('should correctly replaces models with nested "</root>" - #5971', () => runTest('nested-root', spawned));
+    it('should correctly replace models with nested "</root>" - #5971', () => runTest('nested-root', spawned));
 
     it('should replace markdown syntax', () => runTest('markdown', spawned));
 
@@ -352,28 +352,28 @@ describe('generate-xform service', () => {
 
     it('should handle no forms', () => {
       sinon.stub(db.medic, 'allDocs').resolves({ rows: [] });
-      sinon.stub(db.medic, 'bulkDocs');
+      sinon.stub(db, 'saveDocs');
       return service.updateAll().then(() => {
         expect(db.medic.allDocs.callCount).to.equal(1);
-        expect(db.medic.bulkDocs.callCount).to.equal(0);
+        expect(db.saveDocs.callCount).to.equal(0);
       });
     });
 
     it('should ignore json forms', () => {
       sinon.stub(db.medic, 'allDocs').resolves({ rows: [ JSON_FORM_ROW ] });
-      sinon.stub(db.medic, 'bulkDocs');
+      sinon.stub(db, 'saveDocs');
       return service.updateAll().then(() => {
         expect(db.medic.allDocs.callCount).to.equal(1);
-        expect(db.medic.bulkDocs.callCount).to.equal(0);
+        expect(db.saveDocs.callCount).to.equal(0);
       });
     });
 
     it('should ignore collect forms', () => {
       sinon.stub(db.medic, 'allDocs').resolves({ rows: [ COLLECT_FORM_ROW ] });
-      sinon.stub(db.medic, 'bulkDocs');
+      sinon.stub(db, 'saveDocs');
       return service.updateAll().then(() => {
         expect(db.medic.allDocs.callCount).to.equal(1);
-        expect(db.medic.bulkDocs.callCount).to.equal(0);
+        expect(db.saveDocs.callCount).to.equal(0);
       });
     });
 
@@ -392,14 +392,14 @@ describe('generate-xform service', () => {
         }
       } ] });
       sinon.stub(service, 'generate').resolves({ form: currentForm, model: currentModel });
-      sinon.stub(db.medic, 'bulkDocs');
+      sinon.stub(db, 'saveDocs');
       return service.updateAll().then(() => {
         expect(db.medic.allDocs.callCount).to.equal(1);
-        expect(db.medic.bulkDocs.callCount).to.equal(0);
+        expect(db.saveDocs.callCount).to.equal(0);
       });
     });
 
-    it('should throw when not all updated successfully', done => {
+    it('should throw when not all updated successfully', () => {
       const formXml = '<my-xml/>';
       const currentForm = '<html/>';
       const newForm = '<html><title>Hello</title></html>';
@@ -419,12 +419,12 @@ describe('generate-xform service', () => {
         }
       ] });
       sinon.stub(service, 'generate').resolves({ form: newForm, model: newModel });
-      sinon.stub(db.medic, 'bulkDocs').resolves([ { error: 'some error' } ]);
-      service.updateAll()
-        .then(() => done(new Error('expected error to be thrown')))
+      sinon.stub(db, 'saveDocs').resolves([ { error: 'some error' } ]);
+      return service
+        .updateAll()
+        .then(() => expect.fail('Should have thrown'))
         .catch(err => {
           expect(err.message).to.equal('Failed to save updated xforms to the database');
-          done();
         });
     });
 
@@ -463,13 +463,14 @@ describe('generate-xform service', () => {
       sinon.stub(service, 'generate')
         .onCall(0).resolves({ form: currentForm, model: currentModel })
         .onCall(1).resolves({ form: newForm, model: newModel });
-      sinon.stub(db.medic, 'bulkDocs').resolves([ { ok: true } ]);
+      sinon.stub(db, 'saveDocs').resolves([ { ok: true } ]);
       return service.updateAll().then(() => {
         expect(db.medic.allDocs.callCount).to.equal(1);
-        expect(db.medic.bulkDocs.callCount).to.equal(1);
-        expect(db.medic.bulkDocs.args[0][0].length).to.equal(1);
-        expect(db.medic.bulkDocs.args[0][0][0]._id).to.equal('d');
-        expectAttachments(db.medic.bulkDocs.args[0][0][0], newForm, newModel);
+        expect(db.saveDocs.callCount).to.equal(1);
+        expect(db.saveDocs.args[0][0]).to.equal(db.medic);
+        expect(db.saveDocs.args[0][1].length).to.equal(1);
+        expect(db.saveDocs.args[0][1][0]._id).to.equal('d');
+        expectAttachments(db.saveDocs.args[0][1][0], newForm, newModel);
       });
     });
 

--- a/couchdb/10-docker-default.ini
+++ b/couchdb/10-docker-default.ini
@@ -10,6 +10,7 @@ os_process_limit = 1000
 os_process_timeout = 60000
 max_dbs_open = 5000
 attachment_stream_buffer_size = 16384
+max_document_size = 4294967296 ; 4 GB
 
 [chttpd]
 port = 5984
@@ -22,7 +23,7 @@ require_valid_user = true
 port = 5986
 bind_address = 0.0.0.0
 secure_rewrites = false
-max_http_request_size = 134217728 ; 128 MiB
+max_http_request_size = 4294967296 ; 4 GB
 WWW-Authenticate = Basic realm="Medic Mobile Web Services"
 
 [couch_httpd_auth]


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- adds couchdb config `max_document_size` equal to 4GB
- raises couchdb `max_http_request_size` to 4GB
- adds a doc-by-doc retry on 413 errors to `db.saveDocs`

medic/cht-core#8457

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8457-api-forms-payload/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8457-api-forms-payload/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8457-api-forms-payload/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

