### PR TITLE
fix(#8490): handle errors when reordering intercepted couchdb response

### DIFF
--- a/api/src/controllers/bulk-docs.js
+++ b/api/src/controllers/bulk-docs.js
@@ -26,9 +26,13 @@ const invalidRequest = req => {
 };
 
 const interceptResponse = (requestDocs, req, res, response) => {
-  response = JSON.parse(response);
-  const formattedResults = bulkDocs.formatResults(requestDocs, req.body.docs, response);
-  res.json(formattedResults);
+  try {
+    response = JSON.parse(response);
+    const formattedResults = bulkDocs.formatResults(requestDocs, req.body.docs, response);
+    res.json(formattedResults);
+  } catch (error) {
+    serverUtils.serverError(error, req, res);
+  }
 };
 
 module.exports = {


### PR DESCRIPTION
# Description

medic/cht-core#8490

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8490-catch-error-in-intercepted-response/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8490-catch-error-in-intercepted-response/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8490-catch-error-in-intercepted-response/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

