### PR TITLE
8033 fix error saving report

### DIFF
--- a/tests/e2e/default/enketo/pregnancy-danger-sign.wdio-spec.js
+++ b/tests/e2e/default/enketo/pregnancy-danger-sign.wdio-spec.js
@@ -21,7 +21,7 @@ describe('Pregnancy danger sign follow-up form', () => {
     await genericForm.nextPage();
     await pregnancyDangerSignForm.selectVisitedHealthFacility(true);
     await pregnancyDangerSignForm.selectDangerSigns(false);
-    await reportsPage.submitForm();
+    await reportsPage.submitForm(500);
 
     await genericForm.verifyReport();
   });
@@ -50,7 +50,7 @@ describe('Pregnancy danger sign follow-up form', () => {
 
   });
 
-  it('should submit Pregnancy danger sign follow-up form with changes', async () => {
+  it('should submit and edit Pregnancy danger sign follow-up form with changes', async () => {
     await commonPage.goToReports();
 
     await commonPage.openFastActionReport('pregnancy_danger_sign_follow_up', false);
@@ -58,16 +58,13 @@ describe('Pregnancy danger sign follow-up form', () => {
     await genericForm.nextPage();
     await pregnancyDangerSignForm.selectVisitedHealthFacility(true);
     await pregnancyDangerSignForm.selectDangerSigns(false);
-    await reportsPage.submitForm();
+    await reportsPage.submitForm(500);
 
     const reportId = await reportsPage.getCurrentReportId();
     const initialReport = await utils.getDoc(reportId);
 
     expect(initialReport._attachments).to.equal(undefined);
-  });
 
-  it('should edit Pregnancy danger sign follow-up form with changes', async () => {
-    const reportId = await reportsPage.getCurrentReportId();
     await reportsPage.editReport(reportId);
     await pregnancyDangerSignForm.selectPatient('jack');
     await genericForm.nextPage();
@@ -82,7 +79,7 @@ describe('Pregnancy danger sign follow-up form', () => {
     await genericForm.nextPage();
     await pregnancyDangerSignForm.selectVisitedHealthFacility(false);
     await pregnancyDangerSignForm.selectDangerSigns(true);
-    await reportsPage.submitForm();
+    await reportsPage.submitForm(500);
 
     const compareReportId = await reportsPage.getCurrentReportId();
     const compareReport = await utils.getDoc(compareReportId);

--- a/tests/e2e/default/enketo/pregnancy-danger-sign.wdio-spec.js
+++ b/tests/e2e/default/enketo/pregnancy-danger-sign.wdio-spec.js
@@ -50,7 +50,7 @@ describe('Pregnancy danger sign follow-up form', () => {
 
   });
 
-  it('should submit and edit Pregnancy danger sign follow-up form with changes', async () => {
+  it('should submit Pregnancy danger sign follow-up form with changes', async () => {
     await commonPage.goToReports();
 
     await commonPage.openFastActionReport('pregnancy_danger_sign_follow_up', false);
@@ -64,7 +64,10 @@ describe('Pregnancy danger sign follow-up form', () => {
     const initialReport = await utils.getDoc(reportId);
 
     expect(initialReport._attachments).to.equal(undefined);
+  });
 
+  it('should edit Pregnancy danger sign follow-up form with changes', async () => {
+    const reportId = await reportsPage.getCurrentReportId();
     await reportsPage.editReport(reportId);
     await pregnancyDangerSignForm.selectPatient('jack');
     await genericForm.nextPage();

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -119,8 +119,9 @@ const getFieldValue = async (name) => {
   return input.getValue();
 };
 
-const submitForm = async () => {
+const submitForm = async (pause) => {
   await (await submitButton()).waitForDisplayed();
+  await browser.pause(pause);
   await (await submitButton()).click();
   await (await reportBodyDetails()).waitForDisplayed();
 };


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

[description]

medic/cht-core #8033 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8033-fix-error-saving-report/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8033-fix-error-saving-report/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8033-fix-error-saving-report/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

