### PR TITLE
fix(couchdb): fixes triple equals syntax error in verify_membership f…

### DIFF
--- a/couchdb/set-up-cluster.sh
+++ b/couchdb/set-up-cluster.sh
@@ -5,7 +5,7 @@ SLEEP_SECONDS="${SLEEP_SECONDS:-5}"
 NODE_COUNT=3
 
 verify_membership(){
-    curl -s http://$COUCHDB_USER:$COUCHDB_PASSWORD@$SVC_NAME:5984/_membership | jq ".all_nodes == .cluster_nodes and (.all_nodes | length) === $NODE_COUNT"
+    curl -s http://$COUCHDB_USER:$COUCHDB_PASSWORD@$SVC_NAME:5984/_membership | jq ".all_nodes == .cluster_nodes and (.all_nodes | length) == $NODE_COUNT"
 }
 
 enable_cluster(){


### PR DESCRIPTION
# Description

test.json
```json
{
    "all_nodes": [
        "couchdb@couchdb-bidwvr.host.org",
        "couchdb@couchdb-mhwpue.host.org"
    ],
    "cluster_nodes": [
        "couchdb@couchdb-bidwvr.host.org",
        "couchdb@couchdb-mhwpue.host.org"
    ]
}
```

```sh
cat test.json | jq ".all_nodes == .cluster_nodes and (.all_nodes | length) == 2"

-> true
```

```sh
cat test.json | jq ".all_nodes == .cluster_nodes and (.all_nodes | length) === 2"

-> jq: error: syntax error, unexpected '=' (Unix shell quoting issues?) at <top-level>, line 1:
.all_nodes == .cluster_nodes and (.all_nodes | length) === 2
jq: 1 compile error
```

I assume CI/CD pipelines will test this, but if they break you may be depending on the bug.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate



