### PR TITLE
fix(#8539): Fix Sentinel infinite loop on failed transitions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        grunt-cmd: ['ci-webdriver-default', 'ci-webdriver-standard', 'ci-e2e-integration', 'ci-e2e', 'ci-e2e-mobile', 'ci-webdriver-default-mobile']
+        grunt-cmd: ['ci-webdriver-default', 'ci-webdriver-standard', 'ci-e2e-integration', 'ci-webdriver-default-mobile']
 
     steps:
     - name: Login to Docker Hub

--- a/sentinel/src/lib/change-retry-history.js
+++ b/sentinel/src/lib/change-retry-history.js
@@ -1,0 +1,36 @@
+const MAX_HISTORY = 1000;
+const MAX_RETRIES = 5;
+const historyKeys = [];
+const history = {};
+
+const getKey = (change) => change && `${change.id}${change.changes && change.changes[0] && change.changes[0].rev}`;
+
+const add = (change) => {
+  const key = getKey(change);
+  if (!key) {
+    return;
+  }
+
+  if (history[key]) {
+    history[key]++;
+  } else {
+    historyKeys.push(key);
+    history[key] = 1;
+  }
+
+  if (historyKeys.length > MAX_HISTORY) {
+    const deletedKey = historyKeys.shift();
+    delete history[deletedKey];
+  }
+};
+
+const shouldProcess = (change) => {
+  const key = getKey(change);
+
+  return !history[key] || history[key] <= MAX_RETRIES;
+};
+
+module.exports = {
+  add,
+  shouldProcess,
+};

--- a/sentinel/src/lib/feed.js
+++ b/sentinel/src/lib/feed.js
@@ -2,6 +2,7 @@ const async = require('async');
 const logger = require('./logger');
 const db = require('../db');
 const metadata = require('./metadata');
+const changeRetryHistory = require('./change-retry-history');
 const tombstoneUtils = require('@medic/tombstone-utils');
 const transitionsLib = require('../config').getTransitionsLib();
 
@@ -43,8 +44,11 @@ const registerFeed = (seq) => {
   request = db.medic
     .changes({ live: true, since: seq })
     .on('change', change => {
-      if (!change.id.match(IDS_TO_IGNORE) &&
-          !tombstoneUtils.isTombstoneId(change.id)) {
+      if (
+        !change.id.match(IDS_TO_IGNORE) &&
+        !tombstoneUtils.isTombstoneId(change.id) &&
+        changeRetryHistory.shouldProcess(change)
+      ) {
         enqueue(change);
 
         const queueSize = changeQueue.length();
@@ -74,13 +78,16 @@ const changeQueue = async.queue((change, callback) => {
     );
   }
   if (change.deleted) {
-    return tombstoneUtils.processChange(Promise, db.medic, change, logger)
-      .then(() => updateMetadata(change, callback))
-      .catch(callback);
+    return tombstoneUtils
+      .processChange(Promise, db.medic, change, logger)
+      .catch(() => {}) // error already logged by tombstoneUtils
+      // advance sentinel seq even when tombstone creation fails
+      .then(() => updateMetadata(change, callback));
   }
 
   transitionsLib.processChange(change, err => {
     if (err) {
+      changeRetryHistory.add(change);
       return callback(err);
     }
 

--- a/sentinel/tests/unit/lib/change-retry-history.spec.js
+++ b/sentinel/tests/unit/lib/change-retry-history.spec.js
@@ -1,0 +1,125 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+const rewire = require('rewire');
+
+let changeRetryHistory;
+
+describe('change-retry-history', () => {
+  beforeEach(() => {
+    changeRetryHistory = rewire('../../../src/lib/change-retry-history');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('add', () => {
+    it('should not throw errors on bad changes', () => {
+      changeRetryHistory.add();
+      changeRetryHistory.add(false);
+      changeRetryHistory.add('string');
+      changeRetryHistory.add(23);
+      changeRetryHistory.add({});
+      changeRetryHistory.add({ id: 'test', changes: false });
+    });
+
+    it('should add key to history', () => {
+      changeRetryHistory.add({ id: 'theid', changes: [{ rev: '22-rev' }] });
+      expect(changeRetryHistory.__get__('historyKeys')).to.deep.equal(['theid22-rev']);
+      expect(changeRetryHistory.__get__('history')).to.deep.equal({ 'theid22-rev': 1 });
+
+      changeRetryHistory.add({ id: 'theid', changes: [{ rev: '23-rev' }] });
+      expect(changeRetryHistory.__get__('historyKeys')).to.deep.equal(['theid22-rev', 'theid23-rev']);
+      expect(changeRetryHistory.__get__('history')).to.deep.equal({ 'theid22-rev': 1, 'theid23-rev': 1 });
+    });
+
+    it('should increase number when re-adding', () => {
+      changeRetryHistory.add({ id: 'phil', changes: [{ rev: '11-77' }] });
+      expect(changeRetryHistory.__get__('historyKeys')).to.deep.equal(['phil11-77']);
+      expect(changeRetryHistory.__get__('history')).to.deep.equal({ 'phil11-77': 1 });
+
+
+      changeRetryHistory.add({ id: 'phil', changes: [{ rev: '11-77' }] });
+      expect(changeRetryHistory.__get__('historyKeys')).to.deep.equal(['phil11-77']);
+      expect(changeRetryHistory.__get__('history')).to.deep.equal({ 'phil11-77': 2 });
+
+      changeRetryHistory.add({ id: 'phil', changes: [{ rev: '11-77' }] });
+      expect(changeRetryHistory.__get__('historyKeys')).to.deep.equal(['phil11-77']);
+      expect(changeRetryHistory.__get__('history')).to.deep.equal({ 'phil11-77': 3 });
+
+      changeRetryHistory.add({ id: 'phil', changes: [{ rev: '11-77' }] });
+      expect(changeRetryHistory.__get__('history')).to.deep.equal({ 'phil11-77': 4 });
+    });
+
+    it('should push old changes out of queue', () => {
+      Array
+        .from({ length: 1000 })
+        .forEach((_, idx) => changeRetryHistory.add({ id: `${idx + 1}`, changes: [{ rev: `${idx + 1}` }] }));
+
+      expect(changeRetryHistory.__get__('historyKeys').length).to.equal(1000);
+
+      changeRetryHistory.add({ id: 'george', changes: [{ rev: '22-77' }] });
+      expect(changeRetryHistory.__get__('historyKeys').length).to.equal(1000);
+      expect(changeRetryHistory.__get__('historyKeys')[0]).to.equal('22');
+      expect(changeRetryHistory.__get__('historyKeys')[1]).to.equal('33');
+      expect(changeRetryHistory.__get__('historyKeys')[999]).to.equal('george22-77');
+
+      changeRetryHistory.add({ id: 'michael', changes: [{ rev: '33-77' }] });
+      expect(changeRetryHistory.__get__('historyKeys').length).to.equal(1000);
+      expect(changeRetryHistory.__get__('historyKeys')[0]).to.equal('33');
+      expect(changeRetryHistory.__get__('historyKeys')[1]).to.equal('44');
+      expect(changeRetryHistory.__get__('historyKeys')[998]).to.equal('george22-77');
+      expect(changeRetryHistory.__get__('historyKeys')[999]).to.equal('michael33-77');
+    });
+  });
+
+  describe('shouldProcess', () => {
+    it('should not throw errors on bad changes', () => {
+      changeRetryHistory.shouldProcess();
+      changeRetryHistory.shouldProcess(false);
+      changeRetryHistory.shouldProcess('string');
+      changeRetryHistory.shouldProcess(23);
+      changeRetryHistory.shouldProcess({});
+      changeRetryHistory.shouldProcess({ id: 'test', changes: false });
+    });
+
+    it('should return true when item is not present', () => {
+      const change = { id: 'a', changes: [{ rev: '33-77' }] };
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add({ id: 'george', changes: [{ rev: '22-77' }] });
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add({ id: 'michael', changes: [{ rev: '33-77' }] });
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+    });
+
+    it('should return true when item is present but does not exceed limit', () => {
+      const change = { id: 'a', changes: [{ rev: '33-77' }] };
+      changeRetryHistory.add(change);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add(change);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add(change);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add(change);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add(change);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(true);
+      changeRetryHistory.add(change);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(false);
+    });
+
+    it('should return true when item is present and new rev does not exceed limit', () => {
+      const change = { id: 'a', changes: [{ rev: '33-77' }] };
+      changeRetryHistory.add(change);
+      changeRetryHistory.add(change);
+      changeRetryHistory.add(change);
+      changeRetryHistory.add(change);
+      changeRetryHistory.add(change);
+      changeRetryHistory.add(change);
+
+      const newRevChange = { id: 'a', changes: [{ rev: '34-77' }] };
+      expect(changeRetryHistory.shouldProcess(newRevChange)).to.equal(true);
+      expect(changeRetryHistory.shouldProcess(change)).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- advances seq when a tombstone fails to be created
- adds failed doc transitions history. Docs that have failed transitions more than 5 times are not enqueued any more. 

medic/cht-core#8539

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8539-advance-sentinel-seq-on-failed-tombstone/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8539-advance-sentinel-seq-on-failed-tombstone/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8539-advance-sentinel-seq-on-failed-tombstone/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

