### PR TITLE
fix: update auth for session get

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -11,7 +11,7 @@ const get = (path, headers) => {
     url: url.toString(),
     headers: headers,
     json: true
-  });
+  }).auth(environment.username, environment.password, false);
 };
 
 const hasPermission = (userCtx, permission) => {


### PR DESCRIPTION
`require_valid_user = true` as a couch config seems to demand this.

Please if you have the correct couchdb config (2.3.1) let me know. I realise on docker is doesn't seem to need to, but I'm wondering if that's somehow a fact of being on the same host. I'm trying to connect via a haproxy vm.

Honestly PR is at least half just looking for an explanation.