### PR TITLE
fix(couchdb): checks cluster_finished before asserting completion

### DIFF
--- a/couchdb/set-up-cluster.sh
+++ b/couchdb/set-up-cluster.sh
@@ -32,10 +32,14 @@ join_node_to_cluster(){
 
 }
 
+verify_cluster_state_finished() {
+  curl -s http://$COUCHDB_USER:$COUCHDB_PASSWORD@$SVC_NAME:5984/_cluster_setup | jq '.state == "cluster_finished"'
+}
+
 complete_cluster_setup()
 {
-    if $(verify_membership); then
-      echo "Cluster Setup Already Finished"
+    if [ "$(verify_membership)" == 'true' ] && [ "$(verify_cluster_state_finished)" == 'true' ]; then
+      echo "Cluster setup already finished"
     else
       curl -X POST -H "Content-Type: application/json" http://$COUCHDB_USER:$COUCHDB_PASSWORD@$SVC_NAME:5984/_cluster_setup \
       -d '{"action": "finish_cluster"}'


### PR DESCRIPTION
# Description

Since fixing the bug in `verify_membership(`), my cluster deployments have been failing to achieve `cluster_finished` state, getting stuck in `cluster_enabled`. This ensures that `'{"action": "finish_cluster"}'` is run before completion is asserted.

I assume this will be tested via CI testing.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

