### PR TITLE
chore(#8558): don't run Protractor e2e test suites

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        grunt-cmd: ['ci-webdriver-default', 'ci-webdriver-standard', 'ci-e2e-integration', 'ci-e2e', 'ci-e2e-mobile', 'ci-webdriver-default-mobile']
+        grunt-cmd: ['ci-webdriver-default', 'ci-webdriver-standard', 'ci-e2e-integration', 'ci-webdriver-default-mobile']
 
     steps:
     - name: Login to Docker Hub

--- a/config/standard/test/contact-summary/nutrition/contact.json
+++ b/config/standard/test/contact-summary/nutrition/contact.json
@@ -16,5 +16,5 @@
    "type": "person",
    "patient_id": "63538",
    "source_id": "fa18b57666f8fac7c0b2599f714c8eb7",
-   "date_of_birth": "2018-08-05"
+   "date_of_birth": "2023-08-05"
 }

--- a/config/standard/test/contact-summary/nutrition/expected-output.json
+++ b/config/standard/test/contact-summary/nutrition/expected-output.json
@@ -88,7 +88,7 @@
     },
     {
       "label": "contact.age",
-      "value": "2018-08-05",
+      "value": "2023-08-05",
       "width": 4,
       "filter": "age"
     },


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

medic/cht-core#8558

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.2.x-skip-protractor-tests/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.2.x-skip-protractor-tests/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.2.x-skip-protractor-tests/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

