### PR TITLE
chore(tests): tear down test containers when e2e tests complete

### DIFF
--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -983,7 +983,7 @@ const prepServices = async (defaultSettings) => {
 
   updateContainerNames();
 
-  await tearDownServices(true);
+  await tearDownServices();
   await startServices();
   await listenForApi();
   if (defaultSettings) {
@@ -1038,10 +1038,8 @@ const saveLogs = async () => {
   }
 };
 
-const tearDownServices = async (removeOrphans) => {
-  if (removeOrphans) {
-    return dockerComposeCmd('down', '-t', '0', '--remove-orphans', '--volumes');
-  }
+const tearDownServices = async () => {
+  await dockerComposeCmd('down', '-t', '0', '--remove-orphans', '--volumes');
   await saveLogs();
 };
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -20,9 +20,9 @@ process.env.COUCHDB_USER = constants.USERNAME;
 process.env.COUCHDB_PASSWORD = constants.PASSWORD;
 process.env.CERTIFICATE_MODE = constants.CERTIFICATE_MODE;
 process.env.NODE_TLS_REJECT_UNAUTHORIZED=0; // allow self signed certificates
+const DEBUG = process.env.DEBUG;
 
 let originalSettings;
-let e2eDebug;
 let dockerVersion;
 let browserLogStream;
 
@@ -390,7 +390,7 @@ const deleteAllDocs = (except) => {
         }))
     .then(toDelete => {
       const ids = toDelete.map(doc => doc._id);
-      if (e2eDebug) {
+      if (DEBUG) {
         console.log(`Deleting docs and infodocs: ${ids}`);
       }
       const infoIds = ids.map(id => `${id}-info`);
@@ -402,7 +402,7 @@ const deleteAllDocs = (except) => {
             body: { docs: toDelete },
           })
           .then(response => {
-            if (e2eDebug) {
+            if (DEBUG) {
               console.log(`Deleted docs: ${JSON.stringify(response)}`);
             }
           }),
@@ -420,7 +420,7 @@ const deleteAllDocs = (except) => {
             // it's stub in webapp/tests/mocha/unit/testingtests/e2e/utils.spec.js
             return module.exports.sentinelDb.bulkDocs(deletes);
           }).then(response => {
-            if (e2eDebug) {
+            if (DEBUG) {
               console.log(`Deleted sentinel docs: ${JSON.stringify(response)}`);
             }
           })
@@ -1039,8 +1039,10 @@ const saveLogs = async () => {
 };
 
 const tearDownServices = async () => {
-  await dockerComposeCmd('down', '-t', '0', '--remove-orphans', '--volumes');
   await saveLogs();
+  if (!DEBUG) {
+    await dockerComposeCmd('down', '-t', '0', '--remove-orphans', '--volumes');
+  }
 };
 
 const killSpawnedProcess = (proc) => {


### PR DESCRIPTION
Currently, after integration or E2E tests, the test CHT instance does not get stopped/removed. So, running the tests locally results in an additional CHT instance that is constantly running on my local machine (that does not get torn down until the next time I run the e2e/integration tests).

This change will cause the containers to be stopped/removed by default.  However, if the `DEBUG` envar is set when running the tests, the containers will be retained.

(As a side note, I have included some documentation about the `DEBUG` flag in https://github.com/medic/cht-docs/pull/1185)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:tear_down_test_containers/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:tear_down_test_containers/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:tear_down_test_containers/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

