### PR TITLE
chore(#8235):add test to check sentinel error log

### DIFF
--- a/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
+++ b/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
@@ -1,0 +1,27 @@
+const utils = require('@utils');
+const sentinelUtils = require('@utils/sentinel');
+const { setTimeout } = require('timers/promises');
+const { expect } = require('chai');
+
+describe('Sentinel transition error log', async function() {
+  this.timeout(10 * 60 * 1000);
+  after(async () => await utils.revertSettings(true));
+
+  it('log error for unkown transition', async () => {
+    const unknownTransitionPattern = /Unknown transition "something"/;
+    const settings = {
+      transitions: {
+        something: true
+      }
+    };
+
+    const collectLogs = await utils.collectSentinelLogs(unknownTransitionPattern);
+    await utils.updateSettings(settings, 'sentinel');
+    await sentinelUtils.getCurrentSeq();
+    const logs = await collectLogs();
+    expect(logs).to.have.lengthOf(1);
+    await setTimeout(5 * 60 * 1000); // every 5 minutes
+    expect(await collectLogs()).to.have.lengthOf(2);
+  });
+});
+

--- a/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
+++ b/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
@@ -20,7 +20,7 @@ describe('Sentinel transition error log', async function() {
     await sentinelUtils.getCurrentSeq();
     const logs = await collectLogs();
     expect(logs).to.have.lengthOf(1);
-    await setTimeout(5 * 60 * 1000); // every 5 minutes
+    await setTimeout(5 * 60 * 1000); // logs every 5 minutes
     expect(await collectLogs()).to.have.lengthOf(2);
   });
 });

--- a/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
+++ b/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
@@ -1,10 +1,8 @@
 const utils = require('@utils');
-const sentinelUtils = require('@utils/sentinel');
-const { setTimeout } = require('timers/promises');
 const { expect } = require('chai');
 
 describe('Sentinel transition error log', async function() {
-  this.timeout(10 * 60 * 1000);
+
   after(async () => await utils.revertSettings(true));
 
   it('log error for unkown transition', async () => {
@@ -14,14 +12,10 @@ describe('Sentinel transition error log', async function() {
         something: true
       }
     };
-
     const collectLogs = await utils.collectSentinelLogs(unknownTransitionPattern);
     await utils.updateSettings(settings, 'sentinel');
-    await sentinelUtils.getCurrentSeq();
     const logs = await collectLogs();
     expect(logs).to.have.lengthOf(1);
-    await setTimeout(5 * 60 * 1000); // logs every 5 minutes
-    expect(await collectLogs()).to.have.lengthOf(2);
   });
 });
 

--- a/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
+++ b/tests/integration/sentinel/transitions/sentinel-transition-error-log.spec.js
@@ -12,6 +12,7 @@ describe('Sentinel transition error log', async function() {
         something: true
       }
     };
+    
     const collectLogs = await utils.collectSentinelLogs(unknownTransitionPattern);
     await utils.updateSettings(settings, 'sentinel');
     const logs = await collectLogs();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:
cht #8235 
feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

[description]

- Update `app_settings.json` with an unknown or crashing transition. 
- Look at sentinel logs and verify there is a descriptive error. 
- Wait 5 minutes and verify the descriptive error is reprinted.

medic/cht-core #8235 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8235-e2e-for-sentinel-transition-error/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8235-e2e-for-sentinel-transition-error/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8235-e2e-for-sentinel-transition-error/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

