### PR TITLE
fix(cht-conf-test-harness#239): update contact saver to fix error

### DIFF
--- a/webapp/src/js/enketo/contact-saver.js
+++ b/webapp/src/js/enketo/contact-saver.js
@@ -93,7 +93,7 @@ const prepareAndAttachSiblingDocs = (extractLineageService, dbService, doc, orig
 };
 
 const prepareRepeatedDocs = (extractLineageService, doc, repeated) => {
-  const childData = repeated ? repeated.child_data : [];
+  const childData = repeated && repeated.child_data || [];
   return childData.map(child => {
     child.parent = extractLineageService.extract(doc);
     return prepare(child);


### PR DESCRIPTION
# Description

Note the base branch for this change is `enketo-service-refactor`. This contains a fix for https://github.com/medic/cht-conf-test-harness/issues/239 but should not be merged to main. I did not open a cht-core issue for this.

In production, we have [the typescript line](https://github.com/medic/cht-core/blame/cf4a1dde1fe2cca28f201c65f1b70bcd2dda6f6b/webapp/src/ts/services/contact-save.service.ts#L96C33-L96C43) `repeated?.child_data || [];`

In the `enketo-service-refactor` branch used by cht-conf-test-harness, we have this near enemy `repeated ? repeated.child_data : [];`

The behavior differs for defined values of `repeated` with an `undefined` value of `child_data`. This change reconciles the difference. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* __CHT_CORE_COMPOSE_URL__
* __COUCH_SINGLE_COMPOSE_URL__
* __COUCH_CLUSTER_COMPOSE_URL__

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

