### PR TITLE
fix(#8580) fix docker exec calls to be git bash compatible

### DIFF
--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -111,7 +111,9 @@ get_lan_ip() {
 
   # "system_profiler" exists only on MacOS, if it's not here, then run linux style command for
   # getting localhost's IP.  Otherwise use MacOS style command
-  if [ -n "$(required_apps_installed "system_profiler")" ];then
+  # HOWEVER!! "ip" doesn't exist on windows git BASH, so check for that before going into the first if (and
+  # skip it on the second elif because windows won't have "system_profiler"
+  if [[ -n "$(required_apps_installed "system_profiler")" ]] && [[ "$(required_apps_installed "ip")" ]] ;then
     # todo - some of these calls fail when there's no network connectivity - output stuff it shouldn't:
     #       Device "" does not exist.
     routerIP=$(ip r | grep default | head -n1 | awk '{print $3}')
@@ -121,7 +123,7 @@ get_lan_ip() {
     fi
     lanInterface=$(ip r | grep $subnet | grep default | head -n1 | cut -d' ' -f 5)
     lanAddress=$(ip a s "$lanInterface" | awk '/inet /{gsub(/\/.*/,"");print $2}' | head -n1)
-  else
+  elif [ "$(required_apps_installed "system_profiler")" ];then
     subnet=$(netstat -rn| grep default | awk '{print $2}'|grep -Ev '^[a-f]' |cut -f1,2,3 -d'.')
     ifconfig_line=$(ifconfig|grep inet|grep "$subnet" | cut -d' ' -f 2)
     lanAddress=$ifconfig_line

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -113,7 +113,7 @@ get_lan_ip() {
   # getting localhost's IP.  Otherwise use MacOS style command
   # HOWEVER!! "ip" doesn't exist on windows git BASH, so check for that before going into the first if (and
   # skip it on the second elif because windows won't have "system_profiler"
-  if [[ -n "$(required_apps_installed "system_profiler")" ]] && [[ "$(required_apps_installed "ip")" ]] ;then
+  if [ -n "$(required_apps_installed "system_profiler")" ];then
     # todo - some of these calls fail when there's no network connectivity - output stuff it shouldn't:
     #       Device "" does not exist.
     routerIP=$(ip r | grep default | head -n1 | awk '{print $3}')

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -348,9 +348,9 @@ while [[ "$isNginxRunning" != "true" ]]; do
   isNginxRunning=$(get_is_container_running "$nginxContainerId")
 done
 
-docker exec -it $nginxContainerId bash -c "curl -s -o /etc/nginx/private/cert.pem https://local-ip.medicmobile.org/fullchain"
-docker exec -it $nginxContainerId bash -c "curl -s -o /etc/nginx/private/key.pem https://local-ip.medicmobile.org/key"
-docker exec -it $nginxContainerId bash -c "nginx -s reload"
+docker exec $nginxContainerId bash -c "curl -s -o /etc/nginx/private/cert.pem https://local-ip.medicmobile.org/fullchain"
+docker exec $nginxContainerId bash -c "curl -s -o /etc/nginx/private/key.pem https://local-ip.medicmobile.org/key"
+docker exec $nginxContainerId bash -c "nginx -s reload"
 
 echo ""
 echo ""


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# fix docker exec calls to be git bash compatible

This PR removes the `-it` flag to the `docker exec` calls in the docker helper script per this ticket:

> When running [some linux command], most of the time you don't need the `-it` (aka **STDIIN** via `--interactive and **STDOUT** via `--tty` for the psuedo-tty options)

This should be backwards compatible with linux/mac/wsl2 and be forwards compatible with git BASH where the error was discovered.

per medic/cht-core#8580

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8580-gitbash-docker-helper/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8580-gitbash-docker-helper/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8580-gitbash-docker-helper/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

