### PR TITLE
fix(#8589): don't check form expression on edit

### DIFF
--- a/tests/e2e/default/enketo/death-report.wdio-spec.js
+++ b/tests/e2e/default/enketo/death-report.wdio-spec.js
@@ -53,6 +53,14 @@ describe('Submit a death report', () => {
     expect(deathCardInfo.deathPlace).to.equal('Health facility');
   });
 
+  it('should edit the report', async () => {
+    await commonPage.goToReports();
+    const reportId = await reportsPage.getLastSubmittedReportId();
+    await reportsPage.editReport(reportId);
+    await genericForm.nextPage();
+    await reportsPage.submitForm();
+  });
+
   it('Should verify that the report related to the death was created', async () => {
     await commonPage.goToReports();
     const firstReport = await reportsPage.getListReportInfo(await reportsPage.firstReport());

--- a/tests/e2e/default/enketo/edit-report-with-attachment.wdio-spec.js
+++ b/tests/e2e/default/enketo/edit-report-with-attachment.wdio-spec.js
@@ -30,6 +30,9 @@ const formDoc = {
       content_type: 'application/octet-stream',
       data: Buffer.from(oneTextForm).toString('base64'),
     }
+  },
+  context: {
+    expression: 'summary.alive',
   }
 };
 const reportDoc ={
@@ -71,7 +74,6 @@ describe('Edit report with attachmnet', () => {
     await commonElements.goToReports();
 
     await reportsPage.editReport(reportDoc._id);
-    // await browser.debug();
     await reportsPage.submitForm();
 
     const editedReport = await utils.getDoc(reportDoc._id);

--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -94,11 +94,11 @@ export class TrainingCardsComponent implements OnInit, OnDestroy {
 
   private async renderForm(formDoc) {
     try {
-      const formObj = new EnketoFormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
-      formObj.isFormInModal = true;
-      formObj.valuechangeListener = this.resetFormError.bind(this);
+      const formContext = new EnketoFormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
+      formContext.isFormInModal = true;
+      formContext.valuechangeListener = this.resetFormError.bind(this);
 
-      this.form = await this.formService.render(formObj);
+      this.form = await this.formService.render(formContext);
       this.formNoTitle = !formDoc?.title;
       this.loadingContent = false;
       this.recordTelemetryPostRender();

--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -11,6 +11,7 @@ import { GeolocationService } from '@mm-services/geolocation.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { FeedbackService } from '@mm-services/feedback.service';
+import { FormContext } from '@mm-services/enketo.service';
 
 @Component({
   selector: 'training-cards-modal',
@@ -91,11 +92,14 @@ export class TrainingCardsComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async renderForm(form) {
+  private async renderForm(formDoc) {
     try {
-      const selector = `#${this.formWrapperId}`;
-      this.form = await this.formService.render(selector, form, null, null, this.resetFormError.bind(this), true);
-      this.formNoTitle = !form?.title;
+      const formObj = new FormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
+      formObj.isFormInModal = true;
+      formObj.valuechangeListener = this.resetFormError.bind(this);
+
+      this.form = await this.formService.render(formObj);
+      this.formNoTitle = !formDoc?.title;
       this.loadingContent = false;
       this.recordTelemetryPostRender();
     } catch (error) {

--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -11,7 +11,7 @@ import { GeolocationService } from '@mm-services/geolocation.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { FeedbackService } from '@mm-services/feedback.service';
-import { FormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 
 @Component({
   selector: 'training-cards-modal',
@@ -94,7 +94,7 @@ export class TrainingCardsComponent implements OnInit, OnDestroy {
 
   private async renderForm(formDoc) {
     try {
-      const formObj = new FormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
+      const formObj = new EnketoFormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
       formObj.isFormInModal = true;
       formObj.valuechangeListener = this.resetFormError.bind(this);
 

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -244,14 +244,14 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     const formDoc = await this.dbService.get().get(formId);
     this.xmlVersion = formDoc.xmlVersion;
 
-    const formObj = new EnketoFormContext('#contact-form', 'contact', formDoc, this.getFormInstanceData());
-    formObj.editedListener = this.markFormEdited.bind(this);
-    formObj.valuechangeListener = this.resetFormError.bind(this);
-    formObj.titleKey = titleKey;
-
     this.globalActions.setEnketoEditedStatus(false);
 
-    return this.formService.render(formObj);
+    const formContext = new EnketoFormContext('#contact-form', 'contact', formDoc, this.getFormInstanceData());
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
+    formContext.titleKey = titleKey;
+
+    return this.formService.render(formContext);
   }
 
   private setEnketoContact(formInstance) {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
 import { FormService } from '@mm-services/form.service';
-import { EnketoFormContext } from '@mm-services/enketo.service';
+import { FormContext } from '@mm-services/enketo.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { DbService } from '@mm-services/db.service';
 import { ContactSaveService } from '@mm-services/contact-save.service';
@@ -243,21 +243,16 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
   private async renderForm(formId: string, titleKey: string) {
     const formDoc = await this.dbService.get().get(formId);
     this.xmlVersion = formDoc.xmlVersion;
-    const instanceData = this.getFormInstanceData();
-    const markFormEdited = this.markFormEdited.bind(this);
-    const resetFormError = this.resetFormError.bind(this);
-    const formContext: EnketoFormContext = {
-      selector: '#contact-form',
-      formDoc,
-      instanceData,
-      editedListener: markFormEdited,
-      valuechangeListener: resetFormError,
-      titleKey,
-    };
+
+    const formObj = new FormContext('#contact-form', 'contact', formDoc);
+    formObj.data = this.getFormInstanceData();
+    formObj.editedListener = this.markFormEdited.bind(this);
+    formObj.valuechangeListener = this.resetFormError.bind(this);
+    formObj.titleKey = titleKey;
 
     this.globalActions.setEnketoEditedStatus(false);
 
-    return this.formService.renderContactForm(formContext);
+    return this.formService.render(formObj);
   }
 
   private setEnketoContact(formInstance) {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
 import { FormService } from '@mm-services/form.service';
-import { FormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 import { ContactTypesService } from '@mm-services/contact-types.service';
 import { DbService } from '@mm-services/db.service';
 import { ContactSaveService } from '@mm-services/contact-save.service';
@@ -244,8 +244,7 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     const formDoc = await this.dbService.get().get(formId);
     this.xmlVersion = formDoc.xmlVersion;
 
-    const formObj = new FormContext('#contact-form', 'contact', formDoc);
-    formObj.data = this.getFormInstanceData();
+    const formObj = new EnketoFormContext('#contact-form', 'contact', formDoc, this.getFormInstanceData());
     formObj.editedListener = this.markFormEdited.bind(this);
     formObj.valuechangeListener = this.resetFormError.bind(this);
     formObj.titleKey = titleKey;

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -130,11 +130,11 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
         this.globalActions.setTitle(this.translateFromService.get(formDoc.title));
         this.setCancelCallback();
 
-        const formObj = new EnketoFormContext('#contact-report', 'report', formDoc, { source: 'contact', contact });
-        formObj.editedListener = this.markFormEdited.bind(this);
-        formObj.valuechangeListener = this.resetFormError.bind(this);
+        const formContext = new EnketoFormContext('#contact-report', 'report', formDoc, { source: 'contact', contact });
+        formContext.editedListener = this.markFormEdited.bind(this);
+        formContext.valuechangeListener = this.resetFormError.bind(this);
 
-        return this.formService.render(formObj);
+        return this.formService.render(formContext);
       })
       .then((formInstance) => {
         this.form = formInstance;

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -6,7 +6,7 @@ import { isEqual as _isEqual } from 'lodash-es';
 
 import { ContactViewModelGeneratorService } from '@mm-services/contact-view-model-generator.service';
 import { FormService } from '@mm-services/form.service';
-import { FormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
@@ -130,8 +130,7 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
         this.globalActions.setTitle(this.translateFromService.get(formDoc.title));
         this.setCancelCallback();
 
-        const formObj = new FormContext('#contact-report', 'report', formDoc);
-        formObj.data = { source: 'contact', contact };
+        const formObj = new EnketoFormContext('#contact-report', 'report', formDoc, { source: 'contact', contact });
         formObj.editedListener = this.markFormEdited.bind(this);
         formObj.valuechangeListener = this.resetFormError.bind(this);
 

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -6,6 +6,7 @@ import { isEqual as _isEqual } from 'lodash-es';
 
 import { ContactViewModelGeneratorService } from '@mm-services/contact-view-model-generator.service';
 import { FormService } from '@mm-services/form.service';
+import { FormContext } from '@mm-services/enketo.service';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
@@ -124,25 +125,17 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
 
     return this
       .getContactAndForm()
-      .then(([ contact, form ]) => {
+      .then(([ contact, formDoc ]) => {
         this.globalActions.setEnketoEditedStatus(false);
-        this.globalActions.setTitle(this.translateFromService.get(form.title));
+        this.globalActions.setTitle(this.translateFromService.get(formDoc.title));
         this.setCancelCallback();
 
-        const instanceData = {
-          source: 'contact',
-          contact,
-        };
-        const markFormEdited = this.markFormEdited.bind(this);
-        const resetFormError = this.resetFormError.bind(this);
+        const formObj = new FormContext('#contact-report', 'report', formDoc);
+        formObj.data = { source: 'contact', contact };
+        formObj.editedListener = this.markFormEdited.bind(this);
+        formObj.valuechangeListener = this.resetFormError.bind(this);
 
-        return this.formService.render(
-          '#contact-report',
-          form,
-          instanceData,
-          markFormEdited,
-          resetFormError
-        );
+        return this.formService.render(formObj);
       })
       .then((formInstance) => {
         this.form = formInstance;

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -16,7 +16,7 @@ import { ReportsActions } from '@mm-actions/reports';
 import { FormService } from '@mm-services/form.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateService } from '@mm-services/translate.service';
-import { FormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 
 
 @Component({
@@ -195,8 +195,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private async renderForm(formDoc, reportContent, model) {
-    const formObj = new FormContext('#report-form', 'report', formDoc);
-    formObj.data = reportContent;
+    const formObj = new EnketoFormContext('#report-form', 'report', formDoc, reportContent);
     formObj.editing = !!reportContent;
     formObj.editedListener = this.markFormEdited.bind(this);
     formObj.valuechangeListener = this.resetFormError.bind(this);

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -195,13 +195,13 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private async renderForm(formDoc, reportContent, model) {
-    const formObj = new EnketoFormContext('#report-form', 'report', formDoc, reportContent);
-    formObj.editing = !!reportContent;
-    formObj.editedListener = this.markFormEdited.bind(this);
-    formObj.valuechangeListener = this.resetFormError.bind(this);
+    const formContext = new EnketoFormContext('#report-form', 'report', formDoc, reportContent);
+    formContext.editing = !!reportContent;
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
 
     try {
-      const form = await this.formService.render(formObj);
+      const form = await this.formService.render(formContext);
       this.form = form;
       this.globalActions.setLoadingContent(false);
       if (!model.doc || !model.doc._id) {

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -216,12 +216,12 @@ export class TasksContentComponent implements OnInit, OnDestroy {
   private renderForm(action, formDoc) {
     this.globalActions.setEnketoEditedStatus(false);
 
-    const formObj = new EnketoFormContext('#task-report', 'task', formDoc, action.content);
-    formObj.editedListener = this.markFormEdited.bind(this);
-    formObj.valuechangeListener = this.resetFormError.bind(this);
+    const formContext = new EnketoFormContext('#task-report', 'task', formDoc, action.content);
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
 
     return this.formService
-      .render(formObj)
+      .render(formContext)
       .then((formInstance) => {
         this.form = formInstance;
         this.loadingForm = false;

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -4,6 +4,7 @@ import { combineLatest, Subject, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { FormService } from '@mm-services/form.service';
+import { FormContext } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
@@ -214,11 +215,14 @@ export class TasksContentComponent implements OnInit, OnDestroy {
 
   private renderForm(action, formDoc) {
     this.globalActions.setEnketoEditedStatus(false);
-    const markFormEdited = this.markFormEdited.bind(this);
-    const resetFormError = this.resetFormError.bind(this);
+
+    const formObj = new FormContext('#task-report', 'task', formDoc);
+    formObj.data = action.content;
+    formObj.editedListener = this.markFormEdited.bind(this);
+    formObj.valuechangeListener = this.resetFormError.bind(this);
 
     return this.formService
-      .render('#task-report', formDoc, action.content, markFormEdited, resetFormError)
+      .render(formObj)
       .then((formInstance) => {
         this.form = formInstance;
         this.loadingForm = false;

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -4,7 +4,7 @@ import { combineLatest, Subject, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { FormService } from '@mm-services/form.service';
-import { FormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
@@ -216,8 +216,7 @@ export class TasksContentComponent implements OnInit, OnDestroy {
   private renderForm(action, formDoc) {
     this.globalActions.setEnketoEditedStatus(false);
 
-    const formObj = new FormContext('#task-report', 'task', formDoc);
-    formObj.data = action.content;
+    const formObj = new EnketoFormContext('#task-report', 'task', formDoc, action.content);
     formObj.editedListener = this.markFormEdited.bind(this);
     formObj.valuechangeListener = this.resetFormError.bind(this);
 

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -652,7 +652,7 @@ export class EnketoFormContext {
     this.instanceData = instanceData;
   }
 
-  evaluateExpression() {
+  shouldEvaluateExpression() {
     if (this.type === 'report' && this.editing) {
       return false;
     }

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -635,7 +635,7 @@ interface XmlFormContext {
 export class EnketoFormContext {
   selector: string;
   formDoc: Record<string, any>;
-  type: 'contact'|'report'|'task'|'training-card';
+  type: string; // 'contact'|'report'|'task'|'training-card'
   editing: boolean;
   instanceData: null|string|Record<string, any>;
   editedListener: () => void;
@@ -645,7 +645,7 @@ export class EnketoFormContext {
   userContact?: Record<string, any>;
   contactSummary? :Record<string, any>;
 
-  constructor(selector?, type?, formDoc?, instanceData?) {
+  constructor(selector:string, type:string, formDoc:Record<string, any>, instanceData?) {
     this.selector = selector;
     this.type = type;
     this.formDoc = formDoc;

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -165,13 +165,13 @@ export class EnketoService {
   }
 
   private renderFromXmls(xmlFormContext: XmlFormContext, userSettings) {
-    const { doc, data, titleKey, wrapper, isFormInModal, contactSummary } = xmlFormContext;
+    const { doc, instanceData, titleKey, wrapper, isFormInModal, contactSummary } = xmlFormContext;
 
     const formContainer = wrapper.find('.container').first();
     formContainer.html(doc.html.get(0)!);
 
     return this
-      .getEnketoForm(wrapper, doc, data, contactSummary, userSettings)
+      .getEnketoForm(wrapper, doc, instanceData, contactSummary, userSettings)
       .then((form) => {
         this.currentForm = form;
         const loadErrors = this.currentForm.init();
@@ -315,7 +315,7 @@ export class EnketoService {
     });
   }
 
-  private registerEnketoListeners($selector, form, formContext: FormContext) {
+  private registerEnketoListeners($selector, form, formContext: EnketoFormContext) {
     this.registerAddrepeatListener($selector, formContext.formDoc);
     this.registerEditedListener($selector, formContext.editedListener);
     this.registerValuechangeListener($selector, formContext.valuechangeListener);
@@ -323,10 +323,10 @@ export class EnketoService {
       () => this.setupNavButtons($selector, form.pages._getCurrentIndex()));
   }
 
-  public async renderForm(formContext: FormContext, doc, userSettings) {
+  public async renderForm(formContext: EnketoFormContext, doc, userSettings) {
     const {
       formDoc,
-      data,
+      instanceData,
       selector,
       titleKey,
       isFormInModal,
@@ -337,7 +337,7 @@ export class EnketoService {
     const xmlFormContext: XmlFormContext = {
       doc,
       wrapper: $(selector),
-      data,
+      instanceData,
       titleKey,
       isFormInModal,
       contactSummary: formContext.contactSummary,
@@ -626,18 +626,18 @@ interface XmlFormContext {
     hasContactSummary: boolean;
   };
   wrapper: JQuery;
-  data: null|string|Record<string, any>; // String for report forms, Record<> for contact forms.
+  instanceData: null|string|Record<string, any>; // String for report forms, Record<> for contact forms.
   titleKey?: string;
   isFormInModal?: boolean;
   contactSummary?: Record<string, any>;
 }
 
-export class FormContext {
+export class EnketoFormContext {
   selector: string;
   formDoc: Record<string, any>;
   type: 'contact'|'report'|'task'|'training-card';
   editing: boolean;
-  data: null|string|Record<string, any>;
+  instanceData: null|string|Record<string, any>;
   editedListener: () => void;
   valuechangeListener: () => void;
   titleKey?: string;
@@ -645,11 +645,11 @@ export class FormContext {
   userContact?: Record<string, any>;
   contactSummary? :Record<string, any>;
 
-  constructor(selector?, type?, formDoc?, data?) {
+  constructor(selector?, type?, formDoc?, instanceData?) {
     this.selector = selector;
     this.type = type;
     this.formDoc = formDoc;
-    this.data = data;
+    this.instanceData = instanceData;
   }
 
   evaluateExpression() {

--- a/webapp/src/ts/services/form.service.ts
+++ b/webapp/src/ts/services/form.service.ts
@@ -180,14 +180,14 @@ export class FormService {
     }
   }
 
-  render(formObj: EnketoFormContext) {
-    return this.ngZone.runOutsideAngular(() => this._render(formObj));
+  render(formContext: EnketoFormContext) {
+    return this.ngZone.runOutsideAngular(() => this._render(formContext));
   }
 
-  private async _render(formObj: EnketoFormContext) {
+  private async _render(formContext: EnketoFormContext) {
     await this.inited;
-    formObj.userContact = await this.getUserContact(formObj.requiresContact());
-    return this.renderForm(formObj);
+    formContext.userContact = await this.getUserContact(formContext.requiresContact());
+    return this.renderForm(formContext);
   }
 
   private saveDocs(docs) {

--- a/webapp/src/ts/services/form.service.ts
+++ b/webapp/src/ts/services/form.service.ts
@@ -21,7 +21,7 @@ import { FeedbackService } from '@mm-services/feedback.service';
 import { GlobalActions } from '@mm-actions/global';
 import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
-import { EnketoService, FormContext } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
 
 /**
@@ -142,20 +142,20 @@ export class FormService {
       .then(([reports, lineage]) => this.contactSummaryService.get(contact, reports, lineage));
   }
 
-  private canAccessForm(formContext: FormContext) {
+  private canAccessForm(formContext: EnketoFormContext) {
     return this.xmlFormsService.canAccessForm(
       formContext.formDoc,
       formContext.userContact,
       {
-        doc: typeof formContext.data !== 'string' && formContext.data?.contact,
+        doc: typeof formContext.instanceData !== 'string' && formContext.instanceData?.contact,
         contactSummary: formContext.contactSummary?.context,
         evaluateExpression: formContext.evaluateExpression(),
       },
     );
   }
 
-  private async renderForm(formContext: FormContext) {
-    const { formDoc, data } = formContext;
+  private async renderForm(formContext: EnketoFormContext) {
+    const { formDoc, instanceData } = formContext;
 
     try {
       this.unload(this.enketoService.getCurrentForm());
@@ -163,7 +163,7 @@ export class FormService {
         this.transformXml(formDoc),
         this.userSettingsService.getWithLanguage()
       ]);
-      formContext.contactSummary = await this.getContactSummary(doc, data);
+      formContext.contactSummary = await this.getContactSummary(doc, instanceData);
 
       if (!await this.canAccessForm(formContext)) {
         throw { translationKey: 'error.loading.form.no_authorized' };
@@ -180,11 +180,11 @@ export class FormService {
     }
   }
 
-  render(formObj: FormContext) {
+  render(formObj: EnketoFormContext) {
     return this.ngZone.runOutsideAngular(() => this._render(formObj));
   }
 
-  private async _render(formObj: FormContext) {
+  private async _render(formObj: EnketoFormContext) {
     await this.inited;
     formObj.userContact = await this.getUserContact(formObj.requiresContact());
     return this.renderForm(formObj);

--- a/webapp/src/ts/services/form.service.ts
+++ b/webapp/src/ts/services/form.service.ts
@@ -149,7 +149,7 @@ export class FormService {
       {
         doc: typeof formContext.instanceData !== 'string' && formContext.instanceData?.contact,
         contactSummary: formContext.contactSummary?.context,
-        evaluateExpression: formContext.evaluateExpression(),
+        shouldEvaluateExpression: formContext.shouldEvaluateExpression(),
       },
     );
   }

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -244,7 +244,7 @@ export class XmlFormsService {
       return false;
     }
 
-    if (options?.evaluateExpression === false) {
+    if (options?.shouldEvaluateExpression === false) {
       return true;
     }
 

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -244,6 +244,10 @@ export class XmlFormsService {
       return false;
     }
 
+    if (options?.evaluateExpression === false) {
+      return true;
+    }
+
     return await this.checkFormExpression(form, options?.doc, userContact, options?.contactSummary);
   }
 

--- a/webapp/tests/karma/ts/modals/training-cards/training-cards.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/training-cards/training-cards.component.spec.ts
@@ -132,8 +132,7 @@ describe('TrainingCardsComponent', () => {
     expect(xmlFormsService.get.calledOnce).to.be.true;
     expect(xmlFormsService.get.args[0]).to.deep.equal([ 'training:a_form_id' ]);
     expect(formService.render.calledOnce).to.be.true;
-    expect(formService.render.args[0][1]).to.deep.equal(xmlForm);
-    expect(formService.render.args[0][2]).to.equal(null);
+    expect(formService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
     expect(component.form).to.equal(renderedForm);
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
@@ -293,15 +292,14 @@ describe('TrainingCardsComponent', () => {
       expect(xmlFormsService.get.calledOnce).to.be.true;
       expect(xmlFormsService.get.args[0]).to.deep.equal([ 'training:a_form_id' ]);
       expect(formService.render.calledOnce).to.be.true;
-      expect(formService.render.args[0][1]).to.deep.equal(xmlForm);
-      expect(formService.render.args[0][2]).to.equal(null);
+      expect(formService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
       expect(component.form).to.equal(renderedForm);
       expect(consoleErrorMock.notCalled).to.be.true;
       expect(feedbackService.submit.notCalled).to.be.true;
       expect(telemetryService.record.calledOnce).to.be.true;
       expect(telemetryService.record.args[0][0]).to.equal('enketo:training:a_form_id:add:render');
 
-      const resetFormError = formService.render.args[0][4];
+      const resetFormError = formService.render.args[0][0].valuechangeListener;
       resetFormError();
       expect(globalActions.setEnketoError.notCalled).to.be.true; // No error so no call
       component.enketoError = 'some error';

--- a/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
@@ -228,7 +228,7 @@ describe('ContactsEdit component', () => {
       expect(formService.render.args[0][0]).to.deep.include({
         selector: '#contact-form',
         formDoc: { _id: 'random_create', the: 'form' },
-        data: { random: { type: 'contact', contact_type: 'random', parent: '' } },
+        instanceData: { random: { type: 'contact', contact_type: 'random', parent: '' } },
         titleKey: 'random',
       });
 
@@ -244,7 +244,7 @@ describe('ContactsEdit component', () => {
       expect(formService.render.args[1][0]).to.deep.include({
         selector: '#contact-form',
         formDoc: { _id: 'other_create' },
-        data: { other: { type: 'contact', contact_type: 'other', parent: '' } },
+        instanceData: { other: { type: 'contact', contact_type: 'other', parent: '' } },
         titleKey: 'other_key',
       });
     }));
@@ -322,7 +322,7 @@ describe('ContactsEdit component', () => {
         expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'clinic_create_form_id', the: 'form' },
-          data: { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
+          instanceData: { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
           titleKey: 'clinic_create_key',
         });
         expect(component.contentError).to.equal(false);
@@ -353,7 +353,7 @@ describe('ContactsEdit component', () => {
         expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'district_create_form_id', the: 'form' },
-          data: { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
+          instanceData: { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
           titleKey: 'district_create_key',
         });
         expect(component.contentError).to.equal(false);
@@ -453,7 +453,7 @@ describe('ContactsEdit component', () => {
         expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'patient_edit_form', form: true },
-          data: { patient: { type: 'patient', _id: 'the_patient' } },
+          instanceData: { patient: { type: 'patient', _id: 'the_patient' } },
           titleKey: 'patient_edit_key',
         });
         expect(component.enketoContact).to.deep.equal({
@@ -489,7 +489,7 @@ describe('ContactsEdit component', () => {
         expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'a_clinic_type_create_form', data: true },
-          data: { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
+          instanceData: { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
           titleKey: 'edit_key',
         });
         expect(component.enketoContact).to.deep.equal({
@@ -528,7 +528,7 @@ describe('ContactsEdit component', () => {
         expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'the correct_edit_form', data: true },
-          data: { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
+          instanceData: { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
           titleKey: 'edit_key',
         });
         expect(component.enketoContact).to.deep.equal({

--- a/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
@@ -51,7 +51,7 @@ describe('ContactsEdit component', () => {
       queryParams: new Subject(),
     };
     formService = {
-      renderContactForm: sinon.stub(),
+      render: sinon.stub(),
       unload: sinon.stub(),
     };
     lineageModelGeneratorService = { contact: sinon.stub().resolves({ doc: { } }) };
@@ -224,12 +224,11 @@ describe('ContactsEdit component', () => {
       await fixture.whenStable();
 
       expect(contactTypesService.get.callCount).to.equal(1);
-      expect(formService.renderContactForm.callCount).to.equal(1);
-
-      expect(formService.renderContactForm.args[0][0]).to.deep.include({
+      expect(formService.render.callCount).to.equal(1);
+      expect(formService.render.args[0][0]).to.deep.include({
         selector: '#contact-form',
         formDoc: { _id: 'random_create', the: 'form' },
-        instanceData: { random: { type: 'contact', contact_type: 'random', parent: '' } },
+        data: { random: { type: 'contact', contact_type: 'random', parent: '' } },
         titleKey: 'random',
       });
 
@@ -241,11 +240,11 @@ describe('ContactsEdit component', () => {
 
       expect(dbGet.callCount).to.equal(2);
       expect(contactTypesService.get.callCount).to.equal(2);
-      expect(formService.renderContactForm.callCount).to.equal(2);
-      expect(formService.renderContactForm.args[1][0]).to.deep.include({
+      expect(formService.render.callCount).to.equal(2);
+      expect(formService.render.args[1][0]).to.deep.include({
         selector: '#contact-form',
         formDoc: { _id: 'other_create' },
-        instanceData: { other: { type: 'contact', contact_type: 'other', parent: '' } },
+        data: { other: { type: 'contact', contact_type: 'other', parent: '' } },
         titleKey: 'other_key',
       });
     }));
@@ -262,7 +261,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal([undefined]);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -275,7 +274,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['random']);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -294,7 +293,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['person']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['person_create_form_id']);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
         expect(component.contentError).to.equal(true);
       });
@@ -319,11 +318,11 @@ describe('ContactsEdit component', () => {
           formInstance: undefined,
           docId: null,
         });
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'clinic_create_form_id', the: 'form' },
-          instanceData: { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
+          data: { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
           titleKey: 'clinic_create_key',
         });
         expect(component.contentError).to.equal(false);
@@ -350,11 +349,11 @@ describe('ContactsEdit component', () => {
           formInstance: undefined,
           docId: null,
         });
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'district_create_form_id', the: 'form' },
-          instanceData: { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
+          data: { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
           titleKey: 'district_create_key',
         });
         expect(component.contentError).to.equal(false);
@@ -379,7 +378,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['missing_clinic_type']);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -399,7 +398,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['person_type']);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -424,7 +423,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
         expect(component.contentError).to.equal(true);
       });
@@ -450,11 +449,11 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'patient_edit_form', form: true },
-          instanceData: { patient: { type: 'patient', _id: 'the_patient' } },
+          data: { patient: { type: 'patient', _id: 'the_patient' } },
           titleKey: 'patient_edit_key',
         });
         expect(component.enketoContact).to.deep.equal({
@@ -486,11 +485,11 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['a_clinic_type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['a_clinic_type_create_form']);
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'a_clinic_type_create_form', data: true },
-          instanceData: { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
+          data: { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
           titleKey: 'edit_key',
         });
         expect(component.enketoContact).to.deep.equal({
@@ -525,11 +524,11 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['the correct type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['the correct_edit_form']);
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'the correct_edit_form', data: true },
-          instanceData: { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
+          data: { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
           titleKey: 'edit_key',
         });
         expect(component.enketoContact).to.deep.equal({
@@ -611,7 +610,7 @@ describe('ContactsEdit component', () => {
       const form = {
         validate: sinon.stub().resolves(true),
       };
-      formService.renderContactForm.resolves(form);
+      formService.render.resolves(form);
 
       await createComponent();
       await fixture.whenStable();
@@ -646,7 +645,7 @@ describe('ContactsEdit component', () => {
       const form = {
         validate: sinon.stub().resolves(true),
       };
-      formService.renderContactForm.resolves(form);
+      formService.render.resolves(form);
 
       await createComponent();
       await fixture.whenStable();
@@ -681,7 +680,7 @@ describe('ContactsEdit component', () => {
       const form = {
         validate: sinon.stub().resolves(true),
       };
-      formService.renderContactForm.resolves(form);
+      formService.render.resolves(form);
 
       await createComponent();
       await fixture.whenStable();

--- a/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
@@ -160,17 +160,17 @@ describe('contacts report component', () => {
       flush();
 
       expect(formService.render.callCount).to.equal(1);
-      expect(formService.render.args[0][0]).to.equal('#contact-report');
-      expect(formService.render.args[0][1]).to.deep.equal({ title: 'formTitle' });
-      expect(formService.render.args[0][2]).to.deep.equal(
-        {
+      expect(formService.render.args[0][0]).to.deep.include({
+        selector: '#contact-report',
+        formDoc: { title: 'formTitle' },
+        data: {
           source: 'contact',
           contact: {
             _id: 'test_id',
             contact_type: 'test_type'
           }
         }
-      );
+      });
     }));
 
     it('should unsubscribe and unload form on destroy', async () => {

--- a/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
@@ -163,7 +163,7 @@ describe('contacts report component', () => {
       expect(formService.render.args[0][0]).to.deep.include({
         selector: '#contact-report',
         formDoc: { title: 'formTitle' },
-        data: {
+        instanceData: {
           source: 'contact',
           contact: {
             _id: 'test_id',

--- a/webapp/tests/karma/ts/modules/reports/reports-add.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports-add.component.spec.ts
@@ -211,12 +211,11 @@ describe('Reports Add Component', () => {
         expect(setEnketoEditedStatusStub.calledOnce).to.be.true;
         expect(setEnketoEditedStatusStub.args[0]).to.deep.equal([false]);
         expect(formService.render.calledOnce).to.be.true;
-        expect(formService.render.args[0][1]).to.deep.equal(xmlForm);
-        expect(formService.render.args[0][2]).to.equal(undefined);
+        expect(formService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
         expect(component.form).to.equal(renderedForm);
 
-        const markFormEdited = formService.render.args[0][3];
-        const resetFormError = formService.render.args[0][4];
+        const markFormEdited = formService.render.args[0][0].editedListener;
+        const resetFormError = formService.render.args[0][0].valuechangeListener;
 
         markFormEdited();
         expect(setEnketoEditedStatusStub.calledTwice).to.be.true;

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -142,7 +142,7 @@ describe('TasksContentComponent', () => {
       selector: '#task-report',
       type: 'task',
       formDoc: form,
-      data: 'nothing'
+      instanceData: 'nothing'
     });
 
     expect(get.callCount).to.eq(0);
@@ -172,7 +172,7 @@ describe('TasksContentComponent', () => {
     expect(get.args).to.deep.eq([['contact']]);
     expect(geolocationService.init.callCount).to.equal(1);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][0].data).to.deep.eq({
+    expect(render.args[0][0].instanceData).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'nothing',
       task_id: '123',
@@ -252,7 +252,7 @@ describe('TasksContentComponent', () => {
     expect(get.callCount).to.eq(1);
     expect(get.args).to.deep.eq([['dne']]);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][0].data).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
+    expect(render.args[0][0].instanceData).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
   });
 
   it('should work when form not found', async () => {
@@ -364,7 +364,7 @@ describe('TasksContentComponent', () => {
     tick();
 
     expect(render.callCount).to.equal(1);
-    expect(render.args[0][0].data).to.deep.eq({
+    expect(render.args[0][0].instanceData).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'other',
       task_id: '123',
@@ -506,7 +506,7 @@ describe('TasksContentComponent', () => {
         selector: '#task-report',
         type: 'task',
         formDoc: form,
-        data: action.content,
+        instanceData: action.content,
       });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
@@ -566,7 +566,7 @@ describe('TasksContentComponent', () => {
         selector: '#task-report',
         type: 'task',
         formDoc: { ...form },
-        data: { ...action.content },
+        instanceData: { ...action.content },
       });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -138,10 +138,12 @@ describe('TasksContentComponent', () => {
     expect(component.formId).to.equal('A');
 
     expect(render.callCount).to.equal(1);
-    expect(render.getCall(0).args.length).to.equal(5);
-    expect(render.getCall(0).args[0]).to.equal('#task-report');
-    expect(render.getCall(0).args[1]).to.deep.equal(form);
-    expect(render.getCall(0).args[2]).to.equal('nothing');
+    expect(render.args[0][0]).to.deep.include({
+      selector: '#task-report',
+      type: 'task',
+      formDoc: form,
+      data: 'nothing'
+    });
 
     expect(get.callCount).to.eq(0);
     expect(setEnketoEditedStatus.callCount).to.equal(1);
@@ -170,7 +172,7 @@ describe('TasksContentComponent', () => {
     expect(get.args).to.deep.eq([['contact']]);
     expect(geolocationService.init.callCount).to.equal(1);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][2]).to.deep.eq({
+    expect(render.args[0][0].data).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'nothing',
       task_id: '123',
@@ -250,7 +252,7 @@ describe('TasksContentComponent', () => {
     expect(get.callCount).to.eq(1);
     expect(get.args).to.deep.eq([['dne']]);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][2]).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
+    expect(render.args[0][0].data).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
   });
 
   it('should work when form not found', async () => {
@@ -362,7 +364,7 @@ describe('TasksContentComponent', () => {
     tick();
 
     expect(render.callCount).to.equal(1);
-    expect(render.args[0][2]).to.deep.eq({
+    expect(render.args[0][0].data).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'other',
       task_id: '123',
@@ -500,11 +502,12 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(1);
       expect(xmlFormsService.get.args[0]).to.deep.equal(['myform']);
       expect(formService.render.callCount).to.equal(1);
-      expect(formService.render.args[0]).to.deep.include.members([
-        '#task-report',
-        { ...form },
-        { ...action.content },
-      ]);
+      expect(formService.render.args[0][0]).to.deep.include({
+        selector: '#task-report',
+        type: 'task',
+        formDoc: form,
+        data: action.content,
+      });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
       expect(tasksForContactService.getLeafPlaceAncestor.args[0]).to.deep.equal(['my_contact']);
@@ -515,8 +518,8 @@ describe('TasksContentComponent', () => {
       expect((<any>TasksActions.prototype.setTaskGroupContact).args[0]).to.deep.equal([{ any: 'model' }]);
       expect((<any>TasksActions.prototype.setTaskGroupContactLoading).callCount).to.equal(1);
 
-      const markFormEdited = formService.render.args[0][3];
-      const resetFormError = formService.render.args[0][4];
+      const markFormEdited = formService.render.args[0][0].editedListener;
+      const resetFormError = formService.render.args[0][0].valuechangeListener;
 
       expect(setEnketoEditedStatus.callCount).to.equal(1);
       expect(setEnketoEditedStatus.args[0]).to.deep.equal([false]);
@@ -559,11 +562,12 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(1);
       expect(xmlFormsService.get.args[0]).to.deep.equal(['myform']);
       expect(formService.render.callCount).to.equal(1);
-      expect(formService.render.args[0]).to.deep.include.members([
-        '#task-report',
-        { ...form },
-        { ...action.content },
-      ]);
+      expect(formService.render.args[0][0]).to.deep.include({
+        selector: '#task-report',
+        type: 'task',
+        formDoc: { ...form },
+        data: { ...action.content },
+      });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
       expect(tasksForContactService.getLeafPlaceAncestor.args[0]).to.deep.equal(['the_contact']);

--- a/webapp/tests/karma/ts/services/enketo-form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo-form.service.spec.ts
@@ -9,7 +9,7 @@ import { TranslateFromService } from '@mm-services/translate-from.service';
 import { EnketoPrepopulationDataService } from '@mm-services/enketo-prepopulation-data.service';
 import { AttachmentService } from '@mm-services/attachment.service';
 import { TranslateService } from '@mm-services/translate.service';
-import { EnketoService, FormContext } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 
 describe('Enketo Form service', () => {
   // return a mock form ready for putting in #dbContent
@@ -291,8 +291,7 @@ describe('Enketo Form service', () => {
       };
       enketoInit.returns([]);
       EnketoPrepopulationData.resolves(data);
-      const formContext = new FormContext('#div', 'report', mockEnketoDoc('myform'));
-      formContext.data = instanceData;
+      const formContext = new EnketoFormContext('#div', 'report', mockEnketoDoc('myform'), instanceData);
       formContext.contactSummary = { context: { pregnant: true } };
       const doc = {
         html: $('<div>my form</div>'),
@@ -301,7 +300,6 @@ describe('Enketo Form service', () => {
       const userSettings = { language: 'en' };
       return service.renderForm(formContext, doc, userSettings).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
-        console.log(JSON.stringify(EnketoForm.args[0], null, 2));
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
         expect(summary.id).to.equal('contact-summary');

--- a/webapp/tests/karma/ts/services/enketo-form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo-form.service.spec.ts
@@ -9,7 +9,7 @@ import { TranslateFromService } from '@mm-services/translate-from.service';
 import { EnketoPrepopulationDataService } from '@mm-services/enketo-prepopulation-data.service';
 import { AttachmentService } from '@mm-services/attachment.service';
 import { TranslateService } from '@mm-services/translate.service';
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, FormContext } from '@mm-services/enketo.service';
 
 describe('Enketo Form service', () => {
   // return a mock form ready for putting in #dbContent
@@ -291,19 +291,17 @@ describe('Enketo Form service', () => {
       };
       enketoInit.returns([]);
       EnketoPrepopulationData.resolves(data);
-      const formContext = {
-        selector: $('<div></div>'),
-        formDoc: mockEnketoDoc('myform'),
-        instanceData
-      };
+      const formContext = new FormContext('#div', 'report', mockEnketoDoc('myform'));
+      formContext.data = instanceData;
+      formContext.contactSummary = { context: { pregnant: true } };
       const doc = {
         html: $('<div>my form</div>'),
         model: VISIT_MODEL_WITH_CONTACT_SUMMARY,
       };
       const userSettings = { language: 'en' };
-      const contactSummary = { context: { pregnant: true } };
-      return service.renderForm(formContext, doc, userSettings, contactSummary).then(() => {
+      return service.renderForm(formContext, doc, userSettings).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
+        console.log(JSON.stringify(EnketoForm.args[0], null, 2));
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
         expect(summary.id).to.equal('contact-summary');

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -11,7 +11,7 @@ import { AttachmentService } from '@mm-services/attachment.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 
-describe('Enketo Form service', () => {
+describe('Enketo service', () => {
   // return a mock form ready for putting in #dbContent
   const mockEnketoDoc = formInternalId => {
     return {

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -29,7 +29,7 @@ import { FeedbackService } from '@mm-services/feedback.service';
 import * as medicXpathExtensions from '../../../../src/js/enketo/medic-xpath-extensions';
 import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
-import { EnketoService, FormContext } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 
 describe('Enketo service', () => {
   // return a mock form ready for putting in #dbContent
@@ -221,7 +221,7 @@ describe('Enketo service', () => {
     it('renders error when user does not have associated contact', () => {
       UserContact.resolves();
       return service
-        .render(new FormContext('#', 'report', { }))
+        .render(new EnketoFormContext('#', 'report', { }))
         .then(() => {
           expect.fail('Should throw error');
         })
@@ -253,7 +253,7 @@ describe('Enketo service', () => {
       const expectedErrorMessage = expectedErrorTitle + JSON.stringify(expectedErrorDetail);
       enketoInit.returns(expectedErrorDetail);
 
-      const formContext = new FormContext('#div', 'report', mockEnketoDoc('myform'), instanceData);
+      const formContext = new EnketoFormContext('#div', 'report', mockEnketoDoc('myform'), instanceData);
 
       try {
         await service.render(formContext);
@@ -290,7 +290,7 @@ describe('Enketo service', () => {
       enketoInit.returns([]);
       FileReader.utf8.resolves('<some-blob name="xml"/>');
       EnketoPrepopulationData.resolves('<xml></xml>');
-      return service.render(new FormContext('#div', 'task', mockEnketoDoc('myform'))).then(() => {
+      return service.render(new EnketoFormContext('#div', 'task', mockEnketoDoc('myform'))).then(() => {
         expect(UserContact.callCount).to.equal(1);
         expect(EnketoPrepopulationData.callCount).to.equal(1);
         expect(FileReader.utf8.callCount).to.equal(2);
@@ -318,7 +318,7 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>my form</div>')
         .onSecondCall().resolves('my model');
       EnketoPrepopulationData.resolves(data);
-      const formContext = new FormContext('div', 'report', mockEnketoDoc('myform'), data);
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), data);
       return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].modelStr).to.equal('my model');
@@ -355,7 +355,7 @@ describe('Enketo service', () => {
       ContactSummary.resolves({ context: { pregnant: true } });
       Search.resolves([{ _id: 'somereport' }]);
       LineageModelGenerator.contact.resolves({ lineage: [{ _id: 'someparent' }] });
-      const formContext = new FormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
       return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         console.log(JSON.stringify(EnketoForm.args[0], null, 2));
@@ -411,7 +411,7 @@ describe('Enketo service', () => {
         }
       });
       LineageModelGenerator.contact.resolves({ lineage: [] });
-      const formContext = new FormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
       return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
@@ -449,7 +449,7 @@ describe('Enketo service', () => {
           name: 'sharon'
         }
       };
-      const formContext = new FormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
       return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external).to.equal(undefined);
@@ -483,7 +483,7 @@ describe('Enketo service', () => {
       };
       ContactSummary.resolves({ context: { pregnant: true } });
       Search.resolves([{ _id: 'somereport' }]);
-      const formContext = new FormContext('div', 'report',  mockEnketoDoc('myform'), instanceData);
+      const formContext = new EnketoFormContext('div', 'report',  mockEnketoDoc('myform'), instanceData);
       return service.render(formContext).then(() => {
         expect(LineageModelGenerator.contact.callCount).to.equal(1);
         expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
@@ -504,7 +504,7 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>first form</div>')
         .onSecondCall().resolves(VISIT_MODEL);
 
-      await service.render(new FormContext('#div', 'report',  mockEnketoDoc('firstForm')));
+      await service.render(new EnketoFormContext('#div', 'report',  mockEnketoDoc('firstForm')));
       expect(form.resetView.notCalled).to.be.true;
       expect(UserContact.calledOnce).to.be.true;
       expect(EnketoPrepopulationData.calledOnce).to.be.true;
@@ -522,7 +522,7 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>second form</div>')
         .onSecondCall().resolves(VISIT_MODEL_WITH_CONTACT_SUMMARY);
 
-      await service.render(new FormContext('#div', 'report', mockEnketoDoc('secondForm')));
+      await service.render(new EnketoFormContext('#div', 'report', mockEnketoDoc('secondForm')));
       expect(form.resetView.calledOnce).to.be.true;
       expect(UserContact.calledOnce).to.be.true;
       expect(EnketoPrepopulationData.calledOnce).to.be.true;
@@ -552,7 +552,7 @@ describe('Enketo service', () => {
       const renderForm = sinon.spy(EnketoService.prototype, 'renderForm');
 
       try {
-        await service.render(new FormContext('div', 'report', mockEnketoDoc('myform'), data));
+        await service.render(new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), data));
         flush();
         expect.fail('Should throw error');
       } catch (error) {
@@ -582,7 +582,7 @@ describe('Enketo service', () => {
       ContactSummary.resolves({ context: { pregnant: false } });
 
       try {
-        await service.render(new FormContext('div', 'report', mockEnketoDoc('myform')));
+        await service.render(new EnketoFormContext('div', 'report', mockEnketoDoc('myform')));
         flush();
         expect.fail('Should throw error');
       } catch (error) {

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -358,7 +358,6 @@ describe('Form service', () => {
       const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
       return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
-        console.log(JSON.stringify(EnketoForm.args[0], null, 2));
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
         expect(summary.id).to.equal('contact-summary');

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -31,7 +31,7 @@ import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
 import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 
-describe('Enketo service', () => {
+describe('Form service', () => {
   // return a mock form ready for putting in #dbContent
   const mockEnketoDoc = formInternalId => {
     return {
@@ -269,7 +269,7 @@ describe('Enketo service', () => {
             internalId: 'myform',
           },
           { contact_id: '123-user-contact' },
-          { doc: { _id: '123-patient-contact' }, contactSummary: { pregnant: false }, evaluateExpression: true },
+          { doc: { _id: '123-patient-contact' }, contactSummary: { pregnant: false }, shouldEvaluateExpression: true },
         ]);
         expect(enketoInit.callCount).to.equal(1);
         expect(error.message).to.equal(expectedErrorMessage);
@@ -596,7 +596,7 @@ describe('Enketo service', () => {
             internalId: 'myform',
           },
           { contact_id: '123-user-contact' },
-          { doc: undefined, contactSummary: undefined, evaluateExpression: true },
+          { doc: undefined, contactSummary: undefined, shouldEvaluateExpression: true },
         ]);
         expect(enketoInit.notCalled).to.be.true;
         expect(consoleErrorMock.notCalled).to.be.true;


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

medic/cht-core#8589

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8589-edit-form-with-expression/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8589-edit-form-with-expression/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8589-edit-form-with-expression/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

