### PR TITLE
fix(#8589): don't check form expression on edit for 4.3

### DIFF
--- a/tests/e2e/default/enketo/death-report.wdio-spec.js
+++ b/tests/e2e/default/enketo/death-report.wdio-spec.js
@@ -53,6 +53,14 @@ describe('Submit a death report', () => {
     expect(deathCardInfo.deathPlace).to.equal('Health facility');
   });
 
+  it('should edit the report', async () => {
+    await commonPage.goToReports();
+    const reportId = await reportsPage.getLastSubmittedReportId();
+    await reportsPage.editReport(reportId);
+    await genericForm.nextPage();
+    await reportsPage.submitForm();
+  });
+
   it('Should verify that the report related to the death was created', async () => {
     await commonPage.goToReports();
     const firstReport = await reportsPage.getListReportInfo(await reportsPage.firstReport());

--- a/tests/e2e/default/enketo/edit-report-with-attachment.wdio-spec.js
+++ b/tests/e2e/default/enketo/edit-report-with-attachment.wdio-spec.js
@@ -30,6 +30,9 @@ const formDoc = {
       content_type: 'application/octet-stream',
       data: Buffer.from(oneTextForm).toString('base64'),
     }
+  },
+  context: {
+    expression: 'summary.alive',
   }
 };
 const reportDoc ={
@@ -71,7 +74,6 @@ describe('Edit report with attachmnet', () => {
     await commonElements.goToReports();
 
     await reportsPage.editReport(reportDoc._id);
-    // await browser.debug();
     await reportsPage.submitForm();
 
     const editedReport = await utils.getDoc(reportDoc._id);

--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -12,6 +12,7 @@ import { GeolocationService } from '@mm-services/geolocation.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { FeedbackService } from '@mm-services/feedback.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 
 @Component({
   selector: 'training-cards-modal',
@@ -93,11 +94,15 @@ export class TrainingCardsComponent extends MmModalAbstract implements OnInit, O
     }
   }
 
-  private async renderForm(form) {
+  private async renderForm(formDoc) {
     try {
-      const selector = `#${this.formWrapperId}`;
-      this.form = await this.enketoService.render(selector, form, null, null, this.resetFormError.bind(this), true);
-      this.formNoTitle = !form?.title;
+      const formObj = new EnketoFormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
+      formObj.isFormInModal = true;
+      formObj.valuechangeListener = this.resetFormError.bind(this);
+
+      this.form = await this.enketoService.render(formObj);
+      this.formNoTitle = !formDoc?.title;
+
       this.loadingContent = false;
       this.recordTelemetryPostRender();
     } catch(error) {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -245,15 +245,10 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
     const instanceData = this.getFormInstanceData();
     const markFormEdited = this.markFormEdited.bind(this);
     const resetFormError = this.resetFormError.bind(this);
-    const formContext: EnketoFormContext = {
-      selector: '#contact-form',
-      formDoc,
-      instanceData,
-      editedListener: markFormEdited,
-      valuechangeListener: resetFormError,
-      titleKey,
-    };
-
+    const formContext = new EnketoFormContext('#contact-form', 'contact', formDoc, instanceData);
+    formContext.editedListener = markFormEdited;
+    formContext.valuechangeListener = resetFormError;
+    formContext.titleKey = titleKey;
     this.globalActions.setEnketoEditedStatus(false);
 
     return this.enketoService.renderContactForm(formContext);

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { isEqual as _isEqual } from 'lodash-es';
 
 import { ContactViewModelGeneratorService } from '@mm-services/contact-view-model-generator.service';
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
@@ -129,20 +129,13 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
         this.globalActions.setTitle(this.translateFromService.get(form.title));
         this.setCancelCallback();
 
-        const instanceData = {
-          source: 'contact',
-          contact,
-        };
-        const markFormEdited = this.markFormEdited.bind(this);
-        const resetFormError = this.resetFormError.bind(this);
+        const instanceData = { source: 'contact', contact, };
 
-        return this.enketoService.render(
-          '#contact-report',
-          form,
-          instanceData,
-          markFormEdited,
-          resetFormError
-        );
+        const formContext = new EnketoFormContext('#contact-report', 'report', form, instanceData);
+        formContext.editedListener = this.markFormEdited.bind(this);
+        formContext.valuechangeListener = this.resetFormError.bind(this);
+
+        return this.enketoService.render(formContext);
       })
       .then((formInstance) => {
         this.form = formInstance;

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -197,6 +197,7 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
     const formContext = new EnketoFormContext('#report-form', 'report', form, reportContent);
     formContext.editedListener = this.markFormEdited.bind(this);
     formContext.valuechangeListener = this.resetFormError.bind(this);
+    formContext.editing = !!reportContent;
 
     return this.enketoService
       .render(formContext)

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -13,7 +13,7 @@ import { Selectors } from '@mm-selectors/index';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { GlobalActions } from '@mm-actions/global';
 import { ReportsActions } from '@mm-actions/reports';
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateService } from '@mm-services/translate.service';
 
@@ -194,14 +194,12 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   private renderForm(form, reportContent, model) {
+    const formContext = new EnketoFormContext('#report-form', 'report', form, reportContent);
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
+
     return this.enketoService
-      .render(
-        '#report-form',
-        form,
-        reportContent,
-        this.markFormEdited.bind(this),
-        this.resetFormError.bind(this),
-      )
+      .render(formContext)
       .then((form) => {
         this.form = form;
         this.globalActions.setLoadingContent(false);

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -3,7 +3,7 @@ import { Store } from '@ngrx/store';
 import { combineLatest, Subject, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
@@ -214,11 +214,14 @@ export class TasksContentComponent implements OnInit, OnDestroy {
 
   private renderForm(action, formDoc) {
     this.globalActions.setEnketoEditedStatus(false);
-    const markFormEdited = this.markFormEdited.bind(this);
-    const resetFormError = this.resetFormError.bind(this);
+
+    const formContext = new EnketoFormContext('#task-report', 'task', formDoc, action.content);
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
+
 
     return this.enketoService
-      .render('#task-report', formDoc, action.content, markFormEdited, resetFormError)
+      .render(formContext)
       .then((formInstance) => {
         this.form = formInstance;
         this.loadingForm = false;

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -441,7 +441,7 @@ export class EnketoService {
       {
         doc: typeof formContext.instanceData !== 'string' && formContext.instanceData?.contact,
         contactSummary: formContext.contactSummary?.context,
-        evaluateExpression: formContext.evaluateExpression(),
+        shouldEvaluateExpression: formContext.shouldEvaluateExpression(),
       },
     );
   }
@@ -909,7 +909,7 @@ export class EnketoFormContext {
     this.instanceData = data;
   }
 
-  evaluateExpression() {
+  shouldEvaluateExpression() {
     if (this.type === 'report' && this.editing) {
       return false;
     }

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -244,7 +244,7 @@ export class XmlFormsService {
       return false;
     }
 
-    if (options?.evaluateExpression === false) {
+    if (options?.shouldEvaluateExpression === false) {
       return true;
     }
 

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -244,6 +244,10 @@ export class XmlFormsService {
       return false;
     }
 
+    if (options?.evaluateExpression === false) {
+      return true;
+    }
+
     return await this.checkFormExpression(form, options?.doc, userContact, options?.contactSummary);
   }
 

--- a/webapp/tests/karma/ts/modals/training-cards/training-cards.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/training-cards/training-cards.component.spec.ts
@@ -137,8 +137,7 @@ describe('TrainingCardsComponent', () => {
     expect(xmlFormsService.get.calledOnce).to.be.true;
     expect(xmlFormsService.get.args[0]).to.deep.equal([ 'training:a_form_id' ]);
     expect(enketoService.render.calledOnce).to.be.true;
-    expect(enketoService.render.args[0][1]).to.deep.equal(xmlForm);
-    expect(enketoService.render.args[0][2]).to.equal(null);
+    expect(enketoService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
     expect(component.form).to.equal(renderedForm);
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
@@ -298,15 +297,14 @@ describe('TrainingCardsComponent', () => {
       expect(xmlFormsService.get.calledOnce).to.be.true;
       expect(xmlFormsService.get.args[0]).to.deep.equal([ 'training:a_form_id' ]);
       expect(enketoService.render.calledOnce).to.be.true;
-      expect(enketoService.render.args[0][1]).to.deep.equal(xmlForm);
-      expect(enketoService.render.args[0][2]).to.equal(null);
+      expect(enketoService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
       expect(component.form).to.equal(renderedForm);
       expect(consoleErrorMock.notCalled).to.be.true;
       expect(feedbackService.submit.notCalled).to.be.true;
       expect(telemetryService.record.calledOnce).to.be.true;
       expect(telemetryService.record.args[0][0]).to.equal('enketo:training:a_form_id:add:render');
 
-      const resetFormError = enketoService.render.args[0][4];
+      const resetFormError = enketoService.render.args[0][0].valuechangeListener;
       resetFormError();
       expect(globalActions.setEnketoError.notCalled).to.be.true; // No error so no call
       component.enketoError = 'some error';

--- a/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
@@ -160,17 +160,17 @@ describe('contacts report component', () => {
       flush();
 
       expect(enketoService.render.callCount).to.equal(1);
-      expect(enketoService.render.args[0][0]).to.equal('#contact-report');
-      expect(enketoService.render.args[0][1]).to.deep.equal({ title: 'formTitle' });
-      expect(enketoService.render.args[0][2]).to.deep.equal(
-        {
+      expect(enketoService.render.args[0][0]).to.deep.include({
+        selector: '#contact-report',
+        formDoc: { title: 'formTitle' },
+        instanceData: {
           source: 'contact',
           contact: {
             _id: 'test_id',
             contact_type: 'test_type'
           }
         }
-      );
+      });
     }));
 
     it('should unsubscribe and unload form on destroy', async () => {

--- a/webapp/tests/karma/ts/modules/reports/reports-add.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports-add.component.spec.ts
@@ -211,12 +211,11 @@ describe('Reports Add Component', () => {
         expect(setEnketoEditedStatusStub.calledOnce).to.be.true;
         expect(setEnketoEditedStatusStub.args[0]).to.deep.equal([false]);
         expect(enketoService.render.calledOnce).to.be.true;
-        expect(enketoService.render.args[0][1]).to.deep.equal(xmlForm);
-        expect(enketoService.render.args[0][2]).to.equal(undefined);
+        expect(enketoService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
         expect(component.form).to.equal(renderedForm);
 
-        const markFormEdited = enketoService.render.args[0][3];
-        const resetFormError = enketoService.render.args[0][4];
+        const markFormEdited = enketoService.render.args[0][0].editedListener;
+        const resetFormError = enketoService.render.args[0][0].valuechangeListener;
 
         markFormEdited();
         expect(setEnketoEditedStatusStub.calledTwice).to.be.true;

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -138,10 +138,12 @@ describe('TasksContentComponent', () => {
     expect(component.formId).to.equal('A');
 
     expect(render.callCount).to.equal(1);
-    expect(render.getCall(0).args.length).to.equal(5);
-    expect(render.getCall(0).args[0]).to.equal('#task-report');
-    expect(render.getCall(0).args[1]).to.deep.equal(form);
-    expect(render.getCall(0).args[2]).to.equal('nothing');
+    expect(render.args[0][0]).to.deep.include({
+      selector: '#task-report',
+      type: 'task',
+      formDoc: form,
+      instanceData: 'nothing'
+    });
 
     expect(get.callCount).to.eq(0);
     expect(setEnketoEditedStatus.callCount).to.equal(1);
@@ -170,7 +172,7 @@ describe('TasksContentComponent', () => {
     expect(get.args).to.deep.eq([['contact']]);
     expect(geolocationService.init.callCount).to.equal(1);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][2]).to.deep.eq({
+    expect(render.args[0][0].instanceData).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'nothing',
       task_id: '123',
@@ -250,7 +252,7 @@ describe('TasksContentComponent', () => {
     expect(get.callCount).to.eq(1);
     expect(get.args).to.deep.eq([['dne']]);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][2]).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
+    expect(render.args[0][0].instanceData).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
   });
 
   it('should work when form not found', async () => {
@@ -362,7 +364,7 @@ describe('TasksContentComponent', () => {
     tick();
 
     expect(render.callCount).to.equal(1);
-    expect(render.args[0][2]).to.deep.eq({
+    expect(render.args[0][0].instanceData).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'other',
       task_id: '123',
@@ -500,11 +502,12 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(1);
       expect(xmlFormsService.get.args[0]).to.deep.equal(['myform']);
       expect(enketoService.render.callCount).to.equal(1);
-      expect(enketoService.render.args[0]).to.deep.include.members([
-        '#task-report',
-        { ...form },
-        { ...action.content },
-      ]);
+      expect(enketoService.render.args[0][0]).to.deep.include({
+        selector: '#task-report',
+        type: 'task',
+        formDoc: form,
+        instanceData: action.content,
+      });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
       expect(tasksForContactService.getLeafPlaceAncestor.args[0]).to.deep.equal(['my_contact']);
@@ -515,8 +518,8 @@ describe('TasksContentComponent', () => {
       expect((<any>TasksActions.prototype.setTaskGroupContact).args[0]).to.deep.equal([{ any: 'model' }]);
       expect((<any>TasksActions.prototype.setTaskGroupContactLoading).callCount).to.equal(1);
 
-      const markFormEdited = enketoService.render.args[0][3];
-      const resetFormError = enketoService.render.args[0][4];
+      const markFormEdited = enketoService.render.args[0][0].editedListener;
+      const resetFormError = enketoService.render.args[0][0].valuechangeListener;
 
       expect(setEnketoEditedStatus.callCount).to.equal(1);
       expect(setEnketoEditedStatus.args[0]).to.deep.equal([false]);
@@ -559,11 +562,12 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(1);
       expect(xmlFormsService.get.args[0]).to.deep.equal(['myform']);
       expect(enketoService.render.callCount).to.equal(1);
-      expect(enketoService.render.args[0]).to.deep.include.members([
-        '#task-report',
-        { ...form },
-        { ...action.content },
-      ]);
+      expect(enketoService.render.args[0][0]).to.deep.include({
+        selector: '#task-report',
+        type: 'task',
+        formDoc: { ...form },
+        instanceData: { ...action.content },
+      });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
       expect(tasksForContactService.getLeafPlaceAncestor.args[0]).to.deep.equal(['the_contact']);

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -268,7 +268,7 @@ describe('Enketo service', () => {
             internalId: 'myform',
           },
           { contact_id: '123-user-contact' },
-          { doc: { _id: '123-patient-contact' }, contactSummary: { pregnant: false }, evaluateExpression: true },
+          { doc: { _id: '123-patient-contact' }, contactSummary: { pregnant: false }, shouldEvaluateExpression: true },
         ]);
         expect(enketoInit.callCount).to.equal(1);
         expect(error.message).to.equal(expectedErrorMessage);
@@ -652,7 +652,7 @@ describe('Enketo service', () => {
             internalId: 'myform',
           },
           { contact_id: '123-user-contact' },
-          { doc: undefined, contactSummary: undefined, evaluateExpression: true },
+          { doc: undefined, contactSummary: undefined, shouldEvaluateExpression: true },
         ]);
         expect(enketoInit.notCalled).to.be.true;
         expect(error).to.deep.equal({ translationKey: 'error.loading.form.no_authorized' });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

medic/cht-core#8589

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8589-430-backport/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8589-430-backport/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8589-430-backport/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

