### PR TITLE
fix(#8535): wait for service worker before waiting for the popup.

### DIFF
--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -12,7 +12,7 @@ describe('Testing Incorrect locale', () => {
       'n.month': '{MONTHS, plural, =1{1 luna} other{# luni}}',
       'n.week': '{WEEKS, plural, =1{1 saptamana} other{# saptamani}}',
       'reports.none.n.months':
-          '{MONTHS, plural, =1{No reports in the last month.} other{No reports in the last # months.}}',
+        '{MONTHS, plural, =1{No reports in the last month.} other{No reports in the last # months.}}',
       'task.days.left': '{DAYS, plural, =1{1 day left} other{# days left}',
       'tasks.none.n.weeks': '{WEEKS, plural, =1{No tasks in the next week.} other{No tasks in the next # weeks.}}',
       'Reports': 'HilReports',
@@ -37,7 +37,9 @@ describe('Testing Incorrect locale', () => {
   before(async () => {
     await loginPage.cookieLogin();
     await utils.saveDoc(contact);
+    const waitForServiceWorker = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);
     await createLanguage();
+    await waitForServiceWorker.promise;
     await commonElements.closeReloadModal(true);
   });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

medic/cht-core#8535

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8535-fix/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8535-fix/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8535-fix/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

