### PR TITLE
fix(#8589): don't check form expression on report edit

### DIFF
--- a/tests/e2e/default/enketo/death-report.wdio-spec.js
+++ b/tests/e2e/default/enketo/death-report.wdio-spec.js
@@ -53,6 +53,14 @@ describe('Submit a death report', () => {
     expect(deathCardInfo.deathPlace).to.equal('Health facility');
   });
 
+  it('should edit the report', async () => {
+    await commonPage.goToReports();
+    const reportId = await reportsPage.getLastSubmittedReportId();
+    await reportsPage.editReport(reportId);
+    await genericForm.nextPage();
+    await reportsPage.submitForm();
+  });
+
   it('Should verify that the report related to the death was created', async () => {
     await commonPage.goToReports();
     const firstReport = await reportsPage.getListReportInfo(await reportsPage.firstReport());

--- a/tests/e2e/default/enketo/edit-report-with-attachment.wdio-spec.js
+++ b/tests/e2e/default/enketo/edit-report-with-attachment.wdio-spec.js
@@ -30,6 +30,9 @@ const formDoc = {
       content_type: 'application/octet-stream',
       data: Buffer.from(oneTextForm).toString('base64'),
     }
+  },
+  context: {
+    expression: 'summary.alive',
   }
 };
 const reportDoc ={
@@ -71,7 +74,6 @@ describe('Edit report with attachmnet', () => {
     await commonElements.goToReports();
 
     await reportsPage.editReport(reportDoc._id);
-    // await browser.debug();
     await reportsPage.submitForm();
 
     const editedReport = await utils.getDoc(reportDoc._id);

--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -11,6 +11,7 @@ import { GeolocationService } from '@mm-services/geolocation.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { FeedbackService } from '@mm-services/feedback.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 
 @Component({
   selector: 'training-cards-modal',
@@ -91,11 +92,14 @@ export class TrainingCardsComponent implements OnInit, OnDestroy {
     }
   }
 
-  private async renderForm(form) {
+  private async renderForm(formDoc) {
     try {
-      const selector = `#${this.formWrapperId}`;
-      this.form = await this.formService.render(selector, form, null, null, this.resetFormError.bind(this), true);
-      this.formNoTitle = !form?.title;
+      const formContext = new EnketoFormContext(`#${this.formWrapperId}`, 'training-card', formDoc);
+      formContext.isFormInModal = true;
+      formContext.valuechangeListener = this.resetFormError.bind(this);
+
+      this.form = await this.formService.render(formContext);
+      this.formNoTitle = !formDoc?.title;
       this.loadingContent = false;
       this.recordTelemetryPostRender();
     } catch (error) {

--- a/webapp/src/ts/modules/contacts/contacts-edit.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-edit.component.ts
@@ -243,21 +243,15 @@ export class ContactsEditComponent implements OnInit, OnDestroy, AfterViewInit {
   private async renderForm(formId: string, titleKey: string) {
     const formDoc = await this.dbService.get().get(formId);
     this.xmlVersion = formDoc.xmlVersion;
-    const instanceData = this.getFormInstanceData();
-    const markFormEdited = this.markFormEdited.bind(this);
-    const resetFormError = this.resetFormError.bind(this);
-    const formContext: EnketoFormContext = {
-      selector: '#contact-form',
-      formDoc,
-      instanceData,
-      editedListener: markFormEdited,
-      valuechangeListener: resetFormError,
-      titleKey,
-    };
 
     this.globalActions.setEnketoEditedStatus(false);
 
-    return this.formService.renderContactForm(formContext);
+    const formContext = new EnketoFormContext('#contact-form', 'contact', formDoc, this.getFormInstanceData());
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
+    formContext.titleKey = titleKey;
+
+    return this.formService.render(formContext);
   }
 
   private setEnketoContact(formInstance) {

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -6,6 +6,7 @@ import { isEqual as _isEqual } from 'lodash-es';
 
 import { ContactViewModelGeneratorService } from '@mm-services/contact-view-model-generator.service';
 import { FormService } from '@mm-services/form.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 import { GeolocationService } from '@mm-services/geolocation.service';
 import { GlobalActions } from '@mm-actions/global';
 import { Selectors } from '@mm-selectors/index';
@@ -124,25 +125,16 @@ export class ContactsReportComponent implements OnInit, OnDestroy, AfterViewInit
 
     return this
       .getContactAndForm()
-      .then(([ contact, form ]) => {
+      .then(([ contact, formDoc ]) => {
         this.globalActions.setEnketoEditedStatus(false);
-        this.globalActions.setTitle(this.translateFromService.get(form.title));
+        this.globalActions.setTitle(this.translateFromService.get(formDoc.title));
         this.setCancelCallback();
 
-        const instanceData = {
-          source: 'contact',
-          contact,
-        };
-        const markFormEdited = this.markFormEdited.bind(this);
-        const resetFormError = this.resetFormError.bind(this);
+        const formContext = new EnketoFormContext('#contact-report', 'report', formDoc, { source: 'contact', contact });
+        formContext.editedListener = this.markFormEdited.bind(this);
+        formContext.valuechangeListener = this.resetFormError.bind(this);
 
-        return this.formService.render(
-          '#contact-report',
-          form,
-          instanceData,
-          markFormEdited,
-          resetFormError
-        );
+        return this.formService.render(formContext);
       })
       .then((formInstance) => {
         this.form = formInstance;

--- a/webapp/src/ts/modules/reports/reports-add.component.ts
+++ b/webapp/src/ts/modules/reports/reports-add.component.ts
@@ -16,6 +16,7 @@ import { ReportsActions } from '@mm-actions/reports';
 import { FormService } from '@mm-services/form.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateService } from '@mm-services/translate.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 
 
 @Component({
@@ -193,38 +194,33 @@ export class ReportsAddComponent implements OnInit, OnDestroy, AfterViewInit {
           })));
   }
 
-  private renderForm(form, reportContent, model) {
-    return this.formService
-      .render(
-        '#report-form',
-        form,
-        reportContent,
-        this.markFormEdited.bind(this),
-        this.resetFormError.bind(this),
-      )
-      .then((form) => {
-        this.form = form;
-        this.globalActions.setLoadingContent(false);
-        if (!model.doc || !model.doc._id) {
-          return;
-        }
+  private async renderForm(formDoc, reportContent, model) {
+    const formContext = new EnketoFormContext('#report-form', 'report', formDoc, reportContent);
+    formContext.editing = !!reportContent;
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
 
-        return this.ngZone.runOutsideAngular(() => this.renderAttachmentPreviews(model));
-      })
-      .then(() => {
-        this.telemetryData.postRender = Date.now();
-        this.telemetryData.action = model.doc ? 'edit' : 'add';
-        this.telemetryData.form = model.formInternalId;
+    try {
+      const form = await this.formService.render(formContext);
+      this.form = form;
+      this.globalActions.setLoadingContent(false);
+      if (!model.doc || !model.doc._id) {
+        return;
+      }
 
-        this.telemetryService.record(
-          `enketo:reports:${this.telemetryData.form}:${this.telemetryData.action}:render`,
-          this.telemetryData.postRender - this.telemetryData.preRender
-        );
-      })
-      .catch((err) => {
-        this.setError(err);
-        console.error('Error loading form.', err);
-      });
+      await this.ngZone.runOutsideAngular(() => this.renderAttachmentPreviews(model));
+
+      this.telemetryData.postRender = Date.now();
+      this.telemetryData.action = model.doc ? 'edit' : 'add';
+      this.telemetryData.form = model.formInternalId;
+      this.telemetryService.record(
+        `enketo:reports:${this.telemetryData.form}:${this.telemetryData.action}:render`,
+        this.telemetryData.postRender - this.telemetryData.preRender
+      );
+    } catch (err) {
+      this.setError(err);
+      console.error('Error loading form.', err);
+    }
   }
 
   private setError(err) {

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -4,6 +4,7 @@ import { combineLatest, Subject, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { FormService } from '@mm-services/form.service';
+import { EnketoFormContext } from '@mm-services/enketo.service';
 import { TelemetryService } from '@mm-services/telemetry.service';
 import { TranslateFromService } from '@mm-services/translate-from.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
@@ -214,11 +215,13 @@ export class TasksContentComponent implements OnInit, OnDestroy {
 
   private renderForm(action, formDoc) {
     this.globalActions.setEnketoEditedStatus(false);
-    const markFormEdited = this.markFormEdited.bind(this);
-    const resetFormError = this.resetFormError.bind(this);
+
+    const formContext = new EnketoFormContext('#task-report', 'task', formDoc, action.content);
+    formContext.editedListener = this.markFormEdited.bind(this);
+    formContext.valuechangeListener = this.resetFormError.bind(this);
 
     return this.formService
-      .render('#task-report', formDoc, action.content, markFormEdited, resetFormError)
+      .render(formContext)
       .then((formInstance) => {
         this.form = formInstance;
         this.loadingForm = false;

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -323,7 +323,7 @@ export class EnketoService {
       () => this.setupNavButtons($selector, form.pages._getCurrentIndex()));
   }
 
-  public async renderForm(formContext: EnketoFormContext, doc, userSettings, contactSummary) {
+  public async renderForm(formContext: EnketoFormContext, doc, userSettings) {
     const {
       formDoc,
       instanceData,
@@ -340,7 +340,7 @@ export class EnketoService {
       instanceData,
       titleKey,
       isFormInModal,
-      contactSummary,
+      contactSummary: formContext.contactSummary,
     };
     const form = await this.renderFromXmls(xmlFormContext, userSettings);
     const formContainer = xmlFormContext.wrapper.find('.container').first();
@@ -629,16 +629,38 @@ interface XmlFormContext {
   instanceData: null|string|Record<string, any>; // String for report forms, Record<> for contact forms.
   titleKey?: string;
   isFormInModal?: boolean;
-  contactSummary: Record<string, any>;
+  contactSummary?: Record<string, any>;
 }
 
-export interface EnketoFormContext {
+export class EnketoFormContext {
   selector: string;
   formDoc: Record<string, any>;
-  instanceData: null|string|Record<string, any>; // String for report forms, Record<> for contact forms.
+  type: string; // 'contact'|'report'|'task'|'training-card'
+  editing: boolean;
+  instanceData: null|string|Record<string, any>;
   editedListener: () => void;
   valuechangeListener: () => void;
   titleKey?: string;
   isFormInModal?: boolean;
   userContact?: Record<string, any>;
+  contactSummary? :Record<string, any>;
+
+  constructor(selector:string, type:string, formDoc:Record<string, any>, instanceData?) {
+    this.selector = selector;
+    this.type = type;
+    this.formDoc = formDoc;
+    this.instanceData = instanceData;
+  }
+
+  shouldEvaluateExpression() {
+    if (this.type === 'report' && this.editing) {
+      return false;
+    }
+    return true;
+  }
+
+  requiresContact() {
+    // Users can access contact forms even when they don't have a contact associated.
+    return this.type !== 'contact';
+  }
 }

--- a/webapp/src/ts/services/form.service.ts
+++ b/webapp/src/ts/services/form.service.ts
@@ -142,20 +142,20 @@ export class FormService {
       .then(([reports, lineage]) => this.contactSummaryService.get(contact, reports, lineage));
   }
 
-  private canAccessForm(formDoc, user, instanceData, contactSummary) {
+  private canAccessForm(formContext: EnketoFormContext) {
     return this.xmlFormsService.canAccessForm(
-      formDoc,
-      user,
-      { doc: instanceData?.contact, contactSummary: contactSummary?.context },
+      formContext.formDoc,
+      formContext.userContact,
+      {
+        doc: typeof formContext.instanceData !== 'string' && formContext.instanceData?.contact,
+        contactSummary: formContext.contactSummary?.context,
+        shouldEvaluateExpression: formContext.shouldEvaluateExpression(),
+      },
     );
   }
 
   private async renderForm(formContext: EnketoFormContext) {
-    const {
-      formDoc,
-      instanceData,
-      userContact,
-    } = formContext;
+    const { formDoc, instanceData } = formContext;
 
     try {
       this.unload(this.enketoService.getCurrentForm());
@@ -163,12 +163,12 @@ export class FormService {
         this.transformXml(formDoc),
         this.userSettingsService.getWithLanguage()
       ]);
-      const contactSummary = await this.getContactSummary(doc, instanceData);
+      formContext.contactSummary = await this.getContactSummary(doc, instanceData);
 
-      if (!await this.canAccessForm(formDoc, userContact, instanceData, contactSummary)) {
+      if (!await this.canAccessForm(formContext)) {
         throw { translationKey: 'error.loading.form.no_authorized' };
       }
-      return await this.enketoService.renderForm(formContext, doc, userSettings, contactSummary);
+      return await this.enketoService.renderForm(formContext, doc, userSettings);
     } catch (error) {
       if (error.translationKey) {
         throw error;
@@ -180,35 +180,13 @@ export class FormService {
     }
   }
 
-  render(selector, form, instanceData, editedListener, valuechangeListener, isFormInModal = false) {
-    return this.ngZone.runOutsideAngular(() => {
-      return this._render(selector, form, instanceData, editedListener, valuechangeListener, isFormInModal);
-    });
+  render(formContext: EnketoFormContext) {
+    return this.ngZone.runOutsideAngular(() => this._render(formContext));
   }
 
-  private _render(selector, form, instanceData, editedListener, valuechangeListener, isFormInModal) {
-    return Promise
-      .all([
-        this.inited,
-        this.getUserContact(),
-      ])
-      .then(([ , userContact]) => {
-        const formContext: EnketoFormContext = {
-          selector,
-          formDoc: form,
-          instanceData,
-          editedListener,
-          valuechangeListener,
-          isFormInModal,
-          userContact,
-        };
-        return this.renderForm(formContext);
-      });
-  }
-
-  async renderContactForm(formContext: EnketoFormContext) {
-    // Users can access contact forms even when they don't have a contact associated. So not throwing an error.
-    formContext.userContact = await this.userContactService.get();
+  private async _render(formContext: EnketoFormContext) {
+    await this.inited;
+    formContext.userContact = await this.getUserContact(formContext.requiresContact());
     return this.renderForm(formContext);
   }
 
@@ -229,18 +207,15 @@ export class FormService {
       });
   }
 
-  private getUserContact() {
-    return this.userContactService
-      .get()
-      .then((contact) => {
-        if (!contact) {
-          const err: any = new Error('Your user does not have an associated contact, or does not have access to the ' +
-            'associated contact. Talk to your administrator to correct this.');
-          err.translationKey = 'error.loading.form.no_contact';
-          throw err;
-        }
-        return contact;
-      });
+  private async getUserContact(requiresContact:boolean) {
+    const contact = await this.userContactService.get();
+    if (requiresContact && !contact) {
+      const err: any = new Error('Your user does not have an associated contact, or does not have access to the ' +
+        'associated contact. Talk to your administrator to correct this.');
+      err.translationKey = 'error.loading.form.no_contact';
+      throw err;
+    }
+    return contact;
   }
 
   private saveGeo(geoHandle, docs) {
@@ -296,7 +271,7 @@ export class FormService {
       return this.enketoService.completeExistingReport(form, formDoc, docId);
     }
 
-    const contact = await this.getUserContact();
+    const contact = await this.getUserContact(true);
     return this.enketoService.completeNewReport(formInternalId, form, formDoc, contact);
   }
 
@@ -325,3 +300,4 @@ export class FormService {
     this.enketoService.unload(form);
   }
 }
+

--- a/webapp/src/ts/services/xml-forms.service.ts
+++ b/webapp/src/ts/services/xml-forms.service.ts
@@ -244,6 +244,10 @@ export class XmlFormsService {
       return false;
     }
 
+    if (options?.shouldEvaluateExpression === false) {
+      return true;
+    }
+
     return await this.checkFormExpression(form, options?.doc, userContact, options?.contactSummary);
   }
 

--- a/webapp/tests/karma/ts/modals/training-cards/training-cards.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/training-cards/training-cards.component.spec.ts
@@ -132,8 +132,7 @@ describe('TrainingCardsComponent', () => {
     expect(xmlFormsService.get.calledOnce).to.be.true;
     expect(xmlFormsService.get.args[0]).to.deep.equal([ 'training:a_form_id' ]);
     expect(formService.render.calledOnce).to.be.true;
-    expect(formService.render.args[0][1]).to.deep.equal(xmlForm);
-    expect(formService.render.args[0][2]).to.equal(null);
+    expect(formService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
     expect(component.form).to.equal(renderedForm);
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
@@ -293,15 +292,14 @@ describe('TrainingCardsComponent', () => {
       expect(xmlFormsService.get.calledOnce).to.be.true;
       expect(xmlFormsService.get.args[0]).to.deep.equal([ 'training:a_form_id' ]);
       expect(formService.render.calledOnce).to.be.true;
-      expect(formService.render.args[0][1]).to.deep.equal(xmlForm);
-      expect(formService.render.args[0][2]).to.equal(null);
+      expect(formService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
       expect(component.form).to.equal(renderedForm);
       expect(consoleErrorMock.notCalled).to.be.true;
       expect(feedbackService.submit.notCalled).to.be.true;
       expect(telemetryService.record.calledOnce).to.be.true;
       expect(telemetryService.record.args[0][0]).to.equal('enketo:training:a_form_id:add:render');
 
-      const resetFormError = formService.render.args[0][4];
+      const resetFormError = formService.render.args[0][0].valuechangeListener;
       resetFormError();
       expect(globalActions.setEnketoError.notCalled).to.be.true; // No error so no call
       component.enketoError = 'some error';

--- a/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-edit.component.spec.ts
@@ -51,7 +51,7 @@ describe('ContactsEdit component', () => {
       queryParams: new Subject(),
     };
     formService = {
-      renderContactForm: sinon.stub(),
+      render: sinon.stub(),
       unload: sinon.stub(),
     };
     lineageModelGeneratorService = { contact: sinon.stub().resolves({ doc: { } }) };
@@ -224,9 +224,8 @@ describe('ContactsEdit component', () => {
       await fixture.whenStable();
 
       expect(contactTypesService.get.callCount).to.equal(1);
-      expect(formService.renderContactForm.callCount).to.equal(1);
-
-      expect(formService.renderContactForm.args[0][0]).to.deep.include({
+      expect(formService.render.callCount).to.equal(1);
+      expect(formService.render.args[0][0]).to.deep.include({
         selector: '#contact-form',
         formDoc: { _id: 'random_create', the: 'form' },
         instanceData: { random: { type: 'contact', contact_type: 'random', parent: '' } },
@@ -241,8 +240,8 @@ describe('ContactsEdit component', () => {
 
       expect(dbGet.callCount).to.equal(2);
       expect(contactTypesService.get.callCount).to.equal(2);
-      expect(formService.renderContactForm.callCount).to.equal(2);
-      expect(formService.renderContactForm.args[1][0]).to.deep.include({
+      expect(formService.render.callCount).to.equal(2);
+      expect(formService.render.args[1][0]).to.deep.include({
         selector: '#contact-form',
         formDoc: { _id: 'other_create' },
         instanceData: { other: { type: 'contact', contact_type: 'other', parent: '' } },
@@ -262,7 +261,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal([undefined]);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -275,7 +274,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['random']);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -294,7 +293,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['person']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['person_create_form_id']);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
         expect(component.contentError).to.equal(true);
       });
@@ -319,8 +318,8 @@ describe('ContactsEdit component', () => {
           formInstance: undefined,
           docId: null,
         });
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'clinic_create_form_id', the: 'form' },
           instanceData: { clinic: { type: 'contact', contact_type: 'clinic', parent: 'the_district' } },
@@ -350,8 +349,8 @@ describe('ContactsEdit component', () => {
           formInstance: undefined,
           docId: null,
         });
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'district_create_form_id', the: 'form' },
           instanceData: { district_hospital: { type: 'contact', contact_type: 'district_hospital', parent: '' } },
@@ -379,7 +378,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['missing_clinic_type']);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -399,7 +398,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.callCount).to.equal(1);
         expect(contactTypesService.get.args[0]).to.deep.equal(['person_type']);
         expect(dbGet.callCount).to.equal(0);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
       });
 
@@ -424,7 +423,7 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
-        expect(formService.renderContactForm.callCount).to.equal(0);
+        expect(formService.render.callCount).to.equal(0);
         expect(component.enketoContact).to.deep.equal(undefined);
         expect(component.contentError).to.equal(true);
       });
@@ -450,8 +449,8 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['patient']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['patient_edit_form']);
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'patient_edit_form', form: true },
           instanceData: { patient: { type: 'patient', _id: 'the_patient' } },
@@ -486,8 +485,8 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['a_clinic_type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['a_clinic_type_create_form']);
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'a_clinic_type_create_form', data: true },
           instanceData: { a_clinic_type: { type: 'contact', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
@@ -525,8 +524,8 @@ describe('ContactsEdit component', () => {
         expect(contactTypesService.get.args[0]).to.deep.equal(['the correct type']);
         expect(dbGet.callCount).to.equal(1);
         expect(dbGet.args[0]).to.deep.equal(['the correct_edit_form']);
-        expect(formService.renderContactForm.callCount).to.equal(1);
-        expect(formService.renderContactForm.args[0][0]).to.deep.include({
+        expect(formService.render.callCount).to.equal(1);
+        expect(formService.render.args[0][0]).to.deep.include({
           selector: '#contact-form',
           formDoc: { _id: 'the correct_edit_form', data: true },
           instanceData: { 'the correct type': { type: 'clinic', contact_type: 'a_clinic_type', _id: 'the_clinic' } },
@@ -611,7 +610,7 @@ describe('ContactsEdit component', () => {
       const form = {
         validate: sinon.stub().resolves(true),
       };
-      formService.renderContactForm.resolves(form);
+      formService.render.resolves(form);
 
       await createComponent();
       await fixture.whenStable();
@@ -646,7 +645,7 @@ describe('ContactsEdit component', () => {
       const form = {
         validate: sinon.stub().resolves(true),
       };
-      formService.renderContactForm.resolves(form);
+      formService.render.resolves(form);
 
       await createComponent();
       await fixture.whenStable();
@@ -681,7 +680,7 @@ describe('ContactsEdit component', () => {
       const form = {
         validate: sinon.stub().resolves(true),
       };
-      formService.renderContactForm.resolves(form);
+      formService.render.resolves(form);
 
       await createComponent();
       await fixture.whenStable();

--- a/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
@@ -160,17 +160,17 @@ describe('contacts report component', () => {
       flush();
 
       expect(formService.render.callCount).to.equal(1);
-      expect(formService.render.args[0][0]).to.equal('#contact-report');
-      expect(formService.render.args[0][1]).to.deep.equal({ title: 'formTitle' });
-      expect(formService.render.args[0][2]).to.deep.equal(
-        {
+      expect(formService.render.args[0][0]).to.deep.include({
+        selector: '#contact-report',
+        formDoc: { title: 'formTitle' },
+        instanceData: {
           source: 'contact',
           contact: {
             _id: 'test_id',
             contact_type: 'test_type'
           }
         }
-      );
+      });
     }));
 
     it('should unsubscribe and unload form on destroy', async () => {

--- a/webapp/tests/karma/ts/modules/reports/reports-add.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports-add.component.spec.ts
@@ -211,12 +211,11 @@ describe('Reports Add Component', () => {
         expect(setEnketoEditedStatusStub.calledOnce).to.be.true;
         expect(setEnketoEditedStatusStub.args[0]).to.deep.equal([false]);
         expect(formService.render.calledOnce).to.be.true;
-        expect(formService.render.args[0][1]).to.deep.equal(xmlForm);
-        expect(formService.render.args[0][2]).to.equal(undefined);
+        expect(formService.render.args[0][0].formDoc).to.deep.equal(xmlForm);
         expect(component.form).to.equal(renderedForm);
 
-        const markFormEdited = formService.render.args[0][3];
-        const resetFormError = formService.render.args[0][4];
+        const markFormEdited = formService.render.args[0][0].editedListener;
+        const resetFormError = formService.render.args[0][0].valuechangeListener;
 
         markFormEdited();
         expect(setEnketoEditedStatusStub.calledTwice).to.be.true;

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -138,10 +138,12 @@ describe('TasksContentComponent', () => {
     expect(component.formId).to.equal('A');
 
     expect(render.callCount).to.equal(1);
-    expect(render.getCall(0).args.length).to.equal(5);
-    expect(render.getCall(0).args[0]).to.equal('#task-report');
-    expect(render.getCall(0).args[1]).to.deep.equal(form);
-    expect(render.getCall(0).args[2]).to.equal('nothing');
+    expect(render.args[0][0]).to.deep.include({
+      selector: '#task-report',
+      type: 'task',
+      formDoc: form,
+      instanceData: 'nothing'
+    });
 
     expect(get.callCount).to.eq(0);
     expect(setEnketoEditedStatus.callCount).to.equal(1);
@@ -170,7 +172,7 @@ describe('TasksContentComponent', () => {
     expect(get.args).to.deep.eq([['contact']]);
     expect(geolocationService.init.callCount).to.equal(1);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][2]).to.deep.eq({
+    expect(render.args[0][0].instanceData).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'nothing',
       task_id: '123',
@@ -250,7 +252,7 @@ describe('TasksContentComponent', () => {
     expect(get.callCount).to.eq(1);
     expect(get.args).to.deep.eq([['dne']]);
     expect(render.callCount).to.eq(1);
-    expect(render.args[0][2]).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
+    expect(render.args[0][0].instanceData).to.deep.eq({ contact: { _id: 'dne' }, task_id: '123' });
   });
 
   it('should work when form not found', async () => {
@@ -362,7 +364,7 @@ describe('TasksContentComponent', () => {
     tick();
 
     expect(render.callCount).to.equal(1);
-    expect(render.args[0][2]).to.deep.eq({
+    expect(render.args[0][0].instanceData).to.deep.eq({
       contact: { _id: 'contact' },
       something: 'other',
       task_id: '123',
@@ -500,11 +502,12 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(1);
       expect(xmlFormsService.get.args[0]).to.deep.equal(['myform']);
       expect(formService.render.callCount).to.equal(1);
-      expect(formService.render.args[0]).to.deep.include.members([
-        '#task-report',
-        { ...form },
-        { ...action.content },
-      ]);
+      expect(formService.render.args[0][0]).to.deep.include({
+        selector: '#task-report',
+        type: 'task',
+        formDoc: form,
+        instanceData: action.content,
+      });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
       expect(tasksForContactService.getLeafPlaceAncestor.args[0]).to.deep.equal(['my_contact']);
@@ -515,8 +518,8 @@ describe('TasksContentComponent', () => {
       expect((<any>TasksActions.prototype.setTaskGroupContact).args[0]).to.deep.equal([{ any: 'model' }]);
       expect((<any>TasksActions.prototype.setTaskGroupContactLoading).callCount).to.equal(1);
 
-      const markFormEdited = formService.render.args[0][3];
-      const resetFormError = formService.render.args[0][4];
+      const markFormEdited = formService.render.args[0][0].editedListener;
+      const resetFormError = formService.render.args[0][0].valuechangeListener;
 
       expect(setEnketoEditedStatus.callCount).to.equal(1);
       expect(setEnketoEditedStatus.args[0]).to.deep.equal([false]);
@@ -559,11 +562,12 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(1);
       expect(xmlFormsService.get.args[0]).to.deep.equal(['myform']);
       expect(formService.render.callCount).to.equal(1);
-      expect(formService.render.args[0]).to.deep.include.members([
-        '#task-report',
-        { ...form },
-        { ...action.content },
-      ]);
+      expect(formService.render.args[0][0]).to.deep.include({
+        selector: '#task-report',
+        type: 'task',
+        formDoc: { ...form },
+        instanceData: { ...action.content },
+      });
 
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(1);
       expect(tasksForContactService.getLeafPlaceAncestor.args[0]).to.deep.equal(['the_contact']);

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -9,9 +9,9 @@ import { TranslateFromService } from '@mm-services/translate-from.service';
 import { EnketoPrepopulationDataService } from '@mm-services/enketo-prepopulation-data.service';
 import { AttachmentService } from '@mm-services/attachment.service';
 import { TranslateService } from '@mm-services/translate.service';
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 
-describe('Enketo Form service', () => {
+describe('Enketo service', () => {
   // return a mock form ready for putting in #dbContent
   const mockEnketoDoc = formInternalId => {
     return {
@@ -291,18 +291,14 @@ describe('Enketo Form service', () => {
       };
       enketoInit.returns([]);
       EnketoPrepopulationData.resolves(data);
-      const formContext = {
-        selector: $('<div></div>'),
-        formDoc: mockEnketoDoc('myform'),
-        instanceData
-      };
+      const formContext = new EnketoFormContext('#div', 'report', mockEnketoDoc('myform'), instanceData);
+      formContext.contactSummary = { context: { pregnant: true } };
       const doc = {
         html: $('<div>my form</div>'),
         model: VISIT_MODEL_WITH_CONTACT_SUMMARY,
       };
       const userSettings = { language: 'en' };
-      const contactSummary = { context: { pregnant: true } };
-      return service.renderForm(formContext, doc, userSettings, contactSummary).then(() => {
+      return service.renderForm(formContext, doc, userSettings).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -29,9 +29,9 @@ import { FeedbackService } from '@mm-services/feedback.service';
 import * as medicXpathExtensions from '../../../../src/js/enketo/medic-xpath-extensions';
 import { CHTScriptApiService } from '@mm-services/cht-script-api.service';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
-import { EnketoService } from '@mm-services/enketo.service';
+import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
 
-describe('Enketo service', () => {
+describe('Form service', () => {
   // return a mock form ready for putting in #dbContent
   const mockEnketoDoc = formInternalId => {
     return {
@@ -212,14 +212,16 @@ describe('Enketo service', () => {
 
   describe('render', () => {
 
-    beforeEach(() => {
+    beforeEach(async () => {
+      sinon.stub(medicXpathExtensions, 'init');
       service = TestBed.inject(FormService);
+      await service.init();
     });
 
     it('renders error when user does not have associated contact', () => {
       UserContact.resolves();
       return service
-        .render(null, 'not-defined')
+        .render(new EnketoFormContext('#', 'report', { }))
         .then(() => {
           expect.fail('Should throw error');
         })
@@ -251,8 +253,10 @@ describe('Enketo service', () => {
       const expectedErrorMessage = expectedErrorTitle + JSON.stringify(expectedErrorDetail);
       enketoInit.returns(expectedErrorDetail);
 
+      const formContext = new EnketoFormContext('#div', 'report', mockEnketoDoc('myform'), instanceData);
+
       try {
-        await service.render($('<div></div>'), mockEnketoDoc('myform'), instanceData);
+        await service.render(formContext);
         flush();
         expect.fail('Should throw error');
       } catch (error) {
@@ -265,7 +269,7 @@ describe('Enketo service', () => {
             internalId: 'myform',
           },
           { contact_id: '123-user-contact' },
-          { doc: { _id: '123-patient-contact' }, contactSummary: { pregnant: false } },
+          { doc: { _id: '123-patient-contact' }, contactSummary: { pregnant: false }, shouldEvaluateExpression: true },
         ]);
         expect(enketoInit.callCount).to.equal(1);
         expect(error.message).to.equal(expectedErrorMessage);
@@ -286,7 +290,7 @@ describe('Enketo service', () => {
       enketoInit.returns([]);
       FileReader.utf8.resolves('<some-blob name="xml"/>');
       EnketoPrepopulationData.resolves('<xml></xml>');
-      return service.render($('<div></div>'), mockEnketoDoc('myform')).then(() => {
+      return service.render(new EnketoFormContext('#div', 'task', mockEnketoDoc('myform'))).then(() => {
         expect(UserContact.callCount).to.equal(1);
         expect(EnketoPrepopulationData.callCount).to.equal(1);
         expect(FileReader.utf8.callCount).to.equal(2);
@@ -314,7 +318,8 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>my form</div>')
         .onSecondCall().resolves('my model');
       EnketoPrepopulationData.resolves(data);
-      return service.render($('<div></div>'), mockEnketoDoc('myform'), data).then(() => {
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), data);
+      return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].modelStr).to.equal('my model');
         expect(EnketoForm.args[0][1].instanceStr).to.equal(data);
@@ -350,7 +355,8 @@ describe('Enketo service', () => {
       ContactSummary.resolves({ context: { pregnant: true } });
       Search.resolves([{ _id: 'somereport' }]);
       LineageModelGenerator.contact.resolves({ lineage: [{ _id: 'someparent' }] });
-      return service.render($('<div></div>'), mockEnketoDoc('myform'), instanceData).then(() => {
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
@@ -404,7 +410,8 @@ describe('Enketo service', () => {
         }
       });
       LineageModelGenerator.contact.resolves({ lineage: [] });
-      return service.render($('<div></div>'), mockEnketoDoc('myform'), instanceData).then(() => {
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
         const summary = EnketoForm.args[0][1].external[0];
@@ -441,7 +448,8 @@ describe('Enketo service', () => {
           name: 'sharon'
         }
       };
-      return service.render($('<div></div>'), mockEnketoDoc('myform'), instanceData).then(() => {
+      const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external).to.equal(undefined);
         expect(ContactSummary.callCount).to.equal(0);
@@ -474,7 +482,8 @@ describe('Enketo service', () => {
       };
       ContactSummary.resolves({ context: { pregnant: true } });
       Search.resolves([{ _id: 'somereport' }]);
-      return service.render($('<div></div>'), mockEnketoDoc('myform'), instanceData).then(() => {
+      const formContext = new EnketoFormContext('div', 'report',  mockEnketoDoc('myform'), instanceData);
+      return service.render(formContext).then(() => {
         expect(LineageModelGenerator.contact.callCount).to.equal(1);
         expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
         expect(ContactSummary.callCount).to.equal(1);
@@ -494,7 +503,7 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>first form</div>')
         .onSecondCall().resolves(VISIT_MODEL);
 
-      await service.render($('<div id="first-form"></div>'), mockEnketoDoc('firstForm'));
+      await service.render(new EnketoFormContext('#div', 'report',  mockEnketoDoc('firstForm')));
       expect(form.resetView.notCalled).to.be.true;
       expect(UserContact.calledOnce).to.be.true;
       expect(EnketoPrepopulationData.calledOnce).to.be.true;
@@ -512,7 +521,7 @@ describe('Enketo service', () => {
         .onFirstCall().resolves('<div>second form</div>')
         .onSecondCall().resolves(VISIT_MODEL_WITH_CONTACT_SUMMARY);
 
-      await service.render($('<div id="second-form"></div>'), mockEnketoDoc('secondForm'));
+      await service.render(new EnketoFormContext('#div', 'report', mockEnketoDoc('secondForm')));
       expect(form.resetView.calledOnce).to.be.true;
       expect(UserContact.calledOnce).to.be.true;
       expect(EnketoPrepopulationData.calledOnce).to.be.true;
@@ -542,7 +551,7 @@ describe('Enketo service', () => {
       const renderForm = sinon.spy(EnketoService.prototype, 'renderForm');
 
       try {
-        await service.render($('<div></div>'), mockEnketoDoc('myform'), data);
+        await service.render(new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), data));
         flush();
         expect.fail('Should throw error');
       } catch (error) {
@@ -572,10 +581,11 @@ describe('Enketo service', () => {
       ContactSummary.resolves({ context: { pregnant: false } });
 
       try {
-        await service.render($('<div></div>'), mockEnketoDoc('myform'));
+        await service.render(new EnketoFormContext('div', 'report', mockEnketoDoc('myform')));
         flush();
         expect.fail('Should throw error');
       } catch (error) {
+        expect(error).to.deep.equal({ translationKey: 'error.loading.form.no_authorized' });
         expect(UserContact.calledOnce).to.be.true;
         expect(xmlFormsService.canAccessForm.calledOnce).to.be.true;
         expect(xmlFormsService.canAccessForm.args[0]).to.have.deep.members([
@@ -585,10 +595,9 @@ describe('Enketo service', () => {
             internalId: 'myform',
           },
           { contact_id: '123-user-contact' },
-          { doc: undefined, contactSummary: undefined },
+          { doc: undefined, contactSummary: undefined, shouldEvaluateExpression: true },
         ]);
         expect(enketoInit.notCalled).to.be.true;
-        expect(error).to.deep.equal({ translationKey: 'error.loading.form.no_authorized' });
         expect(consoleErrorMock.notCalled).to.be.true;
         expect(feedbackService.submit.notCalled).to.be.true;
       }


### PR DESCRIPTION
#8589

(cherry picked from commit 5723cd3de99fad98450f475ced338ab22b502a2a)

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

medic/cht-core#8589

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.4.x-8589-cherry-pick/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.4.x-8589-cherry-pick/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.4.x-8589-cherry-pick/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

