### PR TITLE
fix(#8578): update scalability suite aws image

### DIFF
--- a/tests/scalability/launch-specification.json
+++ b/tests/scalability/launch-specification.json
@@ -10,8 +10,8 @@
     }
   ],
   "SecurityGroupIds": ["sg-0fa20cd785acec256"],
-  "ImageId": "ami-065ba2b6b298ed80f",
+  "ImageId": "ami-0a24ca1ef53e3d20f",
   "InstanceType": "c5.2xlarge",
-  "KeyName": "qa-scalability", 
+  "KeyName": "qa-scalability",
   "UserData": "IyEvYmluL2Jhc2gKc3VkbyBta2ZzIC10IGV4dDQgL2Rldi9udm1lMG4xOwpzdWRvIG1vdW50IC9kZXYvbnZtZTBuMSAvc3J2OwpzdWRvIGNobW9kIDc3NyAvc3J2OwpjZCAvc3J2OwpnaXQgY2xvbmUgaHR0cHM6Ly9naXRodWIuY29tL21lZGljL2NodC1pbmZyYXN0cnVjdHVyZS5naXQ7CmNkIGNodC1pbmZyYXN0cnVjdHVyZS9zZWxmLWhvc3RpbmcvcHJlcGFyZS1zeXN0ZW0vdWJ1bnR1LzsKbWtkaXIgLXAgL2hvbWUvbWVkaWMvc2VsZi1ob3N0aW5nL21haW4vCmVjaG8gRE9DS0VSX0NPVUNIREJfQURNSU5fUEFTU1dPUkQ9bWVkaWNTY2FsYWJpbGl0eSA+PiAvaG9tZS9tZWRpYy9zZWxmLWhvc3RpbmcvLmVudgplY2hvIEhBX1BBU1NXT1JEPW1lZGljU2NhbGFiaWxpdHkgPj4gL2hvbWUvbWVkaWMvc2VsZi1ob3N0aW5nLy5lbnYKLi9wcmVwYXJlLnNo"
 }

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -6,7 +6,7 @@ mkdir -p /cht
 chmod 777 /cht;
 
 # Install Docker CE
-apt-get update --allow-insecure-repositories
+apt-get update
 apt-get install -y \
     apt-transport-https \
     ca-certificates \
@@ -18,16 +18,16 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o 
 echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update --allow-insecure-repositories
-apt-get install -y docker-ce docker-ce-cli containerd.io --allow-insecure-repositories
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Install docker-compose
 curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" \
 -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 
-mkdir /cht/upgrade-service
-mkdir /cht/compose
+mkdir -p /cht/upgrade-service
+mkdir -p /cht/compose
 
 curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
   -o /cht/upgrade-service/docker-compose.yml

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -2,24 +2,24 @@
 set -e
 
 shutdown -P +60
-mkdir /cht
+mkdir -p /cht
 chmod 777 /cht;
 
 # Install Docker CE
-apt-get update
+apt-get update --allow-insecure-repositories
 apt-get install -y \
     apt-transport-https \
     ca-certificates \
     curl \
     gnupg \
-    lsb-release
+    lsb-release \
 
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
   "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io
+apt-get update --allow-insecure-repositories
+apt-get install -y docker-ce docker-ce-cli containerd.io --allow-insecure-repositories
 
 # Install docker-compose
 curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" \

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -13,7 +13,7 @@ git clone --single-branch --branch $TAG https://github.com/medic/cht-core.git;
 
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 
-apt-get update --allow-insecure-repositories
+apt-get update
 
 echo installing JAVA
 apt-get install default-jre -y

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -4,7 +4,7 @@ set -e
 
 shutdown -P +60
 
-mkdir /cht
+mkdir -p /cht
 chmod 777 /cht;
 cd cht
 
@@ -13,14 +13,13 @@ git clone --single-branch --branch $TAG https://github.com/medic/cht-core.git;
 
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 
-apt-get update
+apt-get update --allow-insecure-repositories
 
 echo installing JAVA
 apt-get install default-jre -y
 
 echo installing node
 apt-get install nodejs npm -y
-
 
 cd cht-core
 npm install patch-package

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -17,7 +17,7 @@ waitForBuildAvailable() {
 runInstance () {
   # --profile CA \ # for local runs
   echo $(aws ec2 run-instances \
-    --image-id ami-0c3d8c5445511bd1d \
+    --image-id ami-0a24ca1ef53e3d20f \
     --instance-type c5.2xlarge \
     --block-device-mappings file://block-device-mapping.json \
     --user-data file://$1 \

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -10,6 +10,7 @@ echo Triggering EC2 Run Instance Command and getting Instance ID
 waitForBuildAvailable() {
   until [ "$(curl -s -w '%{http_code}' -o /dev/null "$MARKET_URL_READ/$STAGING_SERVER/medic:medic:$TAG")" -eq 200 ]
   do
+    echo Waiting for CHT build to be available. Sleeping for 30.
     sleep 30
   done
 }

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -7,6 +7,13 @@ sed -i '4s~^~'BUILD=$MARKET_URL_READ/$STAGING_SERVER/medic:medic:$TAG'\n\n~' pre
 
 echo Triggering EC2 Run Instance Command and getting Instance ID
 
+waitForBuildAvailable() {
+  until [ "$(curl -s -w '%{http_code}' -o /dev/null "$MARKET_URL_READ/$STAGING_SERVER/medic:medic:$TAG")" -eq 200 ]
+  do
+    sleep 30
+  done
+}
+
 runInstance () {
   # --profile CA \ # for local runs
   echo $(aws ec2 run-instances \
@@ -96,6 +103,7 @@ getInstanceUrl () {
   fi
 }
 
+waitForBuildAvailable
 instanceResponse=$(runInstance "prepare-ec2.sh")
 instanceID=$(getInstanceId "$instanceResponse")
 echo Instance id is "$instanceID"


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Old image wouldn't run `apt-get update` command. 
Adds wait for build to be on the market, as opposed to crafting some convoluted GH actions settings (tried and didn't work) to wait for a different workflow to be successful. 

medic/cht-core#8578

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8578-fix-scalability-suite/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8578-fix-scalability-suite/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8578-fix-scalability-suite/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

