### PR TITLE
chore(#8375): make muting test more reliable

### DIFF
--- a/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
+++ b/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
@@ -253,7 +253,6 @@ describe('Muting', () => {
     before(async () => {
       await utils.saveDocs(contacts);
       await utils.createUsers([offlineUser]);
-      await loginPage.login({username: offlineUser.username, password: offlineUser.password});      
     });
 
     after(async () => {
@@ -269,6 +268,8 @@ describe('Muting', () => {
     });
 
     it( 'should not process muting client-side if not enabled', async () => {
+
+      await loginPage.login({username: offlineUser.username, password: offlineUser.password});
 
       const settingsWithDisabled = _.cloneDeep(settings);
       settingsWithDisabled.transitions.muting = { client_side: false };

--- a/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
+++ b/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
@@ -253,6 +253,9 @@ describe('Muting', () => {
     before(async () => {
       await utils.saveDocs(contacts);
       await utils.createUsers([offlineUser]);
+
+      await commonPage.goToBase();
+      await loginPage.login({username: offlineUser.username, password: offlineUser.password});
     });
 
     after(async () => {
@@ -268,9 +271,6 @@ describe('Muting', () => {
     });
 
     it( 'should not process muting client-side if not enabled', async () => {
-
-      await loginPage.login({username: offlineUser.username, password: offlineUser.password});
-
       const settingsWithDisabled = _.cloneDeep(settings);
       settingsWithDisabled.transitions.muting = { client_side: false };
 

--- a/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
+++ b/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
@@ -254,7 +254,7 @@ describe('Muting', () => {
       await utils.saveDocs(contacts);
       await utils.createUsers([offlineUser]);
 
-      await commonPage.goToBase();
+      await browser.url('/');
       await loginPage.login({username: offlineUser.username, password: offlineUser.password});
     });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This feels brute force and if you have any better ideas I'm open to them, but essentially the test fails because it can't log in because an "update is available". This just forces a reload to the login page.

medic/cht-core#8375

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8375-retry-login/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8375-retry-login/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8375-retry-login/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

