### PR TITLE
chore: use existent images when running ci e2e locally

### DIFF
--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -929,12 +929,10 @@ const getTemplateComposeFilePath = file => path.resolve(__dirname, '../..', 'scr
 const getTestComposeFilePath = file => path.resolve(__dirname, `../${file}-test.yml`);
 
 const generateComposeFiles = async () => {
-  const useExistingImages = process.argv.find(arg => arg === '--use-existing');
-  if (useExistingImages) {
-    const oldFilesExist = COMPOSE_FILES.every(file => fs.existsSync(getTestComposeFilePath(file)));
-    if (oldFilesExist) {
-      return;
-    }
+  const useExistingImages = !process.env.VERSION;
+  const composeFilesExist = COMPOSE_FILES.every(file => fs.existsSync(getTestComposeFilePath(file)));
+  if (useExistingImages && composeFilesExist) {
+    return;
   }
 
   const view = {

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1047,7 +1047,7 @@ const saveLogs = async () => {
 const tearDownServices = async () => {
   await saveLogs();
   if (!DEBUG) {
-    await dockerComposeCmd('down', '-t', '0', '--remove-orphans', '--volumes');
+    await dockerComposeCmd('down', '-t', '0', '--remove-orphans', '--volumes', '--rmi');
   }
 };
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -929,6 +929,14 @@ const getTemplateComposeFilePath = file => path.resolve(__dirname, '../..', 'scr
 const getTestComposeFilePath = file => path.resolve(__dirname, `../${file}-test.yml`);
 
 const generateComposeFiles = async () => {
+  const useExistingImages = process.argv.find(arg => arg === '--use-existing');
+  if (useExistingImages) {
+    const oldFilesExist = COMPOSE_FILES.every(file => fs.existsSync(getTestComposeFilePath(file)));
+    if (oldFilesExist) {
+      return;
+    }
+  }
+
   const view = {
     repo: buildVersions.getRepo(),
     tag: buildVersions.getImageTag(),


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

When running e2e tests locally, all the `-local` npm tasks include a build image step. 
With this change, running the ci version of e2e test command will try to reuse existent docker-compose files and existent images.  
Adds `rmi` flag to `docker-compose down` to automatically remove test images.  

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:reuse-old-test-images/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:reuse-old-test-images/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:reuse-old-test-images/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

