### PR TITLE
chore(monkey-patch-node): Node 8 upgrade script

### DIFF
--- a/scripts/cht-3x-node-upgrade/upgrade.sh
+++ b/scripts/cht-3x-node-upgrade/upgrade.sh
@@ -23,7 +23,8 @@ else
   NODE_VERSION="8.17.0"
 fi
 
-BRANCH="node-8-upgrade-script"
+# change BRANCH to "node-8-upgrade-script" to test before merging PR
+BRANCH="master"
 FILE="/srv/node.${NODE_VERSION}.zip"
 URL="https://raw.githubusercontent.com/medic/cht-core/$BRANCH/scripts/cht-3x-node-upgrade/node.${NODE_VERSION}.zip"
 

--- a/scripts/cht-3x-node-upgrade/upgrade.sh
+++ b/scripts/cht-3x-node-upgrade/upgrade.sh
@@ -1,18 +1,32 @@
 #!/bin/bash
 
 #####################################################
-# Upgrade node from 8 -> 12                         #
+# Upgrade node from 8 to latest 8 or 12             #
+# Defaults to version 12, but you can               #
+#     pass "8" or "12" as arguments                 #
 #                                                   #
 # Only for use on CHT 3.x instances that have       #
 # TLS issues on outbound push                       #
 #                                                   #
 # see https://github.com/medic/cht-core/issues/7957 #
+# see https://github.com/medic/config-muso/issues/1016 #
 #                                                   #
 #####################################################
 
-echo "Start...Node version installed:"
-/srv/software/medic-core/v2.1.1/x64/bin/node -v
+set -e
 
+NODE_VERSION="${1:-12}"
+
+if( "$NODE_VERSION" = "12" );then
+  NODE_VERSION="12.22.12"
+else
+  NODE_VERSION="8.17.0"
+fi
+
+echo "Start to install latest Node $NODE_VERSION..."
+
+echo "Current Node version installed before upgrade:"
+/srv/software/medic-core/v2.1.1/x64/bin/node -v
 
 echo ""
 echo "Installing zip..."
@@ -34,12 +48,12 @@ echo ""
 echo "Downloading node and installing..."
 echo ""
 
-curl -so /srv/node.12.22.12.zip https://raw.githubusercontent.com/medic/cht-core/master/scripts/cht-3x-node-upgrade/node.12.22.12.zip
+curl -so /srv/node.$NODE_VERSION.zip https://raw.githubusercontent.com/medic/cht-core/master/scripts/cht-3x-node-upgrade/node.$NODE_VERSION.zip
 
-unzip /srv/node.12.22.12.zip
+unzip /srv/node.$NODE_VERSION.zip
 chmod +x node
 mv /srv/node /srv/software/medic-core/v2.1.1/x64/bin/node
-rm /srv/node.12.22.12.zip
+rm /srv/node.$NODE_VERSION.zip
 
 
 echo ""

--- a/scripts/cht-3x-node-upgrade/upgrade.sh
+++ b/scripts/cht-3x-node-upgrade/upgrade.sh
@@ -17,13 +17,19 @@ set -e
 
 NODE_VERSION="${1:-12}"
 
-if( "$NODE_VERSION" = "12" );then
+if [ "$NODE_VERSION" = "12" ];then
   NODE_VERSION="12.22.12"
 else
   NODE_VERSION="8.17.0"
 fi
 
-echo "Start to install latest Node $NODE_VERSION..."
+BRANCH="node-8-upgrade-script"
+FILE="/srv/node.${NODE_VERSION}.zip"
+URL="https://raw.githubusercontent.com/medic/cht-core/$BRANCH/scripts/cht-3x-node-upgrade/node.${NODE_VERSION}.zip"
+
+echo ""
+echo "Start to install latest Node ${NODE_VERSION}..."
+echo ""
 
 echo "Current Node version installed before upgrade:"
 /srv/software/medic-core/v2.1.1/x64/bin/node -v
@@ -34,8 +40,8 @@ echo ""
 
 cd /srv
 
-apt -qq update
-apt  -qq install -y zip
+apt-get -qq update
+apt-get -qq install -y zip
 echo ""
 echo "Stopping services..."
 echo ""
@@ -47,13 +53,16 @@ echo ""
 echo ""
 echo "Downloading node and installing..."
 echo ""
+echo "Writing to: $FILE"
+echo "Curling from: $URL"
+echo ""
 
-curl -so /srv/node.$NODE_VERSION.zip https://raw.githubusercontent.com/medic/cht-core/master/scripts/cht-3x-node-upgrade/node.$NODE_VERSION.zip
+curl -so $FILE $URL
 
-unzip /srv/node.$NODE_VERSION.zip
+unzip $FILE
 chmod +x node
 mv /srv/node /srv/software/medic-core/v2.1.1/x64/bin/node
-rm /srv/node.$NODE_VERSION.zip
+rm /srv/node.${NODE_VERSION}.zip
 
 
 echo ""


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR enables partners who are running out of support CHT 3.x versions to upgrade their node versions in the container.  Node binary is written to `/srv` when upgraded, so persist across reboots.  The script existed before to help with #7957, but a partner wanted to ugprade to latest node `8.x`, so this PR expands the script to support both Node 12 and node 8, with backwards comparability to default to `12`

## To test
* deploy CHT3.x [locally](https://docs.communityhealthtoolkit.org/apps/guides/hosting/3.x/app-developer/)
* List running containers with `docker ps` - look for the `medic-os` one you just started. 
* Assuming it's called `cht3x-docker-medic-os-1`, you can get shell by calling `docker exec -it  cht3x-docker-medic-os-1 /bin/bash`
* download the script from this branch: `curl -o /srv/upgrade.sh https://raw.githubusercontent.com/medic/cht-core/node-8-upgrade-script/scripts/cht-3x-node-upgrade/upgrade.sh`
* make it executable: `cd /srv/;chmod +x upgrade.sh`
* On line `27` change `BRANCH` to be the branch `node-8-upgrade-script` as it's not yet merged to `master` yet
* run the script 3 times:
   1. once with no input (`./upgrade.sh`) ensuring it upgrades to Node 12 - backwards compatible
   2. once with `12` input (`./upgrade.sh 12`) ensuring it still upgrades to Node 12
   3. Once with `8` input (`./upgrade.sh 8`)  to ensure it upgrades to 8
* After each upgrade ensure web UI works and all services are nominal 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:node-8-upgrade-script/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:node-8-upgrade-script/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:node-8-upgrade-script/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

