### PR TITLE
fix(#8556): make xpath date extensions consistent

### DIFF
--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -85,13 +85,13 @@ const asMoment = (r) => {
     // Create a date at 00:00:00 1st Jan 1970 _in the current timezone_
     const date = new Date(1970, 0, 1);
     date.setDate(1 + days);
-    return moment.utc(date);
+    return moment(date);
   };
   switch (r.t) {
   case 'bool':
-    return moment.utc(NaN);
+    return moment(NaN);
   case 'date':
-    return moment.utc(r.v);
+    return moment(r.v);
   case 'num':
     return dateSinceUnixEpoch(r.v);
   case 'arr':
@@ -100,7 +100,7 @@ const asMoment = (r) => {
     if (RAW_NUMBER.test(r)) {
       return dateSinceUnixEpoch(parseInt(r, 10));
     }
-    const rMoment = moment.utc(r);
+    const rMoment = moment(r);
     if (DATE_STRING.test(r) && rMoment.isValid()) {
       if (r.indexOf('T')) {
         return rMoment;
@@ -108,7 +108,7 @@ const asMoment = (r) => {
 
       const rDate = rMoment.format('YYYY-MM-DD');
       const time = `${rDate}T00:00:00.000${getTimezoneOffsetAsTime(new Date(rDate))}`;
-      return moment.utc(time);
+      return moment(time);
     }
     return rMoment;
   }

--- a/webapp/src/js/enketo/medic-xpath-extensions.js
+++ b/webapp/src/js/enketo/medic-xpath-extensions.js
@@ -85,13 +85,13 @@ const asMoment = (r) => {
     // Create a date at 00:00:00 1st Jan 1970 _in the current timezone_
     const date = new Date(1970, 0, 1);
     date.setDate(1 + days);
-    return moment(date);
+    return moment.utc(date);
   };
   switch (r.t) {
   case 'bool':
-    return moment(NaN);
+    return moment.utc(NaN);
   case 'date':
-    return moment(r.v);
+    return moment.utc(r.v);
   case 'num':
     return dateSinceUnixEpoch(r.v);
   case 'arr':
@@ -100,7 +100,7 @@ const asMoment = (r) => {
     if (RAW_NUMBER.test(r)) {
       return dateSinceUnixEpoch(parseInt(r, 10));
     }
-    const rMoment = moment(r);
+    const rMoment = moment.utc(r);
     if (DATE_STRING.test(r) && rMoment.isValid()) {
       if (r.indexOf('T')) {
         return rMoment;
@@ -108,9 +108,9 @@ const asMoment = (r) => {
 
       const rDate = rMoment.format('YYYY-MM-DD');
       const time = `${rDate}T00:00:00.000${getTimezoneOffsetAsTime(new Date(rDate))}`;
-      return moment(time);
+      return moment.utc(time);
     }
-    return moment(r);
+    return rMoment;
   }
   }
 };

--- a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
+++ b/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
@@ -9,9 +9,14 @@ const func = medicXpathExtensions.func;
 const getTimezoneOffset = Date.prototype.getTimezoneOffset;
 
 describe('medic-xpath-extensions', function() {
-  afterEach(done => {
+
+  beforeEach(() => {
+    // make the result consistent regardless of which timezone the test is run in
+    Date.prototype.getTimezoneOffset = () => -240;
+  });
+
+  afterEach(() => {
     Date.prototype.getTimezoneOffset = getTimezoneOffset;
-    done();
   });
 
   describe('getTimezoneOffsetAsTime()', function() {
@@ -37,6 +42,7 @@ describe('medic-xpath-extensions', function() {
   });
 
   describe('#difference-in-months', function() {
+
     [
       [ '2015-10-01', '2015-10-01', 0, ],
       [ '2015-09-01', '2015-10-01', 1, ],
@@ -97,25 +103,17 @@ describe('medic-xpath-extensions', function() {
   });
 
   describe('#to-bikram-sambat()', () => {
+
     [
       [ { t: 'str', v: '2015-9-2' }, '१६ भदौ २०७२'],
       [ { t: 'str', v: '1999-12-12' }, '२६ मंसिर २०५६'],
-      [ { t: 'date', v: new Date('2015-10-01T00:00:00.000+0000') }, '१४ असोज २०७२'],
+      [ { t: 'date', v: new Date('2015-10-01T00:00:00.000') }, '१४ असोज २०७२'],
+      [ { t: 'num', v: 11111 }, '२१ जेठ २०५७'],
       [ { t: 'arr', v: [{ textContent: '2014-09-22' }] }, '६ असोज २०७१'],
     ].forEach(([date, expected]) => {
       it(`should format the ${date.t} [${JSON.stringify(date.v)}] according to the Bikram Sambat calendar`, () => {
         assert.equal(func['to-bikram-sambat'](date).v, expected);
       });
-    });
-
-    // "num" is a special case because it uses the local timezone. To make this test work in all timezones
-    // we just compare it to the equivalent Date function.
-    it(`should format the num 11111 according to the Bikram Sambat calendar`, () => {
-      const value = 11111; // days since epoch
-      const date = new Date((value - 1) * 24 * 60 * 60 * 1000);
-      const expected = func['to-bikram-sambat']({ t: 'date', v: date }).v;
-      const actual = func['to-bikram-sambat']({ t: 'num', v: value }).v;
-      assert.equal(actual, expected);
     });
 
     [
@@ -138,6 +136,7 @@ describe('medic-xpath-extensions', function() {
   });
 
   describe('#add-date()', () => {
+
     const display = value => value ? value.v : '';
 
     [
@@ -148,8 +147,8 @@ describe('medic-xpath-extensions', function() {
       ],
       [
         [null, { t: 'num', v: 1 }],
-        { t: 'date', v: new Date('2015-10-01T00:00+0000') },
-        '2015-11-01T00:00+0000'
+        { t: 'date', v: new Date('2015-10-01T00:00') },
+        '2015-11-01T00:00'
       ],
       [
         [null, null, { t: 'num', v: 1 }],
@@ -198,8 +197,8 @@ describe('medic-xpath-extensions', function() {
       ],
       [
         [{ t: 'num', v: 1 }],
-        { t: 'str', v: 'Sept 9 2015 00:00+0000' },
-        '2016-09-09T00:00+0000'
+        { t: 'str', v: 'Sept 9 2015 00:00' },
+        '2016-09-09T00:00'
       ],
       [
         [{ t: 'num', v: 1 }],
@@ -209,7 +208,7 @@ describe('medic-xpath-extensions', function() {
       [
         [{ t: 'num', v: 1 }],
         { t: 'arr', v: [{ textContent: '2014-09-22' }] },
-        '2015-09-22T00:00+0000'
+        '2015-09-22T00:00'
       ],
       [
         [{ t: 'str', v: '111' }, null, { t: 'str', v: '-1' }],

--- a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
+++ b/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
@@ -148,8 +148,8 @@ describe('medic-xpath-extensions', function() {
       ],
       [
         [null, { t: 'num', v: 1 }],
-        { t: 'date', v: new Date('2015-10-01T00:00') },
-        '2015-11-01T00:00'
+        { t: 'date', v: new Date('2015-10-01T00:00+0000') },
+        '2015-11-01T00:00+0000'
       ],
       [
         [null, null, { t: 'num', v: 1 }],
@@ -198,8 +198,8 @@ describe('medic-xpath-extensions', function() {
       ],
       [
         [{ t: 'num', v: 1 }],
-        { t: 'str', v: 'Sept 9 2015 00:00' },
-        '2016-09-09T00:00'
+        { t: 'str', v: 'Sept 9 2015 00:00+0000' },
+        '2016-09-09T00:00+0000'
       ],
       [
         [{ t: 'num', v: 1 }],
@@ -209,7 +209,7 @@ describe('medic-xpath-extensions', function() {
       [
         [{ t: 'num', v: 1 }],
         { t: 'arr', v: [{ textContent: '2014-09-22' }] },
-        '2015-09-22T00:00'
+        '2015-09-22T00:00+0000'
       ],
       [
         [{ t: 'str', v: '111' }, null, { t: 'str', v: '-1' }],

--- a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
+++ b/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
@@ -48,14 +48,14 @@ describe('medic-xpath-extensions', function() {
       [ '2015-10-01T11:11:11.111', '2014-10-01T11:11:11.111', -12, ],
       [ '2014-10-01T00:00:00.000', '2015-10-01T00:00:00.000', 12, ],
       [ 'August 19, 1975 00:00:00 GMT', 'August 18, 1976 23:15:30 GMT+07:00', 11 ],
-      [ 'Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 22:00:00 GMT+2300', 0],
+      [ 'Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 24 2005 22:00:00 GMT+2300', 0],
       [ 'Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 22:00:00 GMT+2200', 1]
     ].forEach(function(example) {
       const d1 = { t: 'str', v: example[0] };
       const d2 = { t: 'str', v: example[1] };
       const expectedDifference = example[2];
 
-      it('should report difference between ' + d1 + ' and ' + d2 + ' as ' + expectedDifference, function() {
+      it(`should report difference between ${d1.v} and ${d2.v} as ${expectedDifference}`, function() {
         assert.equal(func['difference-in-months'](d1, d2).v, expectedDifference);
       });
     });
@@ -100,13 +100,22 @@ describe('medic-xpath-extensions', function() {
     [
       [ { t: 'str', v: '2015-9-2' }, '१६ भदौ २०७२'],
       [ { t: 'str', v: '1999-12-12' }, '२६ मंसिर २०५६'],
-      [ { t: 'date', v: new Date('2015-10-01T00:00:00.000') }, '१४ असोज २०७२'],
-      [ { t: 'num', v: 11111 }, '२१ जेठ २०५७'],
+      [ { t: 'date', v: new Date('2015-10-01T00:00:00.000+0000') }, '१४ असोज २०७२'],
       [ { t: 'arr', v: [{ textContent: '2014-09-22' }] }, '६ असोज २०७१'],
     ].forEach(([date, expected]) => {
       it(`should format the ${date.t} [${JSON.stringify(date.v)}] according to the Bikram Sambat calendar`, () => {
         assert.equal(func['to-bikram-sambat'](date).v, expected);
       });
+    });
+
+    // "num" is a special case because it uses the local timezone. To make this test work in all timezones
+    // we just compare it to the equivalent Date function.
+    it(`should format the num 11111 according to the Bikram Sambat calendar`, () => {
+      const value = 11111; // days since epoch
+      const date = new Date((value - 1) * 24 * 60 * 60 * 1000);
+      const expected = func['to-bikram-sambat']({ t: 'date', v: date }).v;
+      const actual = func['to-bikram-sambat']({ t: 'num', v: value }).v;
+      assert.equal(actual, expected);
     });
 
     [


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

[description]

medic/cht-core#8556

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8556-fix-xpath-extensions-tests-in-nzt/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8556-fix-xpath-extensions-tests-in-nzt/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8556-fix-xpath-extensions-tests-in-nzt/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

