### PR TITLE
chore: Flaky test - permission-enabled and incorrect-locale

### DIFF
--- a/tests/e2e/default/more-options-menu/online-user/permissions-enabled.wdio-spec.js
+++ b/tests/e2e/default/more-options-menu/online-user/permissions-enabled.wdio-spec.js
@@ -53,7 +53,7 @@ const smsReport = reportFactory
     { patient, submitter: contact, fields: { lmp_date: 'Dec 3, 2022', patient_id: patient._id}, },
   );
 
-describe('Online User', () => {
+describe('Menu options display - Online user', () => {
   before(async () => await loginPage.cookieLogin());
 
   after(async () => {
@@ -63,13 +63,15 @@ describe('Online User', () => {
 
   afterEach(async () => await commonPage.goToBase());
 
-  it('Options disabled when no items - messages, contacts, people - Message tab', async () => {
-    await commonPage.goToMessages();
-    await commonPage.openMoreOptionsMenu();
-    expect(await commonPage.isMenuOptionEnabled('export', 'messages')).to.be.false;
-  });
+  it('should disabled the export option in Message tab when there are no messages, contacts or people created',
+    async () => {
+      await commonPage.goToMessages();
+      await commonPage.openMoreOptionsMenu();
+      expect(await commonPage.isMenuOptionEnabled('export', 'messages')).to.be.false;
+    });
 
-  it('Options disabled when no items - messages, contacts, people - Contact tab', async () => {
+  it('should disabled the export option and hide the edit and delete options in Contact tab ' +
+    'when there are no messages, contacts or people created', async () => {
     await commonPage.goToPeople();
     await commonPage.openMoreOptionsMenu();
     expect(await commonPage.isMenuOptionEnabled('export', 'contacts')).to.be.false;
@@ -77,7 +79,8 @@ describe('Online User', () => {
     expect(await commonPage.isMenuOptionVisible('delete', 'contacts')).to.be.false;
   });
 
-  it('Options disabled when no items - messages, contacts, people - Report tab', async () => {
+  it('should disabled the export option and hide the edit and delete options in Report tab ' +
+    'when there are no messages, contacts or people created', async () => {
     await commonPage.goToReports();
     await commonPage.openMoreOptionsMenu();
     expect(await commonPage.isMenuOptionEnabled('export', 'reports')).to.be.false;
@@ -85,7 +88,8 @@ describe('Online User', () => {
     expect(await commonPage.isMenuOptionVisible('delete', 'reports')).to.be.false;
   });
 
-  it('Contact tab - no contact selected', async () => {
+  it('should show the export option and hide the edit and delete options in Contact tab ' +
+    'when none of the contacts was opened', async () => {
     await utils.saveDocs([...places.values(), contact, patient]);
     await sentinelUtils.waitForSentinel();
     await commonPage.goToPeople();
@@ -96,7 +100,7 @@ describe('Online User', () => {
   });
 });
 
-describe('Online User - Options enabled when there are items', () => {
+describe('Options enabled when there are items - Online user', () => {
   before(async () => {
     await utils.saveDocs([...places.values(), contact]);
     await utils.createUsers([onlineUser]);
@@ -115,7 +119,15 @@ describe('Online User - Options enabled when there are items', () => {
 
   afterEach(async () => await commonPage.goToBase());
 
-  it('Reports tab - Edit invisible when NON XML report selected', async () => {
+  it('should show the export option in Message tab', async () => {
+    await commonPage.goToMessages();
+    await commonPage.waitForLoaderToDisappear();
+    await commonPage.openMoreOptionsMenu();
+    expect(await commonPage.isMenuOptionEnabled('export', 'messages')).to.be.true;
+  });
+
+  it('should show the export and delete options and hide the edit option in Report tab ' +
+    'when a NON XML report is selected', async () => {
     await commonPage.goToReports();
     await reportPage.goToReportById(smsReportId);
     await (await reportPage.reportBodyDetails()).waitForDisplayed();
@@ -125,14 +137,8 @@ describe('Online User - Options enabled when there are items', () => {
     expect(await commonPage.isMenuOptionEnabled('delete', 'reports')).to.be.true;
   });
 
-  it('Message tab', async () => {
-    await commonPage.goToMessages();
-    await commonPage.waitForLoaderToDisappear();
-    await commonPage.openMoreOptionsMenu();
-    expect(await commonPage.isMenuOptionEnabled('export', 'messages')).to.be.true;
-  });
-
-  it('Reports tab - options enabled when XML report selected', async () => {
+  it('should show the export, edit and delete options in Report tab ' +
+    'when a XML report is selected', async () => {
     await reportPage.goToReportById(xmlReportId);
     await reportPage.reportBodyDetails().waitForDisplayed();
     await commonPage.openMoreOptionsMenu();
@@ -141,7 +147,8 @@ describe('Online User - Options enabled when there are items', () => {
     expect(await commonPage.isMenuOptionEnabled('delete', 'reports')).to.be.true;
   });
 
-  it('Contact Tab  - contact selected', async () => {
+  it('should show the export, edit and delete options in Contact tab ' +
+    'when a contact was opened', async () => {
     await commonPage.goToPeople(contact._id);
     await commonPage.openMoreOptionsMenu();
     expect(await commonPage.isMenuOptionEnabled('export', 'contacts')).to.be.true;

--- a/tests/e2e/default/more-options-menu/online-user/permissions-enabled.wdio-spec.js
+++ b/tests/e2e/default/more-options-menu/online-user/permissions-enabled.wdio-spec.js
@@ -63,7 +63,7 @@ describe('Menu options display - Online user', () => {
 
   afterEach(async () => await commonPage.goToBase());
 
-  it('should disabled the export option in Message tab when there are no messages, contacts or people created',
+  it('should disabled the export option in Message tab when there are no messages, contacts or people created.',
     async () => {
       await commonPage.goToMessages();
       await commonPage.openMoreOptionsMenu();
@@ -71,7 +71,7 @@ describe('Menu options display - Online user', () => {
     });
 
   it('should disabled the export option and hide the edit and delete options in Contact tab ' +
-    'when there are no messages, contacts or people created', async () => {
+    'when there are no messages, contacts or people created.', async () => {
     await commonPage.goToPeople();
     await commonPage.openMoreOptionsMenu();
     expect(await commonPage.isMenuOptionEnabled('export', 'contacts')).to.be.false;
@@ -80,7 +80,7 @@ describe('Menu options display - Online user', () => {
   });
 
   it('should disabled the export option and hide the edit and delete options in Report tab ' +
-    'when there are no messages, contacts or people created', async () => {
+    'when there are no messages, contacts or people created.', async () => {
     await commonPage.goToReports();
     await commonPage.openMoreOptionsMenu();
     expect(await commonPage.isMenuOptionEnabled('export', 'reports')).to.be.false;
@@ -89,7 +89,7 @@ describe('Menu options display - Online user', () => {
   });
 
   it('should show the export option and hide the edit and delete options in Contact tab ' +
-    'when none of the contacts was opened', async () => {
+    'when none of the contacts was opened.', async () => {
     await utils.saveDocs([...places.values(), contact, patient]);
     await sentinelUtils.waitForSentinel();
     await commonPage.goToPeople();
@@ -119,7 +119,7 @@ describe('Options enabled when there are items - Online user', () => {
 
   afterEach(async () => await commonPage.goToBase());
 
-  it('should show the export option in Message tab', async () => {
+  it('should show the export option in Message tab.', async () => {
     await commonPage.goToMessages();
     await commonPage.waitForLoaderToDisappear();
     await commonPage.openMoreOptionsMenu();
@@ -127,7 +127,7 @@ describe('Options enabled when there are items - Online user', () => {
   });
 
   it('should show the export and delete options and hide the edit option in Report tab ' +
-    'when a NON XML report is selected', async () => {
+    'when a NON XML report is selected.', async () => {
     await commonPage.goToReports();
     await reportPage.goToReportById(smsReportId);
     await (await reportPage.reportBodyDetails()).waitForDisplayed();
@@ -138,7 +138,7 @@ describe('Options enabled when there are items - Online user', () => {
   });
 
   it('should show the export, edit and delete options in Report tab ' +
-    'when a XML report is selected', async () => {
+    'when a XML report is selected.', async () => {
     await reportPage.goToReportById(xmlReportId);
     await reportPage.reportBodyDetails().waitForDisplayed();
     await commonPage.openMoreOptionsMenu();
@@ -148,7 +148,7 @@ describe('Options enabled when there are items - Online user', () => {
   });
 
   it('should show the export, edit and delete options in Contact tab ' +
-    'when a contact was opened', async () => {
+    'when a contact was opened.', async () => {
     await commonPage.goToPeople(contact._id);
     await commonPage.openMoreOptionsMenu();
     expect(await commonPage.isMenuOptionEnabled('export', 'contacts')).to.be.true;

--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -4,31 +4,32 @@ const userSettingsElements = require('@page-objects/default/users/user-settings.
 const contactElements = require('@page-objects/default/contacts/contacts.wdio.page');
 const loginPage = require('@page-objects/default/login/login.wdio.page');
 const placeFactory = require('@factories/cht/contacts/place');
+const sentinelUtils = require('@utils/sentinel');
+
+const languageCode = 'hil';
+const createLanguage = async () =>  {
+  await utils.addTranslations(languageCode, {
+    'n.month': '{MONTHS, plural, =1{1 luna} other{# luni}}',
+    'n.week': '{WEEKS, plural, =1{1 saptamana} other{# saptamani}}',
+    'reports.none.n.months':
+      '{MONTHS, plural, =1{No reports in the last month.} other{No reports in the last # months.}}',
+    'task.days.left': '{DAYS, plural, =1{1 day left} other{# days left}',
+    'tasks.none.n.weeks': '{WEEKS, plural, =1{No tasks in the next week.} other{No tasks in the next # weeks.}}',
+    'Reports': 'HilReports',
+    'view.all': 'View all'
+  });
+  await utils.enableLanguage(languageCode);
+};
+
+const contact = placeFactory.place().build({
+  _id: 'district_hil_locale',
+  name: 'hil district',
+  type: 'district_hospital',
+  reported_date: 1000,
+  parent: '',
+});
 
 describe('Testing Incorrect locale', () => {
-  const languageCode = 'hil';
-  const createLanguage = async () =>  {
-    await utils.addTranslations(languageCode, {
-      'n.month': '{MONTHS, plural, =1{1 luna} other{# luni}}',
-      'n.week': '{WEEKS, plural, =1{1 saptamana} other{# saptamani}}',
-      'reports.none.n.months':
-        '{MONTHS, plural, =1{No reports in the last month.} other{No reports in the last # months.}}',
-      'task.days.left': '{DAYS, plural, =1{1 day left} other{# days left}',
-      'tasks.none.n.weeks': '{WEEKS, plural, =1{No tasks in the next week.} other{No tasks in the next # weeks.}}',
-      'Reports': 'HilReports',
-      'view.all': 'View all'
-    });
-    await utils.enableLanguage(languageCode);
-  };
-
-  const contact = placeFactory.place().build({
-    _id: 'district_hil_locale',
-    name: 'hil district',
-    type: 'district_hospital',
-    reported_date: 1000,
-    parent: '',
-  });
-
   after(async () => {
     await browser.setCookies({ name: 'locale', value: 'en' });
     await utils.revertSettings(true);
@@ -37,6 +38,7 @@ describe('Testing Incorrect locale', () => {
   before(async () => {
     await loginPage.cookieLogin();
     await utils.saveDoc(contact);
+    await sentinelUtils.waitForSentinel();
     const waitForServiceWorker = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);
     await createLanguage();
     await waitForServiceWorker.promise;


### PR DESCRIPTION
# Description

This PR contains:

- Delete `describe` inside `describe`
- Make all the tests independent
- Remove code inside the `describe` section

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:flaky-permission-enabled-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:flaky-permission-enabled-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:flaky-permission-enabled-test/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

