### PR TITLE
fix(#8131): display training cards after accepting privacy policies

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2295,9 +2295,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5063,9 +5063,9 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -7967,9 +7967,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -10040,9 +10040,9 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.11.0",

--- a/tests/e2e/default/enketo/training-cards.wdio-spec.js
+++ b/tests/e2e/default/enketo/training-cards.wdio-spec.js
@@ -9,6 +9,8 @@ const userFactory = require('@factories/cht/users/users');
 const personFactory = require('@factories/cht/contacts/person');
 const commonElements = require('@page-objects/default/common/common.wdio.page');
 const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
+const privacyPolicyFactory = require('@factories/cht/settings/privacy-policy');
+const privacyPage = require('@page-objects/default/privacy-policy/privacy-policy.wdio.page');
 
 describe('Training Cards', () => {
   const parent = placeFactory.place().build({ _id: 'dist1', type: 'district_hospital' });
@@ -87,6 +89,19 @@ describe('Training Cards', () => {
     expect(introCard).to.equal(
       'There have been some changes to icons in your app. The next few screens will show you the difference.'
     );
+  });
+
+  it('should display training after privacy policy', async () => {
+    const privacyPolicy = privacyPolicyFactory.privacyPolicy().build();
+    await utils.saveDocs([privacyPolicy]);
+    await commonPage.goToReports();
+    await commonElements.sync();
+    await browser.refresh();
+
+    await trainingCardsPage.checkTrainingCardIsNotDisplayed();
+    await privacyPage.waitAndAcceptPolicy(await privacyPage.privacyWrapper(), privacyPolicyFactory.english, false);
+    await trainingCardsPage.waitForTrainingCards();
+    await trainingCardsPage.quitTraining();
   });
 
   it('should display training after reload and complete training', async () => {

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -46,6 +46,7 @@ import { AnalyticsActions } from '@mm-actions/analytics';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
 import { OLD_REPORTS_FILTER_PERMISSION } from '@mm-modules/reports/reports-filters.component';
 import { OLD_ACTION_BAR_PERMISSION } from '@mm-components/actionbar/actionbar.component';
+import {show} from "jsverify";
 
 const SYNC_STATUS = {
   inProgress: {
@@ -93,6 +94,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   unreadCount = {};
   useOldActionBar = false;
   initialisationComplete = false;
+  trainingCardFormId = false;
 
   constructor (
     private dbSyncService:DBSyncService,
@@ -428,28 +430,49 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   private subscribeToStore() {
-    combineLatest(
+    combineLatest([
       this.store.select(Selectors.getReplicationStatus),
       this.store.select(Selectors.getAndroidAppVersion),
       this.store.select(Selectors.getCurrentTab),
-      this.store.select(Selectors.getPrivacyPolicyAccepted),
-      this.store.select(Selectors.getShowPrivacyPolicy),
       this.store.select(Selectors.getSelectMode),
-    ).subscribe(([
+    ]).subscribe(([
       replicationStatus,
       androidAppVersion,
       currentTab,
-      privacyPolicyAccepted,
-      showPrivacyPolicy,
       selectMode,
     ]) => {
       this.replicationStatus = replicationStatus;
       this.androidAppVersion = androidAppVersion;
       this.currentTab = currentTab;
-      this.showPrivacyPolicy = showPrivacyPolicy;
-      this.privacyPolicyAccepted = privacyPolicyAccepted;
+
       this.selectMode = selectMode;
     });
+
+    combineLatest([
+        this.store.select(Selectors.getPrivacyPolicyAccepted),
+        this.store.select(Selectors.getShowPrivacyPolicy),
+        this.store.select(Selectors.getTrainingCardFormId)
+    ]).subscribe(([
+      privacyPolicyAccepted,
+      showPrivacyPolicy,
+      trainingCardFormId,
+    ]) => {
+      this.showPrivacyPolicy = showPrivacyPolicy;
+      this.privacyPolicyAccepted = privacyPolicyAccepted;
+      this.trainingCardFormId = trainingCardFormId;
+      this.displayTrainingCards();
+    });
+  }
+
+  private displayTrainingCards() {
+    if (this.showPrivacyPolicy && !this.privacyPolicyAccepted) {
+      return;
+    }
+    if (!this.trainingCardFormId) {
+      return;
+    }
+
+    this.trainingCardsService.displayTrainingCards();
   }
 
   private async subscribeToSideFilterStore() {

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -449,9 +449,9 @@ export class AppComponent implements OnInit, AfterViewInit {
     });
 
     combineLatest([
-        this.store.select(Selectors.getPrivacyPolicyAccepted),
-        this.store.select(Selectors.getShowPrivacyPolicy),
-        this.store.select(Selectors.getTrainingCardFormId)
+      this.store.select(Selectors.getPrivacyPolicyAccepted),
+      this.store.select(Selectors.getShowPrivacyPolicy),
+      this.store.select(Selectors.getTrainingCardFormId),
     ]).subscribe(([
       privacyPolicyAccepted,
       showPrivacyPolicy,

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -46,7 +46,6 @@ import { AnalyticsActions } from '@mm-actions/analytics';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
 import { OLD_REPORTS_FILTER_PERMISSION } from '@mm-modules/reports/reports-filters.component';
 import { OLD_ACTION_BAR_PERMISSION } from '@mm-components/actionbar/actionbar.component';
-import {show} from "jsverify";
 
 const SYNC_STATUS = {
   inProgress: {

--- a/webapp/src/ts/modals/training-cards/training-cards.component.ts
+++ b/webapp/src/ts/modals/training-cards/training-cards.component.ts
@@ -105,12 +105,12 @@ export class TrainingCardsComponent implements OnInit, OnDestroy {
   }
 
   private subscribeToStore() {
-    const reduxSubscription = combineLatest(
+    const reduxSubscription = combineLatest([
       this.store.select(Selectors.getEnketoStatus),
       this.store.select(Selectors.getEnketoSavingStatus),
       this.store.select(Selectors.getEnketoError),
       this.store.select(Selectors.getTrainingCardFormId),
-    ).subscribe(([
+    ]).subscribe(([
       enketoStatus,
       enketoSaving,
       enketoError,
@@ -151,6 +151,7 @@ export class TrainingCardsComponent implements OnInit, OnDestroy {
   }
 
   close() {
+    this.globalActions.setTrainingCardFormId(null);
     this.matDialogRef.close();
   }
 

--- a/webapp/src/ts/services/training-cards.service.ts
+++ b/webapp/src/ts/services/training-cards.service.ts
@@ -84,11 +84,6 @@ export class TrainingCardsService {
       return;
     }
 
-    const routeSnapshot = this.routeSnapshotService.get();
-    if (routeSnapshot?.data?.hideTraining) {
-      return;
-    }
-
     try {
       const firstChronologicalTrainingCard = await this.getFirstChronologicalForm(xForms);
       if (!firstChronologicalTrainingCard) {
@@ -96,12 +91,18 @@ export class TrainingCardsService {
       }
 
       this.globalActions.setTrainingCardFormId(firstChronologicalTrainingCard.code);
-      this.modalService.show(TrainingCardsComponent);
-
     } catch (error) {
       console.error('Training Cards :: Error showing modal.', error);
       return;
     }
+  }
+
+  displayTrainingCards() {
+    const routeSnapshot = this.routeSnapshotService.get();
+    if (routeSnapshot?.data?.hideTraining) {
+      return;
+    }
+    this.modalService.show(TrainingCardsComponent);
   }
 
   private async getFirstChronologicalForm(xForms) {

--- a/webapp/tests/karma/ts/services/training-cards.service.spec.ts
+++ b/webapp/tests/karma/ts/services/training-cards.service.spec.ts
@@ -62,7 +62,7 @@ describe('TrainingCardsService', () => {
       .forEach(element => element.remove());
   });
 
-  it('should show uncompleted training form when none are completed', async () => {
+  it('should set uncompleted training form when none are completed', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [] });
     clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
@@ -123,12 +123,11 @@ describe('TrainingCardsService', () => {
     });
     expect(globalActions.setTrainingCardFormId.calledOnce);
     expect(globalActions.setTrainingCardFormId.args[0]).to.have.members([ 'training:form-b' ]);
-    expect(modalService.show.calledOnce).to.be.true;
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
   });
 
-  it('should show uncompleted training form when there are some completed', async () => {
+  it('should set uncompleted training form when there are some completed', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [
       { doc: { form: 'training:form-a' } },
@@ -192,7 +191,7 @@ describe('TrainingCardsService', () => {
     });
     expect(globalActions.setTrainingCardFormId.calledOnce);
     expect(globalActions.setTrainingCardFormId.args[0]).to.have.members([ 'training:form-d' ]);
-    expect(modalService.show.calledOnce).to.be.true;
+    expect(modalService.show.notCalled).to.be.true;
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
   });
@@ -249,7 +248,7 @@ describe('TrainingCardsService', () => {
     });
     expect(globalActions.setTrainingCardFormId.calledOnce);
     expect(globalActions.setTrainingCardFormId.args[0]).to.have.members([ 'training:form-c' ]);
-    expect(modalService.show.calledOnce).to.be.true;
+    expect(modalService.show.notCalled).to.be.true;
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
   });
@@ -314,7 +313,7 @@ describe('TrainingCardsService', () => {
     });
     expect(globalActions.setTrainingCardFormId.calledOnce);
     expect(globalActions.setTrainingCardFormId.args[0]).to.have.members([ 'training:form-c' ]);
-    expect(modalService.show.calledOnce).to.be.true;
+    expect(modalService.show.notCalled).to.be.true;
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
   });
@@ -609,25 +608,16 @@ describe('TrainingCardsService', () => {
     expect(consoleErrorMock.args[0][1].message).to.equal('some error');
   });
 
-  it('should do nothing if route has hideTraining flag', async () => {
+  it('should not display training if route has hideTraining flag', async () => {
     routeSnapshotService.get.returns({ data: { hideTraining: true } });
-
-    service.initTrainingCards();
-
-    expect(xmlFormsService.subscribe.calledOnce).to.be.true;
-    expect(xmlFormsService.subscribe.args[0][0]).to.equal('TrainingCards');
-    expect(xmlFormsService.subscribe.args[0][1]).to.deep.equal({ trainingCards: true });
-    const callback = xmlFormsService.subscribe.args[0][2];
-
-    await callback(null, []);
-
-    expect(sessionService.userCtx.notCalled).to.be.true;
-    expect(sessionService.hasRole.notCalled).to.be.true;
-    expect(localDb.allDocs.notCalled).to.be.true;
-    expect(globalActions.setTrainingCardFormId.notCalled).to.be.true;
+    service.displayTrainingCards();
     expect(modalService.show.notCalled).to.be.true;
-    expect(consoleErrorMock.notCalled).to.be.true;
-    expect(feedbackService.submit.notCalled).to.be.true;
+  });
+
+  it('should display training', () => {
+    routeSnapshotService.get.returns({ data: { hideTraining: false } });
+    service.displayTrainingCards();
+    expect(modalService.show.calledOnce).to.be.true;
   });
 
   it('should show uncompleted training form based on user role', async () => {
@@ -701,7 +691,7 @@ describe('TrainingCardsService', () => {
     });
     expect(globalActions.setTrainingCardFormId.calledOnce);
     expect(globalActions.setTrainingCardFormId.args[0]).to.have.members([ 'training:form-e' ]);
-    expect(modalService.show.calledOnce).to.be.true;
+    expect(modalService.show.notCalled).to.be.true;
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
   });
@@ -750,7 +740,7 @@ describe('TrainingCardsService', () => {
     });
     expect(globalActions.setTrainingCardFormId.calledOnce);
     expect(globalActions.setTrainingCardFormId.args[0]).to.have.members([ 'training:form-d' ]);
-    expect(modalService.show.calledOnce).to.be.true;
+    expect(modalService.show.notCalled).to.be.true;
     expect(consoleErrorMock.notCalled).to.be.true;
     expect(feedbackService.submit.notCalled).to.be.true;
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

#8131

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8131-delay-training-cards-popup/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8131-delay-training-cards-popup/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8131-delay-training-cards-popup/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

