### PR TITLE
chore(#8727): change docker socket path in upgrade e2e test

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -1,6 +1,6 @@
 ### Usage
 
-This directory contains the build files for a pre-configured HAProxy to be used for CHT-Core. It's main objective is to 
+This directory contains the build files for a pre-configured HAProxy to be used for CHT-Core. It's main objective is to
 provide an audit log trail between CHT-API and CouchDB, and load balance all queries across the CouchDB Cluster.
 
 
@@ -25,7 +25,7 @@ After testing, please push your image to DockerHub.
 ### Required Variables
 
 In your docker-compose.yml template, the HAproxy container declaration will require the following variables:
-- HAPROXY_IP: This should be the docker service name, `fqdn`, or set to `0.0.0.0`. If not set, our templates will default this to be a service name of `haproxy`. 
+- HAPROXY_IP: This should be the docker service name, `fqdn`, or set to `0.0.0.0`. If not set, our templates will default this to be a service name of `haproxy`.
 *Note*: For Docker Desktop on Mac users, if you wish to expose HAproxy to your host, you will have to set this as `0.0.0.0`, to expose it as `localhost` outside of the docker network.
 - HAPROXY_PORT: The port you wish HAProxy to run on. Defaults to 5984.
 - COUCHDB_SERVERS: Comma separated list of the docker service name or fqdn of the CouchDB servers. Example: `couchdb-1.local,couchdb-2.local,couchdb-3.local`.

--- a/tests/e2e/standard/wdio.conf.js
+++ b/tests/e2e/standard/wdio.conf.js
@@ -11,7 +11,7 @@ chai.use(require('chai-exclude'));
 const standardConfig = Object.assign(wdioBaseConfig.config, {
   suites: {
     all: [
-      './**/*.wdio-spec.js'
+      './**/registra*.wdio-spec.js'
     ]
   },
 
@@ -26,7 +26,7 @@ const uploadStandardConfig = async () => {
   await exec('npm ci', { cwd: standardConfigPath });
 
   try {
-    await chtConfUtils.runCommand('',  standardConfigPath);
+    await chtConfUtils.runCommand('compile-app-settings upload-app-settings upload-app-forms upload-contact-forms upload-custom-translations',  standardConfigPath);
   } catch (err) {
     console.error(err);
   }

--- a/tests/e2e/standard/wdio.conf.js
+++ b/tests/e2e/standard/wdio.conf.js
@@ -11,7 +11,7 @@ chai.use(require('chai-exclude'));
 const standardConfig = Object.assign(wdioBaseConfig.config, {
   suites: {
     all: [
-      './**/registra*.wdio-spec.js'
+      './**/*.wdio-spec.js'
     ]
   },
 
@@ -26,7 +26,7 @@ const uploadStandardConfig = async () => {
   await exec('npm ci', { cwd: standardConfigPath });
 
   try {
-    await chtConfUtils.runCommand('compile-app-settings upload-app-settings upload-app-forms upload-contact-forms upload-custom-translations',  standardConfigPath);
+    await chtConfUtils.runCommand('',  standardConfigPath);
   } catch (err) {
     console.error(err);
   }

--- a/tests/e2e/upgrade/wdio.conf.js
+++ b/tests/e2e/upgrade/wdio.conf.js
@@ -61,7 +61,7 @@ const dockerComposeCmd = (...params) => {
     CHT_COMPOSE_PATH: CHT_DOCKER_COMPOSE_FOLDER,
     COUCHDB_USER: constants.USERNAME,
     COUCHDB_PASSWORD: constants.PASSWORD,
-    DOCKER_CONFIG_PATH: path.join(os.homedir(), '.docker'),
+    DOCKER_CONFIG_PATH: os.homedir(),
     COUCHDB_DATA: CHT_DATA_FOLDER,
     CHT_COMPOSE_PROJECT_NAME: CHT_COMPOSE_PROJECT_NAME,
     CHT_NETWORK: 'cht-net-upgrade',
@@ -118,7 +118,7 @@ const servicesStartTimeout = () => {
 
 // Override specific properties from wdio base config
 const upgradeConfig = Object.assign(wdioBaseConfig.config, {
-  specs: 
+  specs:
    [
      'upgrade.wdio-spec.js',
      '*.wdio-spec.js'

--- a/tests/e2e/upgrade/wdio.conf.js
+++ b/tests/e2e/upgrade/wdio.conf.js
@@ -52,7 +52,7 @@ const getMainCHTDockerCompose = async () => {
   }
 };
 
-const TEST_TIMEOUT = 250 * 1000;
+const TEST_TIMEOUT = 240 * 1000; // 4 minutes
 
 const dockerComposeCmd = (...params) => {
   const env = {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

#8727 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8727-upgrade-for-macos/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8727-upgrade-for-macos/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8727-upgrade-for-macos/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

