### PR TITLE
k3s-k3d deployment fixes

### DIFF
--- a/scripts/deploy/helm/cht-chart/templates/couchdb-local-volume-persistentvolumeclaim.yaml
+++ b/scripts/deploy/helm/cht-chart/templates/couchdb-local-volume-persistentvolumeclaim.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq (toString .Values.couchdb.clusteredCouch_enabled) "false") (eq (toString .Values.cluster_type) "k3s-k3d") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    cht.service: couchdb-claim0
+  name: local-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.couchdb.couchdb_node_storage_size }}
+  {{- if eq (toString .Values.couchdb_data.preExistingDataAvailable) "true" }}
+  volumeName: couchdb-pv-{{ .Values.namespace }}
+  storageClassName: ""
+  {{- end }}
+status: {}
+{{- end }}

--- a/scripts/deploy/helm/cht-chart/templates/couchdb-local-volume-persistentvolumeclaim.yaml
+++ b/scripts/deploy/helm/cht-chart/templates/couchdb-local-volume-persistentvolumeclaim.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     cht.service: couchdb-claim0
-  name: local-volume
+  name: couchdb-claim0
 spec:
   accessModes:
     - ReadWriteOnce
@@ -13,7 +13,7 @@ spec:
       storage: {{ .Values.couchdb.couchdb_node_storage_size }}
   {{- if eq (toString .Values.couchdb_data.preExistingDataAvailable) "true" }}
   volumeName: couchdb-pv-{{ .Values.namespace }}
-  storageClassName: ""
+  storageClassName: "local-path"
   {{- end }}
 status: {}
 {{- end }}

--- a/scripts/deploy/helm/cht-chart/templates/couchdb-n-persistentvolume.yaml
+++ b/scripts/deploy/helm/cht-chart/templates/couchdb-n-persistentvolume.yaml
@@ -26,7 +26,7 @@ spec:
               /var/lib/{{ $.Values.namespace }}-couchdb{{ $nodeNumber }}
             {{- end }}
           {{- else }}
-            /var/lib/{{ $.Values.namespace }}-couchdb{{ $nodeNumber }}
+            /tmp/
           {{- end }}
   {{- end }}
   nodeAffinity:

--- a/scripts/deploy/helm/cht-chart/templates/couchdb-single-deployment.yaml
+++ b/scripts/deploy/helm/cht-chart/templates/couchdb-single-deployment.yaml
@@ -81,8 +81,8 @@ spec:
       {{- if eq (toString .Values.cluster_type) "k3s-k3d" }}
       volumes:
         - name: local-volume
-          hostPath:
-            path: {{ .Values.local.diskPath }}
+          persistentVolumeClaim:
+            claimName: local-volume
       {{- else }}
       volumes:
         - name: couchdb-claim0

--- a/scripts/deploy/helm/cht-chart/templates/k3d-api-ingress.yaml
+++ b/scripts/deploy/helm/cht-chart/templates/k3d-api-ingress.yaml
@@ -3,7 +3,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: api-ingress
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
+  ingressClassName: traefik
   tls:
   - hosts:
     - {{ .Values.ingress.host }}

--- a/scripts/deploy/helm/cht-chart/values.yaml
+++ b/scripts/deploy/helm/cht-chart/values.yaml
@@ -28,7 +28,7 @@ ingress:
     groupname: "dev-cht-alb"
     tags: "Environment=dev,Team=QA"
     certificate: "arn:aws:iam::<account-id>:server-certificate/2023-wildcard-dev-medicmobile-org-chain"
-  host: "gamma-cht.dev.medicmobile.org"
+  host: "dev.local-ip.medicmobile.org"
   hosted_zone_id: "<the-hosted-zone-id>"
   load_balancer: "dualstack.k8s-devchtalb-3eb0781cbb-694321496.eu-west-2.elb.amazonaws.com"
 

--- a/scripts/deploy/tasks.py
+++ b/scripts/deploy/tasks.py
@@ -6,23 +6,25 @@ import requests
 import re
 import json
 
+
 @task
 def prepare(c, f):
-    with open(f, 'r') as stream:
+    with open(f, "r") as stream:
         try:
             values = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
             print(exc)
             exit(1)
-    environment = values.get('environment', '')
+    environment = values.get("environment", "")
     subprocess.run(["./prepare.sh", environment], check=True)
+
 
 @task
 def load_values(c, f):
     if not f:
         print("No values file provided. Please specify a values file using -f <file>")
         exit(1)
-    with open(f, 'r') as stream:
+    with open(f, "r") as stream:
         try:
             values = yaml.safe_load(stream)
         except yaml.YAMLError as exc:
@@ -30,130 +32,229 @@ def load_values(c, f):
             exit(1)
     return values
 
+
 @task
 def determine_namespace(c, f, values):
-    namespace = values.get('namespace', '')
+    namespace = values.get("namespace", "")
     if not namespace:
         print("Namespace is not specified.")
         exit(1)
     return namespace
 
+
 @task
 def check_namespace_exists(c, namespace):
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    namespace_exists = subprocess.run(["kubectl", "get", "namespace", namespace], capture_output=True, text=True).returncode
+    namespace_exists = subprocess.run(
+        ["kubectl", "get", "namespace", namespace], capture_output=True, text=True
+    ).returncode
     if namespace_exists != 0:
         print(f"Namespace {namespace} does not exist. Creating the namespace.")
-        namespace_manifest = f'''
+        namespace_manifest = f"""
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {namespace}
-'''
-        with open(os.path.join(script_dir, "helm", "namespace.yaml"), 'w') as manifest_file: # NOSONAR
+"""
+        with open(
+            os.path.join(script_dir, "helm", "namespace.yaml"), "w"
+        ) as manifest_file:  # NOSONAR
             manifest_file.write(namespace_manifest)
-        subprocess.run(["kubectl", "apply", "-f", os.path.join(script_dir, "helm", "namespace.yaml")], check=True) # NOSONAR
+        subprocess.run(
+            [
+                "kubectl",
+                "apply",
+                "-f",
+                os.path.join(script_dir, "helm", "namespace.yaml"),
+            ],
+            check=True,
+        )  # NOSONAR
         # Delete the namespace file after creation
-        os.remove(os.path.join(script_dir, "helm", "namespace.yaml")) # NOSONAR
+        os.remove(os.path.join(script_dir, "helm", "namespace.yaml"))  # NOSONAR
     else:
         print(f"Namespace {namespace} already exists.")
 
+
 @task
-def obtain_certificate_and_key(c, values): # NOSONAR
+def obtain_certificate_and_key(c, values):  # NOSONAR
     print("Obtaining certificate...")
-    if values.get('cert_source', '') == 'specify-file-path':
-        crt_file_path = values.get('certificate_crt_file_path', '')
-        key_file_path = values.get('certificate_key_file_path', '')
+    if values.get("cert_source", "") == "specify-file-path":
+        crt_file_path = values.get("certificate_crt_file_path", "")
+        key_file_path = values.get("certificate_key_file_path", "")
         if crt_file_path and key_file_path:
-            subprocess.run(["cp", crt_file_path, "certificate.crt"], check=True) # NOSONAR
-            subprocess.run(["cp", key_file_path, "private.key"], check=True) # NOSONAR
+            subprocess.run(
+                ["cp", crt_file_path, "certificate.crt"], check=True
+            )  # NOSONAR
+            subprocess.run(["cp", key_file_path, "private.key"], check=True)  # NOSONAR
         else:
-            raise Exception("certificate_crt_file_path and certificate_key_file_path must be set in values when cert_source is 'specify-file-path'") # NOSONAR
-    elif values.get('cert_source', '') == 'my-ip-co':
-        subprocess.run(["curl", "https://local-ip.medicmobile.org/fullchain", "-o", "certificate.crt"], check=True) # NOSONAR
-        subprocess.run(["curl", "https://local-ip.medicmobile.org/key", "-o", "private.key"], check=True) # NOSONAR
-    elif values.get('cert_source', '') == 'eks-medic':
+            raise Exception(
+                "certificate_crt_file_path and certificate_key_file_path must be set in values when cert_source is 'specify-file-path'"
+            )  # NOSONAR
+    elif values.get("cert_source", "") == "my-ip-co":
+        subprocess.run(
+            [
+                "curl",
+                "https://local-ip.medicmobile.org/fullchain",
+                "-o",
+                "certificate.crt",
+            ],
+            check=True,
+        )  # NOSONAR
+        subprocess.run(
+            ["curl", "https://local-ip.medicmobile.org/key", "-o", "private.key"],
+            check=True,
+        )  # NOSONAR
+    elif values.get("cert_source", "") == "eks-medic":
         print("Moving on. Certificate provided by the eks cluster.")
     else:
-        raise Exception("cert_source must be either 'specify-file-path', 'my-ip-co', or 'eks-medic'") # NOSONAR
+        raise Exception(
+            "cert_source must be either 'specify-file-path', 'my-ip-co', or 'eks-medic'"
+        )  # NOSONAR
+
 
 @task
 def create_secret(c, namespace, values):
     print("Checking if secret api-tls-secret already exists...")
-    secret_exists = subprocess.run(["kubectl", "get", "secret", "api-tls-secret", "-n", namespace], capture_output=True, text=True).returncode
+    secret_exists = subprocess.run(
+        ["kubectl", "get", "secret", "api-tls-secret", "-n", namespace],
+        capture_output=True,
+        text=True,
+    ).returncode
     if secret_exists != 0:
         print("Secret does not exist. Creating Secret from certificate and key...")
-        obtain_certificate_and_key(c, values)  # Ensure the certificate and key are available before creating the secret
-        subprocess.run(["kubectl", "-n", namespace, "create", "secret", "tls", "api-tls-secret", "--cert=certificate.crt", "--key=private.key"], check=True)
+        obtain_certificate_and_key(
+            c, values
+        )  # Ensure the certificate and key are available before creating the secret
+        subprocess.run(
+            [
+                "kubectl",
+                "-n",
+                namespace,
+                "create",
+                "secret",
+                "tls",
+                "api-tls-secret",
+                "--cert=certificate.crt",
+                "--key=private.key",
+            ],
+            check=True,
+        )
         os.remove("certificate.crt")
         os.remove("private.key")
     else:
         print("Secret api-tls-secret already exists.")
 
+
 @task
 def get_image_tag(c, chtversion):
-    response = requests.get(f'https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:{chtversion}')
+    response = requests.get(
+        f"https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:{chtversion}"
+    )
     response.raise_for_status()
     data = response.json()
 
-    for tag in data['tags']:
-        if tag['container_name'] == 'cht-api':
-            image_tag = tag['image'].split(':')[-1]
+    for tag in data["tags"]:
+        if tag["container_name"] == "cht-api":
+            image_tag = tag["image"].split(":")[-1]
             return image_tag
 
-    raise Exception('cht image tag not found') # NOSONAR
+    raise Exception("cht image tag not found")  # NOSONAR
+
 
 def setup_etc_hosts(c, values):  # NOSONAR
     # If the cluster_type is k3s-k3d and cert_source is my-ip-co, add the host to /etc/hosts
-    if values.get('cluster_type', '') == 'k3s-k3d' and values.get('cert_source', '') == 'my-ip-co':
-        host = values.get('ingress', {}).get('host', '')
-        proc = subprocess.Popen(['sudo', 'cat', '/etc/hosts'], stdout=subprocess.PIPE)
-        lines = [line.decode('utf-8') for line in proc.stdout.readlines()]
+    if (
+        values.get("cluster_type", "") == "k3s-k3d"
+        and values.get("cert_source", "") == "my-ip-co"
+    ):
+        host = values.get("ingress", {}).get("host", "")
+        proc = subprocess.Popen(["sudo", "cat", "/etc/hosts"], stdout=subprocess.PIPE)
+        lines = [line.decode("utf-8") for line in proc.stdout.readlines()]
 
         # Regular expression for a host entry line
-        host_re = re.compile(r'^127\.0\.0\.1\s+' + re.escape(host) + r'(\s|$)')
+        host_re = re.compile(r"^127\.0\.0\.1\s+" + re.escape(host) + r"(\s|$)")
 
         # Check if the host line exists and points to 127.0.0.1
         if not any(host_re.match(line) for line in lines):
-            command = ['sudo', 'bash', '-c', f'echo "127.0.0.1 {host}" >> /etc/hosts']
+            command = ["sudo", "bash", "-c", f'echo "127.0.0.1 {host}" >> /etc/hosts']
             subprocess.run(command)
     else:
-        print("Cluster type is not k3s-k3d or ingress choice is not my-ip-co. Skipping /etc/hosts setup.")
+        print(
+            "Cluster type is not k3s-k3d or ingress choice is not my-ip-co. Skipping /etc/hosts setup."
+        )
+
 
 @task
 def add_route53_entry(c, f):  # NOSONAR
     values = load_values(c, f)
-    host = values.get('ingress', {}).get('host', '')
-    load_balancer = values.get('ingress', {}).get('load_balancer', '')
-    hosted_zone_id = values.get('ingress', {}).get('hostedZoneId', '')
+    host = values.get("ingress", {}).get("host", "")
+    load_balancer = values.get("ingress", {}).get("load_balancer", "")
+    hosted_zone_id = values.get("ingress", {}).get("hostedZoneId", "")
 
     if host and load_balancer and hosted_zone_id:
         # Check if the record already exists
-        check_cmd = f"aws route53 list-resource-record-sets --hosted-zone-id {hosted_zone_id}"
+        check_cmd = (
+            f"aws route53 list-resource-record-sets --hosted-zone-id {hosted_zone_id}"
+        )
         result = subprocess.run(check_cmd, shell=True, capture_output=True, text=True)
         records = json.loads(result.stdout)["ResourceRecordSets"]
 
-        record_exists = any(record["Name"] == host and record["Type"] == "CNAME" for record in records)
+        record_exists = any(
+            record["Name"] == host and record["Type"] == "CNAME" for record in records
+        )
         if not record_exists:
             # Add the record
-            add_cmd = f"aws route53 change-resource-record-sets --hosted-zone-id {hosted_zone_id} --change-batch '{{\"Changes\": [{{\"Action\": \"CREATE\", \"ResourceRecordSet\": {{\"Name\": \"{host}\", \"Type\": \"CNAME\", \"TTL\": 300, \"ResourceRecords\": [{{\"Value\": \"{load_balancer}\"}}]}}}}]}}'"
+            add_cmd = f'aws route53 change-resource-record-sets --hosted-zone-id {hosted_zone_id} --change-batch \'{{"Changes": [{{"Action": "CREATE", "ResourceRecordSet": {{"Name": "{host}", "Type": "CNAME", "TTL": 300, "ResourceRecords": [{{"Value": "{load_balancer}"}}]}}}}]}}\''
             subprocess.run(add_cmd, shell=True)
             print(f"Route53 entry added for {host}")
         else:
             print(f"Route53 entry for {host} already exists")
 
+
 @task
-def helm_install_or_upgrade(c, f, namespace, values, image_tag): # NOSONAR
+def helm_install_or_upgrade(c, f, namespace, values, image_tag):  # NOSONAR
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    chart_filename = "cht-chart-4.x.tgz"
-    project_name = values.get('project_name', '')
-    release_exists = subprocess.run(["helm", "list", "-n", namespace], capture_output=True, text=True).stdout
+    chart_filename = "cht-chart"
+    project_name = values.get("project_name", "")
+    release_exists = subprocess.run(
+        ["helm", "list", "-n", namespace], capture_output=True, text=True
+    ).stdout
     if project_name in release_exists:
         print("Release exists. Performing upgrade.")
-        subprocess.run(["helm", "upgrade", "--install", project_name, os.path.join(script_dir, "helm", chart_filename), "--namespace", namespace, "--values", f, "--set", f"cht_image_tag={image_tag}"], check=True)
+        subprocess.run(
+            [
+                "helm",
+                "upgrade",
+                "--install",
+                project_name,
+                os.path.join(script_dir, "helm", chart_filename),
+                "--namespace",
+                namespace,
+                "--values",
+                f,
+                "--set",
+                f"cht_image_tag={image_tag}",
+            ],
+            check=True,
+        )
     else:
         print("Release does not exist. Performing install.")
-        subprocess.run(["helm", "install", project_name, os.path.join(script_dir, "helm", chart_filename), "--namespace", namespace, "--values", f, "--set", f"cht_image_tag={image_tag}"], check=True)
+        subprocess.run(
+            [
+                "helm",
+                "install",
+                project_name,
+                os.path.join(script_dir, "helm", chart_filename),
+                "--namespace",
+                namespace,
+                "--values",
+                f,
+                "--set",
+                f"cht_image_tag={image_tag}",
+            ],
+            check=True,
+        )
+
 
 @task
 def install(c, f):
@@ -161,11 +262,11 @@ def install(c, f):
     values = load_values(c, f)
     namespace = determine_namespace(c, f, values)
     check_namespace_exists(c, namespace)
-    if values.get('cluster_type', '') == 'k3s-k3d':
+    if values.get("cluster_type", "") == "k3s-k3d":
         obtain_certificate_and_key(c, values)
         create_secret(c, namespace, values)
-    if values.get('environment', '') == 'local':
+    if values.get("environment", "") == "local":
         setup_etc_hosts(c, values)
-    image_tag = get_image_tag(c, values.get('chtversion', ''))
+    image_tag = get_image_tag(c, values.get("chtversion", ""))
     helm_install_or_upgrade(c, f, namespace, values, image_tag)
     add_route53_entry(c, f)


### PR DESCRIPTION
This PR applies the following changes:

1. Updates the traefik ingress to add annotations required for the ingress controller to route SSl traffic to the `api` svc.
2. `couchdb-local-volume-persistentvolumeclaim.yaml` adds the `local-volume` PVC that's  referenced but was not defined to allow for persistence to couchDB containers on a local k3s cluster. 
3. Refactors the helm command in `tasks.py` so that helm runs the files in `/scripts/deploy/helm/cht-chart` rather than `scripts/deploy/helm/cht-chart/cht-chart-4.x.tgz`.

```
eagan@XPS-15-9520-d6d7040e:~/Projects/medic/cht-core$ k get po -n cht-dev 
NAME                                       READY   STATUS    RESTARTS        AGE
cht-sentinel-6cd8fbc4ff-5lm4z              1/1     Running   1 (8m15s ago)   68m
upgrade-service-5974ff6594-dxg9r           1/1     Running   1 (8m15s ago)   68m
cht-couchdb-65cb74d48b-24x8d               1/1     Running   1 (8m15s ago)   68m
cht-api-64599cd6b4-rtd64                   1/1     Running   1 (8m15s ago)   68m
cht-haproxy-healthcheck-5d997d4756-l9lq5   1/1     Running   2 (7m37s ago)   68m
cht-haproxy-d96b68cb9-hb6q7                1/1     Running   3 (7m47s ago)   68m
reagan@XPS-15-9520-d6d7040e:~/Projects/medic/cht-core$ k get ingress api-ingress -n cht-dev -o yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    meta.helm.sh/release-name: cht-dev
    meta.helm.sh/release-namespace: cht-dev
    traefik.ingress.kubernetes.io/router.entrypoints: websecure
    traefik.ingress.kubernetes.io/router.tls: "true"
  creationTimestamp: "2023-11-28T15:18:58Z"
  generation: 1
  labels:
    app.kubernetes.io/managed-by: Helm
  name: api-ingress
  namespace: cht-dev
  resourceVersion: "510607"
  uid: 78bc048e-8852-4ab4-8c26-34ba10468df6
spec:
  ingressClassName: traefik
  rules:
  - host: dev.local-ip.medicmobile.org
    http:
      paths:
      - backend:
          service:
            name: api
            port:
              number: 5988
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - dev.local-ip.medicmobile.org
    secretName: api-tls-secret
status:
  loadBalancer:
    ingress:
    - ip: 172.21.0.3
reagan@XPS-15-9520-d6d7040e:~/Projects/medic/cht-core$ k get svc -n cht-dev
NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
upgrade-service   ClusterIP   10.43.147.60    <none>        5008/TCP                     69m
healthcheck       ClusterIP   10.43.170.220   <none>        5555/TCP                     69m
haproxy           ClusterIP   10.43.77.8      <none>        5984/TCP                     69m
api               ClusterIP   10.43.9.188     <none>        5988/TCP                     69m
couchdb           ClusterIP   10.43.142.48    <none>        5984/TCP,4369/TCP,9100/TCP   69m
```
![Screenshot from 2023-11-28 19 29 15](https://github.com/medic/cht-core/assets/699379/b9b68006-b0f3-447a-ab6a-08d03e504991)
