### PR TITLE
fix(#8689): only get needed facilities

### DIFF
--- a/shared-libs/user-management/src/libs/facility.js
+++ b/shared-libs/user-management/src/libs/facility.js
@@ -1,0 +1,22 @@
+const db = require('./db');
+
+const list = (users, settings) => {
+  const ids = new Set();
+  for (const user of users) {
+    ids.add(user?.doc?.facility_id);
+  }
+  for (const setting of settings) {
+    ids.add(setting?.contact_id);
+  }
+  ids.delete(undefined);
+  if (!ids.size) {
+    return [];
+  }
+  return db.medic.allDocs({ keys: Array.from(ids), include_docs: true })
+    .then(response => response.rows.map(row => row?.doc).filter(doc => !!doc));
+};
+
+module.exports = {
+  list,
+};
+

--- a/shared-libs/user-management/src/libs/facility.js
+++ b/shared-libs/user-management/src/libs/facility.js
@@ -1,6 +1,6 @@
 const db = require('./db');
 
-const list = (users, settings) => {
+const list = async (users, settings) => {
   const ids = new Set();
   for (const user of users) {
     ids.add(user?.doc?.facility_id);
@@ -12,8 +12,8 @@ const list = (users, settings) => {
   if (!ids.size) {
     return [];
   }
-  return db.medic.allDocs({ keys: Array.from(ids), include_docs: true })
-    .then(response => response.rows.map(row => row?.doc).filter(doc => !!doc));
+  const response = await db.medic.allDocs({ keys: Array.from(ids), include_docs: true });
+  return response.rows.map(row => row?.doc).filter(doc => !!doc);
 };
 
 module.exports = {

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const passwordTester = require('simple-password-tester');
 const db = require('./libs/db');
+const facility = require('./libs/facility');
 const lineage = require('./libs/lineage');
 const couchSettings = require('@medic/settings');
 const getRoles = require('./libs/types-and-roles');
@@ -116,11 +117,6 @@ const getAllUserSettings = () => {
 const getAllUsers = () => {
   return db.users.allDocs({ include_docs: true })
     .then(result => result.rows);
-};
-
-const getFacilities = () => {
-  return db.medic.query('medic-client/contacts_by_type', { include_docs: true })
-    .then(result => result.rows.map(row => row.doc));
 };
 
 const validateContact = (id, placeID) => {
@@ -780,11 +776,11 @@ module.exports = {
     return Promise
       .all([
         getAllUsers(),
-        getAllUserSettings(),
-        getFacilities()
+        getAllUserSettings()
       ])
-      .then(([ users, settings, facilities ]) => {
-        return mapUsers(users, settings, facilities);
+      .then(([ users, settings ]) => {
+        return facility.list(users, settings)
+          .then(facilities => mapUsers(users, settings, facilities));
       });
   },
   getUserSettings,

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -772,16 +772,10 @@ const getUserSettings = async({ name }) => {
  */
 module.exports = {
   deleteUser: username => deleteUser(createID(username)),
-  getList: () => {
-    return Promise
-      .all([
-        getAllUsers(),
-        getAllUserSettings()
-      ])
-      .then(([ users, settings ]) => {
-        return facility.list(users, settings)
-          .then(facilities => mapUsers(users, settings, facilities));
-      });
+  getList: async () => {
+    const [ users, settings ] = await Promise.all([ getAllUsers(), getAllUserSettings() ]);
+    const facilities = await facility.list(users, settings);
+    return mapUsers(users, settings, facilities);
   },
   getUserSettings,
   /* eslint-disable max-len */

--- a/shared-libs/user-management/test/unit/libs/facility.spec.js
+++ b/shared-libs/user-management/test/unit/libs/facility.spec.js
@@ -43,6 +43,8 @@ describe('facility', () => {
     ] });
     const result = await list([ userA, userB ], [ settingA, settingB ]);
     expect(result).to.deep.equal([ facilityA, facilityB ]);
+    expect(allDocs.callCount).to.equal(1);
+    expect(allDocs.args[0][0].keys).to.deep.equal([ 'a', 'b', 'e' ]);
   });
 
 });

--- a/shared-libs/user-management/test/unit/libs/facility.spec.js
+++ b/shared-libs/user-management/test/unit/libs/facility.spec.js
@@ -1,0 +1,48 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const { list } = require('../../../src/libs/facility');
+const db = require('../../../src/libs/db');
+
+describe('facility', () => {
+
+  const userA = { doc: { facility_id: 'a' } };
+  const userB = { doc: { facility_id: 'b' } };
+
+  const settingA = { contact_id: 'a' };
+  const settingB = { contact_id: 'e' };
+
+  const facilityA = { _id: 'a' };
+  const facilityB = { _id: 'b' };
+  const facilityNotFound = { error: 'not_found' };
+
+  let allDocs;
+
+  beforeEach(() => {
+    allDocs = sinon.stub();
+    db.init({ medic: { allDocs } });
+  });
+
+  it('handles empty args', async () => {
+    const result = await list([], []);
+    expect(result).to.be.empty;
+    expect(allDocs.callCount).to.equal(0);
+  });
+
+  it('handles incomplete arg docs', async () => {
+    const result = await list([{}], [{}]);
+    expect(result).to.be.empty;
+    expect(allDocs.callCount).to.equal(0);
+  });
+
+  it('finds all facilities', async () => {
+    allDocs.resolves({ rows: [
+      { doc: facilityA },
+      { doc: facilityB },
+      facilityNotFound,
+    ] });
+    const result = await list([ userA, userB ], [ settingA, settingB ]);
+    expect(result).to.deep.equal([ facilityA, facilityB ]);
+  });
+
+});

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -6,6 +6,7 @@ const couchSettings = require('@medic/settings');
 const tokenLogin = require('../../src/token-login');
 const config = require('../../src/libs/config');
 const db = require('../../src/libs/db');
+const facility = require('../../src/libs/facility');
 const lineage = require('../../src/libs/lineage');
 const passwords = require('../../src/libs/passwords');
 const roles = require('../../src/roles');
@@ -38,11 +39,11 @@ describe('Users service', () => {
     addMessage = sinon.stub();
     config.getTransitionsLib.returns({ messages: { addMessage } });
     service = rewire('../../src/users');
-    service.__set__('getFacilities', sinon.stub().returns([
+    sinon.stub(facility, 'list').resolves([
       facilitya,
       facilityb,
       facilityc,
-    ]));
+    ]);
     sinon.stub(couchSettings, 'getCouchConfig').resolves();
     sinon.stub(couchSettings, 'updateAdminPassword').resolves();
     userData = {

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -8,6 +8,13 @@ chai.use(require('chai-shallow-deep-equal'));
 const sentinelUtils = require('@utils/sentinel');
 
 const getUserId = n => `org.couchdb.user:${n}`;
+const password = 'passwordSUP3RS3CR37!';
+const parentPlace = {
+  _id: 'PARENT_PLACE',
+  type: 'district_hospital',
+  name: 'Big Parent Hospital'
+};
+
 
 describe('Users API', () => {
 
@@ -381,15 +388,6 @@ describe('Users API', () => {
   });
 
   describe('/api/v1/users-info', () => {
-
-    const password = 'passwordSUP3RS3CR37!';
-
-    const parentPlace = {
-      _id: 'PARENT_PLACE',
-      type: 'district_hospital',
-      name: 'Big Parent Hospital'
-    };
-
     const users = [
       {
         username: 'offline',
@@ -623,7 +621,6 @@ describe('Users API', () => {
 
   describe('token-login', () => {
     let user;
-    const password = 'passwordSUP3RS3CR37!';
 
     const getUser = (user) => {
       const opts = { path: `/_users/${getUserId(user.username)}` };
@@ -1617,6 +1614,49 @@ describe('Users API', () => {
             },
           });
         });
+    });
+  });
+
+  describe('POST/GET api/v2/users', () => {
+    before(async () => {
+      await utils.saveDoc(parentPlace);
+    });
+
+    after(async () => {
+      await utils.revertDb([], true);
+    });
+
+    it('should create and get users', async () => {
+      const users = Array.from({ length: 10 }).map(() => ({
+        username: uuid(),
+        password: password,
+        place: {
+          type: 'health_center',
+          name: 'Online place',
+          parent: 'PARENT_PLACE'
+        },
+        contact: {
+          name: 'OnlineUser'
+        },
+        roles: ['district_admin', 'mm-online']
+      }));
+
+      const createUserOpts = { path: '/api/v2/users', method: 'POST' };
+      for (const user of users) {
+        await utils.request({ ...createUserOpts, body: user });
+      }
+
+      const savedUsers = await utils.request({ path: '/api/v2/users' });
+      for (const user of users) {
+        const savedUser = savedUsers.find(savedUser => savedUser.username === user.username);
+        expect(savedUser).to.deep.nested.include({
+          id: `org.couchdb.user:${user.username}`,
+          'place.type': user.place.type,
+          'place.name': user.place.name,
+          'place.parent._id': parentPlace._id,
+          'contact.name': user.contact.name,
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

#8689

Upon quick check it was clear why this was performing so badly. This isn't a complete solution because it'll still perform badly with large numbers of users, but should be a significant improvement.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8689-low-hanging-fruit/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8689-low-hanging-fruit/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8689-low-hanging-fruit/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

