### PR TITLE
fix(#8730): fix permission checks for contact fab and actionbar

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2296,9 +2296,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5064,9 +5064,9 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -7973,9 +7973,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -10046,9 +10046,9 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.11.0",

--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -53,7 +53,6 @@ describe('FAB + Actionbar', () => {
       await utils.updatePermissions(onlineUser.roles, ['can_view_old_action_bar']);
       await commonElements.goToPeople(healthCenter._id);
       const actionBarLabels = await commonElements.getActionBarLabels();
-      console.log(actionBarLabels);
 
       expect(actionBarLabels).to.have.members([
         'New household',

--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -1,0 +1,87 @@
+const placeFactory = require('@factories/cht/contacts/place');
+const userFactory = require('@factories/cht/users/users');
+const personFactory = require('@factories/cht/contacts/person');
+const utils = require('@utils');
+const loginPage = require('@page-objects/default/login/login.wdio.page');
+const commonElements = require('@page-objects/default/common/common.wdio.page');
+const { genericForm } = require('@page-objects/default/contacts/contacts.wdio.page');
+
+const places = placeFactory.generateHierarchy();
+const healthCenter = places.get('health_center');
+const onlineUser = userFactory.build({ place: healthCenter._id, roles: [ 'program_officer' ] });
+const patient = personFactory.build({ parent: { _id: healthCenter._id, parent: healthCenter.parent } });
+describe('FAB + Actionbar', () => {
+  before(async () => {
+    await utils.saveDocs([ ...places.values(), patient ]);
+    await utils.createUsers([ onlineUser ]);
+    await loginPage.login(onlineUser);
+  });
+
+  afterEach(async () => {
+    await utils.revertSettings(false);
+  });
+
+  describe('FAB', () => {
+    it('should show new household and new person create option', async () => {
+      await commonElements.goToPeople(healthCenter._id);
+      const fabLabels = await commonElements.getFastActionItemsLabels();
+
+      expect(fabLabels).to.have.members(['New household', 'New person']);
+    });
+
+    it('should show fab when user only has can_create_places permission', async () => {
+      await utils.updatePermissions(onlineUser.roles, [], ['can_create_people']);
+      await commonElements.goToPeople(healthCenter._id);
+
+      await commonElements.clickFastActionFAB({ waitForList: false });
+      const formTitle = await genericForm.getFormTitle();
+      expect(formTitle).to.equal('New household');
+    });
+
+    it('should show fab when user only has can_create_people permission', async () => {
+      await utils.updatePermissions(onlineUser.roles, [], ['can_create_places']);
+      await commonElements.goToPeople(healthCenter._id);
+
+      await commonElements.clickFastActionFAB({ waitForList: false });
+      const formTitle = await genericForm.getFormTitle();
+      expect(formTitle).to.equal('New person');
+    });
+  });
+
+  describe('Action bar', () => {
+    it('should show new household and new person create option', async () => {
+      await utils.updatePermissions(onlineUser.roles, ['can_view_old_action_bar']);
+      await commonElements.goToPeople(healthCenter._id);
+      const actionBarLabels = await commonElements.getActionBarLabels();
+      console.log(actionBarLabels);
+
+      expect(actionBarLabels).to.have.members([
+        'New household',
+        'New person',
+        'New action',
+      ]);
+    });
+
+    it('should not show new person when missing permission', async () => {
+      await utils.updatePermissions(onlineUser.roles, ['can_view_old_action_bar'], ['can_create_people']);
+      await commonElements.goToPeople(healthCenter._id);
+      const actionBarLabels = await commonElements.getActionBarLabels();
+
+      expect(actionBarLabels).to.have.members([
+        'New household',
+        'New action',
+      ]);
+    });
+
+    it('should not show new place when missing permission', async () => {
+      await utils.updatePermissions(onlineUser.roles, ['can_view_old_action_bar'], ['can_create_places']);
+      await commonElements.goToPeople(healthCenter._id);
+      const actionBarLabels = await commonElements.getActionBarLabels();
+
+      expect(actionBarLabels).to.have.members([
+        'New person',
+        'New action',
+      ]);
+    });
+  });
+});

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -12,6 +12,7 @@ const FAST_ACTION_LIST_CONTAINER = '.fast-action-content-wrapper';
 const fastActionListContainer = () => $(FAST_ACTION_LIST_CONTAINER);
 const fastActionListCloseButton = () => $(`${FAST_ACTION_LIST_CONTAINER} .panel-header .panel-header-close`);
 const fastActionById = (id) => $(`${FAST_ACTION_LIST_CONTAINER} .fast-action-item[test-id="${id}"]`);
+const fastActionItems = () => $$(`${FAST_ACTION_LIST_CONTAINER} .fast-action-item`);
 const moreOptionsMenu = () => $('.more-options-menu-container>.mat-mdc-menu-trigger');
 const hamburgerMenuItemSelector = '#header-dropdown li';
 const logoutButton = () => $(`${hamburgerMenuItemSelector} .fa-power-off`);
@@ -27,6 +28,9 @@ const loaders = () => $$('.container-fluid .loader');
 const syncSuccess = () => $(`${hamburgerMenuItemSelector}.sync-status .success`);
 const syncRequired = () => $(`${hamburgerMenuItemSelector}.sync-status .required`);
 const jsonError = async () => (await $('pre')).getText();
+
+const actionBar = () => $('.detail-actions.right-pane');
+const actionBarActions = () => $$('.detail-actions.right-pane span');
 
 //languages
 const activeSnackbar = () => $('#snackbar.active');
@@ -80,6 +84,20 @@ const clickFastActionFAB = async ({ actionId, waitForList }) => {
   if (waitForList) {
     await clickFastActionById(actionId);
   }
+};
+
+const getFastActionItemsLabels = async () => {
+  await closeHamburgerMenu();
+  await (await fastActionFAB()).waitForDisplayed();
+  await (await fastActionFAB()).waitForClickable();
+  await (await fastActionFAB()).click();
+
+  await browser.pause(500);
+  await (await fastActionListContainer()).waitForDisplayed();
+
+  const items = await fastActionItems();
+  const fastActionItemLabels = await Promise.all(items.map(item => item.getText()));
+  return fastActionItemLabels;
 };
 
 const clickFastActionFlat = async ({ actionId, waitForList }) => {
@@ -406,6 +424,14 @@ const loadNextInfiniteScrollPage = async () => {
   await waitForLoaderToDisappear(await $('.left-pane'));
 };
 
+const getActionBarLabels = async () => {
+  await (await actionBar()).waitForDisplayed();
+  await (await actionBarActions())[0].waitForDisplayed();
+  const items = await actionBarActions();
+  const labels = await Promise.all(items.map(item => item.getText()));
+  return labels.filter(label => !!label);
+};
+
 module.exports = {
   openMoreOptionsMenu,
   closeFastActionList,
@@ -466,4 +492,6 @@ module.exports = {
   getAllButtonLabelsNames,
   loadNextInfiniteScrollPage,
   goToUrl,
+  getFastActionItemsLabels,
+  getActionBarLabels,
 };

--- a/webapp/src/ts/components/actionbar/actionbar.component.html
+++ b/webapp/src/ts/components/actionbar/actionbar.component.html
@@ -38,10 +38,10 @@
       </div>
 
       <div class="col-sm-4 general-actions left-pane" *ngIf="currentTab === 'contacts'">
-        <div test-id='create_places' class="actions dropup" mmAuth [mmAuthAny]="[ actionBar?.left?.childPlaces && 'can_create_places' ]">
+        <div test-id='create_places' class="actions dropup" mmAuth [mmAuthAny]="[ 'can_export_all', 'can_export_contacts', 'can_create_places', 'can_create_people' ]">
           <a
             *ngIf="actionBar?.left?.childPlaces?.length > 1"
-            mmAuth="can_edit,can_create_places"
+            mmAuth="can_edit" [mmAuthAny]="['can_create_places', 'can_create_people']"
             class="mm-icon mm-icon-inverse mm-icon-caption dropdown-toggle create-place"
             data-toggle="dropdown"
           >
@@ -51,7 +51,7 @@
 
           <ul
             *ngIf="actionBar?.left?.childPlaces?.length > 1"
-            mmAuth="can_edit,can_create_places"
+            mmAuth="can_edit" [mmAuthAny]="['can_create_places', 'can_create_people']"
             class="dropdown-menu mm-dropdown-menu with-icon"
           >
             <li *ngFor="let child of actionBar.left.childPlaces; trackBy: trackById">
@@ -66,7 +66,7 @@
 
           <a
             *ngIf="actionBar?.left?.childPlaces?.length === 1"
-            mmAuth="can_edit,can_create_places"
+            mmAuth="can_edit" [mmAuthAny]="['can_create_places', 'can_create_people']"
             class="mm-icon mm-icon-inverse mm-icon-caption create-place"
             [routerLink]="actionBar.left.userFacilityId ? ['/', 'contacts', actionBar.left.userFacilityId, 'add', actionBar.left.childPlaces[0]?.id] : ['/', 'contacts', 'add', actionBar.left.childPlaces[0]?.id]"
             [queryParams]="{ from: 'list' }"

--- a/webapp/src/ts/services/fast-action-button.service.ts
+++ b/webapp/src/ts/services/fast-action-button.service.ts
@@ -65,7 +65,7 @@ export class FastActionButtonService {
     return xmlForms
       .map(form => ({
         id: form.code,
-        label: this.getFormTitle(form.titleKey, form.title) || form.code,
+        label: this.getFormTitle(form.titleKey, form.title) ?? form.code,
         icon: { name: form.icon, type: IconType.RESOURCE },
         alwaysOpenInPanel: true,
         canDisplay: () => this.authService.has('can_edit'),
@@ -88,9 +88,12 @@ export class FastActionButtonService {
     return childContactTypes
       .map(contactType => ({
         id: contactType.id,
-        label: this.getFormTitle(contactType.create_key) || contactType.id,
+        label: this.getFormTitle(contactType.create_key) ?? contactType.id,
         icon: { name: contactType.icon, type: IconType.RESOURCE },
-        canDisplay: () => this.authService.has(['can_edit', 'can_create_places']),
+        canDisplay: () => this.authService.has([
+          'can_edit',
+          contactType.person ? 'can_create_people' : 'can_create_places'
+        ]),
         execute: () => {
           const route = ['/contacts', 'add', contactType.id];
           if (parentFacilityId) {
@@ -124,7 +127,7 @@ export class FastActionButtonService {
           this.executeMailto(`sms:${sendTo?.phone}`);
           return;
         }
-        callbackOpenSendMessage && callbackOpenSendMessage(sendTo?._id);
+        callbackOpenSendMessage?.(sendTo?._id);
       },
     };
   }

--- a/webapp/tests/karma/ts/services/fast-action-button.service.spec.ts
+++ b/webapp/tests/karma/ts/services/fast-action-button.service.spec.ts
@@ -198,6 +198,7 @@ describe('Session service', () => {
         childContactTypes: [
           { id: 'child-place-1', create_key: 'child-place-1-title', icon: 'child-place-1-icon' },
           { id: 'child-place-2', icon: 'child-place-2-icon' },
+          { id: 'child-place-3', icon: 'child-place-3-icon', person: true },
         ],
         xmlReportForms: [
           { code: 'report-form-1', titleKey: 'report-form-1-title-key', icon: 'report-form-1-icon' },
@@ -214,12 +215,13 @@ describe('Session service', () => {
 
       const actions = await service.getContactRightSideActions(context);
 
-      expect(actions.length).to.equal(6);
+      expect(actions.length).to.equal(7);
       expect(authService.has.args).to.have.deep.members([
         [ 'can_view_call_action' ],
         [ [ 'can_view_message_action', 'can_edit' ] ],
         [ [ 'can_edit', 'can_create_places' ] ],
         [ [ 'can_edit', 'can_create_places' ] ],
+        [ [ 'can_edit', 'can_create_people' ] ],
         [ 'can_edit' ],
         [ 'can_edit' ],
         [ 'can_edit' ],
@@ -240,19 +242,26 @@ describe('Session service', () => {
         route: [ '/contacts', 'parent-facility-1', 'add', 'child-place-2' ],
         queryParams: null,
       });
-      assertReportFormAction(actions[3], {
+      assertContactFormAction(actions[3], {
+        id: 'child-place-3',
+        label: 'child-place-3',
+        icon: 'child-place-3-icon',
+        route: [ '/contacts', 'parent-facility-1', 'add', 'child-place-3' ],
+        queryParams: null,
+      });
+      assertReportFormAction(actions[4], {
         id: 'report-form-1',
         label: 'report-form-1-title-key',
         icon: 'report-form-1-icon',
         route: [ '/reports', 'add', 'report-form-1' ],
       });
-      assertReportFormAction(actions[4], {
+      assertReportFormAction(actions[5], {
         id: 'report-form-2',
         label: 'report-form-2-title',
         icon: 'report-form-2-icon',
         route: [ '/reports', 'add', 'report-form-2' ],
       });
-      assertReportFormAction(actions[5], {
+      assertReportFormAction(actions[6], {
         id: 'report-form-3',
         label: 'report-form-3',
         icon: 'report-form-3-icon',
@@ -266,6 +275,7 @@ describe('Session service', () => {
         childContactTypes: [
           { id: 'child-place-1', create_key: 'child-place-1-title', icon: 'child-place-1-icon' },
           { id: 'child-place-2', icon: 'child-place-2-icon' },
+          { id: 'child-place-3', icon: 'child-place-3-icon', person: true },
         ],
         xmlReportForms: [
           { code: 'report-form-1', titleKey: 'report-form-1-title-key', icon: 'report-form-1-icon' },
@@ -282,12 +292,13 @@ describe('Session service', () => {
 
       const actions = await service.getContactRightSideActions(context);
 
-      expect(actions.length).to.equal(7);
+      expect(actions.length).to.equal(8);
       expect(authService.has.args).to.have.deep.members([
         [ 'can_view_call_action' ],
         [ [ 'can_view_message_action' ] ],
         [ [ 'can_edit', 'can_create_places' ] ],
         [ [ 'can_edit', 'can_create_places' ] ],
+        [ [ 'can_edit', 'can_create_people' ] ],
         [ 'can_edit' ],
         [ 'can_edit' ],
         [ 'can_edit' ],
@@ -309,19 +320,26 @@ describe('Session service', () => {
         route: [ '/contacts', 'parent-facility-1', 'add', 'child-place-2' ],
         queryParams: null,
       });
-      assertReportFormAction(actions[4], {
+      assertContactFormAction(actions[4], {
+        id: 'child-place-3',
+        label: 'child-place-3',
+        icon: 'child-place-3-icon',
+        route: [ '/contacts', 'parent-facility-1', 'add', 'child-place-3' ],
+        queryParams: null,
+      });
+      assertReportFormAction(actions[5], {
         id: 'report-form-1',
         label: 'report-form-1-title-key',
         icon: 'report-form-1-icon',
         route: [ '/reports', 'add', 'report-form-1' ],
       });
-      assertReportFormAction(actions[5], {
+      assertReportFormAction(actions[6], {
         id: 'report-form-2',
         label: 'report-form-2-title',
         icon: 'report-form-2-icon',
         route: [ '/reports', 'add', 'report-form-2' ],
       });
-      assertReportFormAction(actions[6], {
+      assertReportFormAction(actions[7], {
         id: 'report-form-3',
         label: 'report-form-3',
         icon: 'report-form-3-icon',


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds separate checks for `con_create_people` on contact page actionbar and FAB. 

#8730 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8730-fix-actionbar-permissions/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8730-fix-actionbar-permissions/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8730-fix-actionbar-permissions/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

