### PR TITLE
fix(#8745): don't evaluate form context when opening a task (#8746)

### DIFF
--- a/tests/e2e/default/tasks/forms/home-visit.properties.json
+++ b/tests/e2e/default/tasks/forms/home-visit.properties.json
@@ -1,6 +1,6 @@
 {
   "context": {
-    "expression": "!contact || contact.type === 'person'",
+    "expression": "false",
     "person": true,
     "place": false
   },

--- a/tests/e2e/default/tasks/tasks-breadcrumbs.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks-breadcrumbs.wdio-spec.js
@@ -110,6 +110,13 @@ describe('Tasks tab breadcrumbs', () => {
         },
       ]);
     });
+
+    it('should open task with expression', async () => {
+      await tasksPage.goToTasksTab();
+      const task = await tasksPage.getTaskByContactAndForm('patient1', 'person_create');
+      await task.click();
+      await tasksPage.waitForTaskContentLoaded('Home Visit');
+    });
   });
 
   describe('for supervisor', () => {

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -19,7 +19,7 @@ const compileTasks = async (tasksFileName) => {
   return await chtConfUtils.compileNoolsConfig({ tasks: tasksFilePath });
 };
 
-describe('Task list', () => {
+describe('Tasks', () => {
   const places = placeFactory.generateHierarchy();
   const clinic = places.get('clinic');
   const healthCenter = places.get('health_center');

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -653,6 +653,10 @@ export class EnketoFormContext {
   }
 
   shouldEvaluateExpression() {
+    if (this.type === 'task') {
+      return false;
+    }
+
     if (this.type === 'report' && this.editing) {
       return false;
     }

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -1209,3 +1209,44 @@ describe('Enketo service', () => {
     }));
   });
 });
+
+describe('EnketoFormContext', () => {
+  it('should construct object correctly', () => {
+    const context = new EnketoFormContext('#sel', 'task', { doc: 1 }, { data: 1 });
+    expect(context).to.deep.include({
+      selector: '#sel',
+      type: 'task',
+      formDoc: { doc: 1 },
+      instanceData: { data: 1 },
+    });
+  });
+
+  it('shouldEvaluateExpression should return false for tasks', () => {
+    const ctx = new EnketoFormContext('a', 'task', {}, {});
+    expect(ctx.shouldEvaluateExpression()).to.eq(false);
+  });
+
+  it('shouldEvaluateExpression should return false for editing reports', () => {
+    const ctx = new EnketoFormContext('a', 'report', {}, {});
+    ctx.editing = true;
+    expect(ctx.shouldEvaluateExpression()).to.eq(false);
+  });
+
+  it('shouldEvaluateExpression should return true for reports and contact forms', () => {
+    const ctxReport = new EnketoFormContext('a', 'report', {}, {});
+    expect(ctxReport.shouldEvaluateExpression()).to.eq(true);
+
+    const ctxContact = new EnketoFormContext('a', 'contact', {}, {});
+    expect(ctxContact.shouldEvaluateExpression()).to.eq(true);
+  });
+
+  it('requiresContact should return true when type is not contact', () => {
+    const ctxReport = new EnketoFormContext('a', 'report', {}, {});
+    expect(ctxReport.requiresContact()).to.eq(true);
+  });
+
+  it('requiresContact should return false when type is contact', () => {
+    const ctxReport = new EnketoFormContext('a', 'contact', {}, {});
+    expect(ctxReport.requiresContact()).to.eq(false);
+  });
+});


### PR DESCRIPTION
#8745

(cherry picked from commit 34edb11f7f5b9a2f945945387e70a762098c8148)

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8745-fix-task-form-context-4.4.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8745-fix-task-form-context-4.4.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8745-fix-task-form-context-4.4.x/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

