### PR TITLE
chore(#8739): fix e2e rate limiting

### DIFF
--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -23,7 +23,7 @@ describe('FAB + Actionbar', () => {
   });
 
   afterEach(async () => {
-    await utils.revertSettings(false);
+    await utils.revertSettings(true);
   });
 
   describe('FAB', () => {

--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -18,12 +18,12 @@ describe('FAB + Actionbar', () => {
   });
 
   after(async () => {
-    await commonElements.logout();
+    await browser.reloadSession();
     await utils.deleteUsers([ onlineUser ]);
   });
 
   afterEach(async () => {
-    await utils.revertSettings(true);
+    await utils.revertSettings(false);
   });
 
   describe('FAB', () => {

--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -18,6 +18,7 @@ describe('FAB + Actionbar', () => {
   });
 
   after(async () => {
+    await commonElements.logout();
     await utils.deleteUsers([ onlineUser ]);
   });
 

--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -17,6 +17,10 @@ describe('FAB + Actionbar', () => {
     await loginPage.login(onlineUser);
   });
 
+  after(() => {
+    await utils.deleteUsers([ onlineUser ]);
+  });
+
   afterEach(async () => {
     await utils.revertSettings(false);
   });

--- a/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
+++ b/tests/e2e/default/contacts/fab-actionbar.wdio-spec.js
@@ -17,7 +17,7 @@ describe('FAB + Actionbar', () => {
     await loginPage.login(onlineUser);
   });
 
-  after(() => {
+  after(async () => {
     await utils.deleteUsers([ onlineUser ]);
   });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Logged in user somehow got deleted before the browser session was terminated, which caused a series of 401s that ultimately ended up rate limiting a request from the next e2e test. 
Because all requests come from the same "source", they all count towards the same rate-limiting pool. 

#8739

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* __CHT_CORE_COMPOSE_URL__
* __COUCH_SINGLE_COMPOSE_URL__
* __COUCH_CLUSTER_COMPOSE_URL__

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

