### PR TITLE
fix(#8585): fixing display of question label with summary appearance

### DIFF
--- a/webapp/src/css/enketo/medic.less
+++ b/webapp/src/css/enketo/medic.less
@@ -306,7 +306,7 @@
     }
 
     label .question-label {
-      display: block;
+      display: inline;
     }
 
     .or-appearance-h1:not(.disabled) {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description
The issue happens with the fields type `string`. This was introduced in 2016 in [this commit](https://github.com/medic/cht-core/commit/67965c28f34d191389acd5321e1cf2d7aaf2b1cf#diff-ffd309e5c33dabe1de84b768e50eada8718a478d4516e2bb033aeb52c6f09438R125)


#8585

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8585-fix-Asterisk-for-required-field-in-enketo/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8585-fix-Asterisk-for-required-field-in-enketo/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8585-fix-Asterisk-for-required-field-in-enketo/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

