### PR TITLE
perf(#8771): improve performance of task recalculation for many contacts

### DIFF
--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -307,6 +307,7 @@ describe('pouchdb provider', () => {
   });
 
   describe('taskDataFor', () => {
+    const defaultQueryParams = { skip: undefined, limit: undefined, group_level: undefined };
     it('no contacts yields empty', async() => expect(await pouchdbProvider(db).taskDataFor([])).to.be.empty);
     it('empty contacts yields empty', async() => expect(await pouchdbProvider(db).taskDataFor([])).to.be.empty);
     it('unrecognized contact id yields empty', async () => {
@@ -316,6 +317,10 @@ describe('pouchdb provider', () => {
         taskDocs: [],
         userSettingsId: 'org.couchdb.user:username',
       });
+      expect(db.query.args).to.deep.equal([
+        ['medic-client/reports_by_subject', { keys: ['abc'], include_docs: true, ...defaultQueryParams }],
+        ['medic-client/tasks_by_contact', { keys: ['requester-abc'], include_docs: true, ...defaultQueryParams }],
+      ]);
     });
     it('cht contact yields', async() => {
       const actual = await pouchdbProvider(db).taskDataFor([chtDocs.contact._id, 'abc'], mockUserSettingsDoc);
@@ -332,6 +337,17 @@ describe('pouchdb provider', () => {
         ],
         userSettingsId: 'org.couchdb.user:username',
       });
+
+      expect(db.query.args).to.deep.equal([
+        [
+          'medic-client/reports_by_subject',
+          { keys: [chtDocs.contact._id, 'abc', chtDocs.contact.patient_id], include_docs: true, ...defaultQueryParams },
+        ],
+        [
+          'medic-client/tasks_by_contact',
+          { keys: [`requester-${chtDocs.contact._id}`, 'requester-abc'], include_docs: true, ...defaultQueryParams }
+        ],
+      ]);
     });
 
     it('should exclude multi-subject reports who have other "primary" subjects for contact', async () => {
@@ -382,6 +398,84 @@ describe('pouchdb provider', () => {
           failedTask,
           readyTask,
           taskRequestedByChtContact
+        ],
+        userSettingsId: 'org.couchdb.user:username',
+      });
+    });
+
+    it('should use keys param when there are less than 500 contacts', async () => {
+      const contactIds = Array.from({ length: 490 }).map((_, i) => `contact${i}`);
+      contactIds.push(chtDocs.place._id, chtDocs.contact._id);
+      const tasks = await pouchdbProvider(db).taskDataFor(contactIds, mockUserSettingsDoc);
+
+      expect(db.query.args).to.deep.equal([
+        [
+          'medic-client/reports_by_subject',
+          { keys: [ ...contactIds, 'place_id', 'patient_id' ], include_docs: true, ...defaultQueryParams },
+        ],
+        [
+          'medic-client/tasks_by_contact',
+          { keys: contactIds.map(id => `requester-${id}`), include_docs: true, ...defaultQueryParams }
+        ],
+      ]);
+
+      expect(tasks).excludingEvery('_rev').to.deep.eq({
+        contactDocs: [chtDocs.place, chtDocs.contact],
+        reportDocs: [
+          reportConnectedByPatientAndPlaceUuid,
+          reportConnectedByPlaceUuid,
+          chtDocs.pregnancyReport,
+          reportConnectedByPlace,
+        ],
+        taskDocs: [
+          cancelledTaskForPlace,
+          readyTaskForPlace,
+          taskRequestedByChtPlace,
+          cancelledTask,
+          completedTask,
+          draftTask,
+          failedTask,
+          readyTask,
+          taskRequestedByChtContact
+        ],
+        userSettingsId: 'org.couchdb.user:username',
+      });
+    });
+
+    it('should not use keys param when there are more than 500 contacts', async () => {
+      const contactIds = Array.from({ length: 501 }).map((_, i) => `contact${i}`);
+      contactIds.push(chtDocs.place._id, chtDocs.contact._id);
+      const tasks = await pouchdbProvider(db).taskDataFor(contactIds, mockUserSettingsDoc);
+
+      expect(db.query.args).to.deep.equal([
+        [
+          'medic-client/reports_by_subject',
+          { include_docs: true, ...defaultQueryParams },
+        ],
+        [
+          'medic-client/tasks_by_contact',
+          { include_docs: true, ...defaultQueryParams }
+        ],
+      ]);
+
+      expect(tasks).excludingEvery('_rev').to.deep.eq({
+        contactDocs: [chtDocs.place, chtDocs.contact],
+        reportDocs: [
+          chtDocs.pregnancyReport,
+          reportConnectedByPatientAndPlaceUuid,
+          reportConnectedByPlace,
+          reportConnectedByPlaceUuid,
+        ],
+        taskDocs: [
+          cancelledTask,
+          completedTask,
+          draftTask,
+          failedTask,
+          readyTask,
+          taskRequestedByChtContact,
+          cancelledTaskForPlace,
+          readyTaskForPlace,
+          taskRequestedByChtPlace,
         ],
         userSettingsId: 'org.couchdb.user:username',
       });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

PouchDb is notoriously slow to query views with a large number of keys. This is what happened when task recalculation was triggered. For users with large numbers of contacts, these requests became so heavy it took minutes to complete, sometimes crashing PouchDb entirely. 

This adds a short-circuit to the key loaded query, when there are more than  500 keys, and instead gets all rows and filters them. 
The limit of 500 can be changed. In my sample test with ~10000 reports, it took roughly the same time to get all rows vs query with 500 keys. 

Performance difference: 
| contacts | reports | Query style                   | duration | duration | duration | duration | AVG    | IDB Crashes |
|------------| ------ |-------------------------------|----------|----------|----------|----------|--------|-------------|
| 6661       | 10000 | keys (current)                | 293s   | 276s  | 270s   | 293s   | 283s | 3           |
| 6661       | 10000 | all rows (proposed)           | 64s    | 63s    | 66s   | 58s    | 63s  | 0           |
| 6661       | 10000  | start_key + end_key (attempt) | 100s   | 95s    | 92s    | 92s    | 95s  | 0           |



#8771

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8771-skip-keys-param/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8771-skip-keys-param/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8771-skip-keys-param/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

