### PR TITLE
 fix(#8038): use builds url from env var

### DIFF
--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -28,7 +28,7 @@ angular.module('controllers').controller('UpgradeCtrl',
     const UPGRADE_CONTAINER_WAIT_PERIOD = 3 * 60 * 1000; // 3 minutes
 
     let containerWaitPeriodTimeout;
-    let buildsUrl;
+    let apiBuildsUrl;
 
     const logError = (error, key) => {
       return $translate
@@ -69,7 +69,7 @@ angular.module('controllers').controller('UpgradeCtrl',
     const getCurrentUpgrade = () => {
       return $http
         .get(UPGRADE_URL)
-        .then(({ data: { upgradeDoc, indexers, apiBuildsUrl } }) => {
+        .then(({ data: { upgradeDoc, indexers, buildsUrl } }) => {
           if ($scope.upgradeDoc && !upgradeDoc) {
             const expectedVersion = $scope.upgradeDoc.to && $scope.upgradeDoc.to.build;
             getExistingDeployment(true, expectedVersion);
@@ -77,7 +77,7 @@ angular.module('controllers').controller('UpgradeCtrl',
 
           $scope.upgradeDoc = upgradeDoc;
           $scope.indexerProgress = indexers;
-          buildsUrl = apiBuildsUrl;
+          apiBuildsUrl = buildsUrl;
 
           if (upgradeDoc) {
             $timeout(getCurrentUpgrade, UPGRADE_POLL_FREQ);
@@ -111,7 +111,7 @@ angular.module('controllers').controller('UpgradeCtrl',
 
     const loadBuilds = () => {
       const minVersion = Version.minimumNextRelease($scope.currentDeploy.version);
-      const buildsDb = pouchDB(buildsUrl || DEFAULT_BUILDS_URL);
+      const buildsDb = pouchDB(apiBuildsUrl || DEFAULT_BUILDS_URL);
 
       // NB: Once our build server is on CouchDB 2.0 we can combine these three calls
       //     See: http://docs.couchdb.org/en/2.0.0/api/ddoc/views.html#sending-multiple-queries-to-a-view

--- a/admin/src/js/controllers/upgrade.js
+++ b/admin/src/js/controllers/upgrade.js
@@ -144,7 +144,11 @@ angular.module('controllers').controller('UpgradeCtrl',
         ])
         .then(([ branches, betas, releases, featureReleases ]) => {
           $scope.versions = { branches, betas, releases, featureReleases };
-          buildsDb.destroy();
+          buildsDb.close();
+        })
+        .catch(err => {
+          buildsDb.close();
+          throw err;
         });
     };
 

--- a/admin/tests/unit/controllers/upgrade.spec.js
+++ b/admin/tests/unit/controllers/upgrade.spec.js
@@ -12,6 +12,7 @@ describe('UpgradeCtrl controller', () => {
   let timeout;
   let translate;
   let state;
+  let pouchDb;
 
   const nextTick = () => new Promise(r => setTimeout(r));
 
@@ -27,8 +28,10 @@ describe('UpgradeCtrl controller', () => {
 
     buildsDb = {
       query: sinon.stub(),
+      destroy: sinon.stub()
     };
-    const pouchDb = sinon.stub().returns(buildsDb);
+    pouchDb = sinon.stub();
+    pouchDb.returns(buildsDb);
     modal = sinon.stub();
     http = {
       get: sinon.stub(),
@@ -126,6 +129,77 @@ describe('UpgradeCtrl controller', () => {
     createController();
     await scope.setupPromise;
 
+    expect(pouchDb.callCount).to.equal(1);
+    expect(pouchDb.args[0][0]).to.equal('https://staging.dev.medicmobile.org/_couch/builds_4');
+    expect(scope.loading).to.equal(false);
+    expect(scope.versions).to.deep.equal({
+      branches: [{ version: 'branch1' }, { version: 'branch2' }],
+      betas: [{ version: 'beta1' }, { version: 'beta2' }],
+      releases: [{ version: 'release1' }, { version: 'release2' }],
+      featureReleases: [],
+    });
+    expect(buildsDb.query.callCount).to.equal(3);
+    expect(buildsDb.query.args[0]).to.deep.equal([
+      'builds/releases',
+      {
+        startkey: [ 'branch', 'medic', 'medic', {}],
+        endkey: [ 'branch', 'medic', 'medic'],
+        descending: true,
+        limit: 50,
+      }
+    ]);
+    expect(buildsDb.query.args[1]).to.deep.equal([
+      'builds/releases',
+      {
+        startkey: [ 'beta', 'medic', 'medic', {}],
+        endkey: [ 'beta', 'medic', 'medic', 4, 1, 1, 0 ],
+        descending: true,
+        limit: 50,
+      }
+    ]);
+    expect(buildsDb.query.args[2]).to.deep.equal([
+      'builds/releases',
+      {
+        startkey: [ 'release', 'medic', 'medic', {}],
+        endkey: [ 'release', 'medic', 'medic', 4, 1, 1 ],
+        descending: true,
+        limit: 50,
+      }
+    ]);
+  });
+
+  it('should load builds from configured builds url', async () => {
+    const deployInfo = { the: 'deplopy info', version: '4.1.0' };
+    Object.freeze(deployInfo);
+
+    http.get.withArgs('/api/deploy-info').resolves({ data: deployInfo });
+    http.get.withArgs('/api/v2/upgrade').resolves({ data: { upgradeDoc: undefined, indexers: [], buildsUrl: 'https://mybuildurl.com' } });
+    version.minimumNextRelease.returns({ major: 4, minor: 1, patch: 1, beta: 0 });
+
+    buildsDb.query.onCall(0).resolves({
+      rows: [
+        { id: 'medic:medic:branch1', value: { version: 'branch1' } },
+        { id: 'medic:medic:branch2', value: { version: 'branch2' } },
+      ],
+    });
+    buildsDb.query.onCall(1).resolves({
+      rows: [
+        { id: 'medic:medic:beta1', value: { version: 'beta1' } },
+        { id: 'medic:medic:beta2', value: { version: 'beta2' } },
+      ],
+    });
+    buildsDb.query.onCall(2).resolves({
+      rows: [
+        { id: 'medic:medic:release1', value: { version: 'release1' } },
+        { id: 'medic:medic:release2', value: { version: 'release2' } },
+      ],
+    });
+
+    createController();
+    await scope.setupPromise;
+
+    expect(pouchDb.callCount).to.equal(1);
+    expect(pouchDb.args[0][0]).to.equal('https://mybuildurl.com');
     expect(scope.loading).to.equal(false);
     expect(scope.versions).to.deep.equal({
       branches: [{ version: 'branch1' }, { version: 'branch2' }],

--- a/admin/tests/unit/controllers/upgrade.spec.js
+++ b/admin/tests/unit/controllers/upgrade.spec.js
@@ -28,7 +28,7 @@ describe('UpgradeCtrl controller', () => {
 
     buildsDb = {
       query: sinon.stub(),
-      destroy: sinon.stub()
+      close: sinon.stub()
     };
     pouchDb = sinon.stub();
     pouchDb.returns(buildsDb);
@@ -166,6 +166,7 @@ describe('UpgradeCtrl controller', () => {
         limit: 50,
       }
     ]);
+    expect(buildsDb.close.callCount).to.equal(1);
   });
 
   it('should load builds from configured builds url', async () => {
@@ -235,6 +236,7 @@ describe('UpgradeCtrl controller', () => {
         limit: 50,
       }
     ]);
+    expect(buildsDb.close.callCount).to.equal(1);
   });
 
   it('should catch couch query errors', async () => {
@@ -259,6 +261,7 @@ describe('UpgradeCtrl controller', () => {
 
     expect(scope.loading).to.equal(false);
     expect(scope.versions).to.deep.equal({});
+    expect(buildsDb.close.callCount).to.equal(1);
   });
 
   it('should follow upgrade if already in progress', async () => {

--- a/api/src/controllers/upgrade.js
+++ b/api/src/controllers/upgrade.js
@@ -1,3 +1,4 @@
+const environment = require('../environment');
 const auth = require('../auth');
 const serverUtils = require('../server-utils');
 
@@ -40,7 +41,7 @@ const upgradeInProgress = (req, res) => {
       service.indexerProgress(),
     ]))
     .then(([upgradeDoc, indexers]) => {
-      res.json({ upgradeDoc, indexers });
+      res.json({ upgradeDoc, indexers, buildsUrl: environment.buildsUrl });
     })
     .catch(err => {
       if (err && err.error && err.error.code === 'ECONNREFUSED') {

--- a/api/tests/mocha/controllers/upgrade.spec.js
+++ b/api/tests/mocha/controllers/upgrade.spec.js
@@ -1,6 +1,7 @@
 const should = require('chai').should();
 
 const sinon = require('sinon');
+const environment = require('../../../src/environment');
 const auth = require('../../../src/auth');
 const serverUtils = require('../../../src/server-utils');
 
@@ -27,9 +28,14 @@ describe('Upgrade controller', () => {
     sinon.stub(serverUtils, 'error');
     sinon.stub(service, 'upgrade').resolves();
     sinon.stub(service, 'complete').resolves();
+
+    environment.buildsUrl = 'https://mybuild.com';
   });
 
-  afterEach(() => sinon.restore());
+  afterEach(() => {
+    environment.buildsUrl = '';
+    sinon.restore();
+  });
 
   describe('Upgrade', () => {
     it('checks that user has the right permissions', () => {
@@ -193,6 +199,7 @@ describe('Upgrade controller', () => {
       service.indexerProgress.callCount.should.equal(1);
       res.json.callCount.should.equal(1);
       res.json.args[0].should.deep.equal([ {
+        buildsUrl: 'https://mybuild.com',
         upgradeDoc: { the: 'upgrade' },
         indexers: ['indexers'],
       }]);

--- a/api/tests/mocha/routing.spec.js
+++ b/api/tests/mocha/routing.spec.js
@@ -14,7 +14,7 @@ describe('Routing', () => {
     const environment = rewire('./../../src/environment');
     const adminUpgrade = rewire('./../../../admin/src/js/controllers/upgrade');
     const cspBuildDb = environment.__get__('DEFAULT_BUILDS_URL');
-    const actualBuildDb = adminUpgrade.__get__('BUILDS_DB');
+    const actualBuildDb = adminUpgrade.__get__('DEFAULT_BUILDS_URL');
     chai.expect(cspBuildDb).to.not.eq(undefined);
     chai.expect(cspBuildDb).to.include(actualBuildDb);
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->
#8038 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8038-use-builds-url-from-env/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8038-use-builds-url-from-env/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8038-use-builds-url-from-env/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

