### PR TITLE
chore(#8437): enable alwaysStrict in webapp tsconfig

### DIFF
--- a/webapp/tsconfig.base.json
+++ b/webapp/tsconfig.base.json
@@ -30,7 +30,8 @@
       "@mm-selectors/*": ["src/ts/selectors/*"],
       "@mm-services/*": ["src/ts/services/*"]
     },
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "alwaysStrict": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
# Description
Clearly this is not really necessary (I guess our linting config is already covering this?).  But, seems worth explicitly adding it here so we can check the box on https://github.com/medic/cht-core/issues/8437....

# Code review checklist

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:alwaysStrict/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:alwaysStrict/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:alwaysStrict/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

