### PR TITLE
chore: add an explanation message to 2 assertions in  `routing.spec.js`

### DIFF
--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -174,8 +174,14 @@ describe('routing', () => {
         utils.request(Object.assign({ path: '/api/deploy-info' }, offlineRequestOptions)),
         utils.requestOnTestDb('/_design/medic-client'),
       ]).then(([ deployInfoOnline, deployInfoOffline, ddoc ]) => {
-        expect(semver.valid(deployInfoOnline.version)).to.be.ok;
-        expect(semver.valid(deployInfoOffline.version)).to.be.ok;
+        expect(
+          semver.valid(deployInfoOnline.version),
+          `"${deployInfoOnline.version}" is not valid semver`,
+        ).to.be.ok;
+        expect(
+          semver.valid(deployInfoOffline.version),
+          `"${deployInfoOffline.version}" is not valid semver`,
+        ).to.be.ok;
 
         const { BRANCH } = process.env;
         const deployInfo = {


### PR DESCRIPTION
# Description

Tiny change to get a more helpful message than [`expected null to be truthy`](https://github.com/medic/cht-core/actions/runs/7530916999/job/20498760460?pr=8756#step:17:1036) when these assertions fail

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

# Compose URLs
<!-- Do not change these!  CI will automatically update these to be the deep URLs -->
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:explanation-message-on-test-failure/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:explanation-message-on-test-failure/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:explanation-message-on-test-failure/docker-compose/cht-couchdb-clustered.yml)

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

