### PR TITLE
feat(#8591): adds option for enabling server name indication

### DIFF
--- a/api/.eslintrc
+++ b/api/.eslintrc
@@ -17,6 +17,7 @@
           "@medic/cht-script-api",
           "@medic/contact-types-utils",
           "@medic/contacts",
+          "@medic/couch-request",
           "@medic/infodoc",
           "@medic/lineage",
           "@medic/message-utils",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5699,7 +5699,7 @@
     "node_modules/stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10601,7 +10601,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g=="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -1,4 +1,4 @@
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 const _ = require('lodash');
 const db = require('./db');
 const environment = require('./environment');
@@ -15,7 +15,7 @@ const get = (path, headers) => {
     .forEach(header => delete getHeaders[header]);
 
   const url = new URL(path, environment.serverUrlNoAuth);
-  return rpn.get({
+  return request.get({
     url: url.toString(),
     headers: getHeaders,
     json: true
@@ -103,7 +103,7 @@ module.exports = {
     const authUrl = new URL(environment.serverUrlNoAuth);
     authUrl.username = username;
     authUrl.password = password;
-    return rpn.head({
+    return request.head({
       uri: authUrl.toString(),
       resolveWithFullResponse: true
     })

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const _ = require('lodash');
 const url = require('node:url');
 const auth = require('../auth');

--- a/api/src/db-batch.js
+++ b/api/src/db-batch.js
@@ -3,7 +3,7 @@
  */
 const url = require('url');
 const path = require('path');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const environment = require('./environment');
 const logger = require('./logger');
 const DEFAULT_BATCH_LIMIT = 100; // 100 is a good compromise of performance and stability

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -1,7 +1,7 @@
 const PouchDB = require('pouchdb-core');
 const logger = require('./logger');
 const environment = require('./environment');
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 PouchDB.plugin(require('pouchdb-session-authentication'));
 PouchDB.plugin(require('pouchdb-find'));
@@ -123,13 +123,13 @@ if (UNIT_TEST_ENV) {
       });
   };
 
-  module.exports.allDbs = () => rpn.get({
+  module.exports.allDbs = () => request.get({
     uri: `${environment.serverUrl}/_all_dbs`,
     json: true
   });
 
   module.exports.activeTasks = () => {
-    return rpn
+    return request
       .get({
         url: `${environment.serverUrl}/_active_tasks`,
         json: true
@@ -195,7 +195,7 @@ if (UNIT_TEST_ENV) {
     const securityUrl = new URL(environment.serverUrl);
     securityUrl.pathname = `${dbname}/_security`;
 
-    const securityObject = await rpn.get({ url: securityUrl.toString(), json: true });
+    const securityObject = await request.get({ url: securityUrl.toString(), json: true });
     const property = addAsAdmin ? 'admins' : 'members';
 
     if (!securityObject[property]) {
@@ -212,7 +212,7 @@ if (UNIT_TEST_ENV) {
 
     logger.info(`Adding "${role}" role to ${dbname} ${property}`);
     securityObject[property].roles.push(role);
-    await rpn.put({ url: securityUrl.toString(), json: true, body: securityObject });
+    await request.put({ url: securityUrl.toString(), json: true, body: securityObject });
   };
 
   module.exports.addRoleAsAdmin = (dbname, role) => addRoleToSecurity(dbname, role, true);

--- a/api/src/environment.js
+++ b/api/src/environment.js
@@ -1,8 +1,17 @@
 const path = require('path');
 const logger = require('./logger');
 
-const { UNIT_TEST_ENV, COUCH_URL, BUILDS_URL } = process.env;
+const { 
+  UNIT_TEST_ENV,
+  COUCH_URL,
+  BUILDS_URL, 
+  PROXY_CHANGE_ORIGIN = false
+} = process.env;
+
 const DEFAULT_BUILDS_URL = 'https://staging.dev.medicmobile.org/_couch/builds_4';
+
+const isString = value => typeof value === 'string' || value instanceof String;
+const isTrue = value => isString(value) ? value.toLowerCase() === 'true' : value === true;
 
 if (UNIT_TEST_ENV) {
   module.exports = {
@@ -15,6 +24,9 @@ if (UNIT_TEST_ENV) {
     host: '',
     protocol: '',
     buildsUrl: '',
+    proxies: {
+      changeOrigin: isTrue(PROXY_CHANGE_ORIGIN)
+    }
   };
 } else if (COUCH_URL) {
   // strip trailing slash from to prevent bugs in path matching
@@ -36,7 +48,14 @@ if (UNIT_TEST_ENV) {
     db: parsedUrl.pathname.replace('/', ''),
     ddoc: 'medic',
     username: parsedUrl.username,
-    password: parsedUrl.password
+    password: parsedUrl.password,
+    proxies: {
+      // See http-proxy (https://www.npmjs.com/package/http-proxy#options) 
+      // "changeOrigin: true/false, Default: false - changes the origin of the host header to the target URL"
+      // This allows proxying from HTTP to HTTPS without encountering certificate issues 
+      // for environments where TLS termination happens elsewhere.
+      changeOrigin: isTrue(PROXY_CHANGE_ORIGIN)
+    }
   };
 } else {
   logger.error(

--- a/api/src/migrations/restrict-access-to-audit-db.js
+++ b/api/src/migrations/restrict-access-to-audit-db.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const url = require('url');
 const environment = require('../environment');
 

--- a/api/src/migrations/restrict-access-to-sentinel-db.js
+++ b/api/src/migrations/restrict-access-to-sentinel-db.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const url = require('url');
 const environment = require('../environment');
 

--- a/api/src/migrations/restrict-access-to-vault-db.js
+++ b/api/src/migrations/restrict-access-to-vault-db.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const url = require('url');
 const environment = require('../environment');
 

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -12,15 +12,22 @@ const prometheusMiddleware = require('prometheus-api-metrics');
 const rateLimiterMiddleware = require('./middleware/rate-limiter');
 const logger = require('./logger');
 const isClientHuman = require('./is-client-human');
-const target = 'http://' + environment.host + ':' + environment.port;
-const proxy = require('http-proxy').createProxyServer({ target: target });
+
+const port = typeof environment.port !== 'undefined' && environment.port !== null ? `:${environment.port}` : '';
+const target = `${environment.protocol}//${environment.host}${port}`;
+const proxy = require('http-proxy').createProxyServer({
+  target: target, 
+  changeOrigin: environment.proxies.changeOrigin
+});
 const proxyForAuth = require('http-proxy').createProxyServer({
   target: target,
   selfHandleResponse: true,
+  changeOrigin: environment.proxies.changeOrigin
 });
 const proxyForChanges = require('http-proxy').createProxyServer({
   target: target,
   selfHandleResponse: true,
+  changeOrigin: environment.proxies.changeOrigin
 });
 const login = require('./controllers/login');
 const smsGateway = require('./controllers/sms-gateway');

--- a/api/src/services/africas-talking.js
+++ b/api/src/services/africas-talking.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const secureSettings = require('@medic/settings');
 const logger = require('../logger');
 const config = require('../config');

--- a/api/src/services/monitoring.js
+++ b/api/src/services/monitoring.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const moment = require('moment');
 
 const db = require('../db');

--- a/api/src/services/rapidpro.js
+++ b/api/src/services/rapidpro.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const secureSettings = require('@medic/settings');
 const logger = require('../logger');
 const config = require('../config');

--- a/api/src/services/setup/utils.js
+++ b/api/src/services/setup/utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const _ = require('lodash');
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 const db = require('../../db');
 const logger = require('../../logger');
@@ -332,7 +332,7 @@ const makeUpgradeRequest = async (payload) => {
     throw new Error(`Invalid UPGRADE_SERVICE_URL: ${UPGRADE_SERVICE_URL}`);
   }
 
-  const response = await rpn.post({ url: url.toString(), json: true, body: payload });
+  const response = await request.post({ url: url.toString(), json: true, body: payload });
   const success = upgradeResponseSuccess(payload, response);
   if (!success) {
     logger.error('None of the docker-compose files or containers were updated: %o', response);

--- a/api/src/services/setup/view-indexer.js
+++ b/api/src/services/setup/view-indexer.js
@@ -1,4 +1,4 @@
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 const _ = require('lodash');
 
 const upgradeLogService = require('./upgrade-log');
@@ -62,7 +62,7 @@ const getViewsToIndex = async () => {
 const indexView = async (dbName, ddocId, viewName) => {
   do {
     try {
-      return await rpn.get({
+      return await request.get({
         uri: `${environment.serverUrl}/${dbName}/${ddocId}/_view/${viewName}`,
         json: true,
         qs: { limit: 1 },

--- a/api/src/services/user-db.js
+++ b/api/src/services/user-db.js
@@ -1,7 +1,7 @@
 /**
  * @module user-db
  */
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const url = require('url');
 const db = require('../db');
 const environment = require('../environment');

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const fs = require('fs');
 const chai = require('chai');
 const sinon = require('sinon');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 const environment = require('../../../src/environment');
 const auth = require('../../../src/auth');

--- a/api/tests/mocha/db-batch.spec.js
+++ b/api/tests/mocha/db-batch.spec.js
@@ -1,6 +1,6 @@
 const lib = require('../../src/db-batch');
 const chai = require('chai');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const sinon = require('sinon');
 const environment = require('../../src/environment');
 const viewName = 'myddoc/myview';

--- a/api/tests/mocha/db.spec.js
+++ b/api/tests/mocha/db.spec.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 require('chai').use(require('chai-as-promised'));
 const { expect } = require('chai');
 const rewire = require('rewire');
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 let db;
 let unitTestEnv;
@@ -151,42 +151,42 @@ describe('db', () => {
   describe('activeTasks', () => {
     it('should return active tasks', async () => {
       sinon.stub(env, 'serverUrl').value('https://couch.db');
-      sinon.stub(rpn, 'get').resolves('active_tasks');
+      sinon.stub(request, 'get').resolves('active_tasks');
 
       expect(await db.activeTasks()).to.equal('active_tasks');
 
-      expect(rpn.get.callCount).to.equal(1);
-      expect(rpn.get.args[0]).to.deep.equal([{
+      expect(request.get.callCount).to.equal(1);
+      expect(request.get.args[0]).to.deep.equal([{
         url: 'https://couch.db/_active_tasks',
         json: true,
       }]);
     });
 
     it('should throw error', async () => {
-      sinon.stub(rpn, 'get').rejects(new Error('boom'));
+      sinon.stub(request, 'get').rejects(new Error('boom'));
       await expect(db.activeTasks()).to.be.rejectedWith('boom');
-      expect(rpn.get.callCount).to.equal(1);
+      expect(request.get.callCount).to.equal(1);
     });
   });
 
   describe('allDbs', () => {
     it('should return all databases', async () => {
       sinon.stub(env, 'serverUrl').value('https://couch.db');
-      sinon.stub(rpn, 'get').resolves(['db1', 'db2']);
+      sinon.stub(request, 'get').resolves(['db1', 'db2']);
 
       expect(await db.allDbs()).to.deep.equal(['db1', 'db2']);
 
-      expect(rpn.get.callCount).to.equal(1);
-      expect(rpn.get.args[0]).to.deep.equal([{
+      expect(request.get.callCount).to.equal(1);
+      expect(request.get.args[0]).to.deep.equal([{
         uri: 'https://couch.db/_all_dbs',
         json: true,
       }]);
     });
 
     it('should throw error', async () => {
-      sinon.stub(rpn, 'get').rejects(new Error('boom'));
+      sinon.stub(request, 'get').rejects(new Error('boom'));
       await expect(db.allDbs()).to.be.rejectedWith('boom');
-      expect(rpn.get.callCount).to.equal(1);
+      expect(request.get.callCount).to.equal(1);
     });
   });
 
@@ -237,13 +237,13 @@ describe('db', () => {
   describe('addRoleToSecurity', () => {
     it('should add role as member to db security', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsMember('dbname', 'rolename');
 
-      expect(rpn.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
-      expect(rpn.put.args).to.deep.equal([[
+      expect(request.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
+      expect(request.put.args).to.deep.equal([[
         {
           url: 'http://admin:pass@couchdb:5984/dbname/_security',
           json: true,
@@ -257,13 +257,13 @@ describe('db', () => {
 
     it('should add role as admin to db security', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsAdmin('dbname', 'rolename');
 
-      expect(rpn.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
-      expect(rpn.put.args).to.deep.equal([[
+      expect(request.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
+      expect(request.put.args).to.deep.equal([[
         {
           url: 'http://admin:pass@couchdb:5984/dbname/_security',
           json: true,
@@ -277,35 +277,35 @@ describe('db', () => {
 
     it('should skip member roles that already exist', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsMember('dbname', 'role2');
 
-      expect(rpn.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
-      expect(rpn.put.called).to.equal(false);
+      expect(request.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
+      expect(request.put.called).to.equal(false);
     });
 
     it('should skip admin roles that already exist', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ admins: { roles: ['role1'] }, members: { roles: ['role2'] } });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsAdmin('dbname', 'role1');
 
-      expect(rpn.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
-      expect(rpn.put.called).to.equal(false);
+      expect(request.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
+      expect(request.put.called).to.equal(false);
     });
 
     it('should set members security property if not existing', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ admins: { roles: ['role1'] } });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ admins: { roles: ['role1'] } });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsMember('dbname', 'rolename');
 
-      expect(rpn.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
-      expect(rpn.put.args).to.deep.equal([[
+      expect(request.get.args).to.deep.equal([[ { url: 'http://admin:pass@couchdb:5984/dbname/_security', json: true } ]]);
+      expect(request.put.args).to.deep.equal([[
         {
           url: 'http://admin:pass@couchdb:5984/dbname/_security',
           json: true,
@@ -319,13 +319,13 @@ describe('db', () => {
 
     it('should not mutate default roles', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').callsFake(() => ({ members: {} }));
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').callsFake(() => ({ members: {} }));
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsMember('dbname1', 'rolename1');
       await db.addRoleAsMember('dbname2', 'rolename2');
 
-      expect(rpn.put.args).to.deep.equal([[
+      expect(request.put.args).to.deep.equal([[
         {
           url: 'http://admin:pass@couchdb:5984/dbname1/_security',
           json: true,
@@ -346,13 +346,13 @@ describe('db', () => {
 
     it('should set admins security property if not existing', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pwd@host:6984');
-      sinon.stub(rpn, 'get').resolves({ members: { roles: ['role2'] } });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ members: { roles: ['role2'] } });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsAdmin('name', 'arole');
 
-      expect(rpn.get.args).to.deep.equal([[ { url: 'http://admin:pwd@host:6984/name/_security', json: true } ]]);
-      expect(rpn.put.args).to.deep.equal([[
+      expect(request.get.args).to.deep.equal([[ { url: 'http://admin:pwd@host:6984/name/_security', json: true } ]]);
+      expect(request.put.args).to.deep.equal([[
         {
           url: 'http://admin:pwd@host:6984/name/_security',
           json: true,
@@ -366,26 +366,26 @@ describe('db', () => {
 
     it('should throw get security errors', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').rejects(new Error('not_found'));
+      sinon.stub(request, 'get').rejects(new Error('not_found'));
 
       await expect(db.addRoleAsMember('data', 'attr')).to.be.rejectedWith(Error, 'not_found');
     });
 
     it('should throw put security errors', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ members: { roles: ['role2'] } });
-      sinon.stub(rpn, 'put').rejects(new Error('forbidden or something'));
+      sinon.stub(request, 'get').resolves({ members: { roles: ['role2'] } });
+      sinon.stub(request, 'put').rejects(new Error('forbidden or something'));
 
       await expect(db.addRoleAsMember('data', 'attr')).to.be.rejectedWith(Error, 'forbidden or something');
     });
 
     it('should set default security when security is invalid', async () => {
       sinon.stub(env, 'serverUrl').get(() => 'http://admin:pass@couchdb:5984');
-      sinon.stub(rpn, 'get').resolves({ members: false });
-      sinon.stub(rpn, 'put').resolves();
+      sinon.stub(request, 'get').resolves({ members: false });
+      sinon.stub(request, 'put').resolves();
 
       await db.addRoleAsMember('data', 'attr');
-      expect(rpn.put.args).to.deep.equal([[
+      expect(request.put.args).to.deep.equal([[
         {
           url: 'http://admin:pass@couchdb:5984/data/_security',
           json: true,

--- a/api/tests/mocha/migrations/associate-records-with-people.spec.js
+++ b/api/tests/mocha/migrations/associate-records-with-people.spec.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const chai = require('chai');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const db = require('../../../src/db');
 const migration = require('../../../src/migrations/associate-records-with-people');
 

--- a/api/tests/mocha/migrations/restrict-access-to-audit-db.spec.js
+++ b/api/tests/mocha/migrations/restrict-access-to-audit-db.spec.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const chai = require('chai');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const environment = require('../../../src/environment');
 const migration = require('../../../src/migrations/restrict-access-to-audit-db');
 

--- a/api/tests/mocha/migrations/restrict-access-to-sentinel-db.spec.js
+++ b/api/tests/mocha/migrations/restrict-access-to-sentinel-db.spec.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const chai = require('chai');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const environment = require('../../../src/environment');
 const migration = require('../../../src/migrations/restrict-access-to-sentinel-db');
 

--- a/api/tests/mocha/services/africas-talking.spec.js
+++ b/api/tests/mocha/services/africas-talking.spec.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const sinon = require('sinon');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const secureSettings = require('@medic/settings');
 const config = require('../../../src/config');
 const service = require('../../../src/services/africas-talking');

--- a/api/tests/mocha/services/monitoring.spec.js
+++ b/api/tests/mocha/services/monitoring.spec.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const chai = require('chai');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const _ = require('lodash');
 
 const db = require('../../../src/db');

--- a/api/tests/mocha/services/rapidpro.spec.js
+++ b/api/tests/mocha/services/rapidpro.spec.js
@@ -2,7 +2,7 @@ const { expect, assert } = require('chai');
 const sinon = require('sinon');
 const rewire = require('rewire');
 
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const secureSettings = require('@medic/settings');
 const config = require('../../../src/config');
 const db = require('../../../src/db');

--- a/api/tests/mocha/services/user-db.spec.js
+++ b/api/tests/mocha/services/user-db.spec.js
@@ -1,7 +1,7 @@
 const service = require('../../../src/services/user-db');
 const db = require('../../../src/db');
 const environment = require('../../../src/environment');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const chai = require('chai');
 const sinon = require('sinon');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,6 +4400,10 @@
       "resolved": "shared-libs/contacts",
       "link": true
     },
+    "node_modules/@medic/couch-request": {
+      "resolved": "shared-libs/couch-request",
+      "link": true
+    },
     "node_modules/@medic/eslint-config": {
       "version": "1.1.0",
       "dev": true,
@@ -33992,6 +33996,15 @@
         "moment": "^2.29.1"
       }
     },
+    "shared-libs/couch-request": {
+      "name": "@medic/couch-request",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "request-promise-native": "^1.0.9"
+      }
+    },
     "shared-libs/infodoc": {
       "name": "@medic/infodoc",
       "version": "1.0.0",
@@ -34031,10 +34044,10 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@medic/couch-request": "file:../couch-request",
         "@medic/settings": "file:../settings",
         "object-path": "^0.11.8",
         "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "url-join": "^4.0.1"
       }
     },
@@ -34084,15 +34097,17 @@
     "shared-libs/server-checks": {
       "name": "@medic/server-checks",
       "version": "1.0.1",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@medic/couch-request": "file:../couch-request"
+      }
     },
     "shared-libs/settings": {
       "name": "@medic/settings",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.8"
+        "@medic/couch-request": "file:../couch-request"
       }
     },
     "shared-libs/task-utils": {
@@ -34115,6 +34130,7 @@
       "dependencies": {
         "@medic/contact-types-utils": "file:../contact-types-utils",
         "@medic/contacts": "file:../contacts",
+        "@medic/couch-request": "file:../couch-request",
         "@medic/infodoc": "file:../infodoc",
         "@medic/lineage": "file:../lineage",
         "@medic/message-utils": "file:../message-utils",
@@ -34136,8 +34152,6 @@
         "moment": "^2.29.1",
         "mustache": "^4.2.0",
         "object-path": "^0.11.8",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "url-join": "^4.0.1"
       },
       "devDependencies": {
@@ -37105,6 +37119,13 @@
         "moment": "^2.29.1"
       }
     },
+    "@medic/couch-request": {
+      "version": "file:shared-libs/couch-request",
+      "requires": {
+        "lodash": "^4.17.21",
+        "request-promise-native": "^1.0.9"
+      }
+    },
     "@medic/eslint-config": {
       "version": "1.1.0",
       "dev": true
@@ -37138,10 +37159,10 @@
     "@medic/outbound": {
       "version": "file:shared-libs/outbound",
       "requires": {
+        "@medic/couch-request": "file:../couch-request",
         "@medic/settings": "file:../settings",
         "object-path": "^0.11.8",
         "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "url-join": "^4.0.1"
       }
     },
@@ -37179,13 +37200,15 @@
       }
     },
     "@medic/server-checks": {
-      "version": "file:shared-libs/server-checks"
+      "version": "file:shared-libs/server-checks",
+      "requires": {
+        "@medic/couch-request": "file:../couch-request"
+      }
     },
     "@medic/settings": {
       "version": "file:shared-libs/settings",
       "requires": {
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.8"
+        "@medic/couch-request": "file:../couch-request"
       }
     },
     "@medic/task-utils": {
@@ -37202,6 +37225,7 @@
       "requires": {
         "@medic/contact-types-utils": "file:../contact-types-utils",
         "@medic/contacts": "file:../contacts",
+        "@medic/couch-request": "file:../couch-request",
         "@medic/infodoc": "file:../infodoc",
         "@medic/lineage": "file:../lineage",
         "@medic/message-utils": "file:../message-utils",
@@ -37224,8 +37248,6 @@
         "moment": "^2.29.1",
         "mustache": "^4.2.0",
         "object-path": "^0.11.8",
-        "request": "^2.88.2",
-        "request-promise-native": "^1.0.9",
         "url-join": "^4.0.1"
       },
       "dependencies": {

--- a/sentinel/.eslintrc
+++ b/sentinel/.eslintrc
@@ -16,6 +16,7 @@
           "@medic/cht-script-api",
           "@medic/contact-types-utils",
           "@medic/contacts",
+          "@medic/couch-request",
           "@medic/infodoc",
           "@medic/lineage",
           "@medic/message-utils",

--- a/sentinel/src/db.js
+++ b/sentinel/src/db.js
@@ -1,5 +1,5 @@
 const logger = require('../src/lib/logger');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 const { COUCH_URL, UNIT_TEST_ENV } = process.env;
 

--- a/sentinel/src/schedule/reminders.js
+++ b/sentinel/src/schedule/reminders.js
@@ -1,7 +1,7 @@
 const { performance } = require('perf_hooks');
 const _ = require('lodash');
 const moment = require('moment');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 const config = require('../config');
 const db = require('../db');
@@ -108,7 +108,7 @@ const getPlaceIds = (keys, startDocId) => {
   // using `request` library because PouchDB doesn't support `start_key_doc_id` in view queries
   // using `start_key_doc_id` because using `skip` is *very* slow
   return request
-    .get(`${db.couchUrl}/_design/medic-client/_view/contacts_by_type`, { qs: query, json: true })
+    .get({ url: `${db.couchUrl}/_design/medic-client/_view/contacts_by_type`, qs: query, json: true })
     .then(result => result.rows.map(row => row.id));
 };
 

--- a/sentinel/src/schedule/replications.js
+++ b/sentinel/src/schedule/replications.js
@@ -1,7 +1,7 @@
 const later = require('later');
 const db = require('../db');
 const logger = require('../lib/logger');
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 const PURGE_LOG_ID = '_local/purge_log';
 // default CouchDB purge max_document_id_number
@@ -32,7 +32,7 @@ const purgeDocs = (sourceDb, changes) => {
         body: docsToPurge,
       };
 
-      return rpn.post(opts);
+      return request.post(opts);
     });
 };
 

--- a/sentinel/tests/unit/db.spec.js
+++ b/sentinel/tests/unit/db.spec.js
@@ -1,7 +1,7 @@
 const sinon = require('sinon');
 const { expect } = require('chai');
 const rewire = require('rewire');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 
 let db;
 let couchUrl;

--- a/sentinel/tests/unit/schedule/replications.spec.js
+++ b/sentinel/tests/unit/schedule/replications.spec.js
@@ -1,7 +1,7 @@
 const later = require('later');
 const sinon = require('sinon');
 const assert = require('chai').assert;
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 const rewire = require('rewire');
 
 const db = require('../../../src/db');
@@ -203,7 +203,7 @@ describe('replications', () => {
         source.changes.callsFake(() => Promise.resolve(changes.splice(0, 1)[0]));
         // presume all docs are already replicated
         target.changes.callsFake(({ doc_ids }) => Promise.resolve({ results: doc_ids.map(id => ({ id })) }));
-        sinon.stub(rpn, 'post').resolves();
+        sinon.stub(request, 'post').resolves();
 
         return replications.replicateDbs(['source'], 'target').then(() => {
           assert.equal(source.get.callCount, 1);
@@ -214,8 +214,8 @@ describe('replications', () => {
           assert.deepEqual(source.changes.args[2], [{ since: 200, limit: 100, batch_size: 100 }]);
           assert.deepEqual(source.changes.args[3], [{ since: 300, limit: 100, batch_size: 100 }]);
           assert.deepEqual(source.changes.args[4], [{ since: 400, limit: 100, batch_size: 100 }]);
-          assert.equal(rpn.post.callCount, 3);
-          assert.deepEqual(rpn.post.args[0], [{
+          assert.equal(request.post.callCount, 3);
+          assert.deepEqual(request.post.args[0], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -223,7 +223,7 @@ describe('replications', () => {
               'feedback-1': ['4'],
             }
           }]);
-          assert.deepEqual(rpn.post.args[1], [{
+          assert.deepEqual(request.post.args[1], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -232,7 +232,7 @@ describe('replications', () => {
               'telemetry-3': ['1'],
             }
           }]);
-          assert.deepEqual(rpn.post.args[2], [{
+          assert.deepEqual(request.post.args[2], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -325,7 +325,7 @@ describe('replications', () => {
         source.changes.callsFake(() => Promise.resolve(changes.splice(0, 1)[0]));
         // presume all docs are already replicated
         target.changes.callsFake(({ doc_ids }) => Promise.resolve({ results: doc_ids.map(id => ({ id })) }));
-        sinon.stub(rpn, 'post').resolves();
+        sinon.stub(request, 'post').resolves();
 
         return replications.replicateDbs(['source'], 'target').then(() => {
           assert.equal(source.get.callCount, 1);
@@ -336,8 +336,8 @@ describe('replications', () => {
           assert.deepEqual(source.changes.args[2], [{ since: 300, limit: 100, batch_size: 100 }]);
           assert.deepEqual(source.changes.args[3], [{ since: 400, limit: 100, batch_size: 100 }]);
           assert.deepEqual(source.changes.args[4], [{ since: 500, limit: 100, batch_size: 100 }]);
-          assert.equal(rpn.post.callCount, 3);
-          assert.deepEqual(rpn.post.args[0], [{
+          assert.equal(request.post.callCount, 3);
+          assert.deepEqual(request.post.args[0], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -345,7 +345,7 @@ describe('replications', () => {
               'feedback-1': ['4'],
             }
           }]);
-          assert.deepEqual(rpn.post.args[1], [{
+          assert.deepEqual(request.post.args[1], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -354,7 +354,7 @@ describe('replications', () => {
               'telemetry-3': ['1'],
             }
           }]);
-          assert.deepEqual(rpn.post.args[2], [{
+          assert.deepEqual(request.post.args[2], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -414,7 +414,7 @@ describe('replications', () => {
         const replicatedIds = ['telemetry-1', 'feedback-1', 'feedback-2'];
         target.changes.callsFake(({ doc_ids }) => (
           Promise.resolve({ results: doc_ids.filter(id => replicatedIds.includes(id)).map(id => ({ id })) })));
-        sinon.stub(rpn, 'post').resolves();
+        sinon.stub(request, 'post').resolves();
 
         return replications.replicateDbs(['source'], 'target').then(() => {
           assert.equal(source.get.callCount, 1);
@@ -424,8 +424,8 @@ describe('replications', () => {
           assert.deepEqual(source.changes.args[1], [{ since: 100, limit: 100, batch_size: 100 }]);
           assert.deepEqual(source.changes.args[2], [{ since: 200, limit: 100, batch_size: 100 }]);
           assert.deepEqual(source.changes.args[3], [{ since: 220, limit: 100, batch_size: 100 }]);
-          assert.equal(rpn.post.callCount, 2);
-          assert.deepEqual(rpn.post.args[0], [{
+          assert.equal(request.post.callCount, 2);
+          assert.deepEqual(request.post.args[0], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -433,7 +433,7 @@ describe('replications', () => {
               'feedback-1': ['4'],
             }
           }]);
-          assert.deepEqual(rpn.post.args[1], [{
+          assert.deepEqual(request.post.args[1], [{
             uri: `${db.serverUrl}/source/_purge`,
             json: true,
             body: {
@@ -501,7 +501,7 @@ describe('replications', () => {
         source.changes.callsFake(() => Promise.resolve(changes.splice(0, 1)[0]));
         // presume all docs are already replicated
         target.changes.callsFake(({ doc_ids }) => Promise.resolve({ results: doc_ids.map(id => ({ id })) }));
-        sinon.stub(rpn, 'post').onCall(0).resolves().onCall(1).rejects({ some: 'error' });
+        sinon.stub(request, 'post').onCall(0).resolves().onCall(1).rejects({ some: 'error' });
 
         return replications
           .replicateDbs(['source'], 'target')
@@ -513,8 +513,8 @@ describe('replications', () => {
             assert.equal(source.changes.callCount, 2);
             assert.deepEqual(source.changes.args[0], [{ since: 0, limit: 100, batch_size: 100 }]);
             assert.deepEqual(source.changes.args[1], [{ since: 100, limit: 100, batch_size: 100 }]);
-            assert.equal(rpn.post.callCount, 2);
-            assert.deepEqual(rpn.post.args[0], [{
+            assert.equal(request.post.callCount, 2);
+            assert.deepEqual(request.post.args[0], [{
               uri: `${db.serverUrl}/source/_purge`,
               json: true,
               body: {
@@ -522,7 +522,7 @@ describe('replications', () => {
                 'feedback-1': ['4'],
               }
             }]);
-            assert.deepEqual(rpn.post.args[1], [{
+            assert.deepEqual(request.post.args[1], [{
               uri: `${db.serverUrl}/source/_purge`,
               json: true,
               body: {

--- a/shared-libs/couch-request/package-lock.json
+++ b/shared-libs/couch-request/package-lock.json
@@ -1,0 +1,531 @@
+{
+  "name": "@medic/couch-request",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@medic/couch-request",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "request-promise-native": "^1.0.9"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "peer": true
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "peer": true
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "peer": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "peer": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "peer": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "peer": true
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "peer": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "peer": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "peer": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "peer": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "peer": true
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "peer": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "peer": true
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "peer": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "peer": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "peer": true
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "peer": true
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "peer": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "dependencies": {
+        "lodash": "^4.17.19"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "peer": true
+    },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "peer": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "peer": true
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "peer": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    }
+  }
+}

--- a/shared-libs/couch-request/package.json
+++ b/shared-libs/couch-request/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@medic/couch-request",
+  "version": "1.0.0",
+  "description": "Provides a declarative global options interface for http requests",
+  "main": "src/couch-request.js",
+  "scripts": {
+    "test": "mocha ./test"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "lodash": "^4.17.21",
+    "request-promise-native": "^1.0.9"
+  }
+}

--- a/shared-libs/couch-request/src/couch-request.js
+++ b/shared-libs/couch-request/src/couch-request.js
@@ -1,0 +1,111 @@
+const request = require('request-promise-native');
+const isPlainObject = require('lodash/isPlainObject');
+const servername = new URL(process.env.COUCH_URL).hostname;
+
+const isString = value => typeof value === 'string' || value instanceof String;
+const isTrue = value => isString(value) ? value.toLowerCase() === 'true' : value === true;
+
+const addServername = isTrue(process.env.ADD_SERVERNAME_TO_HTTP_AGENT);
+const methods = {
+  GET: 'GET',
+  POST: 'POST',
+  DELETE: 'DELETE',
+  PUT: 'PUT',
+  HEAD: 'HEAD'
+};
+
+
+const mergeOptions = (target, source, exclusions = []) => {
+  for (const [key, value] of Object.entries(source)) {
+    if (Array.isArray(exclusions) && exclusions.includes(key)) {
+      return target;
+    }
+    target[key] = value; // locally, mutation is preferable to spreading as it doesn't
+    // make new objects in memory. Assuming this is a hot path.
+  }
+  return target;
+};
+
+// When proxying to HTTPS from HTTP (for example where an ingress does TLS termination in an SNI environment),
+// not including a 'servername' for a request to the HTTPS server (eg, def.org) produces the 
+// following error:
+// 
+// 'ERR_TLS_CERT_ALTNAME_INVALID'
+// "RequestError: Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames:
+//  Host: abc.com. is not in the cert's altnames: DNS:def.org"
+// 
+// The addition of 'servername' resolves this error. See docs for 'tls.connect(options[, callback])'
+//  (https://nodejs.org/api/tls.html): "Server name for the SNI (Server Name Indication) TLS extension  It is the
+//  name of the host being connected to, and must be a host name, and not an IP address.".
+// 
+
+const validate = (firstIsString, method, first, second = {}) => {
+
+  if (Object.hasOwn(methods, method) === false) {
+    throw new Error(`Unsupported method (${method}) passed to call.`);
+  }
+
+  if (isPlainObject(second) === false) {
+    throw new Error(`"options" must be a plain object'`);
+  }
+
+  if (firstIsString === false && isPlainObject(first) === false) {
+    throw new Error(`"options" must be a plain object'`);
+  }
+};
+
+
+const req = (method, first, second = {}) => {
+
+  const firstIsString = isString(first);
+
+  try {
+    validate(firstIsString, method, first, second);
+  } catch (e) {
+    return Promise.reject(e);
+  }
+
+  const chosenOptions = firstIsString ? second : first;
+
+  const exclusions = firstIsString ? ['url', 'uri', 'method'] : ['method'];
+  const target = addServername ? { servername } : { };
+  
+  const mergedOptions = mergeOptions(target, chosenOptions, exclusions);
+
+  return firstIsString ? getRequestType(method)(first, mergedOptions) : getRequestType(method)(mergedOptions);
+};
+
+const getRequestType = (method) => {
+  // This is intended to simplify testing as sinon does not stub an
+  // exported function (eg, 'export = requestPromise') but only methods.
+  // From reading, proxyquire would need to be used to solve: https://www.npmjs.com/package/proxyquire
+  // See: https://github.com/sinonjs/sinon/issues/562#issuecomment-79227487
+  switch (method) {
+  case methods.GET: {
+    return request.get;
+  }
+  case methods.POST: {
+    return request.post;
+  }
+  case methods.PUT: {
+    return request.put;
+  }
+  case methods.DELETE: {
+    return request.delete;
+  }
+  case methods.HEAD: {
+    return request.head;
+  }
+  default: {
+    return Promise.reject(Error(`Unsupported method (${method}) passed to call.`));
+  }
+  }
+};
+
+module.exports = {
+  get: (first, second = {}) => req(methods.GET, first, second),
+  post: (first, second = {}) => req(methods.POST, first, second),
+  put: (first, second = {}) => req(methods.PUT, first, second),
+  delete: (first, second = {}) => req(methods.DELETE, first, second),
+  head: (first, second = {}) => req(methods.HEAD, first, second),
+};

--- a/shared-libs/couch-request/test/couch-request.js
+++ b/shared-libs/couch-request/test/couch-request.js
@@ -1,0 +1,428 @@
+
+const chai = require('chai').use(require('chai-as-promised'));
+const request = require('request-promise-native');
+const sinon = require('sinon');
+const rewire = require('rewire');
+
+class Unicorn { }
+const notPlainObjects = [[1, 2, 3], new Unicorn(), new Map([[1, 1], [2, 2], [3, 3]]), new Set([1, 2, 3]),
+  () => { }, true, null, 1, NaN, Infinity, /foo/, new Date(), new Error(), new Int8Array(), new Float32Array(),
+  new Float64Array(), new Uint8Array(), new Uint8ClampedArray(), new Uint16Array(), new Uint32Array(),
+  new ArrayBuffer(), new WeakMap(), new WeakSet()];
+const notPlainObjectsWithString = notPlainObjects.concat(['foo']);
+const optionsErrorMsg = '"options" must be a plain object';
+
+describe('Couch request rejects non-plain objects', () => {
+
+  let couch_request;
+
+  before(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      COUCH_URL: 'http://admin:password@test.com:5984/medic',
+      ADD_SERVERNAME_TO_HTTP_AGENT: 'true' 
+    });
+    couch_request = rewire('../src/couch-request');
+  });
+
+  notPlainObjectsWithString.forEach(notPlainObject => {
+    if (typeof notPlainObject === 'undefined' || notPlainObject === null) {
+      it(`Rejects notPlainObject as second arg (method: get): (string, notPlainObject == null)`, done => {
+        chai.expect(couch_request.get('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: post): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.post('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: put): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.put('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: delete): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.delete('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: head): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.head('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+    } else {
+      const toString = `${notPlainObject.toString()}`;
+      const result = toString === '' ? Object.getPrototypeOf(notPlainObject).constructor.name : toString;
+      it(`Rejects notPlainObject as second arg (method: get): (string, ${result})`, done => {
+        chai.expect(couch_request.get('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: post): ${result}`, done => {
+        chai.expect(couch_request.post('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: put): ${result}`, done => {
+        chai.expect(couch_request.put('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: delete): ${result}`, done => {
+        chai.expect(couch_request.delete('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as second arg (method: head): ${result}`, done => {
+        chai.expect(couch_request.head('string', notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+    }
+  });
+  
+  notPlainObjects.forEach(notPlainObject => {
+    if (typeof notPlainObject === 'undefined' || notPlainObject === null) {
+      it(`Rejects notPlainObject as first arg (method: get): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.get(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: post): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.post(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: put): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.put(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: delete): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.delete(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: head): (notPlainObject == null)`, done => {
+        chai.expect(couch_request.head(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+    } else {
+      const toString = `${notPlainObject.toString()}`;
+      const result = toString === '' ? Object.getPrototypeOf(notPlainObject).constructor.name : toString;
+      it(`Rejects notPlainObject as first arg (method: get): (${result})`, done => {
+        chai.expect(couch_request.get(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: post): ${result}`, done => {
+        chai.expect(couch_request.post(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: put): ${result}`, done => {
+        chai.expect(couch_request.put(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: delete): ${result}`, done => {
+        chai.expect(couch_request.delete(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+      it(`Rejects notPlainObject as first arg (method: head): ${result}`, done => {
+        chai.expect(couch_request.head(notPlainObject)).to.eventually.be.rejectedWith(optionsErrorMsg)
+          .and.be.an.instanceOf(Error).notify(done);
+      });
+    }
+  });
+});
+
+describe('Couch request with servername added receives correct options and returns stub value', () => {
+
+  let couch_request;
+
+  before(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      COUCH_URL: 'http://admin:password@test.com:5984/medic',
+      ADD_SERVERNAME_TO_HTTP_AGENT: 'true' 
+    });
+    couch_request = rewire('../src/couch-request');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const options = [{ 
+    foo: 'bar', url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly',
+    uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly',
+    method: 'GET' // Should not be passed to options
+  }];
+
+  options.forEach(option => {
+    
+    it(`Get: Called with composite options and returns 'get'`, async function () {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.returns(Promise.resolve('get'));
+      const result = await couch_request.get(option);
+      sinon.assert.calledWith(requestGet, { 
+        servername: 'test.com', foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('get');
+    });
+    it(`Get: Called with url as first parameter and composite options and returns 'get'`, async function () {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.returns(Promise.resolve('get'));
+      const result = await couch_request.get('a-test-url', option);
+      sinon.assert.calledWith(requestGet, 'a-test-url', { servername: 'test.com', foo: 'bar'});
+      chai.expect(result).to.equal('get');
+    });
+    it(`Post: Called with composite options and returns 'post'`, async function () {
+      const requestPost = sinon.stub(request, 'post');
+      requestPost.returns(Promise.resolve('post'));
+      const result = await couch_request.post(option);
+      sinon.assert.calledWith(requestPost, {
+        servername: 'test.com', foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('post');
+    });
+    it(`Post: Called with url as first parameter and composite options and returns 'post'`, async function () {
+      const requestPost = sinon.stub(request, 'post');
+      requestPost.returns(Promise.resolve('post'));
+      const result = await couch_request.post('a-test-url', option);
+      sinon.assert.calledWith(requestPost, 'a-test-url', {
+        servername: 'test.com', foo: 'bar' });
+      chai.expect(result).to.equal('post');
+    });
+    it(`Head: Called with composite options and returns 'head'`, async function () {
+      const requestHead = sinon.stub(request, 'head');
+      requestHead.returns(Promise.resolve('head'));
+      const result = await couch_request.head(option);
+      sinon.assert.calledWith(requestHead, {
+        servername: 'test.com', foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('head');
+    });
+    it(`Head: Called with url as first parameter and composite options and returns 'head'`, async function () {
+      const requestHead = sinon.stub(request, 'head');
+      requestHead.returns(Promise.resolve('head'));
+      const result = await couch_request.head('a-test-url', option);
+      sinon.assert.calledWith(requestHead, 'a-test-url',  {
+        servername: 'test.com', foo: 'bar' });
+      chai.expect(result).to.equal('head');
+    });
+    it(`Delete: Called with composite options and returns 'delete'`, async function () {
+      const requestDelete = sinon.stub(request, 'delete');
+      requestDelete.returns(Promise.resolve('delete'));
+      const result = await couch_request.delete(option);
+      sinon.assert.calledWith(requestDelete, {
+        servername: 'test.com', foo: 'bar', 
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('delete');
+    });
+    it(`Delete: Called with url as first parameter and composite options and returns 'delete'`, async function () {
+      const requestDelete = sinon.stub(request, 'delete');
+      requestDelete.returns(Promise.resolve('delete'));
+      const result = await couch_request.delete('a-test-url', option);
+      sinon.assert.calledWith(requestDelete, 'a-test-url', {
+        servername: 'test.com', foo: 'bar' });
+      chai.expect(result).to.equal('delete');
+    });
+    it(`Put: Called with composite options and returns 'put'`, async function () {
+      const requestPut = sinon.stub(request, 'put');
+      requestPut.returns(Promise.resolve('put'));
+      const result = await couch_request.put(option);
+      sinon.assert.calledWith(requestPut, {
+        servername: 'test.com', foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('put');
+    });
+    it(`Put: Called with url as first parameter and composite options and returns 'put'`, async function () {
+      const requestPut = sinon.stub(request, 'put');
+      requestPut.returns(Promise.resolve('put'));
+      const result = await couch_request.put('a-test-url', option);
+      sinon.assert.calledWith(requestPut, 'a-test-url', {
+        servername: 'test.com', foo: 'bar' });
+      chai.expect(result).to.equal('put');
+    });
+  });
+
+  const overrideOptions = [{ foo: 'bar', servername: 'bar' }];
+  
+  overrideOptions.forEach(option => {
+
+    it(`Get: Called with options overridden and returns 'get'`, async function () {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.returns(Promise.resolve('get'));
+      const result = await couch_request.get(option);
+      sinon.assert.calledWith(requestGet, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('get');
+    });
+    it(`Get: Called with url in first param and options overridden and returns 'get'`, async function () {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.returns(Promise.resolve('get'));
+      const result = await couch_request.get('a-test-url', option);
+      sinon.assert.calledWith(requestGet, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('get');
+    });
+    it(`Post: Called with options overridden and returns 'post'`, async function () {
+      const requestPost = sinon.stub(request, 'post');
+      requestPost.returns(Promise.resolve('post'));
+      const result = await couch_request.post(option);
+      sinon.assert.calledWith(requestPost, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('post');
+    });
+    it(`Post: Called with url in first param and options overridden and returns 'post'`, async function () {
+      const requestPost = sinon.stub(request, 'post');
+      requestPost.returns(Promise.resolve('post'));
+      const result = await couch_request.post('a-test-url', option);
+      sinon.assert.calledWith(requestPost, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('post');
+    });
+    it(`Head: Called with options overridden and returns 'head'`, async function () {
+      const requestHead = sinon.stub(request, 'head');
+      requestHead.returns(Promise.resolve('head'));
+      const result = await couch_request.head(option);
+      sinon.assert.calledWith(requestHead, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('head');
+    });
+    it(`Head: Called with url in first param and options overridden and returns 'head'`, async function () {
+      const requestHead = sinon.stub(request, 'head');
+      requestHead.returns(Promise.resolve('head'));
+      const result = await couch_request.head('a-test-url', option);
+      sinon.assert.calledWith(requestHead, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('head');
+    });
+    it(`Delete: Called with options overridden and returns 'delete'`, async function () {
+      const requestDelete = sinon.stub(request, 'delete');
+      requestDelete.returns(Promise.resolve('delete'));
+      const result = await couch_request.delete(option);
+      sinon.assert.calledWith(requestDelete, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('delete');
+    });
+    it(`Delete: Called with url in first param and options overridden and returns 'delete'`, async function () {
+      const requestDelete = sinon.stub(request, 'delete');
+      requestDelete.returns(Promise.resolve('delete'));
+      const result = await couch_request.delete('a-test-url', option);
+      sinon.assert.calledWith(requestDelete, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('delete');
+    });
+    it(`Put: Called with options overridden and returns 'put'`, async function () {
+      const requestPut = sinon.stub(request, 'put');
+      requestPut.returns(Promise.resolve('put'));
+      const result = await couch_request.put(option);
+      sinon.assert.calledWith(requestPut, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('put');
+    });
+    it(`Put: Called with url in first param and options overridden and returns 'put'`, async function () {
+      const requestPut = sinon.stub(request, 'put');
+      requestPut.returns(Promise.resolve('put'));
+      const result = await couch_request.put('a-test-url', option);
+      sinon.assert.calledWith(requestPut, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('put');
+    });
+  });
+});
+
+describe('Couch request with default servername omitted receives correct options and returns stub value', () => {
+
+  let couch_request;
+
+  before(() => {
+    sinon.stub(process, 'env').value({
+      ...process.env,
+      COUCH_URL: 'http://admin:password@test.com:5984/medic',
+      ADD_SERVERNAME_TO_HTTP_AGENT: 'false' 
+    });
+    couch_request = rewire('../src/couch-request');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const options = [{ 
+    foo: 'bar', url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly',
+    uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly',
+    method: 'GET' // Should not be passed to options
+  }];
+
+  options.forEach(option => {
+    
+    it(`Get: Called with composite options and returns 'get'`, async function () {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.returns(Promise.resolve('get'));
+      const result = await couch_request.get(option);
+      sinon.assert.calledWith(requestGet, { 
+        foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('get');
+    });
+    it(`Post: Called with composite options and returns 'post'`, async function () {
+      const requestPost = sinon.stub(request, 'post');
+      requestPost.returns(Promise.resolve('post'));
+      const result = await couch_request.post(option);
+      sinon.assert.calledWith(requestPost, {
+        foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('post');
+    });
+    it(`Head: Called with url as first parameter and composite options and returns 'head'`, async function () {
+      const requestHead = sinon.stub(request, 'head');
+      requestHead.returns(Promise.resolve('head'));
+      const result = await couch_request.head('a-test-url', option);
+      sinon.assert.calledWith(requestHead, 'a-test-url',  {
+        foo: 'bar' });
+      chai.expect(result).to.equal('head');
+    });
+    it(`Delete: Called with url as first parameter and composite options and returns 'delete'`, async function () {
+      const requestDelete = sinon.stub(request, 'delete');
+      requestDelete.returns(Promise.resolve('delete'));
+      const result = await couch_request.delete('a-test-url', option);
+      sinon.assert.calledWith(requestDelete, 'a-test-url', {
+        foo: 'bar' });
+      chai.expect(result).to.equal('delete');
+    });
+    it(`Put: Called with composite options and returns 'put'`, async function () {
+      const requestPut = sinon.stub(request, 'put');
+      requestPut.returns(Promise.resolve('put'));
+      const result = await couch_request.put(option);
+      sinon.assert.calledWith(requestPut, {
+        foo: 'bar',
+        url: 'shouldBeOverriddenWhenFirstParamIsAStringOnly', uri: 'shouldBeOverriddenWhenFirstParamIsAStringOnly' });
+      chai.expect(result).to.equal('put');
+    });
+  });
+
+  const overrideOptions = [{ foo: 'bar', servername: 'bar' }];
+  
+  overrideOptions.forEach(option => {
+
+    it(`Get: Called with url in first param and options overridden,
+     servername allowed as optional override and returns 'get'`, async function () {
+      const requestGet = sinon.stub(request, 'get');
+      requestGet.returns(Promise.resolve('get'));
+      const result = await couch_request.get('a-test-url', option);
+      sinon.assert.calledWith(requestGet, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('get');
+    });
+    it(`Post: Called with options overridden,
+      servername allowed as optional override and returns 'post'`, async function () {
+      const requestPost = sinon.stub(request, 'post');
+      requestPost.returns(Promise.resolve('post'));
+      const result = await couch_request.post(option);
+      sinon.assert.calledWith(requestPost, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('post');
+    });
+    it(`Head: Called with url in first param and options overridden,
+     servername allowed as optional override and returns 'head'`, async function () {
+      const requestHead = sinon.stub(request, 'head');
+      requestHead.returns(Promise.resolve('head'));
+      const result = await couch_request.head('a-test-url', option);
+      sinon.assert.calledWith(requestHead, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('head');
+    });
+    it(`Delete: Called with options overridden,
+     servername allowed as optional override and returns 'delete'`, async function () {
+      const requestDelete = sinon.stub(request, 'delete');
+      requestDelete.returns(Promise.resolve('delete'));
+      const result = await couch_request.delete(option);
+      sinon.assert.calledWith(requestDelete, { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('delete');
+    });
+    it(`Put: Called with url in first param and options overridden,
+     servername allowed as optional override and returns 'put'`, async function () {
+      const requestPut = sinon.stub(request, 'put');
+      requestPut.returns(Promise.resolve('put'));
+      const result = await couch_request.put('a-test-url', option);
+      sinon.assert.calledWith(requestPut, 'a-test-url', { servername: 'bar', foo: 'bar' });
+      chai.expect(result).to.equal('put');
+    });
+  });
+});

--- a/shared-libs/outbound/package.json
+++ b/shared-libs/outbound/package.json
@@ -9,10 +9,10 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@medic/couch-request": "file:../couch-request",
     "@medic/settings": "file:../settings",
     "object-path": "^0.11.8",
     "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "url-join": "^4.0.1"
   }
 }

--- a/shared-libs/outbound/src/outbound.js
+++ b/shared-libs/outbound/src/outbound.js
@@ -13,7 +13,7 @@ const _ = require('lodash');
 const crypto = require('crypto');
 const objectPath = require('object-path');
 const urlJoin = require('url-join');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const vm = require('vm');
 
 const secureSettings = require('@medic/settings');

--- a/shared-libs/outbound/test/outbound.spec.js
+++ b/shared-libs/outbound/test/outbound.spec.js
@@ -2,7 +2,7 @@ const assert = require('chai').assert;
 const sinon = require('sinon');
 const rewire = require('rewire');
 const secureSettings = require('@medic/settings');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const outbound = rewire('../src/outbound');
 
 describe('outbound shared library', () => {

--- a/shared-libs/server-checks/package.json
+++ b/shared-libs/server-checks/package.json
@@ -7,5 +7,8 @@
     "test": "nyc --nycrcPath='../nyc.config.js' mocha ./test"
   },
   "author": "",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@medic/couch-request": "file:../couch-request"
+  }
 }

--- a/shared-libs/server-checks/src/checks.js
+++ b/shared-libs/server-checks/src/checks.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const MIN_MAJOR = 16;
 
 /* eslint-disable no-console */

--- a/shared-libs/server-checks/test/checks.js
+++ b/shared-libs/server-checks/test/checks.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const http = require('http');
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const rewire = require('rewire');
 
 let service;

--- a/shared-libs/settings/package.json
+++ b/shared-libs/settings/package.json
@@ -9,7 +9,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.8"
+    "@medic/couch-request": "file:../couch-request"
   }
 }

--- a/shared-libs/settings/src/index.js
+++ b/shared-libs/settings/src/index.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const request = require('@medic/couch-request');
 const crypto = require('crypto');
 
 const IV_LENGTH = 16;
@@ -24,7 +24,7 @@ const getCredentialsDoc = (id) => {
     return Promise.reject(new Error('You must pass the key for the credentials you want'));
   }
   return request
-    .get(getVaultUrl(id), { json: true })
+    .get({ url: getVaultUrl(id), json: true })
     .catch(err => {
       if (err.statusCode === 404) {
         // No credentials defined
@@ -40,7 +40,7 @@ const getKey = () => {
   // https://docs.couchdb.org/en/stable/config/auth.html#chttpd_auth/secret
   const url = `${getCouchConfigUrl()}/couch_httpd_auth/secret`;
   return request
-    .get(url, { json: true })
+    .get({ url, json: true })
     .then(key => {
       if (!key.length) {
         throw new Error('Invalid cypher. CouchDB Secret needs to be set in order to use secure credentials.');
@@ -106,7 +106,7 @@ const setCredentials = (id, password) => {
         doc = { _id: getCredentialId(id) };
       }
       doc.password = encrypted;
-      return request.put(getVaultUrl(id), { json: true, body: doc });
+      return request.put({ url: getVaultUrl(id), json: true, body: doc });
     });
 };
 

--- a/shared-libs/transitions/package.json
+++ b/shared-libs/transitions/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@medic/contact-types-utils": "file:../contact-types-utils",
     "@medic/contacts": "file:../contacts",
+    "@medic/couch-request": "file:../couch-request",
     "@medic/infodoc": "file:../infodoc",
     "@medic/lineage": "file:../lineage",
     "@medic/message-utils": "file:../message-utils",
@@ -34,8 +35,6 @@
     "moment": "^2.29.1",
     "mustache": "^4.2.0",
     "object-path": "^0.11.8",
-    "request": "^2.88.2",
-    "request-promise-native": "^1.0.9",
     "url-join": "^4.0.1"
   }
 }

--- a/shared-libs/transitions/src/schedule/due_tasks.js
+++ b/shared-libs/transitions/src/schedule/due_tasks.js
@@ -5,7 +5,7 @@ const utils = require('../lib/utils');
 const date = require('../date');
 const config = require('../config');
 const db = require('../db');
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 const lineage = require('@medic/lineage')(Promise, db.medic);
 const messageUtils = require('@medic/message-utils');
 
@@ -97,7 +97,7 @@ const getBatch = (query, startKey, startKeyDocId) => {
   let nextKey;
   let nextKeyDocId;
 
-  return rpn
+  return request
     .get(options)
     .then(result => {
       if (!result.rows || !result.rows.length) {

--- a/shared-libs/transitions/test/unit/due_tasks.js
+++ b/shared-libs/transitions/test/unit/due_tasks.js
@@ -6,7 +6,7 @@ chai.use(chaiExclude);
 const moment = require('moment');
 const utils = require('../../src/lib/utils');
 const db = require('../../src/db');
-const rpn = require('request-promise-native');
+const request = require('@medic/couch-request');
 const config = require('../../src/config');
 
 describe('due tasks', () => {
@@ -30,7 +30,7 @@ describe('due tasks', () => {
   });
 
   it('due_tasks handles view returning no rows', () => {
-    const view = sinon.stub(rpn, 'get')
+    const view = sinon.stub(request, 'get')
       .resolves({
         rows: [],
       });
@@ -73,7 +73,7 @@ describe('due tasks', () => {
         },
       ],
     };
-    const view = sinon.stub(rpn, 'get').resolves({
+    const view = sinon.stub(request, 'get').resolves({
       rows: [
         {
           id: id,
@@ -132,7 +132,7 @@ describe('due tasks', () => {
       ],
     };
     const hydrate = sinon.stub(schedule._lineage, 'hydrateDocs').resolves([doc]);
-    const view = sinon.stub(rpn, 'get').resolves({
+    const view = sinon.stub(request, 'get').resolves({
       rows: [
         {
           id: id,
@@ -189,7 +189,7 @@ describe('due tasks', () => {
       ],
     };
 
-    const view = sinon.stub(rpn, 'get')
+    const view = sinon.stub(request, 'get')
       .onCall(0).resolves({
         rows: [
           {
@@ -295,7 +295,7 @@ describe('due tasks', () => {
         },
       ],
     };
-    const view = sinon.stub(rpn, 'get').resolves({
+    const view = sinon.stub(request, 'get').resolves({
       rows: [
         {
           id: id,
@@ -398,7 +398,7 @@ describe('due tasks', () => {
         },
       ],
     };
-    const view = sinon.stub(rpn, 'get').resolves({
+    const view = sinon.stub(request, 'get').resolves({
       rows: [
         {
           id: id,
@@ -481,14 +481,14 @@ describe('due tasks', () => {
       ],
     };
 
-    sinon.stub(rpn, 'get').resolves({ rows: [
+    sinon.stub(request, 'get').resolves({ rows: [
       { id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified }
     ]});
     sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
     sinon.stub(db.medic, 'put').resolves();
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 1);
+      assert.equal(request.get.callCount, 1);
       assert.equal(db.medic.put.callCount, 0);
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
@@ -560,12 +560,15 @@ describe('due tasks', () => {
       ],
     };
 
-    sinon.stub(rpn, 'get').resolves({ rows: [{ id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified }]});
+    sinon.stub(request, 'get').resolves(
+      { rows: [{ id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified }]
+      }
+    );
     sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
     sinon.stub(db.medic, 'put').resolves();
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 1);
+      assert.equal(request.get.callCount, 1);
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
       assert.equal(utils.getRegistrations.callCount, 1);
@@ -675,14 +678,14 @@ describe('due tasks', () => {
       ],
     };
 
-    sinon.stub(rpn, 'get').resolves({ rows: [
+    sinon.stub(request, 'get').resolves({ rows: [
       { id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified },
     ]});
     sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
     sinon.stub(db.medic, 'put').resolves();
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 1);
+      assert.equal(request.get.callCount, 1);
       assert.equal(utils.translate.callCount, 1);
       assert.equal(utils.translate.args[0][0], 'visit-1');
       assert.equal(utils.getRegistrations.callCount, 2);
@@ -787,14 +790,14 @@ describe('due tasks', () => {
       ],
     };
 
-    sinon.stub(rpn, 'get').resolves({ rows: [
+    sinon.stub(request, 'get').resolves({ rows: [
       { id: 'report_id', key: [ 'scheduled', due.valueOf() ], doc: minified }
     ]});
     sinon.stub(schedule._lineage, 'hydrateDocs').resolves([hydrated]);
     sinon.stub(db.medic, 'put').resolves({});
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 1);
+      assert.equal(request.get.callCount, 1);
       assert.equal(db.medic.put.callCount, 1);
 
       assert.equal(utils.translate.callCount, 1);
@@ -915,7 +918,7 @@ describe('due tasks', () => {
       ],
       reported_date: due.valueOf(),
     };
-    const view = sinon.stub(rpn, 'get').resolves({
+    const view = sinon.stub(request, 'get').resolves({
       rows: [
         {
           id: id,
@@ -965,7 +968,7 @@ describe('due tasks', () => {
     const now = moment('2020-02-01 00:00:00');
     sinon.stub(date, 'getDate').returns(now);
     sinon.stub(db, 'couchUrl').value('http://admin:pass@127.0.0.1:5984/medic');
-    const view = sinon.stub(rpn, 'get').resolves({ rows: [] });
+    const view = sinon.stub(request, 'get').resolves({ rows: [] });
 
     return schedule.execute().then(() => {
       assert.equal(view.callCount, 1);
@@ -1084,7 +1087,7 @@ describe('due tasks', () => {
     ];
 
     sinon
-      .stub(rpn, 'get')
+      .stub(request, 'get')
       .onCall(0).resolves({ rows: firstResults })
       .onCall(1).resolves({ rows: secondResults })
       .onCall(2).resolves({ rows: [] });
@@ -1111,8 +1114,8 @@ describe('due tasks', () => {
     sinon.stub(utils, 'translate').returns('Message for doc {{_id}}');
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 3);
-      assert.deepEqual(rpn.get.args[0], [{
+      assert.equal(request.get.callCount, 3);
+      assert.deepEqual(request.get.args[0], [{
         baseUrl: 'http://admin:pass@127.0.0.1:5984/medic',
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
@@ -1123,7 +1126,7 @@ describe('due tasks', () => {
         },
         json: true
       }]);
-      assert.deepEqual(rpn.get.args[1], [{
+      assert.deepEqual(request.get.args[1], [{
         baseUrl: 'http://admin:pass@127.0.0.1:5984/medic',
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
@@ -1135,7 +1138,7 @@ describe('due tasks', () => {
         },
         json: true
       }]);
-      assert.deepEqual(rpn.get.args[2], [{
+      assert.deepEqual(request.get.args[2], [{
         baseUrl: 'http://admin:pass@127.0.0.1:5984/medic',
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
@@ -1310,7 +1313,7 @@ describe('due tasks', () => {
     ];
 
     sinon
-      .stub(rpn, 'get')
+      .stub(request, 'get')
       .onCall(0).resolves({ rows: firstResults })
       .onCall(1).resolves({ rows: secondResults })
       .onCall(2).resolves({ rows: [{
@@ -1352,8 +1355,8 @@ describe('due tasks', () => {
     sinon.stub(utils, 'translate').returns(false);
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 3);
-      assert.deepEqual(rpn.get.args[0], [{
+      assert.equal(request.get.callCount, 3);
+      assert.deepEqual(request.get.args[0], [{
         baseUrl: 'http://admin:pass@127.0.0.1:5984/medic',
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
@@ -1364,7 +1367,7 @@ describe('due tasks', () => {
         },
         json: true
       }]);
-      assert.deepEqual(rpn.get.args[1], [{
+      assert.deepEqual(request.get.args[1], [{
         baseUrl: 'http://admin:pass@127.0.0.1:5984/medic',
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
@@ -1376,7 +1379,7 @@ describe('due tasks', () => {
         },
         json: true
       }]);
-      assert.deepEqual(rpn.get.args[2], [{
+      assert.deepEqual(request.get.args[2], [{
         baseUrl: 'http://admin:pass@127.0.0.1:5984/medic',
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
@@ -1451,7 +1454,7 @@ describe('due tasks', () => {
       doc: secondDoc
     });
 
-    sinon.stub(rpn, 'get')
+    sinon.stub(request, 'get')
       .onCall(0).resolves({ rows: firstResponseRows })
       .onCall(1).resolves({ rows: secondResponseRows })
       .onCall(2).resolves({ rows: [] });
@@ -1479,9 +1482,9 @@ describe('due tasks', () => {
     sinon.stub(db.medic, 'put').resolves();
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 3);
+      assert.equal(request.get.callCount, 3);
 
-      assert.deepNestedInclude(rpn.get.args[0][0], {
+      assert.deepNestedInclude(request.get.args[0][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,
@@ -1490,7 +1493,7 @@ describe('due tasks', () => {
           startkey: JSON.stringify([ 'scheduled', moment(now).subtract(7, 'days').valueOf() ]),
         }
       });
-      assert.deepNestedInclude(rpn.get.args[1][0], {
+      assert.deepNestedInclude(request.get.args[1][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,
@@ -1500,7 +1503,7 @@ describe('due tasks', () => {
           startkey_docid: minifiedDoc._id,
         }
       });
-      assert.deepNestedInclude(rpn.get.args[2][0], {
+      assert.deepNestedInclude(request.get.args[2][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,
@@ -1584,7 +1587,7 @@ describe('due tasks', () => {
       doc: secondDoc
     });
 
-    sinon.stub(rpn, 'get')
+    sinon.stub(request, 'get')
       .onCall(0).resolves({ rows: firstResponseRows })
       .onCall(1).resolves({ rows: secondResponseRows })
       .onCall(2).resolves({ rows: thirdResponseRows })
@@ -1613,9 +1616,9 @@ describe('due tasks', () => {
     sinon.stub(db.medic, 'put').resolves();
 
     return schedule.execute().then(() => {
-      assert.equal(rpn.get.callCount, 4);
+      assert.equal(request.get.callCount, 4);
 
-      assert.deepNestedInclude(rpn.get.args[0][0], {
+      assert.deepNestedInclude(request.get.args[0][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,
@@ -1624,7 +1627,7 @@ describe('due tasks', () => {
           startkey: JSON.stringify([ 'scheduled', moment(now).subtract(7, 'days').valueOf() ]),
         }
       });
-      assert.deepNestedInclude(rpn.get.args[1][0], {
+      assert.deepNestedInclude(request.get.args[1][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,
@@ -1634,7 +1637,7 @@ describe('due tasks', () => {
           startkey_docid: minifiedDoc._id,
         }
       });
-      assert.deepNestedInclude(rpn.get.args[2][0], {
+      assert.deepNestedInclude(request.get.args[2][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,
@@ -1644,7 +1647,7 @@ describe('due tasks', () => {
           startkey_docid: minifiedDoc._id,
         }
       });
-      assert.deepNestedInclude(rpn.get.args[3][0], {
+      assert.deepNestedInclude(request.get.args[3][0], {
         uri: '/_design/medic/_view/messages_by_state',
         qs: {
           include_docs: true,


### PR DESCRIPTION
# Description

Have designed a unified wrapper for `request-promise-native` to centralise global options and to add a `servername` by default. It's overridable in the case that you ever want to have a different `servername` or an empty one.

When proxying to HTTPS from HTTP (for example where an ingress does TLS termination), not including a 'servername' for a request to the HTTPS server (eg, def.org) the request produces the following error (where `abc.com` is the calling server):

 ```
'ERR_TLS_CERT_ALTNAME_INVALID'
"RequestError: Error [ERR_TLS_CERT_ALTNAME_INVALID]: Hostname/IP does not match certificate's altnames:
 Host: abc.com. is not in the cert's altnames: DNS:def.org"
```

The addition of `servername` as an option passed to the HTTP agent resolves this error. 

See docs for `tls.connect(options[, callback])` (https://nodejs.org/api/tls.html): "Server name for the SNI (Server Name Indication) TLS extension.  It is the  name of the host being connected to, and must be a host name, and not an IP address.".

Have written unit tests and have run other tests with the changes included. Relying on your CI for E2E and other tests.

**Note:** Have not changed the use of `request-promise-native` outside of calls to Couch.

Some prior discussions under this PR (branch name was throwing an error): https://github.com/medic/cht-core/pull/8579

Closes this issue: https://github.com/medic/cht-core/issues/8591

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.


