### PR TITLE
fix(#8803): refactor formatContacts to reduce cognitive complexity

### DIFF
--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -230,55 +230,73 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.authService.has('can_view_last_visited_date');
   }
 
-  // Revert 
   private formatContacts(contacts) {
-    return contacts.map(updatedContact => {
-      const contact = { ...updatedContact };
-      const typeId = this.contactTypesService.getTypeId(contact);
-      const type = this.contactTypesService.getTypeById(this.contactTypes, typeId);
-      contact.route = 'contacts';
-      contact.icon = type && type.icon;
-      contact.heading = contact.name || '';
-      contact.valid = true;
-      contact.summary = null;
-      contact.primary = contact.home;
-      contact.dod = contact.date_of_death;
-      if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
-        if (contact.lastVisitedDate === 0) {
-          contact.overdue = true;
-          contact.summary = this.translateService.instant('contact.last.visited.unknown');
-        } else {
-          const now = new Date().getTime();
-          const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
-          contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
-          contact.summary = this.translateService.instant(
-            'contact.last.visited.date',
-            { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
-          );
-        }
+    return contacts.map(contact => this.formatContact(contact));
+  }
 
-        const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
-        contact.visits = {
-          count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
-          summary: this.translateService.instant(
-            'contacts.visits.visits',
-            { VISITS: contact.visitCount }
-          )
-        };
+  private formatContact(updatedContact) {
+    const contact = { ...updatedContact };
+    const typeId = this.contactTypesService.getTypeId(contact);
+    const type = this.contactTypesService.getTypeById(this.contactTypes, typeId);
+    this.getContactDetails(contact, type);
+    this.getVisitDetails(contact, type);
+    return contact;
+  }
 
-        if (contact.visitCountGoal) {
-          if (!contact.visitCount) {
-            contact.visits.status = 'pending';
-          } else if (contact.visitCount < contact.visitCountGoal) {
-            contact.visits.status = 'started';
-          } else {
-            contact.visits.status = 'done';
-          }
-        }
+  private getContactDetails(contact, type) {
+    contact.route = 'contacts';
+    contact.icon = type && type.icon;
+    contact.heading = contact.name || '';
+    contact.valid = true;
+    contact.summary = null;
+    contact.primary = contact.home;
+    contact.dod = contact.date_of_death;
+  }
+
+  private getVisitDetails(contact, type) {
+    if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
+      this.setVisitOverdue(contact);
+      this.getVisitCountDetails(contact);
+      this.evaluateVisitGoal(contact);
+    }
+  }
+
+  private setVisitOverdue(contact) {
+    if (contact.lastVisitedDate === 0) {
+      contact.overdue = true;
+      contact.summary = this.translateService.instant('contact.last.visit.unknown');
+    } else {
+      const now = new Date().getTime();
+      const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
+      contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
+      contact.summary = this.translateService.instant(
+        'contact.last.visited.date',
+        { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
+      );
+    }
+  }
+
+  private getVisitCountDetails(contact) {
+    const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
+    contact.visits = {
+      count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
+      summary: this.translateService.instant(
+        'contacts.visits.visits',
+        { VISITS: contact.visitCount }
+      )
+    };
+  }
+
+  private evaluateVisitGoal(contact) {
+    if (contact.visitCountGoal) {
+      if (!contact.visitCount) {
+        contact.visits.status = 'pending';
+      } else if (contact.visitCount < contact.visitCountGoal) {
+        contact.visits.status = 'started';
+      } else {
+        contact.visits.status = 'done';
       }
-
-      return contact;
-    });
+    }
   }
 
   private getChildren() {

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -231,53 +231,71 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private formatContacts(contacts) {
-    return contacts.map(updatedContact => {
-      const contact = { ...updatedContact };
-      const typeId = this.contactTypesService.getTypeId(contact);
-      const type = this.contactTypesService.getTypeById(this.contactTypes, typeId);
-      contact.route = 'contacts';
-      contact.icon = type && type.icon;
-      contact.heading = contact.name || '';
-      contact.valid = true;
-      contact.summary = null;
-      contact.primary = contact.home;
-      contact.dod = contact.date_of_death;
-      if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
-        if (contact.lastVisitedDate === 0) {
-          contact.overdue = true;
-          contact.summary = this.translateService.instant('contact.last.visited.unknown');
-        } else {
-          const now = new Date().getTime();
-          const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
-          contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
-          contact.summary = this.translateService.instant(
-            'contact.last.visited.date',
-            { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
-          );
-        }
+    return contacts.map(contact => this.formatContact(contact));
+  }
 
-        const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
-        contact.visits = {
-          count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
-          summary: this.translateService.instant(
-            'contacts.visits.visits',
-            { VISITS: contact.visitCount }
-          )
-        };
+  private formatContact(updatedContact) {
+    const contact = { ...updatedContact };
+    const typeId = this.contactTypesService.getTypeId(contact);
+    const type = this.contactTypesService.getTypeById(this.contactTypes, typeId);
+    this.getContactDetails(contact, type);
+    this.getVisitDetails(contact, type);
+    return contact;
+  }
 
-        if (contact.visitCountGoal) {
-          if (!contact.visitCount) {
-            contact.visits.status = 'pending';
-          } else if (contact.visitCount < contact.visitCountGoal) {
-            contact.visits.status = 'started';
-          } else {
-            contact.visits.status = 'done';
-          }
-        }
+  private getContactDetails(contact, type) {
+    contact.route = 'contacts';
+    contact.icon = type && type.icon;
+    contact.valid = true;
+    contact.summary = null;
+    contact.primary = contact.home;
+    contact.dod = contact.date_of_death;
+  }
+
+  private getVisitDetails(contact, type) {
+    if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
+      this.setVisitOverdue(contact);
+      this.getVisitCountDetails(contact);
+      this.evaluateVisitGoal(contact);
+    }
+  }
+
+  private setVisitOverdue(contact) {
+    if (contact.lastVisitedDate === 0) {
+      contact.overdue = true;
+      contact.summary = this.translateService.instant('contact.last.visit.unknown');
+    } else {
+      const now = new Date().getTime();
+      const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
+      contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
+      contact.summary = this.translateService.instant(
+        'contact.last.visited.date',
+        { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
+      );
+    }
+  }
+
+  private getVisitCountDetails(contact) {
+    const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
+    contact.visits = {
+      count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
+      summary: this.translateService.instant(
+        'contacts.visits.visits',
+        { VISITS: contact.visitCount }
+      )
+    };
+  }
+
+  private evaluateVisitGoal(contact) {
+    if (contact.visitCountGoal) {
+      if (!contact.visitCount) {
+        contact.visits.status = 'pending';
+      } else if (contact.visitCount < contact.visitCountGoal) {
+        contact.visits.status = 'started';
+      } else {
+        contact.visits.status = 'done';
       }
-
-      return contact;
-    });
+    }
   }
 
   private getChildren() {

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -190,7 +190,7 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
     this.subscription.add(reduxSubscription);
   }
 
-  private isRelevantVisitReport(doc) {
+  private isRelevantVisitReport (doc) {
     const isRelevantDelete = doc && doc._deleted && this.isSortedByLastVisited();
     return (
       doc &&
@@ -207,7 +207,7 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
   private getUserHomePlaceSummary(homePlaceId?: string) {
     return this.userSettingsService
       .get()
-      .then((userSettings: any) => {
+      .then((userSettings:any) => {
         const facilityId = homePlaceId ?? userSettings.facility_id;
         if (facilityId) {
           this.globalActions.setUserFacilityId(facilityId);
@@ -224,7 +224,7 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
 
   private canViewLastVisitedDate() {
     if (this.sessionService.isAdmin()) {
-      // disable UHC for DB admins
+    // disable UHC for DB admins
       return Promise.resolve(false);
     }
     return this.authService.has('can_view_last_visited_date');
@@ -375,7 +375,7 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
       searchFilters = this.filters;
     }
 
-    const extensions: any = {};
+    const extensions:any = {};
     if (this.lastVisitedDateExtras) {
       extensions.displayLastVisitedDate = true;
       extensions.visitCountSettings = this.visitCountSettings;
@@ -396,7 +396,7 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
       .then(updatedContacts => {
         // If you have a home place make sure its at the top
         if (this.usersHomePlace) {
-          const homeIndex = _findIndex(updatedContacts, (contact: any) => {
+          const homeIndex = _findIndex(updatedContacts, (contact:any) => {
             return contact._id === this.usersHomePlace._id;
           });
           this.additionalListItem =

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -230,83 +230,55 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.authService.has('can_view_last_visited_date');
   }
 
+  // Revert 
   private formatContacts(contacts) {
-    return contacts.map(contact => this.formatContact(contact));
-  }
+    return contacts.map(updatedContact => {
+      const contact = { ...updatedContact };
+      const typeId = this.contactTypesService.getTypeId(contact);
+      const type = this.contactTypesService.getTypeById(this.contactTypes, typeId);
+      contact.route = 'contacts';
+      contact.icon = type && type.icon;
+      contact.heading = contact.name || '';
+      contact.valid = true;
+      contact.summary = null;
+      contact.primary = contact.home;
+      contact.dod = contact.date_of_death;
+      if (type && type.count_visits && Number.isInteger(contact.lastVisitedDate)) {
+        if (contact.lastVisitedDate === 0) {
+          contact.overdue = true;
+          contact.summary = this.translateService.instant('contact.last.visited.unknown');
+        } else {
+          const now = new Date().getTime();
+          const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
+          contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
+          contact.summary = this.translateService.instant(
+            'contact.last.visited.date',
+            { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
+          );
+        }
 
-  private formatContact(updatedContact) {
-    const contact = { ...updatedContact };
-    const type = this.getContactType(contact);
-    this.populateContactDetails(contact, type);
-    this.setVisitDetails(contact, type);
-    return contact;
-  }
+        const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
+        contact.visits = {
+          count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
+          summary: this.translateService.instant(
+            'contacts.visits.visits',
+            { VISITS: contact.visitCount }
+          )
+        };
 
-  private getContactType(contact) {
-    const typeId = this.contactTypesService.getTypeId(contact);
-    return this.contactTypesService.getTypeById(this.contactTypes, typeId);
-  }
+        if (contact.visitCountGoal) {
+          if (!contact.visitCount) {
+            contact.visits.status = 'pending';
+          } else if (contact.visitCount < contact.visitCountGoal) {
+            contact.visits.status = 'started';
+          } else {
+            contact.visits.status = 'done';
+          }
+        }
+      }
 
-  private populateContactDetails(contact, type) {
-    contact.route = 'contacts';
-    contact.icon = type?.icon;
-    contact.valid = true;
-    contact.summary = null;
-    contact.primary = contact.home;
-    contact.dod = contact.date_of_death;
-  }
-
-  private setVisitDetails(contact, type) {
-    if (!type?.count_visits || !Number.isInteger(contact.lastVisitedDate)) {
-      return;
-    }
-    this.setVisitOverdue(contact);
-    this.setVisitCountDetails(contact);
-    this.evaluateVisitGoal(contact);
-  }
-
-  private setVisitOverdue(contact) {
-    if (contact.lastVisitedDate === 0) {
-      contact.overdue = true;
-      contact.summary = this.translateService.instant('contact.last.visit.unknown');
-      return;
-    }
-    const now = new Date().getTime();
-    const oneMonthAgo = now - (30 * 24 * 60 * 60 * 1000);
-    contact.overdue = contact.lastVisitedDate <= oneMonthAgo;
-    contact.summary = this.translateService.instant(
-      'contact.last.visited.date',
-      { date: this.relativeDateService.getRelativeDate(contact.lastVisitedDate, {}) }
-    );
-  }
-
-  private setVisitCountDetails(contact) {
-    const visitCount = Math.min(contact.visitCount, 99) + (contact.visitCount > 99 ? '+' : '');
-    contact.visits = {
-      count: this.translateService.instant('contacts.visits.count', { count: visitCount }),
-      summary: this.translateService.instant(
-        'contacts.visits.visits',
-        { VISITS: contact.visitCount }
-      )
-    };
-  }
-
-  private evaluateVisitGoal(contact) {
-    const { visitCountGoal, visitCount } = contact;
-    if (!visitCountGoal) {
-      return;
-    }
-    contact.visits.status = this.setVisitStatus(visitCount, visitCountGoal);
-  }
-
-  private setVisitStatus(visitCount, visitCountGoal) {
-    if (!visitCount) {
-      return 'pending';
-    }
-    if (visitCount < visitCountGoal) {
-      return 'started';
-    }
-    return 'done';
+      return contact;
+    });
   }
 
   private getChildren() {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

Refactor [formatContacts](https://github.com/medic/cht-core/blob/e16f5df6dfdf6437d9deb14a25f96f77cb84eb10/webapp/src/ts/modules/contacts/contacts.component.ts#L233) to reduce cognitive complexity.

<!-- ISSUE NUMBER -->

Closes #8803 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8803-refactor-format-contacts/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8803-refactor-format-contacts/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8803-refactor-format-contacts/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

