### PR TITLE
chore(#8901): support underscores in branch names

### DIFF
--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -37,7 +37,7 @@ const getApiUrl = (pathname = '') => {
   return apiUrl.toString();
 };
 
-const releaseName = TAG || BRANCH || `${packageJson.version}-local-development`;
+const releaseName = versions.escapeVersion(TAG || BRANCH || `${packageJson.version}-local-development`);
 
 const setBuildInfo = () => {
   const buildInfoPath = path.resolve(ddocsBuildPath, 'medic-db', 'medic', 'build_info');

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -37,7 +37,7 @@ const getApiUrl = (pathname = '') => {
   return apiUrl.toString();
 };
 
-const releaseName = versions.escapeVersion(TAG || BRANCH || `${packageJson.version}-local-development`);
+const releaseName = TAG || versions.escapeBranchName(BRANCH) || `${packageJson.version}-local-development`;
 
 const setBuildInfo = () => {
   const buildInfoPath = path.resolve(ddocsBuildPath, 'medic-db', 'medic', 'build_info');

--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -10,10 +10,9 @@ const {
   INTERNAL_CONTRIBUTOR,
 } = process.env;
 
-const getBranch = () => BRANCH === 'master' ? 'alpha' : escapeVersion(BRANCH);
-
 const getBranchVersion = (release) => {
-  const base = getBranch();
+  const branch = BRANCH === 'master' ? 'alpha' : escapeVersion(BRANCH);
+  const base = `${packageJson.version}-${branch}`;
   return release ? base : `${base}.${BUILD_NUMBER}`;
 };
 

--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -53,7 +53,7 @@ const getImageTag = (service, release = false) => {
   return service ? `${getRepo(repo)}/cht-${service}:${tag}` : tag;
 };
 
-const escapeVersion = (version) => version.replace(/[\/\|_]/g, '-');
+const escapeVersion = (version) => version.replace(/[/|_]/g, '-');
 
 module.exports = {
   getImageTag,

--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -53,7 +53,7 @@ const getImageTag = (service, release = false) => {
   return service ? `${getRepo(repo)}/cht-${service}:${tag}` : tag;
 };
 
-const escapeVersion = (version) => version.replace(/\/|_/g, '-');
+const escapeVersion = (version) => version.replace(/[\/\|_]/g, '-');
 
 module.exports = {
   getImageTag,

--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -49,14 +49,17 @@ const getVersion = (release) => {
 const getImageTag = (service, release = false) => {
   const version = getVersion(release);
   const repo = release ? ECR_PUBLIC_REPO : ECR_REPO;
-  const tag = version.replace(/\/|_/g, '-');
+  const tag = escapeVersion(version);
   return service ? `${getRepo(repo)}/cht-${service}:${tag}` : tag;
 };
+
+const escapeVersion = (version) => version.replace(/\/|_/g, '-');
 
 module.exports = {
   getImageTag,
   getVersion,
   getRepo,
+  escapeVersion,
   SERVICES: ['api', 'sentinel'],
   INFRASTRUCTURE: ['couchdb', 'haproxy', 'haproxy-healthcheck', 'nginx'],
 };

--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -10,8 +10,10 @@ const {
   INTERNAL_CONTRIBUTOR,
 } = process.env;
 
+const escapeBranchName = (branch) => branch?.replace(/[/|_]/g, '-');
+
 const getBranchVersion = (release) => {
-  const branch = BRANCH === 'master' ? 'alpha' : escapeVersion(BRANCH);
+  const branch = BRANCH === 'master' ? 'alpha' : escapeBranchName(BRANCH);
   const base = `${packageJson.version}-${branch}`;
   return release ? base : `${base}.${BUILD_NUMBER}`;
 };
@@ -53,13 +55,11 @@ const getImageTag = (service, release = false) => {
   return service ? `${getRepo(repo)}/cht-${service}:${version}` : version;
 };
 
-const escapeVersion = (version) => version.replace(/[/|_]/g, '-');
-
 module.exports = {
   getImageTag,
   getVersion,
   getRepo,
-  escapeVersion,
+  escapeBranchName,
   SERVICES: ['api', 'sentinel'],
   INFRASTRUCTURE: ['couchdb', 'haproxy', 'haproxy-healthcheck', 'nginx'],
 };

--- a/scripts/build/versions.js
+++ b/scripts/build/versions.js
@@ -10,8 +10,10 @@ const {
   INTERNAL_CONTRIBUTOR,
 } = process.env;
 
+const getBranch = () => BRANCH === 'master' ? 'alpha' : escapeVersion(BRANCH);
+
 const getBranchVersion = (release) => {
-  const base = BRANCH === 'master' ? `${packageJson.version}-alpha` : `${packageJson.version}-${BRANCH}`;
+  const base = getBranch();
   return release ? base : `${base}.${BUILD_NUMBER}`;
 };
 
@@ -49,8 +51,7 @@ const getVersion = (release) => {
 const getImageTag = (service, release = false) => {
   const version = getVersion(release);
   const repo = release ? ECR_PUBLIC_REPO : ECR_REPO;
-  const tag = escapeVersion(version);
-  return service ? `${getRepo(repo)}/cht-${service}:${tag}` : tag;
+  return service ? `${getRepo(repo)}/cht-${service}:${version}` : version;
 };
 
 const escapeVersion = (version) => version.replace(/[/|_]/g, '-');

--- a/scripts/ci/publish.js
+++ b/scripts/ci/publish.js
@@ -9,7 +9,8 @@ const {
   TAG,
   BRANCH
 } = process.env;
-const releaseName = TAG || BRANCH;
+const versions = require('../build/versions');
+const releaseName = TAG || versions.escapeVersion(BRANCH);
 const PouchDB = require('pouchdb-core');
 PouchDB.plugin(require('pouchdb-adapter-http'));
 

--- a/scripts/ci/publish.js
+++ b/scripts/ci/publish.js
@@ -10,15 +10,15 @@ const {
   BRANCH
 } = process.env;
 const versions = require('../build/versions');
-const releaseName = TAG || versions.escapeVersion(BRANCH);
-const PouchDB = require('pouchdb-core');
-PouchDB.plugin(require('pouchdb-adapter-http'));
 
+const releaseName = TAG || versions.escapeBranchName(BRANCH);
 if (!releaseName) {
   console.log('Not a tag or a branch so not publishing. Most likely this is a PR build which is merged with master');
   process.exit(0);
 }
 
+const PouchDB = require('pouchdb-core');
+PouchDB.plugin(require('pouchdb-adapter-http'));
 const testingDb = new PouchDB(`${MARKET_URL}/${BUILDS_SERVER}`);
 const stagingDb = new PouchDB(`${MARKET_URL}/${STAGING_SERVER}`);
 

--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -78,7 +78,8 @@ describe('Telemetry', () => {
       'metadata.user': user.username,
       'metadata.versions.app': clientDdoc.build_info.version,
     });
-    const ciBuild = TAG || BRANCH;
-    expect(clientDdoc.build_info.version).to.include(ciBuild || clientDdoc.build_info.base_version);
+
+    const version = (TAG || BRANCH || clientDdoc.build_info.base_version || '').replace(/[/|_]/g, '-');
+    expect(clientDdoc.build_info.version).to.include(version);
   });
 });

--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -79,7 +79,7 @@ describe('Telemetry', () => {
       'metadata.versions.app': clientDdoc.build_info.version,
     });
 
-    const version = TAG || utils.escapeBranchName(BRANCH) || clientDdoc.build_info.base_version || '';
+    const version = TAG || utils.escapeBranchName(BRANCH) || clientDdoc.build_info.base_version;
     expect(clientDdoc.build_info.version).to.include(version);
   });
 });

--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -79,7 +79,7 @@ describe('Telemetry', () => {
       'metadata.versions.app': clientDdoc.build_info.version,
     });
 
-    const version = (TAG || BRANCH || clientDdoc.build_info.base_version || '').replace(/[/|_]/g, '-');
+    const version = TAG || utils.escapeBranchName(BRANCH) || clientDdoc.build_info.base_version || '';
     expect(clientDdoc.build_info.version).to.include(version);
   });
 });

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -124,8 +124,8 @@ describe('Performing an upgrade', () => {
     await browser.refresh();
     await commonPage.waitForPageLoaded();
     await commonPage.goToAboutPage();
-    const escapedBranch = BRANCH.replace(/[/|_]/g, '-');
-    expect(await aboutPage.getVersion()).to.include(TAG ? TAG : `${escapedBranch} (`);
+    const expected = TAG || `${utils.escapeBranchName(BRANCH)} (`;
+    expect(await aboutPage.getVersion()).to.include(expected);
     await commonPage.logout();
   });
 

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -124,7 +124,8 @@ describe('Performing an upgrade', () => {
     await browser.refresh();
     await commonPage.waitForPageLoaded();
     await commonPage.goToAboutPage();
-    expect(await aboutPage.getVersion()).to.include(TAG ? TAG : `${BRANCH} (`);
+    const escapedBranch = BRANCH.replace(/[/|_]/g, '-');
+    expect(await aboutPage.getVersion()).to.include(TAG ? TAG : `${escapedBranch} (`);
     await commonPage.logout();
   });
 

--- a/tests/e2e/upgrade/webapp.wdio-spec.js
+++ b/tests/e2e/upgrade/webapp.wdio-spec.js
@@ -57,6 +57,7 @@ describe('Webapp after upgrade', () => {
 
   it('should display correct version on the about page', async () => {
     await common.goToAboutPage();
-    expect(await aboutPage.getVersion()).to.include(TAG ? TAG : `${BRANCH} (`);
+    const escapedBranch = BRANCH.replace(/[/|_]/g, '-');
+    expect(await aboutPage.getVersion()).to.include(TAG ? TAG : `${escapedBranch} (`);
   });
 });

--- a/tests/e2e/upgrade/webapp.wdio-spec.js
+++ b/tests/e2e/upgrade/webapp.wdio-spec.js
@@ -57,7 +57,7 @@ describe('Webapp after upgrade', () => {
 
   it('should display correct version on the about page', async () => {
     await common.goToAboutPage();
-    const escapedBranch = BRANCH.replace(/[/|_]/g, '-');
-    expect(await aboutPage.getVersion()).to.include(TAG ? TAG : `${escapedBranch} (`);
+    const expected = TAG || `${utils.escapeBranchName(BRANCH)} (`;
+    expect(await aboutPage.getVersion()).to.include(expected);
   });
 });

--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -6,6 +6,7 @@ const deploymentInProgress = () => $('legend*=Deployment in progress');
 const deploymentComplete = () => $('div*=Deployment complete');
 
 const getInstallButton = async (branch, tag) => {
+  branch = branch.replace(/[/|_]/g, '-');
   let selector = `span*=${branch} (`;
   if (tag) {
     selector = tag.includes('beta') ? `span*=${tag}` : `span=${tag}`;

--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -5,13 +5,16 @@ const cancelUpgradeButton = () => $('button*=Cancel');
 const deploymentInProgress = () => $('legend*=Deployment in progress');
 const deploymentComplete = () => $('div*=Deployment complete');
 
-const getInstallButton = async (branch, tag) => {
-  branch = branch.replace(/[/|_]/g, '-');
-  let selector = `span*=${branch} (`;
+const getInstallButtonSelector = (branch, tag) => {
   if (tag) {
-    selector = tag.includes('beta') ? `span*=${tag}` : `span=${tag}`;
+    const match = tag.includes('beta') ? '*=' : '=';
+    return `span${match}${tag}`;
   }
-  const element = await $(selector);
+  return `span*=${utils.escapeBranchName(branch)} (`;
+};
+
+const getInstallButton = async (branch, tag) => {
+  const element = await $(getInstallButtonSelector(branch, tag));
   const parent = await (await element.parentElement()).parentElement();
   return await parent.$('.btn-primary');
 };

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1260,6 +1260,8 @@ const logFeedbackDocs = async (test) => {
 
 const isMinimumChromeVersion = process.env.CHROME_VERSION === MINIMUM_BROWSER_VERSION;
 
+const escapeBranchName = (branch) => branch.replace(/[/|_]/g, '-');
+
 module.exports = {
   db,
   sentinelDb,
@@ -1330,4 +1332,5 @@ module.exports = {
   getSentinelDate,
   logFeedbackDocs,
   isMinimumChromeVersion,
+  escapeBranchName,
 };

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1260,7 +1260,7 @@ const logFeedbackDocs = async (test) => {
 
 const isMinimumChromeVersion = process.env.CHROME_VERSION === MINIMUM_BROWSER_VERSION;
 
-const escapeBranchName = (branch) => branch.replace(/[/|_]/g, '-');
+const escapeBranchName = (branch) => branch?.replace(/[/|_]/g, '-');
 
 module.exports = {
   db,


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->
#8901 

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8901-branch_with/underscores|and-things/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8901-branch_with/underscores|and-things/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8901-branch_with/underscores|and-things/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

