### PR TITLE
chore(#8612) Fix docker helper to have valid TLS on 1st run

### DIFF
--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -159,7 +159,7 @@ get_nginx_container_id() {
   docker ps --all --filter "publish=${NGINX_HTTPS_PORT}" --filter "name=${projectName}" --quiet  2>/dev/null
 }
 
-nginx_is_running() {
+is_nginx_running() {
   containerId=$1
 
   # first check if container has State.Running == "true"
@@ -169,7 +169,7 @@ nginx_is_running() {
 
     # now confirm that nginx returns a 301 http code to curl, meaning it's ready to serve requests
     # and also ready to have the TLS cert installed
-    http_code=$(docker exec -it  "$containerId" bash -c "curl -o /dev/null -s -w \"%{http_code}\" http://localhost")
+    http_code=$(docker exec "$containerId" bash -c "curl -o /dev/null -s -w \"%{http_code}\" http://localhost")
     if [[ "$http_code" == "301" ]]; then
       echo "true"
       return 0
@@ -422,7 +422,7 @@ set +e
 echo "Starting project \"${projectName}\". First run takes a while. Will try for up to five minutes..." | tr -d '\n'
 
 nginxContainerId=$(get_nginx_container_id)
-running=$(nginx_is_running "$nginxContainerId")
+running=$(is_nginx_running "$nginxContainerId")
 i=0
 
 if [ ! -z ${DEBUG+x} ];then get_system_and_docker_info; fi
@@ -449,7 +449,7 @@ while [[ "$running" != "true" ]]; do
     nginxContainerId=$(get_nginx_container_id)
   fi
 
-  running=$(nginx_is_running "$nginxContainerId")
+  running=$(is_nginx_running "$nginxContainerId")
 done
 
 docker exec -it $nginxContainerId bash -c "curl -s -o /etc/nginx/private/cert.pem https://local-ip.medicmobile.org/fullchain"  2>/dev/null


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

### This PR

Fixes docker helper 4.x to have valid TLS on 1st run:
* refactors `get_is_container_running()` to be called `nginx_is_running()` (only nginx is ever used with it)
* adds an extra check that `nginx` returns a `301` as opposed to `000` or other failure, ensuring it is up and running

Per #8612


### Background

I narrowed down the bug to these three lines being called before `nginx` container was fully running:

```
docker exec -it $nginxContainerId bash -c "curl -s -o /etc/nginx/private/cert.pem https://local-ip.medicmobile.org/fullchain"  2>/dev/null
docker exec -it $nginxContainerId bash -c "curl -s -o /etc/nginx/private/key.pem https://local-ip.medicmobile.org/key"  2>/dev/null
docker exec -it $nginxContainerId bash -c "nginx -s reload"  2>/dev/null
```

By adding a `sleep 5` above these, I could get it to work giving `nginx` container more time to boot.  However, this was non-deterministic and may still fail.  I settled on explicitly waiting for a `301` redirect from the `/` path on `http` to the `https` port.   


### Testing

Test these steps on `master` to ensure they fail and then test on `8612_no_tls_1st_start_nginx` branch to ensure they succeed.   Before starting, create a new docker helper project called `8612_no_tls_1st_start`. Then:

1. run this one liner to reset the instance: `docker rm -f 8612_no_tls_1st_start_nginx_1; docker volume rm -f 8612_no_tls_1st_start_cht-ssl;docker kill $(docker ps -q);./cht-docker-compose.sh 8612_no_tls_1st_start.env`
2. open the URL output in docker helper script  in a new incognito tab = remember offline first - stuff gets cached!  using a **new** incognito tab ensure no cache
3. see if TLS is invalid (self signed cert) or valid (let's encrypt)

Make sure there's no regressions and these work on `8612_no_tls_1st_start_nginx` branch:
* can start existing docker helper project
* can start a new   docker helper project
* can  `stop` a running docker helper project


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8612_no_tls_1st_start_nginx/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8612_no_tls_1st_start_nginx/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8612_no_tls_1st_start_nginx/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

