### PR TITLE
fix(#8868): don't forward all headers for get requests

### DIFF
--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -7,8 +7,8 @@ const { roles, users } = require('@medic/user-management')(config, db);
 
 const get = (path, headers) => {
   const getHeaders = { ...headers };
-  delete getHeaders['content-length'];
-  delete getHeaders['Content-Length'];
+  const contentLengthHeaders = Object.keys(getHeaders).filter(header => /^content-length$/i.test(header));
+  contentLengthHeaders.forEach(header => delete getHeaders[header]);
   const url = new URL(path, environment.serverUrlNoAuth);
   return rpn.get({
     url: url.toString(),

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -5,9 +5,11 @@ const environment = require('./environment');
 const config = require('./config');
 const { roles, users } = require('@medic/user-management')(config, db);
 
+const contentLengthRegex = /^content-length$/i;
+
 const get = (path, headers) => {
   const getHeaders = { ...headers };
-  const contentLengthHeaders = Object.keys(getHeaders).filter(header => /^content-length$/i.test(header));
+  const contentLengthHeaders = Object.keys(getHeaders).filter(header => contentLengthRegex.test(header));
   contentLengthHeaders.forEach(header => delete getHeaders[header]);
   const url = new URL(path, environment.serverUrlNoAuth);
   return rpn.get({

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -1,4 +1,4 @@
-const request = require('request-promise-native');
+const rpn = require('request-promise-native');
 const _ = require('lodash');
 const db = require('./db');
 const environment = require('./environment');
@@ -6,10 +6,13 @@ const config = require('./config');
 const { roles, users } = require('@medic/user-management')(config, db);
 
 const get = (path, headers) => {
+  const getHeaders = { ...headers };
+  delete getHeaders['content-length'];
+  delete getHeaders['Content-Length'];
   const url = new URL(path, environment.serverUrlNoAuth);
-  return request.get({
+  return rpn.get({
     url: url.toString(),
-    headers: headers,
+    headers: getHeaders,
     json: true
   });
 };
@@ -95,7 +98,7 @@ module.exports = {
     const authUrl = new URL(environment.serverUrlNoAuth);
     authUrl.username = username;
     authUrl.password = password;
-    return request.head({
+    return rpn.head({
       uri: authUrl.toString(),
       resolveWithFullResponse: true
     })

--- a/api/src/auth.js
+++ b/api/src/auth.js
@@ -9,8 +9,11 @@ const contentLengthRegex = /^content-length$/i;
 
 const get = (path, headers) => {
   const getHeaders = { ...headers };
-  const contentLengthHeaders = Object.keys(getHeaders).filter(header => contentLengthRegex.test(header));
-  contentLengthHeaders.forEach(header => delete getHeaders[header]);
+  Object
+    .keys(getHeaders)
+    .filter(header => contentLengthRegex.test(header))
+    .forEach(header => delete getHeaders[header]);
+
   const url = new URL(path, environment.serverUrlNoAuth);
   return rpn.get({
     url: url.toString(),

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -145,13 +145,15 @@ describe('Auth', () => {
     });
 
     it('should clean content-length headers before forwarding', async () => {
-      sinon.stub(rpn, 'get').resolves({ userCtx: { name: 'user', roles: ['userrole'] }});
+      sinon.stub(rpn, 'get').resolves({ userCtx: { name: 'theuser', roles: ['userrole'] }});
 
       req.headers['content-length'] = 100;
       req.headers['Content-Length'] = 22;
+      req.headers['Content-length'] = 44;
+      req.headers['content-Length'] = 82;
 
       const result = await auth.getUserCtx(req);
-      chai.expect(result).to.deep.equal({ name: 'user', roles: ['userrole'] });
+      chai.expect(result).to.deep.equal({ name: 'theuser', roles: ['userrole'] });
       chai.expect(rpn.get.args).to.deep.equal([[{
         url: 'http://abc.com/_session',
         json: true,

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -167,7 +167,7 @@ describe('Auth', () => {
     it('should throw a custom 401 error', async () => {
       sinon.stub(rpn, 'get').rejects({ statusCode: 401, error: 'not logged in' });
 
-      await expect(auth.getUserCtx(req)).to.be.rejected.and.eventually.deep.equal({
+      await chai.expect(auth.getUserCtx(req)).to.be.rejected.and.eventually.deep.equal({
         code: 401,
         message: 'Not logged in',
         err: { statusCode: 401, error: 'not logged in' }
@@ -179,7 +179,7 @@ describe('Auth', () => {
     it('should throw non-401 errors', async () => {
       sinon.stub(rpn, 'get').rejects({ statusCode: 400, error: 'invalid' });
 
-      await expect(auth.getUserCtx(req)).to.be.rejected.and.eventually.deep.equal({
+      await chai.expect(auth.getUserCtx(req)).to.be.rejected.and.eventually.deep.equal({
         statusCode: 400,
         error: 'invalid'
       });
@@ -190,7 +190,7 @@ describe('Auth', () => {
     it('should throw 500 when auth is invalid', async () => {
       sinon.stub(rpn, 'get').resolves({ userCtx: { invalid: 'userctx' }});
 
-      await expect(auth.getUserCtx(req)).to.be.rejected.and.eventually.deep.equal({
+      await chai.expect(auth.getUserCtx(req)).to.be.rejected.and.eventually.deep.equal({
         code: 500,
         message: 'Failed to authenticate'
       });

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -5,7 +5,6 @@ const sinon = require('sinon');
 const auth = require('../../src/auth');
 const config = require('../../src/config');
 const environment = require('../../src/environment');
-const {expect} = require("chai");
 
 let req;
 

--- a/api/tests/mocha/auth.spec.js
+++ b/api/tests/mocha/auth.spec.js
@@ -151,6 +151,7 @@ describe('Auth', () => {
       req.headers['Content-Length'] = 22;
       req.headers['Content-length'] = 44;
       req.headers['content-Length'] = 82;
+      req.headers['CONTENT-LENGTH'] = 240;
 
       const result = await auth.getUserCtx(req);
       chai.expect(result).to.deep.equal({ name: 'theuser', roles: ['userrole'] });

--- a/haproxy/default_frontend.cfg
+++ b/haproxy/default_frontend.cfg
@@ -35,11 +35,11 @@ defaults
   option httplog
   option forwardfor
   option redispatch
-  option http-keep-alive
+  option http-server-close
   timeout client 15000000
   timeout server 360000000
   timeout connect 1500000
-  timeout http-keep-alive 5s
+  timeout http-keep-alive 5m
 
   errorfiles json
 

--- a/haproxy/default_frontend.cfg
+++ b/haproxy/default_frontend.cfg
@@ -35,11 +35,11 @@ defaults
   option httplog
   option forwardfor
   option redispatch
-  option http-server-close
+  option http-keep-alive
   timeout client 15000000
   timeout server 360000000
   timeout connect 1500000
-  timeout http-keep-alive 5m
+  timeout http-keep-alive 5s
 
   errorfiles json
 

--- a/tests/integration/haproxy/keep-alive-script/Dockerfile
+++ b/tests/integration/haproxy/keep-alive-script/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.19
+
+RUN apk add --update --no-cache curl
+
+COPY cmd.sh /
+RUN chmod +x /cmd.sh
+
+CMD ["/cmd.sh"]

--- a/tests/integration/haproxy/keep-alive-script/cmd.sh
+++ b/tests/integration/haproxy/keep-alive-script/cmd.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+data='{"user":"'$USER'","password":"'$PASSWORD'"}'
+
+curl -v POST 'http://api:5988/medic/login' -d $data -H 'Content-Type:application/json'
+

--- a/tests/integration/haproxy/keep-alive-script/docker-compose.yml
+++ b/tests/integration/haproxy/keep-alive-script/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+
+services:
+  login_call:
+    build: .
+    networks:
+      net:
+    environment:
+      - USER
+      - PASSWORD
+
+networks:
+  net:
+    name: cht-net-e2e
+    external: true

--- a/tests/integration/haproxy/keep-alive.spec.js
+++ b/tests/integration/haproxy/keep-alive.spec.js
@@ -1,0 +1,45 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const constants = require('@constants');
+
+const runDockerCommand = (command, params, env=process.env) => {
+  return new Promise((resolve, reject) => {
+    const cmd = spawn(command, params, { cwd: path.join(__dirname, 'keep-alive-script'), env });
+    const output = [];
+    const log = (data) => output.push(data.toString());
+    cmd.on('error', reject);
+    cmd.stdout.on('data', log);
+    cmd.stderr.on('data', log);
+    cmd.on('close', () => resolve(output.join(' ')));
+  });
+};
+
+const runScript = async () => {
+  const env = { ...process.env };
+  env.USER = constants.USERNAME;
+  env.PASSWORD = constants.PASSWORD;
+  return await runDockerCommand('docker-compose', ['up', '--build', '--force-recreate'], env);
+};
+const getLogs = async () => {
+  return await runDockerCommand('docker-compose', ['logs', '--no-log-prefix']);
+};
+
+describe('logging in through API directly', () => {
+  after(async () => {
+    await runDockerCommand('docker-compose', ['down', '--remove-orphans']);
+  });
+
+  it('should allow logins', async () => {
+    await runScript();
+    const logs = await getLogs();
+
+    console.log(logs);
+
+    expect(logs).to.not.include('HTTP/1.1 400 Bad Request');
+
+    expect(logs).to.include('HTTP/1.1 302 Found');
+    expect(logs).to.include('Connection: keep-alive');
+    expect(logs).to.include('Set-Cookie: AuthSession=');
+    expect(logs).to.include('Set-Cookie: userCtx=');
+  });
+});


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Node 19 adds keep-alive header to requests by default. This makes the `content-length` header very significant **and** important because it enables the server to know when one request has been fully received and another one is sent through the same connection. 
When authenticating a user, we take all headers from the original user's request and pass them to a GET /_session request, presumably so we don't have to filter out all the ways through which the user can authenticate (cookie, authorization etc). This meant that if the original request was a POST, and it had a `content-length` header, this header was also forwarded. This meant that when the connection would later be reused, the server (haproxy in this case) would truncate the previous's request `content-length` number of characters from the next request, believing the previous request was not finished. Obviously, this new truncated request was invalid and generated a 400 status code. 

This only seems to happen when accessing API directly or through the AWS load balancer, and never when running requests through nginx. 

To avoid next request truncation, I am no longer forwarding `content-length` headers in the session request. 

#8868

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8868-dont-forward-all-headers-for-get/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8868-dont-forward-all-headers-for-get/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8868-dont-forward-all-headers-for-get/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

