### PR TITLE
Add error object to sentinel start up error log (#8348)

### DIFF
--- a/sentinel/server.js
+++ b/sentinel/server.js
@@ -19,14 +19,25 @@ const waitForApi = () => new Promise(resolve => {
   // This waits forever, with no escape hatch, because there is no way currently
   // to know what API is doing, and migrations could legitimately take days
   const url = `http://${process.env.API_HOST || 'localhost'}:${process.env.API_PORT || 5988}/setup/poll`;
+
+  let errorLogAttempts = 0;
+
   const waitLoop = () => {
     request({ url, json: true }, (err, response, body) => {
       if (err) {
         logger.info('Waiting for API to be ready...');
+
+        const canLogError = errorLogAttempts % 10 === 0;
+        if (canLogError) {
+          logger.error('%o', err);
+        }
+
+        errorLogAttempts++;
         return setTimeout(() => waitLoop(), 10 * 1000);
       }
 
       logger.info(`API is ready: ${JSON.stringify(body)}`);
+      errorLogAttempts = 0;
       resolve();
     });
   };


### PR DESCRIPTION
fix(#8348): add error object to sentinel start-up error log

# Description

When starting the sentinel project in development mode, the message ` Waiting for API to be ready ...` gets printed on the console if the module is not able to reach the dev-api project. 

Adding the `err` object as part of the logs will provide more insights on what could be the reason the app is not able to connect to the dev-api.  To minimize the impact of the log size, and the repetition of the same error over and over,  The error object will be logged at every tenth attempt of connection.

#8348 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

