### PR TITLE
fix(#8844): adding link to exit error page

### DIFF
--- a/webapp/src/ts/modules/error/error.component.html
+++ b/webapp/src/ts/modules/error/error.component.html
@@ -2,14 +2,19 @@
 
 <div class="inner">
   <div *ngIf="translationsLoaded" class="col-sm-12 page help">
-    <h3>{{error.title | translate}}</h3>
-    <p>{{error.description | translate}}</p>
+    <h3>{{ error.title | translate }}</h3>
+    <p>{{ error.description | translate }}</p>
+    <br>
+    <a (click)="exit()">{{ (error.showReloadLink ? 'reload.app' : 'Back') | translate }}</a>
   </div>
   <div *ngIf="!translationsLoaded" class="col-sm-12 page help">
     <div class="loader inline small" *ngIf="!timeoutElapsed"></div>
     <div *ngIf="timeoutElapsed">
       <h3>Error</h3>
       <p>Error loading. Check your internet connection and try again or check with an administrator.</p>
+      <br>
+      <a (click)="exit()">Back</a>
     </div>
   </div>
 </div>
+

--- a/webapp/src/ts/modules/error/error.component.html
+++ b/webapp/src/ts/modules/error/error.component.html
@@ -5,7 +5,7 @@
     <h3>{{ error.title | translate }}</h3>
     <p>{{ error.description | translate }}</p>
     <br>
-    <a (click)="exit()">{{ (error.showReloadLink ? 'reload.app' : 'Back') | translate }}</a>
+    <a (click)="exit()">{{ (error.showBackLink ? 'Back' : 'reload.app') | translate }}</a>
   </div>
   <div *ngIf="!translationsLoaded" class="col-sm-12 page help">
     <div class="loader inline small" *ngIf="!timeoutElapsed"></div>
@@ -13,7 +13,7 @@
       <h3>Error</h3>
       <p>Error loading. Check your internet connection and try again or check with an administrator.</p>
       <br>
-      <a (click)="exit()">Back</a>
+      <a (click)="exit()">Reload application</a>
     </div>
   </div>
 </div>

--- a/webapp/src/ts/modules/error/error.component.ts
+++ b/webapp/src/ts/modules/error/error.component.ts
@@ -1,31 +1,33 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subscription, timer } from 'rxjs';
 
 import { Selectors } from '@mm-selectors/index';
 import { TranslateService } from '@mm-services/translate.service';
-
-const errors = {
-  403: {
-    title: 'error.403.title',
-    description: 'error.403.description'
-  },
-  404: {
-    title: 'error.404.title',
-    description: 'error.404.description'
-  },
-  503: {
-    title: 'error.503.description',
-    description: 'error.503.description'
-  },
-};
-const timeoutDuration = 5000; // 5 seconds
+import { NavigationService } from '@mm-services/navigation.service';
 
 @Component({
   templateUrl: './error.component.html'
 })
 export class ErrorComponent implements OnInit, OnDestroy {
+  private readonly TIMEOUT_DURATION = 5 * 1000;
+  private readonly ERRORS = {
+    403: {
+      title: 'error.403.title',
+      description: 'error.403.description',
+      showReloadLink: true,
+    },
+    404: {
+      title: 'error.404.title',
+      description: 'error.404.description'
+    },
+    503: {
+      title: 'error.503.description',
+      description: 'error.503.description'
+    },
+  };
+
   error;
   translationsLoaded = false;
   timeoutElapsed = false;
@@ -35,10 +37,12 @@ export class ErrorComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private translateService: TranslateService,
     private store: Store,
+    private router: Router,
+    private navigationService: NavigationService,
   ) {}
 
   ngOnInit(): void {
-    this.error = errors[this.route.snapshot.params.code] || errors['404'];
+    this.error = this.ERRORS[this.route.snapshot.params.code] || this.ERRORS['404'];
     this.translationsLoaded = this.translateService.instant('error.403.description') !== 'error.403.description';
 
     const subscription = this.store
@@ -61,9 +65,20 @@ export class ErrorComponent implements OnInit, OnDestroy {
   }
 
   private startTimeout(): void {
-    const timeoutTimer = timer(timeoutDuration).subscribe(() => {
-      this.timeoutElapsed = true;
-    });
+    const timeoutTimer = timer(this.TIMEOUT_DURATION).subscribe(() => this.timeoutElapsed = true);
     this.subscriptions.add(timeoutTimer);
+  }
+
+  async exit() {
+    const prevUrl = this.navigationService.getPreviousUrl();
+    const HOME = '/home';
+
+    if ([ undefined, '/', HOME ].find(item => prevUrl === item)) {
+      await this.router.navigate([ HOME ]);
+      window.location.reload();
+      return;
+    }
+
+    await this.router.navigateByUrl(prevUrl);
   }
 }

--- a/webapp/src/ts/modules/error/error.component.ts
+++ b/webapp/src/ts/modules/error/error.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
 import { Subscription, timer } from 'rxjs';
@@ -11,6 +12,7 @@ import { NavigationService } from '@mm-services/navigation.service';
   templateUrl: './error.component.html'
 })
 export class ErrorComponent implements OnInit, OnDestroy {
+  private windowRef;
   private readonly TIMEOUT_DURATION = 5 * 1000;
   private readonly ERRORS = {
     403: {
@@ -39,7 +41,10 @@ export class ErrorComponent implements OnInit, OnDestroy {
     private store: Store,
     private router: Router,
     private navigationService: NavigationService,
-  ) {}
+    @Inject(DOCUMENT) private document: Document,
+  ) {
+    this.windowRef = this.document.defaultView;
+  }
 
   ngOnInit(): void {
     this.error = this.ERRORS[this.route.snapshot.params.code] || this.ERRORS['404'];
@@ -73,9 +78,9 @@ export class ErrorComponent implements OnInit, OnDestroy {
     const prevUrl = this.navigationService.getPreviousUrl();
     const HOME = '/home';
 
-    if ([ undefined, '/', HOME ].find(item => prevUrl === item)) {
+    if (!prevUrl || [ '/', HOME ].find(item => prevUrl === item)) {
       await this.router.navigate([ HOME ]);
-      window.location.reload();
+      this.windowRef?.location?.reload();
       return;
     }
 

--- a/webapp/src/ts/modules/error/error.component.ts
+++ b/webapp/src/ts/modules/error/error.component.ts
@@ -18,11 +18,12 @@ export class ErrorComponent implements OnInit, OnDestroy {
     403: {
       title: 'error.403.title',
       description: 'error.403.description',
-      showReloadLink: true,
+      showBackLink: true,
     },
     404: {
       title: 'error.404.title',
-      description: 'error.404.description'
+      description: 'error.404.description',
+      showBackLink: true,
     },
     503: {
       title: 'error.503.description',

--- a/webapp/src/ts/modules/error/error.component.ts
+++ b/webapp/src/ts/modules/error/error.component.ts
@@ -76,10 +76,12 @@ export class ErrorComponent implements OnInit, OnDestroy {
   }
 
   async exit() {
-    const prevUrl = this.navigationService.getPreviousUrl();
     const HOME = '/home';
+    const prevUrl = this.navigationService.getPreviousUrl();
+    const isHomePage = prevUrl === '/' || prevUrl === HOME;
+    const isErrorPage = prevUrl?.startsWith('/error');
 
-    if (!prevUrl || [ '/', HOME ].find(item => prevUrl === item)) {
+    if (!prevUrl || isHomePage || isErrorPage) {
       await this.router.navigate([ HOME ]);
       this.windowRef?.location?.reload();
       return;

--- a/webapp/src/ts/services/navigation.service.ts
+++ b/webapp/src/ts/services/navigation.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
+import { NavigationEnd, Router } from '@angular/router';
 import { Store } from '@ngrx/store';
+import { filter } from 'rxjs/operators';
 
 import { RouteSnapshotService } from '@mm-services/route-snapshot.service';
 import { Selectors } from '@mm-selectors/index';
@@ -12,6 +13,8 @@ import { HeaderTabsService } from '@mm-services/header-tabs.service';
 export class NavigationService {
   private primaryTab;
   private currentTab;
+  private prevUrlNotErrorPage;
+  private currentUrl;
 
   constructor(
     private router: Router,
@@ -20,7 +23,20 @@ export class NavigationService {
     private store: Store,
   ) {
     this.subscribeToStore();
+    this.subscribeToRouter();
     this.getPrimaryTab();
+  }
+
+  private subscribeToRouter() {
+    this.currentUrl = this.router.url;
+    this.router.events
+      .pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe((event: NavigationEnd) => {
+        if (!this.currentUrl.startsWith('/error/')) {
+          this.prevUrlNotErrorPage = this.currentUrl;
+        }
+        this.currentUrl = event.url;
+      });
   }
 
   private subscribeToStore() {
@@ -83,5 +99,9 @@ export class NavigationService {
 
     this.router.navigate([ this.primaryTab.route ]);
     return true;
+  }
+
+  getPreviousUrl(){
+    return this.prevUrlNotErrorPage;
   }
 }

--- a/webapp/src/ts/services/navigation.service.ts
+++ b/webapp/src/ts/services/navigation.service.ts
@@ -13,7 +13,7 @@ import { HeaderTabsService } from '@mm-services/header-tabs.service';
 export class NavigationService {
   private primaryTab;
   private currentTab;
-  private prevUrlNotErrorPage;
+  private previousUrl;
   private currentUrl;
 
   constructor(
@@ -32,9 +32,7 @@ export class NavigationService {
     this.router.events
       .pipe(filter(event => event instanceof NavigationEnd))
       .subscribe((event: NavigationEnd) => {
-        if (!this.currentUrl.startsWith('/error/')) {
-          this.prevUrlNotErrorPage = this.currentUrl;
-        }
+        this.previousUrl = this.currentUrl;
         this.currentUrl = event.url;
       });
   }
@@ -102,6 +100,6 @@ export class NavigationService {
   }
 
   getPreviousUrl(){
-    return this.prevUrlNotErrorPage;
+    return this.previousUrl;
   }
 }

--- a/webapp/tests/karma/ts/modules/error/error.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/error/error.component.spec.ts
@@ -1,0 +1,105 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { provideMockStore } from '@ngrx/store/testing';
+import { DOCUMENT } from '@angular/common';
+
+import { ErrorComponent } from '@mm-modules/error/error.component';
+import { NavigationService } from '@mm-services/navigation.service';
+
+describe('ErrorComponent', () => {
+  let component: ErrorComponent;
+  let fixture: ComponentFixture<ErrorComponent>;
+  let navigationService;
+  let routerMock;
+  let documentMock;
+
+  beforeEach(async () => {
+    navigationService = { getPreviousUrl: sinon.stub() };
+    routerMock = {
+      navigate: sinon.stub(),
+      navigateByUrl: sinon.stub(),
+    };
+    documentMock = {
+      body: document.createElement('body'),
+      createElement: sinon.stub().returns(document.createElement('div')),
+      createComment: sinon.stub().returns(document.createElement('div')),
+      querySelectorAll: sinon.stub().returns([document.createElement('div')]),
+      querySelector: sinon.stub().returns(document.createElement('div')),
+      defaultView: { location: { reload: sinon.stub() } },
+    };
+
+    await TestBed
+      .configureTestingModule({
+        declarations: [ ErrorComponent ],
+        imports: [
+          TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
+        ],
+        providers: [
+          provideMockStore({ selectors: [] }),
+          { provide: NavigationService, useValue: navigationService },
+          { provide: Router, useValue: routerMock },
+          { provide: ActivatedRoute, useValue: {} },
+          { provide: DOCUMENT, useValue: documentMock },
+        ]
+      })
+      .compileComponents();
+    fixture = TestBed.createComponent(ErrorComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should create component', () => {
+    expect(component).to.exist;
+  });
+
+  describe('exit()', () => {
+    it('should navigate to previous URL', () => {
+      navigationService.getPreviousUrl.returns('/path/to/page');
+
+      component.exit();
+
+      expect(routerMock.navigate.notCalled).to.be.true;
+      expect(routerMock.navigateByUrl.calledOnce).to.be.true;
+      expect(routerMock.navigateByUrl.args[0]).to.have.deep.members([ '/path/to/page' ]);
+    });
+
+    it('should navigate to home and reload when no previous URL', () => {
+      navigationService.getPreviousUrl.returns(undefined);
+
+      component.exit();
+
+      expect(routerMock.navigateByUrl.notCalled).to.be.true;
+      expect(routerMock.navigate.calledOnce).to.be.true;
+      expect(routerMock.navigate.args[0]).to.have.deep.members([ [ '/home' ] ]);
+      expect(documentMock.defaultView.location.reload.notCalled).to.be.true;
+    });
+
+    it('should navigate to home and reload  when previous URL is root', () => {
+      navigationService.getPreviousUrl.returns('/');
+
+      component.exit();
+
+      expect(routerMock.navigateByUrl.notCalled).to.be.true;
+      expect(routerMock.navigate.calledOnce).to.be.true;
+      expect(routerMock.navigate.args[0]).to.have.deep.members([ [ '/home' ] ]);
+      expect(documentMock.defaultView.location.reload.notCalled).to.be.true;
+    });
+
+    it('should navigate back to home and reload  when previous URL is home', () => {
+      navigationService.getPreviousUrl.returns('/home');
+
+      component.exit();
+
+      expect(routerMock.navigateByUrl.notCalled).to.be.true;
+      expect(routerMock.navigate.calledOnce).to.be.true;
+      expect(routerMock.navigate.args[0]).to.have.deep.members([ [ '/home' ] ]);
+      expect(documentMock.defaultView.location.reload.notCalled).to.be.true;
+    });
+  });
+});

--- a/webapp/tests/karma/ts/modules/error/error.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/error/error.component.spec.ts
@@ -101,5 +101,16 @@ describe('ErrorComponent', () => {
       expect(routerMock.navigate.args[0]).to.have.deep.members([ [ '/home' ] ]);
       expect(documentMock.defaultView.location.reload.notCalled).to.be.true;
     });
+
+    it('should navigate back to home and reload  when previous URL is the error page', () => {
+      navigationService.getPreviousUrl.returns('/error/404');
+
+      component.exit();
+
+      expect(routerMock.navigateByUrl.notCalled).to.be.true;
+      expect(routerMock.navigate.calledOnce).to.be.true;
+      expect(routerMock.navigate.args[0]).to.have.deep.members([ [ '/home' ] ]);
+      expect(documentMock.defaultView.location.reload.notCalled).to.be.true;
+    });
   });
 });

--- a/webapp/tests/karma/ts/services/navigation.service.spec.ts
+++ b/webapp/tests/karma/ts/services/navigation.service.spec.ts
@@ -316,14 +316,14 @@ describe('NavigationService', () => {
       expect(url).to.equal('/');
     }));
 
-    it('should return previous url that is not error page', fakeAsync(() => {
+    it('should return previous url even if it is error page', fakeAsync(() => {
       router.url = '/error/403';
       service = TestBed.inject(NavigationService);
       routerEventSubject.next({ url: '/path/a' });
       flush();
 
       let url = service.getPreviousUrl();
-      expect(url).to.be.undefined;
+      expect(url).to.equal('/error/403');
 
       routerEventSubject.next({ url: '/path/b' });
       url = service.getPreviousUrl();

--- a/webapp/tests/karma/ts/services/navigation.service.spec.ts
+++ b/webapp/tests/karma/ts/services/navigation.service.spec.ts
@@ -17,6 +17,7 @@ describe('NavigationService', () => {
 
   beforeEach(() => {
     router = {
+      events: { pipe: sinon.stub().returns({ subscribe: sinon.stub() }) },
       navigate: sinon.stub(),
       routerState: {
         root: { snapshot: { } }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds a link to the exit error page and test coverage of new code. 
- When no navigation history (hard-reload) navigates to Home (message tab in default config)
- When 
  - "access denied" and "no found" navigate to the previous page, shows `back` label to match error message context ([conversation with Nicole](https://medic.slack.com/archives/C02GME3BQE6/p1710791439222369?thread_ts=1710759172.451819&cid=C02GME3BQE6)).
  - Any other error navigates to the previous page and shows `Reload application` label

Tests: 

https://github.com/medic/cht-core/assets/66472237/990b3dbc-84a3-46e9-926e-4f095748f729



<details>
<summary>Desktop view</summary>

<img width="700" src="https://github.com/medic/cht-core/assets/66472237/b6436f15-2728-4143-b58a-1f1636312d60">
<img width="700" src="https://github.com/medic/cht-core/assets/66472237/d2b98556-4c3d-45af-9461-c0c2779771ac">
<img width="700" alt="Screenshot 2024-03-25 at 7 01 04 PM" src="https://github.com/medic/cht-core/assets/66472237/6d308feb-cf77-4936-9dcc-78b335752370">
</details>


<details>
<summary>Mobile view</summary>

<img width="400" src="https://github.com/medic/cht-core/assets/66472237/e2398404-a630-4fe7-899d-d750a983b4ff">
<img width="400" src="https://github.com/medic/cht-core/assets/66472237/69e55dc3-5a8e-43da-b415-5cbfed250137">
<img width="400" alt="Screenshot 2024-03-25 at 7 00 57 PM" src="https://github.com/medic/cht-core/assets/66472237/c350cae6-5224-48e0-9db5-6d5e2f705c77">
</details>


#8844 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8844-exit-link-in-error-page/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8844-exit-link-in-error-page/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8844-exit-link-in-error-page/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

