### PR TITLE
feat(#8986): Look up a single user from their username

### DIFF
--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -238,7 +238,7 @@ module.exports = {
 
   v2: {
     get: async (req, res) => {
-      if (req.params.username) {
+      if (req.params?.username) {
         try {
           const username = req.params.username;
           const credentials = auth.basicAuthCredentials(req);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -416,6 +416,7 @@ app.post('/api/v1/forms/validate', textParser, forms.validate);
 
 app.get('/api/v1/users', users.get);
 app.get('/api/v2/users', users.v2.get);
+app.get('/api/v2/users/:username', users.v2.get);
 app.postJson('/api/v1/users', users.create);
 app.postJsonOrCsv('/api/v2/users', users.v2.create);
 app.postJson('/api/v1/users/:username', users.update);

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -804,7 +804,7 @@ module.exports = {
   getUser: async (username) => {
     const [user, setting] = await getUserDocsByName(username);
     const facilities = await facility.list([user], [setting]);
-    return mapUsers([user], [setting], facilities);
+    return mapUsers([user], [setting], facilities)[0];
   },
   getList: async (filters) => {
     const [users, settings] = await getUsersAndSettings(filters);

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -768,7 +768,7 @@ const hydrateUserSettings = (userSettings) => {
 
 const getUserDoc = (username, dbName) => {
   return db[dbName]
-    .get(`org.couchdb.user:${username}`)
+    .get(createID(username))
     .catch(err => {
       err.db = dbName;
       throw err;
@@ -801,6 +801,11 @@ const getUserSettings = async({ name }) => {
  */
 module.exports = {
   deleteUser: username => deleteUser(createID(username)),
+  getUser: async (username) => {
+    const [user, setting] = await getUserDocsByName(username);
+    const facilities = await facility.list([user], [setting]);
+    return mapUsers([user], [setting], facilities);
+  },
   getList: async (filters) => {
     const [users, settings] = await getUsersAndSettings(filters);
     const facilities = await facility.list(users);


### PR DESCRIPTION
# Description

#8877 
Adds a new route `GET /api/v2/users/:username` to get a single user. Regular users can only query themselves, users with the `can_view_users` permission can query anyone.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8877-lookup-single-user-by-username/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8877-lookup-single-user-by-username/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8877-lookup-single-user-by-username/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

