### PR TITLE
fix(#8815): fix contact-summary calculation to include all reports

### DIFF
--- a/tests/e2e/default/contacts/contact-details.wdio-spec.js
+++ b/tests/e2e/default/contacts/contact-details.wdio-spec.js
@@ -45,15 +45,13 @@ describe('Contact details page', () => {
         }
       ));
 
-    const pregnancyReport = [
-      pregnancyFactory.build({
-        fields: {
-          patient_id: patient._id,
-          patient_uuid: patient._id,
-          patient_name: patient.name,
-        },
-      }),
-    ];
+    const pregnancyReport = pregnancyFactory.build({
+      fields: {
+        patient_id: patient._id,
+        patient_uuid: patient._id,
+        patient_name: patient.name,
+      },
+    });
 
     const updatePermissions = async (role, addPermissions, removePermissions = []) => {
       const settings = await utils.getSettings();
@@ -72,8 +70,7 @@ describe('Contact details page', () => {
       await updatePermissions(role, permissions);
 
       await utils.saveDocs([parent, patient]);
-      await utils.saveDocs(reports);
-      await utils.saveDocs(pregnancyReport);
+      await utils.saveDocs([...reports, pregnancyReport]
 
       await utils.createUsers([user]);
 

--- a/tests/e2e/default/contacts/contact-details.wdio-spec.js
+++ b/tests/e2e/default/contacts/contact-details.wdio-spec.js
@@ -98,8 +98,8 @@ describe('Contact details page', () => {
       'validate that the pregnancy card is always displayed', async () => {
 
         expect(await contactPage.pregnancyCard().isDisplayed()).to.be.true;
-        const pregnancyCardInfo = await contactPage.getTestPregnancyCardInfo();
-        expect(pregnancyCardInfo.weeksPregnant).to.equal('23');
+        const pregnancyCardInfo = await contactPage.getPregnancyCardInfo();
+        expect(pregnancyCardInfo.weeksPregnant).to.equal('12');
         expect(pregnancyCardInfo.risk).to.equal('High risk');
       }
     );

--- a/tests/e2e/default/contacts/contact-details.wdio-spec.js
+++ b/tests/e2e/default/contacts/contact-details.wdio-spec.js
@@ -70,7 +70,7 @@ describe('Contact details page', () => {
       await updatePermissions(role, permissions);
 
       await utils.saveDocs([parent, patient]);
-      await utils.saveDocs([...reports, pregnancyReport]
+      await utils.saveDocs([...reports, pregnancyReport]);
 
       await utils.createUsers([user]);
 

--- a/tests/e2e/default/contacts/contact-details.wdio-spec.js
+++ b/tests/e2e/default/contacts/contact-details.wdio-spec.js
@@ -34,14 +34,16 @@ describe('Contact details page', () => {
     const user = userFactory.build({ username: 'offlineuser', roles: [role] });
     const patient = personFactory.build({ parent: { _id: user.place._id, parent: { _id: parent._id } } });
 
-    const reports = Array.from({ length: 60 }).map(() => reportFactory.report().build(
-      { form: 'pregnancy_danger_sign' },
-      {
-        patient,
-        submitter: user.contact,
-        fields: { t_danger_signs_referral_follow_up: 'yes' },
-      }
-    ));
+    const reports = Array
+      .from({ length: 60 })
+      .map(() => reportFactory.report().build(
+        { form: 'pregnancy_danger_sign' },
+        {
+          patient,
+          submitter: user.contact,
+          fields: { t_danger_signs_referral_follow_up: 'yes' },
+        }
+      ));
 
     const pregnancyReport = [
       pregnancyFactory.build({
@@ -96,6 +98,9 @@ describe('Contact details page', () => {
       'validate that the pregnancy card is always displayed', async () => {
 
         expect(await contactPage.pregnancyCard().isDisplayed()).to.be.true;
+        const pregnancyCardInfo = await contactPage.getTestPregnancyCardInfo();
+        expect(pregnancyCardInfo.weeksPregnant).to.equal('23');
+        expect(pregnancyCardInfo.risk).to.equal('High risk');
       }
     );
 

--- a/tests/e2e/default/contacts/contact-details.wdio-spec.js
+++ b/tests/e2e/default/contacts/contact-details.wdio-spec.js
@@ -92,7 +92,7 @@ describe('Contact details page', () => {
 
     it(
       'should show contact summary that has the full context for reports > 50' +
-      'validate that the pregnancy card is always displayed', async () => {
+      ' validate that the pregnancy card is always displayed', async () => {
 
         expect(await contactPage.pregnancyCard().isDisplayed()).to.be.true;
         const pregnancyCardInfo = await contactPage.getPregnancyCardInfo();

--- a/tests/factories/cht/reports/pregnancy.js
+++ b/tests/factories/cht/reports/pregnancy.js
@@ -42,7 +42,7 @@ const defaultFields = {
   'patient_short_name': 'the woman',
   'patient_short_name_start': 'The woman',
   'lmp_date_8601': lmp,
-  'edd_8601': lmp,
+  'edd_8601': '',
   'days_since_lmp': '77',
   'weeks_since_lmp': '34',
   'weeks_since_lmp_rounded': '34',
@@ -70,7 +70,7 @@ const defaultFields = {
     },
     'g_lmp_date_8601': '',
     'g_lmp_date': lmp,
-    'g_edd_8601': lmp,
+    'g_edd_8601': '',
     'g_edd': ''
   },
   'anc_visits_hf': {
@@ -183,7 +183,7 @@ const defaultFields = {
     '__lmp_date': lmp,
     '__lmp_approx_weeks': '34',
     '__lmp_approx_months': '',
-    '__edd': lmp,
+    '__edd': '',
     '__num_previous_anc_hf_visits': '1',
     '__previous_anc_hf_visit_dates': '',
     '__next_anc_hf_visit_date_known': 'no',

--- a/tests/factories/cht/reports/pregnancy.js
+++ b/tests/factories/cht/reports/pregnancy.js
@@ -1,5 +1,6 @@
 const Factory = require('rosie').Factory;
 const { faker } = require('@faker-js/faker');
+const moment = require('moment');
 const uuid = require('uuid');
 const _ = require('lodash');
 const geolocation = require('./geolocation');
@@ -16,15 +17,8 @@ const defaultSubmitter = {
   }
 };
 
-const edd = faker.date
-  .between({ from: '2024-06-01T00:00:00.000Z', to: '2024-06-30T00:00:00.000Z' })
-  .toISOString()
-  .split('T')[0];
-
-const lmp = faker.date
-  .between({ from: '2023-11-01T00:00:00.000Z', to: '2023-11-30T00:00:00.000Z' })
-  .toISOString()
-  .split('T')[0];
+const nextANCVisit = moment().add(2, 'day');
+const lmp = moment().subtract(3, 'months');
 
 const defaultFields = {
   'inputs': {
@@ -48,7 +42,7 @@ const defaultFields = {
   'patient_short_name': 'the woman',
   'patient_short_name_start': 'The woman',
   'lmp_date_8601': lmp,
-  'edd_8601': edd,
+  'edd_8601': lmp,
   'days_since_lmp': '77',
   'weeks_since_lmp': '34',
   'weeks_since_lmp_rounded': '34',
@@ -56,8 +50,8 @@ const defaultFields = {
   'hiv_status_known': 'no',
   'deworming_med_received': '',
   'tt_received': 'no',
-  't_pregnancy_follow_up_date': '',
-  't_pregnancy_follow_up': 'no',
+  't_pregnancy_follow_up_date': nextANCVisit,
+  't_pregnancy_follow_up': 'yes',
   't_danger_signs_referral_follow_up_date': faker.date.recent({ days: 5 }).toISOString(),
   't_danger_signs_referral_follow_up': 'yes',
   'gestational_age': {
@@ -76,7 +70,7 @@ const defaultFields = {
     },
     'g_lmp_date_8601': '',
     'g_lmp_date': lmp,
-    'g_edd_8601': edd,
+    'g_edd_8601': lmp,
     'g_edd': ''
   },
   'anc_visits_hf': {
@@ -189,7 +183,7 @@ const defaultFields = {
     '__lmp_date': lmp,
     '__lmp_approx_weeks': '34',
     '__lmp_approx_months': '',
-    '__edd': edd,
+    '__edd': lmp,
     '__num_previous_anc_hf_visits': '1',
     '__previous_anc_hf_visit_dates': '',
     '__next_anc_hf_visit_date_known': 'no',

--- a/tests/factories/cht/reports/pregnancy.js
+++ b/tests/factories/cht/reports/pregnancy.js
@@ -1,4 +1,5 @@
 const Factory = require('rosie').Factory;
+const { faker } = require('@faker-js/faker');
 const uuid = require('uuid');
 const _ = require('lodash');
 const geolocation = require('./geolocation');
@@ -14,6 +15,16 @@ const defaultSubmitter = {
     }
   }
 };
+
+const edd = faker.date
+  .between({ from: '2024-06-01T00:00:00.000Z', to: '2024-06-30T00:00:00.000Z' })
+  .toISOString()
+  .split('T')[0];
+
+const lmp = faker.date
+  .between({ from: '2023-11-01T00:00:00.000Z', to: '2023-11-30T00:00:00.000Z' })
+  .toISOString()
+  .split('T')[0];
 
 const defaultFields = {
   'inputs': {
@@ -36,8 +47,8 @@ const defaultFields = {
   'patient_name': 'Adelia Akiyama',
   'patient_short_name': 'the woman',
   'patient_short_name_start': 'The woman',
-  'lmp_date_8601': '2021-02-02',
-  'edd_8601': '2021-11-09',
+  'lmp_date_8601': lmp,
+  'edd_8601': edd,
   'days_since_lmp': '77',
   'weeks_since_lmp': '34',
   'weeks_since_lmp_rounded': '34',
@@ -47,8 +58,8 @@ const defaultFields = {
   'tt_received': 'no',
   't_pregnancy_follow_up_date': '',
   't_pregnancy_follow_up': 'no',
-  't_danger_signs_referral_follow_up_date': '2021-04-23T00:00:00.000-04:00',
-  't_danger_signs_referral_follow_up': 'no',
+  't_danger_signs_referral_follow_up_date': faker.date.recent({ days: 5 }).toISOString(),
+  't_danger_signs_referral_follow_up': 'yes',
   'gestational_age': {
     'register_method': {
       'register_note': '',
@@ -63,10 +74,10 @@ const defaultFields = {
       'edd_note': '',
       'edd_check_note': ''
     },
-    'g_lmp_date_8601': '2021-02-02',
-    'g_lmp_date': '2 Feb, 2021',
-    'g_edd_8601': '2021-11-09',
-    'g_edd': '9 Nov, 2021'
+    'g_lmp_date_8601': '',
+    'g_lmp_date': lmp,
+    'g_edd_8601': edd,
+    'g_edd': ''
   },
   'anc_visits_hf': {
     'anc_visits_hf_past': {
@@ -102,7 +113,7 @@ const defaultFields = {
   'danger_signs': {
     'danger_signs_note': '',
     'danger_signs_question_note': '',
-    'vaginal_bleeding': 'no',
+    'vaginal_bleeding': 'yes',
     'fits': 'no',
     'severe_abdominal_pain': 'no',
     'severe_headache': 'no',
@@ -163,7 +174,7 @@ const defaultFields = {
     'r_following_tasks': '',
     'r_fup_pregnancy_visit': '',
     'next_visit_weeks': '1',
-    'edd_summary': '9 Nov, 2021',
+    'edd_summary': '',
     'next_appointment_date': '',
     'custom_translations': {
       'custom_woman_label_translator': 'woman',
@@ -175,15 +186,15 @@ const defaultFields = {
   'data': {
     '__lmp_method': 'method_approx',
     '__no_lmp_registration_reason': '',
-    '__lmp_date': '2021-02-02',
+    '__lmp_date': lmp,
     '__lmp_approx_weeks': '34',
     '__lmp_approx_months': '',
-    '__edd': '2021-11-09',
+    '__edd': edd,
     '__num_previous_anc_hf_visits': '1',
     '__previous_anc_hf_visit_dates': '',
     '__next_anc_hf_visit_date_known': 'no',
     '__next_anc_hf_visit_date': '',
-    '__has_risk_factors': 'no',
+    '__has_risk_factors': 'yes',
     '__first_pregnancy': 'no',
     '__previous_miscarriage': 'no',
     '__previous_difficulties': 'no',
@@ -196,7 +207,7 @@ const defaultFields = {
     '__additional_high_risk_condition_to_report': 'no',
     '__additional_high_risk_condition': '',
     '__has_danger_sign': 'no',
-    '__vaginal_bleeding': 'no',
+    '__vaginal_bleeding': 'yes',
     '__fits': 'no',
     '__severe_abdominal_pain': 'no',
     '__severe_headache': 'no',

--- a/tests/page-objects/default/contacts/contacts.wdio.page.js
+++ b/tests/page-objects/default/contacts/contacts.wdio.page.js
@@ -321,6 +321,15 @@ const getPregnancyCardInfo = async () => {
   };
 };
 
+const getTestPregnancyCardInfo = async () => {
+  await pregnancyCard().waitForDisplayed();
+  return {
+    weeksPregnant: await weeksPregnant().getText(),
+    deliveryDate: await edd().getText(),
+    risk: await highRisk().getText(),
+  };
+};
+
 const getPregnancyLabel = async () => {
   await pregnancyLabel().waitForDisplayed();
   return (await pregnancyLabel()).getText();
@@ -435,6 +444,7 @@ module.exports = {
   getContactCardText,
   pregnancyCard,
   getPregnancyCardInfo,
+  getTestPregnancyCardInfo,
   deathCard,
   getDeathCardInfo,
   contactMuted,

--- a/tests/page-objects/default/contacts/contacts.wdio.page.js
+++ b/tests/page-objects/default/contacts/contacts.wdio.page.js
@@ -321,15 +321,6 @@ const getPregnancyCardInfo = async () => {
   };
 };
 
-const getTestPregnancyCardInfo = async () => {
-  await pregnancyCard().waitForDisplayed();
-  return {
-    weeksPregnant: await weeksPregnant().getText(),
-    deliveryDate: await edd().getText(),
-    risk: await highRisk().getText(),
-  };
-};
-
 const getPregnancyLabel = async () => {
   await pregnancyLabel().waitForDisplayed();
   return (await pregnancyLabel()).getText();
@@ -444,7 +435,6 @@ module.exports = {
   getContactCardText,
   pregnancyCard,
   getPregnancyCardInfo,
-  getTestPregnancyCardInfo,
   deathCard,
   getDeathCardInfo,
   contactMuted,

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -54,7 +54,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   relevantReportForms;
   childContactTypes;
   filteredTasks = [];
-  filteredReports = [];
+  filteredReports: any[] = [];
   DISPLAY_LIMIT = 50;
 
   constructor(
@@ -238,9 +238,17 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
     const reportStartDate = months ? moment().subtract(months, 'months') : null;
 
     const allReports = reports || this.selectedContact?.reports || [];
-    this.filteredReports = allReports
-      .filter((report) => !reportStartDate || reportStartDate.isBefore(report.reported_date))
-      .slice(0, this.DISPLAY_LIMIT);
+    const newFilteredReports: any[] = [];
+    for (const report of allReports) {
+      if (!reportStartDate || reportStartDate.isBefore(report.reported_date)) {
+        newFilteredReports.push(report);
+      }
+      if (newFilteredReports.length >= this.DISPLAY_LIMIT) {
+        break;
+      }
+    }
+
+    this.filteredReports = newFilteredReports;
   }
 
   filterTasks(weeks?, tasks?) {

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -167,7 +167,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
         }
         await this.setChildTypesBySelectedContact();
         await this.setSettings();
-        await Promise.all([ this.setRightActionBar(), this.updateFastActions() ]);
+        await Promise.all([this.setRightActionBar(), this.updateFastActions()]);
         this.subscribeToAllContactXmlForms();
         this.subscribeToSelectedContactXmlForms();
       });
@@ -200,7 +200,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   }
 
   private subscribeToRoute() {
-    const routeSubscription =  this.route.params.subscribe((params) => {
+    const routeSubscription = this.route.params.subscribe((params) => {
       if (params.id) {
         this.contactsActions.selectContact(this.route.snapshot.params.id);
         this.globalActions.clearNavigation();
@@ -217,8 +217,8 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
       key: 'contacts-content',
       filter: (change) => {
         return this.contactChangeFilterService.matchContact(change, this.selectedContact) ||
-               this.contactChangeFilterService.isRelevantContact(change, this.selectedContact) ||
-               this.contactChangeFilterService.isRelevantReport(change, this.selectedContact);
+          this.contactChangeFilterService.isRelevantContact(change, this.selectedContact) ||
+          this.contactChangeFilterService.isRelevantReport(change, this.selectedContact);
       },
       callback: (change) => {
         const matchedContact = this.contactChangeFilterService.matchContact(change, this.selectedContact);
@@ -238,17 +238,21 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
     const reportStartDate = months ? moment().subtract(months, 'months') : null;
 
     const allReports = reports || this.selectedContact?.reports || [];
-    const newFilteredReports: any[] = [];
+
+    this.filteredReports = this.getFilteredReports(allReports, reportStartDate, this.DISPLAY_LIMIT);
+  }
+
+  private getFilteredReports(allReports: any[], reportStartDate: moment.Moment | null, displayLimit: number): any[] {
+    const filteredReports: any[] = [];
     for (const report of allReports) {
       if (!reportStartDate || reportStartDate.isBefore(report.reported_date)) {
-        newFilteredReports.push(report);
+        filteredReports.push(report);
       }
-      if (newFilteredReports.length >= this.DISPLAY_LIMIT) {
+      if (filteredReports.length >= displayLimit) {
         break;
       }
     }
-
-    this.filteredReports = newFilteredReports;
+    return filteredReports;
   }
 
   filterTasks(weeks?, tasks?) {

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -249,17 +249,13 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
         break;
       }
 
-      if (this.validateReport(report, reportStartDate)) {
+      if (reportStartDate?.isBefore(report.reported_date)) {
         filteredReports.push(report);
       }
     }
     return filteredReports;
   }
-
-  private validateReport(report: any, reportStartDate): boolean {
-    return !reportStartDate || reportStartDate.isBefore(report.reported_date);
-  }
-
+  
   filterTasks(weeks?, tasks?) {
     this.tasksTimeWindowWeeks = weeks;
     const taskEndDate = weeks ? moment().add(weeks, 'weeks').format('YYYY-MM-DD') : null;

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -55,7 +55,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   childContactTypes;
   filteredTasks = [];
   filteredReports = [];
-  FILTER_DISPLAY_LIMIT = 50;
+  DISPLAY_LIMIT = 50;
 
   constructor(
     private store: Store,
@@ -236,31 +236,20 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   filterReports(months?, reports?) {
     this.reportsTimeWindowMonths = months;
     const reportStartDate = months ? moment().subtract(months, 'months') : null;
+
     const allReports = reports || this.selectedContact?.reports || [];
-
-    if (!reportStartDate) {
-      this.filteredReports = allReports;
-      return;
-    }
-
     this.filteredReports = allReports
-      .filter((report) => reportStartDate.isBefore(report.reported_date))
-      .slice(0, this.FILTER_DISPLAY_LIMIT);
+      .filter((report) => !reportStartDate || reportStartDate.isBefore(report.reported_date))
+      .slice(0, this.DISPLAY_LIMIT);
   }
 
   filterTasks(weeks?, tasks?) {
     this.tasksTimeWindowWeeks = weeks;
     const taskEndDate = weeks ? moment().add(weeks, 'weeks').format('YYYY-MM-DD') : null;
     const allTasks = tasks || this.selectedContact?.tasks || [];
-
-    if (!taskEndDate) {
-      this.filteredTasks = allTasks;
-      return;
-    }
-
     this.filteredTasks = allTasks
       .filter((task) => !taskEndDate || task.dueDate <= taskEndDate)
-      .slice(0, this.FILTER_DISPLAY_LIMIT);
+      .slice(0, this.DISPLAY_LIMIT);
   }
 
   private async setRightActionBar() {

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -245,14 +245,19 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   private getFilteredReports(allReports: any[], reportStartDate, displayLimit): any[] {
     const filteredReports: any[] = [];
     for (const report of allReports) {
-      if (!reportStartDate || reportStartDate.isBefore(report.reported_date)) {
+      if (filteredReports.length >= displayLimit) {
+        break;
+      }
+
+      if (this.validateReport(report, reportStartDate)) {
         filteredReports.push(report);
-        if (filteredReports.length >= displayLimit) {
-          break;
-        }
       }
     }
     return filteredReports;
+  }
+
+  private validateReport(report: any, reportStartDate): boolean {
+    return !reportStartDate || reportStartDate.isBefore(report.reported_date);
   }
 
   filterTasks(weeks?, tasks?) {

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -242,14 +242,14 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
     this.filteredReports = this.getFilteredReports(allReports, reportStartDate, this.DISPLAY_LIMIT);
   }
 
-  private getFilteredReports(allReports: any[], reportStartDate: moment.Moment | null, displayLimit: number): any[] {
+  private getFilteredReports(allReports: any[], reportStartDate, displayLimit): any[] {
     const filteredReports: any[] = [];
     for (const report of allReports) {
       if (!reportStartDate || reportStartDate.isBefore(report.reported_date)) {
         filteredReports.push(report);
-      }
-      if (filteredReports.length >= displayLimit) {
-        break;
+        if (filteredReports.length >= displayLimit) {
+          break;
+        }
       }
     }
     return filteredReports;

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -55,6 +55,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   childContactTypes;
   filteredTasks = [];
   filteredReports = [];
+  FILTER_DISPLAY_LIMIT = 50;
 
   constructor(
     private store: Store,
@@ -235,17 +236,31 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   filterReports(months?, reports?) {
     this.reportsTimeWindowMonths = months;
     const reportStartDate = months ? moment().subtract(months, 'months') : null;
-
     const allReports = reports || this.selectedContact?.reports || [];
+
+    if (!reportStartDate) {
+      this.filteredReports = allReports;
+      return;
+    }
+
     this.filteredReports = allReports
-      .filter((report) => !reportStartDate || reportStartDate.isBefore(report.reported_date));
+      .filter((report) => reportStartDate.isBefore(report.reported_date))
+      .slice(0, this.FILTER_DISPLAY_LIMIT);
   }
 
   filterTasks(weeks?, tasks?) {
     this.tasksTimeWindowWeeks = weeks;
     const taskEndDate = weeks ? moment().add(weeks, 'weeks').format('YYYY-MM-DD') : null;
     const allTasks = tasks || this.selectedContact?.tasks || [];
-    this.filteredTasks = allTasks.filter((task) => !taskEndDate || task.dueDate <= taskEndDate);
+
+    if (!taskEndDate) {
+      this.filteredTasks = allTasks;
+      return;
+    }
+
+    this.filteredTasks = allTasks
+      .filter((task) => !taskEndDate || task.dueDate <= taskEndDate)
+      .slice(0, this.FILTER_DISPLAY_LIMIT);
   }
 
   private async setRightActionBar() {

--- a/webapp/src/ts/services/contact-view-model-generator.service.ts
+++ b/webapp/src/ts/services/contact-view-model-generator.service.ts
@@ -36,6 +36,8 @@ import { TranslateService } from '@mm-services/translate.service';
   providedIn: 'root'
 })
 export class ContactViewModelGeneratorService {
+  LIMIT_SELECT_ALL_REPORTS = 500;
+
   constructor(
     private lineageModelGeneratorService:LineageModelGeneratorService,
     private dbService:DbService,
@@ -309,7 +311,7 @@ export class ContactViewModelGeneratorService {
     });
     const filter = { subjectIds: _flattenDeep(subjectIds) };
     return this.searchService
-      .search('reports', filter, { include_docs: true })
+      .search('reports', filter, { include_docs: true, limit: this.LIMIT_SELECT_ALL_REPORTS })
       .then((reports) => {
         reports.forEach((report) => {
           report.valid = !report.errors || !report.errors.length;


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR fixes the unintended bug where the number of reports that would be retrieved for the contact and passed to the `contact-summary` calculation was [capped at 50](https://github.com/medic/cht-core/blob/3e126356afba2c75e68a5c70dab2eb8bf60e65c5/webapp/src/ts/services/search.service.ts#L133). So, the `contact-summary` for contacts associated with >50 reports, would not have the full context of all that contacts reports.

With this fix, for the sake of accuracy, we provide all the reports associated with that contact (limit of 500 reports).

### Before the fix 
<details>
<summary>Video showing created woman has pregnancy card when reports are less than 50</summary>

https://github.com/medic/cht-core/assets/2597305/d2d2b462-c91a-4509-952c-dd41645a2f71

</details>

<details>
<summary>Video showing pregnancy card for woman does not appear when reports than 50 reports and the pregnancy report is not part of the 50</summary>

https://github.com/medic/cht-core/assets/2597305/00f9d879-ab17-41fa-a9a9-fbf37a39c27c

</details>

### After the fix 


Closes #8815 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8815-fix-contact-summary/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8815-fix-contact-summary/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8815-fix-contact-summary/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

