### PR TITLE
perf(#9006): reduce contacts page_size and refactor ngOnInit

### DIFF
--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -52,11 +52,13 @@ module.exports = function(Promise, DB) {
     const firstMapKeys = Object.keys(responsesMapById[0]);
     let intersectionSet = new Set(firstMapKeys);
 
+    // NOSONAR_BEGIN
     responsesMapById.slice(1).forEach(map => {
       intersectionSet = new Set(
         [...intersectionSet].filter(id => Object.hasOwnProperty.call(map, id))
       );
     });
+    // NOSONAR_END
 
     // we use the last query response values for sorting by default, but we allow other responses to "pitch in"
     // used for displaying muted contacts to the bottom when sorting by last visited date

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -49,21 +49,12 @@ module.exports = function(Promise, DB) {
       return map;
     });
 
-    const firstMapKeys = Object.keys(responsesMapById[0]);
-    let intersectionSet = new Set(firstMapKeys);
-
-    // NOSONAR_BEGIN
-    responsesMapById.slice(1).forEach(map => {
-      intersectionSet = new Set(
-        [...intersectionSet].filter(id => Object.hasOwnProperty.call(map, id))
-      );
-    });
-    // NOSONAR_END
+    const intersection = _.intersection(...responsesMapById.map(Object.keys));
 
     // we use the last query response values for sorting by default, but we allow other responses to "pitch in"
     // used for displaying muted contacts to the bottom when sorting by last visited date
     const lastResponse = responsesMapById.pop();
-    const result = [...intersectionSet].map(id => {
+    const result = intersection.map(id => {
       const row = lastResponse[id];
       responsesMapById.forEach(idMap => {
         if (idMap[id].sort) {

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -49,12 +49,18 @@ module.exports = function(Promise, DB) {
       return map;
     });
 
-    const intersection = _.intersection(...responsesMapById.map(Object.keys));
+    const firstMapKeys = Object.keys(responsesMapById[0]);
+    let intersection = new Set(firstMapKeys);
+    responsesMapById.slice(1).forEach((map) => {
+      intersection = new Set(
+        Object.keys(map).filter((id) => intersection.has(id))
+      );
+    });
 
     // we use the last query response values for sorting by default, but we allow other responses to "pitch in"
     // used for displaying muted contacts to the bottom when sorting by last visited date
     const lastResponse = responsesMapById.pop();
-    const result = intersection.map(id => {
+    const result = Array.from(intersection).map((id) => {
       const row = lastResponse[id];
       responsesMapById.forEach(idMap => {
         if (idMap[id].sort) {

--- a/shared-libs/search/src/search.js
+++ b/shared-libs/search/src/search.js
@@ -50,17 +50,18 @@ module.exports = function(Promise, DB) {
     });
 
     const firstMapKeys = Object.keys(responsesMapById[0]);
-    let intersection = new Set(firstMapKeys);
-    responsesMapById.slice(1).forEach((map) => {
-      intersection = new Set(
-        Object.keys(map).filter((id) => intersection.has(id))
+    let intersectionSet = new Set(firstMapKeys);
+
+    responsesMapById.slice(1).forEach(map => {
+      intersectionSet = new Set(
+        [...intersectionSet].filter(id => Object.hasOwnProperty.call(map, id))
       );
     });
 
     // we use the last query response values for sorting by default, but we allow other responses to "pitch in"
     // used for displaying muted contacts to the bottom when sorting by last visited date
     const lastResponse = responsesMapById.pop();
-    const result = Array.from(intersection).map((id) => {
+    const result = [...intersectionSet].map(id => {
       const row = lastResponse[id];
       responsesMapById.forEach(idMap => {
         if (idMap[id].sort) {

--- a/tests/e2e/default/contacts/infinite-scrolling.wdio-spec.js
+++ b/tests/e2e/default/contacts/infinite-scrolling.wdio-spec.js
@@ -4,7 +4,7 @@ const login = require('@page-objects/default/login/login.wdio.page');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
 const contactsPage = require('@page-objects/default/contacts/contacts.wdio.page');
 
-const PAGE_SIZE = 50;
+const PAGE_SIZE = 25;
 describe('Infinite scrolling', () => {
   before(async () => {
     const type = 'district_hospital';

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -29,7 +29,7 @@ import { PerformanceService } from '@mm-services/performance.service';
   templateUrl: './contacts.component.html'
 })
 export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
-  private readonly PAGE_SIZE = 50;
+  private readonly PAGE_SIZE = 25;
   private subscription: Subscription = new Subscription();
   private globalActions: GlobalActions;
   private contactsActions: ContactsActions;

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -83,32 +83,78 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
     this.contactsActions = new ContactsActions(store);
   }
 
-  ngOnInit() {
+  async ngOnInit() {
     const trackPerformance = this.performanceService.track();
     this.isOnlineOnly = this.sessionService.isOnlineOnly();
     this.globalActions.clearFilters(); // clear any global filters first
     this.subscribeToStore();
+    this.manageChangesSubscription();
 
+    try {
+      const [settings, homePlaceSummary, viewLastVisitedDate, contactTypes] = await Promise.all([
+        this.settingsService.get(),
+        this.getUserHomePlaceSummary(),
+        this.canViewLastVisitedDate(),
+        this.contactTypesService.getAll(),
+      ]);
+
+      this.visitCountSettings = this.UHCSettings.getVisitCountSettings(settings);
+      this.usersHomePlace = homePlaceSummary;
+      this.lastVisitedDateExtras = viewLastVisitedDate;
+      this.contactTypes = contactTypes;
+
+      if (this.lastVisitedDateExtras && this.UHCSettings.getContactsDefaultSort(settings)) {
+        this.sortDirection = this.defaultSortDirection = this.UHCSettings.getContactsDefaultSort(settings);
+      }
+
+      const children = await this.getChildren();
+      this.childPlaces = children;
+      this.defaultFilters = {
+        types: {
+          selected: this.childPlaces.map(type => type.id),
+        },
+      };
+
+      this.subscribeToAllContactXmlForms();
+      await this.search();
+    } catch (err) {
+      this.error = true;
+      this.loading = false;
+      this.appending = false;
+      console.error('Error initializing contacts component', err);
+    } finally {
+      trackPerformance?.stop({
+        name: 'contact_list:load',
+        recordApdex: true,
+      });
+    }
+  }
+
+  private async handleChange(change): Promise<void> {
+    const limit = this.contactsList.length;
+    if (change.deleted) {
+      this.contactsActions.removeContactFromList({ _id: change.id });
+      this.hasContacts = !!this.contactsList.length;
+    }
+    if (this.usersHomePlace && change.id === this.usersHomePlace._id) {
+      this.usersHomePlace = await this.getUserHomePlaceSummary(change.id);
+    }
+    const withIds =
+      this.isSortedByLastVisited() &&
+      !!this.isRelevantVisitReport(change.doc) &&
+      !change.deleted;
+    await this.query({
+      limit,
+      withIds,
+      silent: true,
+    });
+  }
+
+  private manageChangesSubscription() {
     const changesSubscription = this.changesService.subscribe({
       key: 'contacts-list',
-      callback: async (change) => {
-        const limit = this.contactsList.length;
-        if (change.deleted) {
-          this.contactsActions.removeContactFromList({ _id: change.id });
-          this.hasContacts = this.contactsList.length;
-        }
-        if (this.usersHomePlace && change.id === this.usersHomePlace._id) {
-          this.usersHomePlace = await this.getUserHomePlaceSummary(change.id);
-        }
-        const withIds =
-          this.isSortedByLastVisited() &&
-          !!this.isRelevantVisitReport(change.doc) &&
-          !change.deleted;
-        return this.query({
-          limit,
-          withIds,
-          silent: true,
-        });
+      callback: (change) => {
+        this.handleChange(change).catch(err => console.error(err));
       },
       filter: (change) => {
         return (
@@ -120,47 +166,6 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
       },
     });
     this.subscription.add(changesSubscription);
-
-    Promise
-      .all([
-        this.getUserHomePlaceSummary(),
-        this.canViewLastVisitedDate(),
-        this.settingsService.get(),
-        this.contactTypesService.getAll()
-      ])
-      .then(([homePlaceSummary, viewLastVisitedDate, settings, contactTypes]) => {
-        this.usersHomePlace = homePlaceSummary;
-        this.lastVisitedDateExtras = viewLastVisitedDate;
-        this.visitCountSettings = this.UHCSettings.getVisitCountSettings(settings);
-        if (this.lastVisitedDateExtras && this.UHCSettings.getContactsDefaultSort(settings)) {
-          this.sortDirection = this.defaultSortDirection = this.UHCSettings.getContactsDefaultSort(settings);
-        }
-        this.contactTypes = contactTypes;
-        return this.getChildren();
-      })
-      .then((children) => {
-        this.childPlaces = children;
-        this.defaultFilters = {
-          types: {
-            selected: this.childPlaces.map(type => type.id)
-          }
-        };
-
-        this.subscribeToAllContactXmlForms();
-        return this.search();
-      })
-      .catch((err) => {
-        this.error = true;
-        this.loading = false;
-        this.appending = false;
-        console.error('Error searching for contacts', err);
-      })
-      .finally(() => {
-        trackPerformance?.stop({
-          name: 'contact_list:load',
-          recordApdex: true,
-        });
-      });
   }
 
   async ngAfterViewInit() {

--- a/webapp/tests/karma/ts/modules/contacts/contacts.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts.component.spec.ts
@@ -420,7 +420,7 @@ describe('Contacts component', () => {
       scrollLoaderCallback();
       expect(searchService.search.args[1][2]).to.deep.equal({
         paginating: true,
-        limit: 50,
+        limit: 25,
         skip: 50,
       });
       expect(stopPerformanceTrackStub.calledTwice).to.be.true;
@@ -450,7 +450,7 @@ describe('Contacts component', () => {
       expect(contacts.length).to.equal(51);
       expect(searchService.search.args[1][2]).to.deep.equal({
         paginating: true,
-        limit: 50,
+        limit: 25,
         skip: 50,
       });
       expect(stopPerformanceTrackStub.calledTwice).to.be.true;
@@ -527,7 +527,7 @@ describe('Contacts component', () => {
       const contacts = component.contactsActions.updateContactsList.args[0][0];
 
       expect(contacts.length).to.equal(11);
-      searchResults = Array(50).fill(searchResult);
+      searchResults = Array(25).fill(searchResult);
       searchService.search.resolves(searchResults);
       store.overrideSelector(Selectors.getContactsList, searchResults);
       store.refreshState();
@@ -536,24 +536,24 @@ describe('Contacts component', () => {
       component.search();
       flush();
 
-      expect(searchService.search.args[1][2]).to.deep.equal({ limit: 50 });
+      expect(searchService.search.args[1][2]).to.deep.equal({ limit: 25 });
 
       const updatedContacts = component.contactsActions.updateContactsList.args[1][0].length;
-      expect(updatedContacts).to.equal(50);
+      expect(updatedContacts).to.equal(25);
       store.overrideSelector(Selectors.getContactsList, searchResults);
       scrollLoaderCallback();
       store.overrideSelector(Selectors.getContactsList, searchResults);
 
       expect(searchService.search.args[2][2]).to.deep.equal({
-        limit: 50,
+        limit: 25,
         paginating: true,
-        skip: 50,
+        skip: 25,
       });
     }));
 
     it('when paginating, does not modify the skip when it finds homeplace #4085', fakeAsync(() => {
       const searchResult = { _id: 'search-result' };
-      searchResults = Array(49).fill(searchResult);
+      searchResults = Array(24).fill(searchResult);
       searchResults.push({ _id: 'district-id' });
       searchService.search.resolves(searchResults);
       store.overrideSelector(Selectors.getContactsList, searchResults);
@@ -564,11 +564,11 @@ describe('Contacts component', () => {
       const contacts = component.contactsActions.updateContactsList.args[0][0];
       scrollLoaderCallback();
 
-      expect(contacts.length).to.equal(50);
+      expect(contacts.length).to.equal(25);
       expect(searchService.search.args[1][2]).to.deep.equal({
-        limit: 50,
+        limit: 25,
         paginating: true,
-        skip: 50,
+        skip: 25,
       });
     }));
 
@@ -580,7 +580,7 @@ describe('Contacts component', () => {
         }
         return result;
       };
-      searchResults = mockResults(50);
+      searchResults = mockResults(25);
       searchService.search.resolves(searchResults);
       store.overrideSelector(Selectors.getContactsList, searchResults);
       component.contactsActions.updateContactsList = sinon.stub();
@@ -588,36 +588,36 @@ describe('Contacts component', () => {
       component.ngOnInit();
       flush();
       const contacts = component.contactsActions.updateContactsList.args[0][0];
-      expect(contacts.length).to.equal(51);
+      expect(contacts.length).to.equal(26);
 
       store.refreshState();
-      searchResults = mockResults(49, 50);
+      searchResults = mockResults(24, 25);
       searchService.search.resolves(searchResults.concat(contacts));
       store.overrideSelector(Selectors.getContactsList, searchResults.concat(contacts));
 
       scrollLoaderCallback();
       flush();
       const updatedContacts = component.contactsActions.updateContactsList.args[1][0];
-      expect(updatedContacts.length).to.equal(100);
+      expect(updatedContacts.length).to.equal(50);
       expect(searchService.search.args[1][2]).to.deep.equal({
-        limit: 50,
+        limit: 25,
         paginating: true,
-        skip: 50,
+        skip: 25,
       });
 
       store.refreshState();
-      searchResults = mockResults(50, 100);
+      searchResults = mockResults(25, 50);
       searchService.search.resolves(searchResults.concat(updatedContacts));
       store.overrideSelector(Selectors.getContactsList, searchResults.concat(updatedContacts));
       scrollLoaderCallback();
       flush();
       expect(searchService.search.args[2][2]).to.deep.equal({
-        limit: 50,
+        limit: 25,
         paginating: true,
-        skip: 100,
+        skip: 50,
       });
       const updateContactsList = component.contactsActions.updateContactsList.args[2][0];
-      expect(updateContactsList.length).to.equal(150);
+      expect(updateContactsList.length).to.equal(75);
     }));
   });
 
@@ -655,7 +655,7 @@ describe('Contacts component', () => {
       flush();
       changesCallback({ doc: { _id: '123' } });
       expect(searchService.search.callCount).to.equal(2);
-      expect(searchService.search.args[1][2].limit).to.equal(50);
+      expect(searchService.search.args[1][2].limit).to.equal(25);
     }));
 
     it('when handling deletes, does not shorten the list #4080', fakeAsync(() => {
@@ -701,7 +701,7 @@ describe('Contacts component', () => {
         [
           'contacts',
           { types: { selected: ['childType'] } },
-          { limit: 50 },
+          { limit: 25 },
           {},
           undefined,
         ]
@@ -724,7 +724,7 @@ describe('Contacts component', () => {
         [
           'contacts',
           { types: { selected: ['childType'] } },
-          { limit: 50 },
+          { limit: 25 },
           {
             displayLastVisitedDate: true,
             visitCountSettings: {},
@@ -763,7 +763,7 @@ describe('Contacts component', () => {
         [
           'contacts',
           { types: { selected: ['childType'] } },
-          { limit: 50 },
+          { limit: 25 },
           {
             displayLastVisitedDate: true,
             visitCountSettings: { monthStartDate: false, visitCountGoal: 1 },
@@ -802,7 +802,7 @@ describe('Contacts component', () => {
         [
           'contacts',
           { types: { selected: ['childType'] } },
-          { limit: 50 },
+          { limit: 25 },
           {
             displayLastVisitedDate: true,
             visitCountSettings: { monthStartDate: false, visitCountGoal: 1 },
@@ -845,7 +845,7 @@ describe('Contacts component', () => {
         [
           'contacts',
           { types: { selected: ['childType'] } },
-          { limit: 50 },
+          { limit: 25 },
           {
             displayLastVisitedDate: true,
             visitCountSettings: { monthStartDate: 25, visitCountGoal: 125 },
@@ -1048,7 +1048,7 @@ describe('Contacts component', () => {
                 expect(searchService.search.args[1]).to.deep.equal([
                   'contacts',
                   { types: { selected: ['childType'] } },
-                  { limit: 49, withIds: true, silent: true },
+                  { limit: 24, withIds: true, silent: true },
                   {
                     displayLastVisitedDate: true,
                     visitCountSettings: {},
@@ -1061,7 +1061,7 @@ describe('Contacts component', () => {
                   expect(searchService.search.args[i]).to.deep.equal([
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 49, withIds: false, silent: true },
+                    { limit: 24, withIds: false, silent: true },
                     {
                       displayLastVisitedDate: true,
                       visitCountSettings: {},
@@ -1101,7 +1101,7 @@ describe('Contacts component', () => {
                 expect(searchService.search.args[i]).to.deep.equal([
                   'contacts',
                   { types: { selected: ['childType'] } },
-                  { limit: 49, withIds: false, silent: true },
+                  { limit: 24, withIds: false, silent: true },
                   {
                     displayLastVisitedDate: true,
                     visitCountSettings: {},
@@ -1138,7 +1138,7 @@ describe('Contacts component', () => {
                 expect(searchService.search.args[1]).to.deep.equal([
                   'contacts',
                   { types: { selected: ['childType'] } },
-                  { limit: 49, withIds: true, silent: true },
+                  { limit: 24, withIds: true, silent: true },
                   {
                     displayLastVisitedDate: true,
                     visitCountSettings: {},
@@ -1151,7 +1151,7 @@ describe('Contacts component', () => {
                   expect(searchService.search.args[i]).to.deep.equal([
                     'contacts',
                     { types: { selected: ['childType'] } },
-                    { limit: 49, withIds: false, silent: true },
+                    { limit: 24, withIds: false, silent: true },
                     {
                       displayLastVisitedDate: true,
                       visitCountSettings: {},
@@ -1193,7 +1193,7 @@ describe('Contacts component', () => {
                 expect(searchService.search.args[i]).to.deep.equal([
                   'contacts',
                   { types: { selected: ['childType'] } },
-                  { limit: 49, withIds: false, silent: true },
+                  { limit: 24, withIds: false, silent: true },
                   {},
                   undefined,
                 ]);
@@ -1235,7 +1235,7 @@ describe('Contacts component', () => {
                     expect(searchService.search.args[i]).to.deep.equal([
                       'contacts',
                       { types: { selected: ['childType'] } },
-                      { limit: 49, withIds: false, silent: true },
+                      { limit: 24, withIds: false, silent: true },
                       {},
                       undefined,
                     ]);
@@ -1262,7 +1262,7 @@ describe('Contacts component', () => {
           expect(searchService.search.args[0]).to.deep.equal([
             'contacts',
             { types: { selected: ['childType'] } },
-            { limit: 50 },
+            { limit: 25 },
             {},
             undefined,
           ]);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- Refactor `ngOnInit` to use `async/await` and add a unified `try/catch` block 

#9006 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9006-improve-contact-list-apdex/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9006-improve-contact-list-apdex/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9006-improve-contact-list-apdex/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

