### PR TITLE
feat(#9012): save transition run timestamp in infodoc

### DIFF
--- a/shared-libs/infodoc/src/infodoc.js
+++ b/shared-libs/infodoc/src/infodoc.js
@@ -147,7 +147,7 @@ const updateTransition = (change, transition, ok) => {
     last_rev: change.doc._rev,
     seq: change.seq,
     ok: ok,
-    timestamp: (new Date()).toISOString(),
+    run_date: (new Date()).toISOString(),
   };
 };
 

--- a/shared-libs/infodoc/src/infodoc.js
+++ b/shared-libs/infodoc/src/infodoc.js
@@ -147,6 +147,7 @@ const updateTransition = (change, transition, ok) => {
     last_rev: change.doc._rev,
     seq: change.seq,
     ok: ok,
+    timestamp: (new Date()).toISOString(),
   };
 };
 

--- a/shared-libs/infodoc/test/infodoc.js
+++ b/shared-libs/infodoc/test/infodoc.js
@@ -426,7 +426,7 @@ describe('infodoc', () => {
               ok: true,
               seq: 12,
               last_rev: 2,
-              timestamp: then.toISOString(),
+              run_date: then.toISOString(),
             }
           }
         }
@@ -441,13 +441,13 @@ describe('infodoc', () => {
               ok: true,
               seq: 12,
               last_rev: 2,
-              timestamp: then.toISOString(),
+              run_date: then.toISOString(),
             },
             accept_patient_reports: {
               ok: false,
               seq: 12,
               last_rev: 2,
-              timestamp: now.toISOString(),
+              run_date: now.toISOString(),
             }
           }
         }

--- a/shared-libs/transitions/test/unit/finalize-transition.js
+++ b/shared-libs/transitions/test/unit/finalize-transition.js
@@ -89,7 +89,7 @@ describe('finalize transition', () => {
         assert(info.transitions.x.ok);
         assert(info.transitions.x.last_rev);
         assert(info.transitions.x.seq);
-        assert(info.transitions.x.timestamp);
+        assert(info.transitions.x.run_date);
         assert.equal(doc.errors, undefined);
         assert.equal(doc.foo, 'bar');
         done();

--- a/shared-libs/transitions/test/unit/finalize-transition.js
+++ b/shared-libs/transitions/test/unit/finalize-transition.js
@@ -89,6 +89,7 @@ describe('finalize transition', () => {
         assert(info.transitions.x.ok);
         assert(info.transitions.x.last_rev);
         assert(info.transitions.x.seq);
+        assert(info.transitions.x.timestamp);
         assert.equal(doc.errors, undefined);
         assert.equal(doc.foo, 'bar');
         done();

--- a/tests/integration/infodocs/infodocs.spec.js
+++ b/tests/integration/infodocs/infodocs.spec.js
@@ -234,7 +234,7 @@ describe('infodocs', () => {
         'transitions.generate_shortcode_on_contacts.last_rev': rev,
         'transitions.generate_shortcode_on_contacts.ok': true,
       });
-      const transitionTs = moment(infoDoc.transitions.generate_shortcode_on_contacts.timestamp);
+      const transitionTs = moment(infoDoc.transitions.generate_shortcode_on_contacts.run_date);
       assert.equal(transitionTs.diff(sentinelDate, 'minute'), 0);
     });
   });

--- a/tests/integration/infodocs/infodocs.spec.js
+++ b/tests/integration/infodocs/infodocs.spec.js
@@ -1,6 +1,8 @@
 const { assert } = require('chai');
 const utils = require('@utils');
 const sentinelUtils = require('@utils/sentinel');
+const uuid = require('uuid').v4;
+const moment = require('moment');
 
 //
 // NB: using sentinel processing to delay the reading of infodocs is not guaranteed to be successful
@@ -10,107 +12,75 @@ const sentinelUtils = require('@utils/sentinel');
 // process.
 //
 /* eslint-disable no-console */
-const delayedInfoDocsOf = ids => sentinelUtils.waitForSentinel(ids).then(() => sentinelUtils.getInfoDocs(ids));
+const delayedInfoDocsOf = async (ids) => {
+  await sentinelUtils.waitForSentinel(ids);
+  return sentinelUtils.getInfoDocs(ids);
+};
 
 describe('infodocs', () => {
   afterEach(() => utils.revertDb([], true));
 
-  const singleDocTest = method => {
+  const singleDocTest = async (method) => {
     const doc = {
       _id: 'infodoc-maintain-on-' + method,
       some: 'data'
     };
     const path = method === 'PUT' ? `/${doc._id}` : '/';
     let infoDoc;
-    let deleteRev;
 
-    // First write...
-    return utils.requestOnTestDb({
-      path: path,
-      method: method,
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: doc
-    }).then(result => {
-      // ...should succeed and...
-      assert.isTrue(result.ok);
-      doc._rev = result.rev;
-      doc.more = 'data';
+    const result = await utils.requestOnTestDb({ path, method, body: doc });
+    assert.isTrue(result.ok);
+    doc._rev = result.rev;
+    doc.more = 'data';
 
-      return delayedInfoDocsOf(doc._id);
-    }).then(([result]) => {
-      // ...create an info doc...
-      assert.deepInclude(result, {
-        _id: doc._id + '-info',
-        type: 'info',
-        doc_id: doc._id
-      });
-      // ...with the initial and latest replication dates set.
-      assert.isOk(result.initial_replication_date);
-      assert.isOk(result.latest_replication_date);
+    [infoDoc] = await delayedInfoDocsOf(doc._id);
 
-      infoDoc = result;
-
-      // Second write with correct _rev...
-
-      return utils.requestOnTestDb({
-        path: path,
-        method: method,
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: doc
-      });
-    }).then(result => {
-      // ...should succeed and...
-      assert.isTrue(result.ok);
-
-      deleteRev = result.rev;
-
-      return delayedInfoDocsOf(doc._id);
-    }).then(([result]) => {
-      // ...leave the initial date the same while changing the latest date.
-      assert.equal(result.initial_replication_date, infoDoc.initial_replication_date);
-      assert.notEqual(result.latest_replication_date, infoDoc.latest_replication_date);
-
-      infoDoc = result;
-
-      // Third write with the old _rev...
-      return utils.requestOnTestDb({
-        path: path,
-        method: method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: doc
-      }).catch(err => err);
-    }).then(result => {
-      // ...should fail with a conflict...
-      assert.equal(result.statusCode, 409);
-
-      return delayedInfoDocsOf(doc._id);
-    }).then(([result]) => {
-      // ...and the infodoc should remain the same.
-      assert.equal(result.initial_replication_date, infoDoc.initial_replication_date);
-      assert.equal(result.latest_replication_date, infoDoc.latest_replication_date);
-
-      // A delete...
-      doc._deleted = true;
-      doc._rev = deleteRev;
-
-      return utils.requestOnTestDb({
-        path: path,
-        method: method,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: doc
-      });
-    }).then(result => {
-      // ...should succeed...
-      assert.isTrue(result.ok);
+    assert.deepInclude(infoDoc, {
+      _id: doc._id + '-info',
+      type: 'info',
+      doc_id: doc._id
     });
+
+    assert.isOk(infoDoc.initial_replication_date);
+    assert.isOk(infoDoc.latest_replication_date);
+
+    const update = await utils.requestOnTestDb({ path, method, body: doc });
+    assert.isTrue(update.ok);
+
+    const [updatedInfodoc] = await delayedInfoDocsOf(doc._id);
+
+    assert.equal(updatedInfodoc.initial_replication_date, infoDoc.initial_replication_date);
+    assert.notEqual(updatedInfodoc.latest_replication_date, infoDoc.latest_replication_date);
+
+    infoDoc = updatedInfodoc;
+
+    try {
+      await utils.requestOnTestDb({ path, method, body: doc });
+      assert.fail('request should fail with conflict');
+    } catch (err) {
+      assert.equal(err.statusCode, 409);
+    }
+
+    const [newInfoDoc] = await delayedInfoDocsOf(doc._id);
+    assert.equal(newInfoDoc.initial_replication_date, infoDoc.initial_replication_date);
+    assert.equal(newInfoDoc.latest_replication_date, infoDoc.latest_replication_date);
+
+    doc._deleted = true;
+    doc._rev = update.rev;
+
+    await utils.requestOnTestDb({ path, method, body: doc });
+
+    await utils.stopSentinel();
+    await utils.startSentinel();
+
+    // this might time out when we start the container and it clears the background queue so
+    // fast that, by the time we watch the logs, it had already completed. if this proves to be the case, we would
+    // need to edit the waitForSentinelLogs command to include more trailing logs or something.
+    const waitForLogs = await utils.waitForSentinelLogs(/Task backgroundCleanup completed /);
+    await waitForLogs.promise;
+
+    const results = await delayedInfoDocsOf(doc._id);
+    assert.equal(results[0], undefined);
   };
 
   // These tests are using an admin user
@@ -120,7 +90,7 @@ describe('infodocs', () => {
     it('on PUT', () => singleDocTest('PUT'));
     it('on POST', () => singleDocTest('POST'));
 
-    it('on bulk docs', () => {
+    it('on bulk docs', async () => {
       const docs = [
         {
           'no_id': 'to_begin_with'
@@ -133,91 +103,46 @@ describe('infodocs', () => {
         }
       ];
 
-      let infoDocs;
+      const result = await utils.db.bulkDocs(docs);
+      assert.equal(result.filter(r => r.ok).length, docs.length);
 
-      return utils.requestOnTestDb({
-        path: '/_bulk_docs',
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: {docs: docs}
-      }).then(result => {
-        // ...should succeed for all docs
-        assert.equal(result.filter(r => r.ok).length, 3);
+      docs[0]._id = result[0].id;
+      docs[0]._rev = result[0].rev;
+      docs[1]._rev = result[1].rev;
 
-        docs[0]._id = result[0].id;
-        docs[0]._rev = result[0].rev;
-        docs[1]._rev = result[1].rev;
+      const infoDocs = await delayedInfoDocsOf(docs.map(d => d._id));
 
-        return delayedInfoDocsOf(docs.map(d => d._id));
-      }).then(results => {
-        infoDocs = results;
+      assert.equal(infoDocs.length, 3);
+      infoDocs.forEach((infoDoc, idx) => {
+        const doc = docs[idx];
 
-        // ...and create all of the infodocs.
-        assert.equal(infoDocs.length, 3);
-        infoDocs.forEach((infoDoc, idx) => {
-          const doc = docs[idx];
-
-          assert.deepInclude(infoDoc, {
-            _id: doc._id + '-info',
-            type: 'info',
-            doc_id: doc._id
-          }, `infodoc for ${doc._id} created correctly`);
-          assert.isOk(infoDoc.initial_replication_date, `infodoc initial_replication_date for ${doc._id} exists`);
-          assert.isOk(infoDoc.latest_replication_date, `infodoc latest_replication_date for ${doc._id} exists`);
-        });
-
-        // When we write docs for the second time...
-        return utils.requestOnTestDb({
-          path: '/_bulk_docs',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: {docs: docs}
-        });
-      }).then(result => {
-        // ...we expect the first two to work (because we updated their revs)...
-        assert.isTrue(result[0].ok);
-        assert.isTrue(result[1].ok);
-        // ...and the third to fail...
-        assert.isNotOk(result[2].ok);
-
-        docs[0]._rev = result[0].rev;
-        docs[1]._rev = result[1].rev;
-
-        return delayedInfoDocsOf(docs.map(d => d._id));
-      }).then(newInfoDocs => {
-        // ...which means that the first two latest_replication_date values should change...
-        assert.notEqual(newInfoDocs[0].latest_replication_date, infoDocs[0].latest_replication_date);
-        assert.notEqual(newInfoDocs[1].latest_replication_date, infoDocs[1].latest_replication_date);
-        // ..and the last should not.
-        assert.equal(newInfoDocs[2].latest_replication_date, infoDocs[2].latest_replication_date);
-
-        docs.pop(); // (remove the failing one, we're done with it)
-
-        // When we delete a doc...
-        docs[1]._deleted = true;
-
-        return utils.requestOnTestDb({
-          path: '/_bulk_docs',
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: {docs: docs}
-        });
-      }).then(result => {
-        // ...everything should work...
-        assert.isTrue(result[0].ok);
-        assert.isTrue(result[1].ok);
+        assert.deepInclude(infoDoc, {
+          _id: doc._id + '-info',
+          type: 'info',
+          doc_id: doc._id
+        }, `infodoc for ${doc._id} created correctly`);
+        assert.isOk(infoDoc.initial_replication_date, `infodoc initial_replication_date for ${doc._id} exists`);
+        assert.isOk(infoDoc.latest_replication_date, `infodoc latest_replication_date for ${doc._id} exists`);
       });
+
+      const update = await utils.db.bulkDocs(docs);
+      assert.isTrue(update[0].ok);
+      assert.isTrue(update[1].ok);
+      assert.isNotOk(update[2].ok);
+
+      docs[0]._rev = update[0].rev;
+      docs[1]._rev = update[1].rev;
+
+      const newInfoDocs = await delayedInfoDocsOf(docs.map(d => d._id));
+
+      assert.notEqual(newInfoDocs[0].latest_replication_date, infoDocs[0].latest_replication_date);
+      assert.notEqual(newInfoDocs[1].latest_replication_date, infoDocs[1].latest_replication_date);
+      assert.equal(newInfoDocs[2].latest_replication_date, infoDocs[2].latest_replication_date);
     });
   });
 
   describe('legacy data support', () => {
-    it('finds and migrates data from the medic doc', () => {
+    it('finds and migrates data from the medic doc', async () => {
       const testDoc = {
         _id: 'yuiop',
         data: 'data',
@@ -226,35 +151,24 @@ describe('infodocs', () => {
         }
       };
 
-      // Prepare an existing document
-      return utils.stopSentinel()
-        .then(() => utils.db.post(testDoc))
-        .then(({id, rev}) => {
-          testDoc._id = id;
-          testDoc._rev = rev;
+      await utils.stopSentinel();
+      const result = await utils.db.post(testDoc);
+      testDoc._rev = result.rev;
 
-          // Skip the preceeding write in sentinel
-          return utils.setTransitionSeqToNow();
-        })
-        .then(utils.startSentinel)
-        .then(() => {
-          // Now update the document via api and with sentinel ready to roll
+      await utils.setTransitionSeqToNow();
+      await utils.startSentinel();
 
-          testDoc.data = 'data changed';
+      testDoc.data = 'data changed';
+      await utils.saveDoc(testDoc);
 
-          // Should be through api
-          return utils.saveDoc(testDoc);
-        })
-        .then(() => delayedInfoDocsOf(testDoc._id))
-        .then(([infodoc]) => {
-          assert.isOk(infodoc.initial_replication_date, 'expected an initial_replication_date');
-          assert.isOk(infodoc.latest_replication_date, 'expected a latest_replication_date');
-          assert.deepEqual(infodoc.transitions, {
-            some: 'transition info'
-          });
-        });
+      const [infodoc] = await delayedInfoDocsOf(testDoc._id);
+
+      assert.isOk(infodoc.initial_replication_date, 'expected an initial_replication_date');
+      assert.isOk(infodoc.latest_replication_date, 'expected a latest_replication_date');
+      assert.deepEqual(infodoc.transitions, { some: 'transition info' });
     });
-    it('finds and migrates data from the medic infodoc', () => {
+
+    it('finds and migrates data from the medic infodoc', async () => {
       // In legacy situations the transition info was on the doc, while other
       // information was on the infodoc
       const testDoc = {
@@ -270,44 +184,58 @@ describe('infodocs', () => {
         latest_replication_date: 2000
       };
 
-      // Prepare an existing document
-      return utils.stopSentinel()
-        .then(() => utils.db.post(testDoc))
-        .then(({id, rev}) => {
-          testDoc._id = id;
-          testDoc._rev = rev;
-          legacyInfodoc._id = `${id}-info`;
-          legacyInfodoc.doc_id = id;
+      await utils.stopSentinel();
+      const result = await utils.db.post(testDoc);
+      testDoc._rev = result.rev;
+      testDoc._id = result.id;
 
-          return utils.db.put(legacyInfodoc);
-        })
-        // Skip the preceeding write in sentinel
-        .then(() => utils.setTransitionSeqToNow())
-        .then(utils.startSentinel)
-        .then(() => {
-          // Now update the document via api and with sentinel ready to roll
+      legacyInfodoc._id = `${result.id}-info`;
+      legacyInfodoc.doc_id = result.id;
 
-          testDoc.data = 'data changed';
+      await utils.db.put(legacyInfodoc);
+      await utils.setTransitionSeqToNow();
+      await utils.startSentinel();
 
-          // Should be through api
-          return utils.saveDoc(testDoc);
-        })
-        .then(() => delayedInfoDocsOf(testDoc._id))
-        .then(([infodoc]) => {
-          return utils.db.get(legacyInfodoc._id).catch(() => true)
-            .then(legacyInfodocDeleted => {
-              assert.isTrue(legacyInfodocDeleted);
-              assert.equal(infodoc.initial_replication_date, 1000);
-              assert.isOk(infodoc.latest_replication_date !== 2000); // updated
-              assert.deepEqual(infodoc.transitions, {
-                some: 'transition info'
-              });
-              assert.equal(infodoc.some, 'legacy data');
-            });
-        }).catch(err => {
-          console.log(err);
-          throw err;
-        });
+      testDoc.data = 'data changed';
+      await utils.saveDoc(testDoc);
+
+      const [infodoc] = await delayedInfoDocsOf(testDoc._id);
+
+      try {
+        await utils.db.get(legacyInfodoc._id);
+        assert.fail('doc should be deleted');
+      } catch (err) {
+        assert.equal(err.status, 404);
+      }
+      assert.equal(infodoc.initial_replication_date, 1000);
+      assert.isOk(infodoc.latest_replication_date !== 2000); // updated
+      assert.deepEqual(infodoc.transitions, { some: 'transition info' });
+      assert.equal(infodoc.some, 'legacy data');
+    });
+  });
+
+  describe('transitions infos', () => {
+    it('should set correct transition date', async () => {
+      const settings = {
+        transitions: { generate_shortcode_on_contacts: true }
+      };
+      await utils.updateSettings(settings, 'sentinel');
+
+      const doc = { _id: uuid(), type: 'person' };
+      const { rev } = await utils.saveDoc(doc);
+
+      const sentinelDate = await utils.getSentinelDate();
+      const [infoDoc] = await delayedInfoDocsOf(doc._id);
+
+      assert.deepNestedInclude(infoDoc, {
+        _id: doc._id + '-info',
+        type: 'info',
+        doc_id: doc._id,
+        'transitions.generate_shortcode_on_contacts.last_rev': rev,
+        'transitions.generate_shortcode_on_contacts.ok': true,
+      });
+      const transitionTs = moment(infoDoc.transitions.generate_shortcode_on_contacts.timestamp);
+      assert.equal(transitionTs.diff(sentinelDate, 'minute'), 0);
     });
   });
 });

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1235,7 +1235,7 @@ const getSentinelDate = () => getContainerDate('sentinel');
 const getContainerDate = (container) => {
   container = getContainerName(container);
   try {
-    return moment(execSync(`docker exec ${container} date '+%Y-%m-%d %H:%M:%S'`).toString(), 'YYYY-MM-DD HH:mm:ss');
+    return moment.utc(execSync(`docker exec ${container} date '+%Y-%m-%d %H:%M:%S'`).toString(), 'YYYY-MM-DD HH:mm:ss');
   } catch (error) {
     console.error('docker exec date failed. NOTE this error is not relevant if running outside of docker');
     console.error(error.message);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds a new `run_date` field to infodoc transitions information. Date is saved in ISO format to be consistent with the other date fields in the doc (initial and latest replication date). 
Refactors / condenses old infodoc e2e tests to use async/await. 

#9012

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9012-infodoc-transition-date/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9012-infodoc-transition-date/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9012-infodoc-transition-date/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

