### PR TITLE
chore(#9015): update date diff xpath tests to work in any TZ

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "unit-api": "UNIT_TEST_ENV=1 nyc --nycrcPath='api/nyc.config.js' mocha 'api/tests/mocha/**/*.js'",
     "unit-sentinel": "UNIT_TEST_ENV=1 nyc --nycrcPath='sentinel/nyc.config.js' mocha 'sentinel/tests/**/*.js'",
     "unit-shared-lib": "UNIT_TEST_ENV=1 npm test --workspaces --if-present",
-    "unit-webapp": "UNIT_TEST_ENV=1 mocha 'webapp/tests/mocha/**/*.spec.js' && cd webapp && npm run unit -- --watch=false && npm run unit:cht-form -- --watch=false",
+    "unit-webapp": "cd webapp && npm run unit:mocha:tz && npm run unit -- --watch=false && npm run unit:cht-form -- --watch=false",
     "unit-webapp-continuous": "cd webapp && npm run unit -- --watch=true",
     "unit-nginx": "cd nginx/tests && make test",
     "unit-haproxy": "cd haproxy/tests && make test",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -14,8 +14,10 @@
   },
   "scripts": {
     "postinstall": "patch-package",
-    "unit": "UNIT_TEST_ENV=1 ng test webapp",
+    "unit:mocha": "UNIT_TEST_ENV=1 mocha 'tests/mocha/**/*.spec.js'",
+    "unit:mocha:tz": "TZ=Canada/Pacific npm run unit:mocha && TZ=Africa/Monrovia npm run unit:mocha && TZ=Pacific/Auckland npm run unit:mocha",
     "unit:cht-form": "ng test cht-form",
+    "unit": "UNIT_TEST_ENV=1 ng test webapp",
     "build": "ng build",
     "build:cht-form": "ng build cht-form",
     "compile": "ngc"

--- a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
+++ b/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
@@ -93,7 +93,7 @@ describe('medic-xpath-extensions', function () {
       ['2015-10-01T11:11:11.111', '2014-10-01T11:11:11.111', -12,],
       ['2014-10-01T00:00:00.000', '2015-10-01T00:00:00.000', 12,],
       ['August 19, 1975 00:00:00 GMT', 'August 18, 1976 23:15:30 GMT+07:00', 11],
-      ['Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 21:59:59 GMT+2300', 0],
+      ['Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 22:00:00 GMT+2300', 0],
       ['Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 22:00:00 GMT+2200', 1]
     ].forEach(function (example) {
       const d1 = { t: 'str', v: example[0] };
@@ -175,7 +175,7 @@ describe('medic-xpath-extensions', function () {
     const diffInDays = func['cht:difference-in-days'];
 
     it('should handle cases where end date is before start date and return negative number', function () {
-      const result = diffInDays(wrapDate('2023-08-01 UTC'), wrapDate('2023-01-01 UTC'));
+      const result = diffInDays(wrapDate('2023-08-01'), wrapDate('2023-01-01'));
       assert.equal(result.v, -212);
     });
 
@@ -185,7 +185,7 @@ describe('medic-xpath-extensions', function () {
     });
 
     it('should return the difference when valid inputs are provided', function () {
-      const result = diffInDays(wrapDate('2023-01-01 UTC'), wrapDate('2023-08-01 UTC'));
+      const result = diffInDays(wrapDate('2023-01-01'), wrapDate('2023-08-01'));
       assert.deepStrictEqual(result.v, 212);
     });
 

--- a/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
+++ b/webapp/tests/mocha/unit/enketo/medic-xpath-extensions.spec.js
@@ -93,7 +93,7 @@ describe('medic-xpath-extensions', function () {
       ['2015-10-01T11:11:11.111', '2014-10-01T11:11:11.111', -12,],
       ['2014-10-01T00:00:00.000', '2015-10-01T00:00:00.000', 12,],
       ['August 19, 1975 00:00:00 GMT', 'August 18, 1976 23:15:30 GMT+07:00', 11],
-      ['Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 22:00:00 GMT+2300', 0],
+      ['Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 21:59:59 GMT+2300', 0],
       ['Sun Sep 25 2005 1:00:00 GMT+0100', 'Sun Oct 25 2005 22:00:00 GMT+2200', 1]
     ].forEach(function (example) {
       const d1 = { t: 'str', v: example[0] };
@@ -175,7 +175,7 @@ describe('medic-xpath-extensions', function () {
     const diffInDays = func['cht:difference-in-days'];
 
     it('should handle cases where end date is before start date and return negative number', function () {
-      const result = diffInDays(wrapDate('2023-08-01'), wrapDate('2023-01-01'));
+      const result = diffInDays(wrapDate('2023-08-01 UTC'), wrapDate('2023-01-01 UTC'));
       assert.equal(result.v, -212);
     });
 
@@ -185,7 +185,7 @@ describe('medic-xpath-extensions', function () {
     });
 
     it('should return the difference when valid inputs are provided', function () {
-      const result = diffInDays(wrapDate('2023-01-01'), wrapDate('2023-08-01'));
+      const result = diffInDays(wrapDate('2023-01-01 UTC'), wrapDate('2023-08-01 UTC'));
       assert.deepStrictEqual(result.v, 212);
     });
 

--- a/webapp/tests/mocha/unit/validate_doc_update.spec.js
+++ b/webapp/tests/mocha/unit/validate_doc_update.spec.js
@@ -38,12 +38,12 @@ describe('validate doc update', () => {
   };
 
   const clientValidateDocUpdate = function() {
-    const fn = fs.readFileSync('./ddocs/medic-db/medic-client/validate_doc_update.js');
+    const fn = fs.readFileSync(`${__dirname}/../../../../ddocs/medic-db/medic-client/validate_doc_update.js`);
     eval('log = console.log; (' + fn + ')').apply(null, arguments);
   };
 
   const serverValidateDocUpdate = function() {
-    const fn = fs.readFileSync('./ddocs/medic-db/medic/validate_doc_update.js');
+    const fn = fs.readFileSync(`${__dirname}/../../../../ddocs/medic-db/medic/validate_doc_update.js`);
     eval('log = console.log; (' + fn + ')').apply(null, arguments);
   };
 


### PR DESCRIPTION
# Description

Closes #9015

These tests should now work in any TZ! Honestly, I am not super concerned about the exact date comparison assertions since we are just deferring all the comparison logic to `moment`.  These assertions are a "nice to have" if/when we ever got to refactoring this logic, but in reality they are mostly asserting moment's functionality....

I confirmed that these tests all run in at least the following TZs:

- `Canada/Pacific`
- `Africa/Monrovia`
- `Pacific/Auckland`
- `UTC`

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9015_fix_tz_tests/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9015_fix_tz_tests/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9015_fix_tz_tests/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

