### PR TITLE
feat(#8917): Support Android app links verification

### DIFF
--- a/api/src/controllers/well-known.js
+++ b/api/src/controllers/well-known.js
@@ -1,0 +1,13 @@
+const settingsService = require('../services/settings');
+const serverUtils = require('../server-utils');
+
+module.exports = {
+  assetlinks: async (req, res) => {
+    const settings = await settingsService.get();
+    if (Object.hasOwn(settings, 'assetlinks')) {
+      return res.json(settings.assetlinks);
+    }
+
+    serverUtils.error({ code: 404, error: 'not_found', reason: 'No assetlinks.json configured' }, req, res);
+  },
+};

--- a/api/src/controllers/well-known.js
+++ b/api/src/controllers/well-known.js
@@ -3,15 +3,14 @@ const serverUtils = require('../server-utils');
 
 module.exports = {
   assetlinks: async (req, res) => {
-    try {
-      const settings = await settingsService.get();
-      if (settings.assetlinks) {
-        return res.json(settings.assetlinks);
-      }
+    return settingsService.get()
+      .then((settings) => {
+        if (!settings.assetlinks) {
+          throw { code: 404, error: 'not_found', reason: 'No assetlinks.json configured' };
+        }
 
-      serverUtils.error({ code: 404, error: 'not_found', reason: 'No assetlinks.json configured' }, req, res);
-    } catch (error) {
-      serverUtils.error(error, req, res);
-    }
+        return res.json(settings.assetlinks);
+      })
+      .catch(error => serverUtils.error(error, req, res));
   },
 };

--- a/api/src/controllers/well-known.js
+++ b/api/src/controllers/well-known.js
@@ -5,7 +5,7 @@ module.exports = {
   assetlinks: async (req, res) => {
     try {
       const settings = await settingsService.get();
-      if (Object.hasOwn(settings, 'assetlinks')) {
+      if (settings.assetlinks) {
         return res.json(settings.assetlinks);
       }
 

--- a/api/src/controllers/well-known.js
+++ b/api/src/controllers/well-known.js
@@ -3,14 +3,15 @@ const serverUtils = require('../server-utils');
 
 module.exports = {
   assetlinks: async (req, res) => {
-    return settingsService.get()
-      .then((settings) => {
-        if (!settings.assetlinks) {
-          throw { code: 404, error: 'not_found', reason: 'No assetlinks.json configured' };
-        }
-
+    try {
+      const settings = await settingsService.get();
+      if (settings.assetlinks) {
         return res.json(settings.assetlinks);
-      })
-      .catch(error => serverUtils.error(error, req, res));
+      }
+
+      serverUtils.error({ code: 404, reason: 'No assetlinks.json configured' }, req, res);
+    } catch (error) {
+      serverUtils.error(error, req, res);
+    }
   },
 };

--- a/api/src/controllers/well-known.js
+++ b/api/src/controllers/well-known.js
@@ -3,11 +3,15 @@ const serverUtils = require('../server-utils');
 
 module.exports = {
   assetlinks: async (req, res) => {
-    const settings = await settingsService.get();
-    if (Object.hasOwn(settings, 'assetlinks')) {
-      return res.json(settings.assetlinks);
-    }
+    try {
+      const settings = await settingsService.get();
+      if (Object.hasOwn(settings, 'assetlinks')) {
+        return res.json(settings.assetlinks);
+      }
 
-    serverUtils.error({ code: 404, error: 'not_found', reason: 'No assetlinks.json configured' }, req, res);
+      serverUtils.error({ code: 404, error: 'not_found', reason: 'No assetlinks.json configured' }, req, res);
+    } catch (error) {
+      serverUtils.error(error, req, res);
+    }
   },
 };

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -227,7 +227,7 @@ app.use(compression({
   }
 }));
 
-app.get('/.well-known/assetlinks.json', async (req, res, next) => {
+app.get('/.well-known/assetlinks.json', async (req, res) => {
   const settings = await settingsService.get();
   const key = 'TODO';
   if (Object.hasOwn(settings, key)) {

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -229,9 +229,8 @@ app.use(compression({
 
 app.get('/.well-known/assetlinks.json', async (req, res) => {
   const settings = await settingsService.get();
-  const key = 'TODO';
-  if (Object.hasOwn(settings, key)) {
-    return res.json(settings[key]);
+  if (Object.hasOwn(settings, 'assetlinks')) {
+    return res.json(settings.assetlinks);
   }
 
   res.status(404);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -48,6 +48,7 @@ const faviconController = require('./controllers/favicon');
 const replicationLimitLogController = require('./controllers/replication-limit-log');
 const connectedUserLog = require('./middleware/connected-user-log').log;
 const getLocale = require('./middleware/locale').getLocale;
+const settingsService = require('./services/settings');
 const startupLog = require('./services/setup/startup-log');
 const staticResources = /\/(templates|static)\//;
 // CouchDB is very relaxed in matching routes
@@ -225,6 +226,17 @@ app.use(compression({
     return compression.filter(req, res);
   }
 }));
+
+app.get('/.well-known/assetlinks.json', async (req, res, next) => {
+  const settings = await settingsService.get();
+  const key = 'TODO';
+  if (Object.hasOwn(settings, key)) {
+    return res.json(settings[key]);
+  }
+
+  res.status(404);
+  res.json({ error: 'not_found', reason: 'No assetlinks.json configured' });
+});
 
 // TODO: investigate blocking writes to _users from the outside. Reads maybe as well, though may be harder
 //       https://github.com/medic/medic/issues/4089

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -46,9 +46,9 @@ const privacyPolicyController = require('./controllers/privacy-policy');
 const couchConfigController = require('./controllers/couch-config');
 const faviconController = require('./controllers/favicon');
 const replicationLimitLogController = require('./controllers/replication-limit-log');
+const wellKnownController = require('./controllers/well-known');
 const connectedUserLog = require('./middleware/connected-user-log').log;
 const getLocale = require('./middleware/locale').getLocale;
-const settingsService = require('./services/settings');
 const startupLog = require('./services/setup/startup-log');
 const staticResources = /\/(templates|static)\//;
 // CouchDB is very relaxed in matching routes
@@ -227,15 +227,7 @@ app.use(compression({
   }
 }));
 
-app.get('/.well-known/assetlinks.json', async (req, res) => {
-  const settings = await settingsService.get();
-  if (Object.hasOwn(settings, 'assetlinks')) {
-    return res.json(settings.assetlinks);
-  }
-
-  res.status(404);
-  res.json({ error: 'not_found', reason: 'No assetlinks.json configured' });
-});
+app.get('/.well-known/assetlinks.json', wellKnownController.assetlinks);
 
 // TODO: investigate blocking writes to _users from the outside. Reads maybe as well, though may be harder
 //       https://github.com/medic/medic/issues/4089

--- a/api/tests/mocha/controllers/well-known.spec.js
+++ b/api/tests/mocha/controllers/well-known.spec.js
@@ -3,6 +3,7 @@ const chai = require('chai');
 
 const controller = require('../../../src/controllers/well-known');
 const settingsService = require('../../../src/services/settings');
+const serverUtils = require('../../../src/server-utils');
 
 describe('well-known controller', () => {
   let req;
@@ -10,14 +11,9 @@ describe('well-known controller', () => {
   let settingsGet;
 
   beforeEach(() => {
-    req = {
-      accepts: sinon.stub().returns('json'),
-    };
+    req = {};
     res = {
       json: sinon.stub(),
-      status: sinon.stub(),
-      type: sinon.stub(),
-      end: sinon.stub(),
     };
     settingsGet = sinon.stub(settingsService, 'get');
   });
@@ -35,17 +31,19 @@ describe('well-known controller', () => {
 
     it('should respond 404 not found if not configured', async () => {
       settingsGet.resolves({});
+      sinon.stub(serverUtils, 'error');
 
       await controller.assetlinks(req, res);
-      chai.expect(res.status.args[0][0]).to.equal(404);
+      chai.expect(serverUtils.error.args[0][0].code).to.equal(404);
       chai.expect(res.json.callCount).to.equal(0);
     });
 
     it('should respond 500 with an error if settings service is failing', async () => {
       settingsGet.rejects();
+      sinon.stub(serverUtils, 'error');
 
       await controller.assetlinks(req, res);
-      chai.expect(res.status.args[0][0]).to.equal(500);
+      chai.expect(serverUtils.error.args[0][0]).to.be.an.instanceOf(Error);
       chai.expect(res.json.callCount).to.equal(0);
     });
   });

--- a/api/tests/mocha/controllers/well-known.spec.js
+++ b/api/tests/mocha/controllers/well-known.spec.js
@@ -1,0 +1,52 @@
+const sinon = require('sinon');
+const chai = require('chai');
+
+const controller = require('../../../src/controllers/well-known');
+const settingsService = require('../../../src/services/settings');
+
+describe('well-known controller', () => {
+  let req;
+  let res;
+  let settingsGet;
+
+  beforeEach(() => {
+    req = {
+      accepts: sinon.stub().returns('json'),
+    };
+    res = {
+      json: sinon.stub(),
+      status: sinon.stub(),
+      type: sinon.stub(),
+      end: sinon.stub(),
+    };
+    settingsGet = sinon.stub(settingsService, 'get');
+  });
+  afterEach(() => sinon.restore());
+
+  describe('assetlinks', () => {
+    it('should respond with assetlinks.json if configured', async () => {
+      const assetlinks = { anything: true };
+      settingsGet.resolves({ assetlinks });
+
+      await controller.assetlinks(req, res);
+      chai.expect(res.json.callCount).to.equal(1);
+      chai.expect(res.json.args[0][0]).to.deep.equal(assetlinks);
+    });
+
+    it('should respond 404 not found if not configured', async () => {
+      settingsGet.resolves({});
+
+      await controller.assetlinks(req, res);
+      chai.expect(res.status.args[0][0]).to.equal(404);
+      chai.expect(res.json.callCount).to.equal(0);
+    });
+
+    it('should respond 500 with an error if settings service is failing', async () => {
+      settingsGet.rejects();
+
+      await controller.assetlinks(req, res);
+      chai.expect(res.status.args[0][0]).to.equal(500);
+      chai.expect(res.json.callCount).to.equal(0);
+    });
+  });
+});

--- a/tests/integration/api/controllers/well-known.spec.js
+++ b/tests/integration/api/controllers/well-known.spec.js
@@ -1,0 +1,43 @@
+const chai = require('chai');
+const utils = require('@utils');
+
+const unauthenticatedGetRequestOptions = {
+  method: 'GET',
+  noAuth: true
+};
+
+describe('well-known', () => {
+  describe('GET /.well-known/assetlinks.json', () => {
+    afterEach(() => utils.revertSettings(true));
+
+    it('returns 404 if not configured', async () => {
+      await utils.request({
+        path: '/.well-known/assetlinks.json',
+        ...unauthenticatedGetRequestOptions,
+      })
+        .then(() => chai.expect.fail('should have thrown'))
+        .catch(error => {
+          chai.expect(error.response.statusCode).to.equal(404);
+        });
+    });
+
+    it('returns the file as json', async () => {
+      const assetlinks = [{
+        relation: ['delegate_permission/common.handle_all_urls'],
+        target: {
+          namespace: 'org.medicmobile.webapp.mobile',
+          package_name: 'org.medicmobile.webapp.mobile',
+          sha256_cert_fingerprints:
+            ['62:BF:C1:78:24:D8:4D:5C:B4:E1:8B:66:98:EA:14:16:57:6F:A4:E5:96:CD:93:81:B2:65:19:71:A7:80:EA:4D']
+        }
+      }];
+      await utils.updateSettings({ assetlinks }, true);
+
+      const response = await utils.request(Object.assign(
+        { path: '/.well-known/assetlinks.json' },
+        unauthenticatedGetRequestOptions,
+      ));
+      chai.expect(response).to.deep.equal(assetlinks);
+    });
+  });
+});

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -83,7 +83,6 @@ describe('routing', () => {
   afterEach(() => utils.revertDb(DOCS_TO_KEEP, true));
 
   describe('unauthenticated routing', () => {
-
     describe('API restricts endpoints which need authentication', () => {
 
       const tests = [
@@ -150,6 +149,38 @@ describe('routing', () => {
         });
       });
 
+    });
+
+    describe('Android app links verification', () => {
+      it('returns 404 if it\'s not configured', async () => {
+        await utils.request(Object.assign(
+          { path: '/.well-known/assetlinks.json' },
+          unauthenticatedGetRequestOptions,
+        ))
+          .then(() => expect.fail('should have thrown'))
+          .catch(error => {
+            expect(error.response.statusCode).to.equal(404);
+          });
+      });
+
+      it('returns the file as json', async () => {
+        const assetlinks = [{
+          relation: ['delegate_permission/common.handle_all_urls'],
+          target: {
+            namespace: 'org.medicmobile.webapp.mobile',
+            package_name: 'org.medicmobile.webapp.mobile',
+            sha256_cert_fingerprints:
+              ['62:BF:C1:78:24:D8:4D:5C:B4:E1:8B:66:98:EA:14:16:57:6F:A4:E5:96:CD:93:81:B2:65:19:71:A7:80:EA:4D']
+          }
+        }];
+        await utils.updateSettings({ assetlinks }, true);
+
+        const response = await utils.request(Object.assign(
+          { path: '/.well-known/assetlinks.json' },
+          unauthenticatedGetRequestOptions,
+        ));
+        expect(response).to.deep.equal(assetlinks);
+      });
     });
 
     it('API allows endpoints which do not need authentication', () => {

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -151,38 +151,6 @@ describe('routing', () => {
 
     });
 
-    describe('Android app links verification', () => {
-      it('returns 404 if it\'s not configured', async () => {
-        await utils.request(Object.assign(
-          { path: '/.well-known/assetlinks.json' },
-          unauthenticatedGetRequestOptions,
-        ))
-          .then(() => expect.fail('should have thrown'))
-          .catch(error => {
-            expect(error.response.statusCode).to.equal(404);
-          });
-      });
-
-      it('returns the file as json', async () => {
-        const assetlinks = [{
-          relation: ['delegate_permission/common.handle_all_urls'],
-          target: {
-            namespace: 'org.medicmobile.webapp.mobile',
-            package_name: 'org.medicmobile.webapp.mobile',
-            sha256_cert_fingerprints:
-              ['62:BF:C1:78:24:D8:4D:5C:B4:E1:8B:66:98:EA:14:16:57:6F:A4:E5:96:CD:93:81:B2:65:19:71:A7:80:EA:4D']
-          }
-        }];
-        await utils.updateSettings({ assetlinks }, true);
-
-        const response = await utils.request(Object.assign(
-          { path: '/.well-known/assetlinks.json' },
-          unauthenticatedGetRequestOptions,
-        ));
-        expect(response).to.deep.equal(assetlinks);
-      });
-    });
-
     it('API allows endpoints which do not need authentication', () => {
       return Promise.all([
         utils.requestOnTestDb(Object.assign({ path: '/login', json: false }, unauthenticatedGetRequestOptions)),


### PR DESCRIPTION
# Description

#8917

Have partners configure the `assetlinks` property in `app_settings.json` and the CHT will automatically serve it at `/.well-known/assetlinks.json` for them

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8917-serve-android-url-verification-assetlinks/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8917-serve-android-url-verification-assetlinks/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8917-serve-android-url-verification-assetlinks/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

