### PR TITLE
chore(#8338): use CouchDb session in e2e tests requests

### DIFF
--- a/tests/e2e/default/transitions/create-user-for-contacts.replace-user.wdio-spec.js
+++ b/tests/e2e/default/transitions/create-user-for-contacts.replace-user.wdio-spec.js
@@ -137,6 +137,7 @@ const submitLoginRequest = ({ username, password }) => {
     body: { user: username, password, locale: 'en' },
     method: 'POST',
     simple: false,
+    noAuth: true,
   };
   return utils.request(opts);
 };

--- a/tests/integration/api/controllers/monitoring.spec.js
+++ b/tests/integration/api/controllers/monitoring.spec.js
@@ -87,7 +87,7 @@ describe('monitoring', () => {
           count: 0,
         },
         connected_users: {
-          count: 0, //not logged in browser
+          count: 1, //not logged in browser
         },
       });
     });
@@ -185,7 +185,7 @@ describe('monitoring', () => {
           count: 0,
         },
         connected_users: {
-          count: 0,
+          count: 1,
         },
       });
     });

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -722,8 +722,7 @@ describe('routing', () => {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: { name: username, password },
-          username,
-          password
+          auth: { username, password }
         });
       };
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -54,6 +54,7 @@ const usersDb = new PouchDB(`${constants.BASE_URL}/_users`, { auth });
 const logsDb = new PouchDB(`${constants.BASE_URL}/${constants.DB_NAME}-logs`, { auth });
 const existingFeedbackDocIds = [];
 const MINIMUM_BROWSER_VERSION = '90';
+const cookieJar = rpn.jar();
 
 const makeTempDir = (prefix) => fs.mkdtempSync(path.join(path.join(os.tmpdir(), prefix || 'ci-')));
 const env = {
@@ -124,12 +125,42 @@ const setupUserDoc = (userName = constants.USERNAME, userDoc = userSettings.buil
     });
 };
 
+const getSession = async () => {
+  if (cookieJar.getCookies(constants.BASE_URL).length) {
+    return;
+  }
+
+  const options = {
+    method: 'POST',
+    uri: `${constants.BASE_URL}/_session`,
+    json: true,
+    body: { name: auth.username, password: auth.password},
+    auth,
+    resolveWithFullResponse: true,
+  };
+  const response = await rpn(options);
+  const setCookie = response.headers?.['set-cookie'];
+  const header = Array.isArray(setCookie) ? setCookie.find(header => header.startsWith('AuthSession')) : setCookie;
+  if (header) {
+    try {
+      cookieJar.setCookie(rpn.cookie(header), constants.BASE_URL);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+};
+
+const isLoginRequest = options => {
+  return options.path === '/medic/login' && options.body.user !== auth.username;
+};
+
 // First Object is passed to http.request, second is for specific options / flags
 // for this wrapper
-const request = (options, { debug } = {}) => { //NOSONAR
+const request = async (options, { debug } = {}) => { //NOSONAR
   options = typeof options === 'string' ? { path: options } : _.clone(options);
-  if (!options.noAuth) {
-    options.auth = options.auth || auth;
+  if (!options.noAuth && !options.auth && !isLoginRequest(options)) {
+    await getSession();
+    options.jar = cookieJar;
   }
   options.uri = options.uri || `${constants.BASE_URL}${options.path}`;
   options.json = options.json === undefined ? true : options.json;
@@ -154,11 +185,13 @@ const request = (options, { debug } = {}) => { //NOSONAR
     return resolveWithFullResponse || !(/^2/.test('' + response.statusCode)) ? response : response.body;
   };
 
-  return rpn(options).catch(err => {
+  try {
+    return await rpn(options);
+  } catch (err) {
     err.responseBody = err?.response?.body;
-    console.warn(`Error with request: ${options.method || 'GET'} ${options.uri}`);
+    console.warn(`Error with request: ${options.method || 'GET'} ${options.uri} ${err.statusCode}`);
     throw err;
-  });
+  }
 };
 
 const requestOnTestDb = (options, debug) => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

#8338

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8338-e2e-session/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8338-e2e-session/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8338-e2e-session/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

