### PR TITLE
chore(#8788): use beforeEach so retries work

### DIFF
--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -30,12 +30,12 @@ const contact = placeFactory.place().build({
 });
 
 describe('Testing Incorrect locale', () => {
-  after(async () => {
-    await browser.setCookies({ name: 'locale', value: 'en' });
+  afterEach(async () => {
     await utils.revertSettings(true);
+    await browser.setCookies({ name: 'locale', value: 'en' });
   });
 
-  before(async () => {
+  beforeEach(async () => {
     await loginPage.cookieLogin();
     await utils.saveDoc(contact);
     await sentinelUtils.waitForSentinel();

--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -7,6 +7,7 @@ const placeFactory = require('@factories/cht/contacts/place');
 const sentinelUtils = require('@utils/sentinel');
 
 const languageCode = 'hil';
+
 const createLanguage = async () =>  {
   await utils.addTranslations(languageCode, {
     'n.month': '{MONTHS, plural, =1{1 luna} other{# luni}}',
@@ -21,21 +22,21 @@ const createLanguage = async () =>  {
   await utils.enableLanguage(languageCode);
 };
 
-const contact = placeFactory.place().build({
-  _id: 'district_hil_locale',
-  name: 'hil district',
-  type: 'district_hospital',
-  reported_date: 1000,
-  parent: '',
-});
+const createContact = () => {
+  return placeFactory.place().build({
+    name: 'hil district',
+    type: 'district_hospital',
+    reported_date: 1000,
+    parent: '',
+  });
+};
+
+let contact;
 
 describe('Testing Incorrect locale', () => {
-  afterEach(async () => {
-    await utils.revertSettings(true);
-    await browser.setCookies({ name: 'locale', value: 'en' });
-  });
 
   beforeEach(async () => {
+    contact = createContact();
     await loginPage.cookieLogin();
     await utils.saveDoc(contact);
     await sentinelUtils.waitForSentinel();
@@ -43,6 +44,12 @@ describe('Testing Incorrect locale', () => {
     await createLanguage();
     await waitForServiceWorker.promise;
     await commonElements.closeReloadModal(true);
+  });
+
+  afterEach(async () => {
+    await utils.deleteDocs([ contact._id, `messages-${languageCode}` ]);
+    await utils.revertSettings(true);
+    await browser.setCookies({ name: 'locale', value: 'en' });
   });
 
   it('should work with incorrect locale', async () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->
#8788 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8788-retry-before-and-after/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8788-retry-before-and-after/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8788-retry-before-and-after/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

