### PR TITLE
chore(#8437): add `noImplicitThis` to webapp tsconfig

### DIFF
--- a/webapp/src/ts/services/android-api.service.ts
+++ b/webapp/src/ts/services/android-api.service.ts
@@ -50,6 +50,7 @@ export class AndroidApiService {
     $container
       .find('select.select2-hidden-accessible')
       .each(function() {
+        // @ts-expect-error Intentionally referencing shadowed `this` variable.
         const elem = <any>$(this);
         if (elem.select2('isOpen')) {
           elem.select2('close');
@@ -92,6 +93,7 @@ export class AndroidApiService {
   private closeTopModal($modals) {
     let $topModal;
     $modals.each(function() {
+      // @ts-expect-error Intentionally referencing shadowed `this` variable.
       const $modal = $(this);
       if (!$topModal) {
         $topModal = $modal;

--- a/webapp/tsconfig.base.json
+++ b/webapp/tsconfig.base.json
@@ -31,7 +31,8 @@
       "@mm-services/*": ["src/ts/services/*"]
     },
     "strictNullChecks": true,
-    "alwaysStrict": true
+    "alwaysStrict": true,
+    "noImplicitThis": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
# Description

https://github.com/medic/cht-core/issues/8437

Very minor change to set [`noImplicitThis` ](https://www.typescriptlang.org/tsconfig/#noImplicitThis) that is one more step in the direction of being able to enable `strict` mode.  

There were only two places where we were violating this rule and both of them were deliberate because we are using a shadowed `this` to be able to reference DOM elements.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8437_no_implicit_this/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8437_no_implicit_this/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8437_no_implicit_this/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

