### PR TITLE
chore(#8437): set strictBindCallApply and strictPropertyInitialization in tsconfig

### DIFF
--- a/webapp/src/ts/components/fast-action-button/fast-action-button.component.ts
+++ b/webapp/src/ts/components/fast-action-button/fast-action-button.component.ts
@@ -19,8 +19,8 @@ import { Selectors } from '@mm-selectors/index';
 })
 export class FastActionButtonComponent implements OnInit, OnDestroy {
 
-  @Input() config: FastActionConfig;
-  @Input() fastActions: FastAction[];
+  @Input() config?: FastActionConfig;
+  @Input() fastActions?: FastAction[];
   @ViewChild('contentWrapper') contentWrapper;
 
   private subscriptions: Subscription = new Subscription();
@@ -75,7 +75,7 @@ export class FastActionButtonComponent implements OnInit, OnDestroy {
    * Returns a Fast Action that can be executed right away without opening the dialog or bottom sheet.
    */
   getFastExecutableAction(): FastAction | undefined {
-    if (this.fastActions.length === 1 && !this.fastActions[0]?.alwaysOpenInPanel) {
+    if (this.fastActions?.length === 1 && !this.fastActions[0]?.alwaysOpenInPanel) {
       return this.fastActions[0];
     }
     return;

--- a/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
+++ b/webapp/src/ts/components/filters/date-filter/date-filter.component.ts
@@ -22,7 +22,7 @@ export class DateFilterComponent implements OnInit, OnDestroy, AbstractFilter, A
   private globalActions;
   private subscription: Subscription = new Subscription();
   inputLabel;
-  error: string;
+  error?: string;
   dateRange = {
     from: undefined as any,
     to: undefined as any,

--- a/webapp/src/ts/components/modal-layout/modal-layout.component.ts
+++ b/webapp/src/ts/components/modal-layout/modal-layout.component.ts
@@ -6,16 +6,16 @@ import { Component, Input, Output, EventEmitter, HostListener, Attribute } from 
 })
 export class ModalLayoutComponent {
   @Attribute('id') id;
-  @Input() processing: boolean;
-  @Input() error: string;
-  @Input() titleKey: string;
-  @Input() submitKey: string;
-  @Input() submittingKey: string;
-  @Input() isFlatButton: boolean; // Best used for modals with forms
-  @Input() cancelKey: string;
-  @Input() hideFooter: boolean;
-  @Input() hideCancelButton: boolean;
-  @Input() hasEnketoForm: boolean;
+  @Input() processing?: boolean;
+  @Input() error?: string;
+  @Input() titleKey?: string;
+  @Input() submitKey?: string;
+  @Input() submittingKey?: string;
+  @Input() isFlatButton?: boolean; // Best used for modals with forms
+  @Input() cancelKey?: string;
+  @Input() hideFooter?: boolean;
+  @Input() hideCancelButton?: boolean;
+  @Input() hasEnketoForm?: boolean;
   @Output() onCancel: EventEmitter<any> = new EventEmitter();
   @Output() onSubmit: EventEmitter<any> = new EventEmitter();
 

--- a/webapp/src/ts/components/search-bar/search-bar.component.ts
+++ b/webapp/src/ts/components/search-bar/search-bar.component.ts
@@ -35,7 +35,7 @@ export class SearchBarComponent implements AfterContentInit, AfterViewInit, OnDe
   activeFilters: number = 0;
   openSearch = false;
 
-  @ViewChild(FreetextFilterComponent) freetextFilter: FreetextFilterComponent;
+  @ViewChild(FreetextFilterComponent) freetextFilter?: FreetextFilterComponent;
 
   constructor(
     private store: Store,
@@ -70,7 +70,7 @@ export class SearchBarComponent implements AfterContentInit, AfterViewInit, OnDe
     if (this.disabled) {
       return;
     }
-    this.freetextFilter.clear(true);
+    this.freetextFilter?.clear(true);
     this.toggleMobileSearch(false);
   }
 

--- a/webapp/src/ts/directives/auth.directive.ts
+++ b/webapp/src/ts/directives/auth.directive.ts
@@ -6,9 +6,9 @@ import { AuthService } from '../services/auth.service';
   selector: '[mmAuth]'
 })
 export class AuthDirective implements OnChanges {
-  @Input() mmAuth: string;
-  @Input() mmAuthAny: any;
-  @Input() mmAuthOnline: boolean;
+  @Input() mmAuth?: string;
+  @Input() mmAuthAny?: any;
+  @Input() mmAuthOnline?: boolean;
 
   private hidden = true;
 

--- a/webapp/src/ts/modules/configuration-user/configuration-user.component.ts
+++ b/webapp/src/ts/modules/configuration-user/configuration-user.component.ts
@@ -11,8 +11,8 @@ import { SessionService } from '@mm-services/session.service';
 })
 export class ConfigurationUserComponent implements OnInit {
 
-  loading: boolean;
-  canUpdatePassword: boolean;
+  loading?: boolean;
+  canUpdatePassword?: boolean;
 
   constructor(
     private modalService: ModalService,

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -50,7 +50,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
   private childTypesBySelectedContact: Record<string, any>[] = [];
   private filters;
   canDeleteContact = false; // this disables the "Delete" button until children load
-  fastActionList: FastAction[];
+  fastActionList?: FastAction[];
   relevantReportForms;
   childContactTypes;
   filteredTasks = [];

--- a/webapp/src/ts/modules/contacts/contacts-filters.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-filters.component.ts
@@ -24,7 +24,7 @@ export class ContactsFiltersComponent {
   @Input() sortDirection;
   @Input() lastVisitedDateExtras;
 
-  @ViewChild(FreetextFilterComponent) freetextFilter:FreetextFilterComponent;
+  @ViewChild(FreetextFilterComponent) freetextFilter?:FreetextFilterComponent;
 
   applyFilters() {
     this.search.emit();

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -34,14 +34,14 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
   private globalActions: GlobalActions;
   private contactsActions: ContactsActions;
   private listContains;
-  private destroyed: boolean;
-  private isOnlineOnly: boolean;
+  private destroyed?: boolean;
+  private isOnlineOnly?: boolean;
 
-  fastActionList: FastAction[];
+  fastActionList?: FastAction[];
   contactsList;
   loading = false;
   error;
-  appending: boolean;
+  appending?: boolean;
   hasContacts = true;
   filters: Filter = {};
   defaultFilters: Filter = {};
@@ -56,7 +56,7 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
   sortDirection = this.defaultSortDirection;
   additionalListItem = false;
   useSearchNewDesign = true;
-  enketoEdited: boolean;
+  enketoEdited?: boolean;
   selectedContact;
 
   constructor(

--- a/webapp/src/ts/modules/messages/messages-content.component.ts
+++ b/webapp/src/ts/modules/messages/messages-content.component.ts
@@ -37,8 +37,8 @@ import { PerformanceService } from '@mm-services/performance.service';
 })
 export class MessagesContentComponent implements OnInit, OnDestroy, AfterViewInit, AfterViewChecked {
   private userCtx;
-  private globalActions: GlobalActions;
-  private messagesActions: MessagesActions;
+  private globalActions!: GlobalActions;
+  private messagesActions!: MessagesActions;
   loadingContent;
   loadingMoreContent = false;
   selectedConversation;

--- a/webapp/src/ts/modules/messages/messages-more-menu.component.ts
+++ b/webapp/src/ts/modules/messages/messages-more-menu.component.ts
@@ -14,7 +14,7 @@ export class MessagesMoreMenuComponent implements OnInit {
   @Output() exportMessages: EventEmitter<any> = new EventEmitter();
 
   private hasExportPermission = false;
-  private isOnlineOnly: boolean;
+  private isOnlineOnly?: boolean;
 
   useOldActionBar = false;
 

--- a/webapp/src/ts/modules/messages/messages.component.ts
+++ b/webapp/src/ts/modules/messages/messages.component.ts
@@ -27,7 +27,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
   private destroyed = false;
 
   subscriptions: Subscription = new Subscription();
-  fastActionList: FastAction[];
+  fastActionList?: FastAction[];
   loading = true;
   loadingContent = false;
   conversations: Record<string, any>[] = [];

--- a/webapp/src/ts/modules/reports/reports-content.component.ts
+++ b/webapp/src/ts/modules/reports/reports-content.component.ts
@@ -30,7 +30,7 @@ export class ReportsContentComponent implements OnInit, OnDestroy {
   selectMode;
   validChecks;
   summaries;
-  fastActionList: FastAction[];
+  fastActionList?: FastAction[];
 
   constructor(
     private changesService:ChangesService,

--- a/webapp/src/ts/modules/reports/reports-filters.component.ts
+++ b/webapp/src/ts/modules/reports/reports-filters.component.ts
@@ -29,11 +29,11 @@ export class ReportsFiltersComponent implements AfterViewInit, OnDestroy {
   @Output() search: EventEmitter<any> = new EventEmitter();
   @Input() reset;
 
-  @ViewChild(FormTypeFilterComponent) formTypeFilter:FormTypeFilterComponent;
-  @ViewChild(FacilityFilterComponent) facilityFilter:FacilityFilterComponent;
-  @ViewChild(DateFilterComponent) dateFilter:DateFilterComponent;
-  @ViewChild(FreetextFilterComponent) freetextFilter:FreetextFilterComponent;
-  @ViewChild(StatusFilterComponent) statusFilter:StatusFilterComponent;
+  @ViewChild(FormTypeFilterComponent) formTypeFilter?:FormTypeFilterComponent;
+  @ViewChild(FacilityFilterComponent) facilityFilter?:FacilityFilterComponent;
+  @ViewChild(DateFilterComponent) dateFilter?:DateFilterComponent;
+  @ViewChild(FreetextFilterComponent) freetextFilter?:FreetextFilterComponent;
+  @ViewChild(StatusFilterComponent) statusFilter?:StatusFilterComponent;
 
   ngAfterViewInit() {
     this.searchFiltersService.init(this.freetextFilter);

--- a/webapp/src/ts/modules/reports/reports-more-menu.component.ts
+++ b/webapp/src/ts/modules/reports/reports-more-menu.component.ts
@@ -32,9 +32,9 @@ export class ReportsMoreMenuComponent implements OnInit, OnDestroy {
   private hasEditVerifyPermission = false;
   private hasUpdatePermission = false;
   private selectMode = false;
-  private loadingContent: boolean;
+  private loadingContent?: boolean;
   private snapshotData: Data | undefined;
-  private isOnlineOnly: boolean;
+  private isOnlineOnly?: boolean;
   private dialogRef: MatDialogRef<any> | undefined;
   private bottomSheetRef: MatBottomSheetRef<any> | undefined;
 

--- a/webapp/src/ts/modules/reports/reports-sidebar-filter.component.ts
+++ b/webapp/src/ts/modules/reports/reports-sidebar-filter.component.ts
@@ -18,11 +18,11 @@ export class ReportsSidebarFilterComponent implements AfterViewInit, OnDestroy {
   @Output() search: EventEmitter<any> = new EventEmitter();
   @Input() disabled;
 
-  @ViewChild(FormTypeFilterComponent) formTypeFilter: FormTypeFilterComponent;
-  @ViewChild(FacilityFilterComponent) facilityFilter: FacilityFilterComponent;
-  @ViewChild('fromDate') fromDateFilter: DateFilterComponent;
-  @ViewChild('toDate') toDateFilter: DateFilterComponent;
-  @ViewChild(StatusFilterComponent) statusFilter: StatusFilterComponent;
+  @ViewChild(FormTypeFilterComponent) formTypeFilter!: FormTypeFilterComponent;
+  @ViewChild(FacilityFilterComponent) facilityFilter!: FacilityFilterComponent;
+  @ViewChild('fromDate') fromDateFilter!: DateFilterComponent;
+  @ViewChild('toDate') toDateFilter!: DateFilterComponent;
+  @ViewChild(StatusFilterComponent) statusFilter!: StatusFilterComponent;
 
   private globalActions;
   private filters: FilterComponent[] = [];

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -32,12 +32,12 @@ const CAN_DEFAULT_FACILITY_FILTER = 'can_default_facility_filter';
   templateUrl: './reports.component.html'
 })
 export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
-  @ViewChild(ReportsSidebarFilterComponent) reportsSidebarFilter: ReportsSidebarFilterComponent;
+  @ViewChild(ReportsSidebarFilterComponent) reportsSidebarFilter?: ReportsSidebarFilterComponent;
 
   private globalActions: GlobalActions;
   private reportsActions: ReportsActions;
   private listContains;
-  private destroyed: boolean;
+  private destroyed?: boolean;
   private isOnlineOnly = false;
   private canDefaultFilter = false;
   private trackInitialLoadPerformance;
@@ -47,22 +47,22 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   selectedReport;
   selectedReports;
   forms;
-  error: boolean;
-  errorSyntax: boolean;
+  error?: boolean;
+  errorSyntax?: boolean;
   loading = true;
   appending = false;
-  moreItems: boolean;
+  moreItems?: boolean;
   filters: Filter = {};
-  hasReports: boolean;
+  hasReports?: boolean;
   selectMode = false;
   selectModeAvailable = false;
-  showContent: boolean;
-  enketoEdited: boolean;
+  showContent?: boolean;
+  enketoEdited?: boolean;
   useSidebarFilter = true;
   isSidebarFilterOpen = false;
   isExporting = false;
   userParentPlace;
-  fastActionList: FastAction[];
+  fastActionList?: FastAction[];
 
   LIMIT_SELECT_ALL_REPORTS = 500;
 
@@ -354,7 +354,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   private doInitialSearch() {
     if (this.canDefaultFilter && this.userParentPlace?._id) {
       // The facility filter will trigger the search.
-      this.reportsSidebarFilter.setDefaultFacilityFilter({ facility: this.userParentPlace });
+      this.reportsSidebarFilter?.setDefaultFacilityFilter({ facility: this.userParentPlace });
       return;
     }
 

--- a/webapp/src/ts/services/android-app-launcher.service.ts
+++ b/webapp/src/ts/services/android-app-launcher.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class AndroidAppLauncherService {
-  private resolve: Function | null;
+  private resolve?: Function | null;
 
   constructor() { }
 

--- a/webapp/src/ts/services/browser-detector.service.ts
+++ b/webapp/src/ts/services/browser-detector.service.ts
@@ -12,7 +12,7 @@ type VersionNumber = 'SNAPSHOT' | `v${string}.${string}.${string}${VersionSuffix
   providedIn: 'root'
 })
 export class BrowserDetectorService {
-  private _parser: Bowser.Parser.Parser;
+  private _parser?: Bowser.Parser.Parser;
   private androidAppVersion: VersionNumber | undefined;
 
   public constructor(private store: Store) {

--- a/webapp/src/ts/services/create-user-for-contacts.service.ts
+++ b/webapp/src/ts/services/create-user-for-contacts.service.ts
@@ -9,7 +9,7 @@ import { UserContactService } from '@mm-services/user-contact.service';
   providedIn: 'root'
 })
 export class CreateUserForContactsService {
-  private currentUsername: string;
+  private currentUsername!: string;
 
   constructor(
     private settingsService: SettingsService,

--- a/webapp/src/ts/services/enketo.service.ts
+++ b/webapp/src/ts/services/enketo.service.ts
@@ -627,10 +627,10 @@ export class EnketoFormContext {
   selector: string;
   formDoc: Record<string, any>;
   type: string; // 'contact'|'report'|'task'|'training-card'
-  editing: boolean;
+  editing?: boolean;
   instanceData: null|string|Record<string, any>;
-  editedListener: () => void;
-  valuechangeListener: () => void;
+  editedListener?: () => void;
+  valuechangeListener?: () => void;
   titleKey?: string;
   isFormInModal?: boolean;
   userContact?: Record<string, any>;

--- a/webapp/src/ts/services/indexed-db.service.ts
+++ b/webapp/src/ts/services/indexed-db.service.ts
@@ -10,7 +10,7 @@ export class IndexedDbService {
   private readonly LOCAL_DOC = '_local/indexeddb-placeholder';
   private loadingLocalDoc: Promise<IndexedDBDoc> | undefined;
   private hasDatabasesFn: boolean;
-  private isUpdatingLocalDoc: boolean;
+  private isUpdatingLocalDoc?: boolean;
 
   constructor(
     private dbService: DbService,

--- a/webapp/src/ts/services/search-filters.service.ts
+++ b/webapp/src/ts/services/search-filters.service.ts
@@ -6,7 +6,7 @@ import { FreetextFilterComponent } from '@mm-components/filters/freetext-filter/
   providedIn: 'root'
 })
 export class SearchFiltersService {
-  freetextFilter:FreetextFilterComponent | null;
+  freetextFilter?: FreetextFilterComponent | null;
 
   constructor() {
   }

--- a/webapp/tsconfig.base.json
+++ b/webapp/tsconfig.base.json
@@ -32,7 +32,9 @@
     },
     "strictNullChecks": true,
     "alwaysStrict": true,
-    "noImplicitThis": true
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
# Description

Continuing to chip away at https://github.com/medic/cht-core/issues/8437 so we can get `strict` mode enabled on our TS in webapp!

We had no violations of `strictBindCallApply` so nothing had to change to apply this.

For `strictPropertyInitialization`, I had to make some changes to the type definitions for a number of fields. Basically, when you set a type on a field, TS wants that field to be _initialized_ (either immediately or in the constructor).  In our Angular code, some of these fields are initialized later in the Angular lifecycle (e.g. during the `ngOnInit`) or the field is actually only ever initialized in certain workflows and otherwise is `undefined`.  

So, in most cases, I have marked the field as possibly `undefined` by marking it with `?`.  Most of the time this had no down-stream effects (since the other code already protected against this case). In a few places, I had to add some [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) for extra protection.  

In a couple special cases, I had to use the [definite assignment assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#definite-assignment-assertions) (`!`) instead. This was because the code referencing the field was very dependent on that field not being `undefined` (to the point that it was clear from the structure of the existing code that the field always ended up being initialized before it was used). This is not the _safest_ thing to do from a typing perspective, but it seems like a reasonable compromise for existing code.

Most importantly, none of these changes should have any affect on the actual code at all!  These should all be type-space changes. They will affect the type that gets inferred, but should not change the JS code that ultimately gets transpiled...


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

