### PR TITLE
chore(#8788): move beforeeach to test for retry but also get debug info

### DIFF
--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -35,15 +35,8 @@ let contact;
 
 describe('Testing Incorrect locale', () => {
 
-  beforeEach(async () => {
+  beforeEach(() => {
     contact = createContact();
-    await loginPage.cookieLogin();
-    await utils.saveDoc(contact);
-    await sentinelUtils.waitForSentinel();
-    const waitForServiceWorker = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);
-    await createLanguage();
-    await waitForServiceWorker.promise;
-    await commonElements.closeReloadModal(true);
   });
 
   afterEach(async () => {
@@ -51,8 +44,16 @@ describe('Testing Incorrect locale', () => {
     await utils.revertSettings(true);
     await browser.setCookies({ name: 'locale', value: 'en' });
   });
-
+  
   it('should work with incorrect locale', async () => {
+    await loginPage.cookieLogin();
+    await utils.saveDoc(contact);
+    await sentinelUtils.waitForSentinel();
+    const waitForServiceWorker = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);
+    await createLanguage();
+    await waitForServiceWorker.promise;
+    await commonElements.closeReloadModal(true);
+
     await userSettingsElements.setLanguage(languageCode);
 
     const text = await commonElements.getReportsButtonLabel().getText();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->
#8788

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8788-put-beforeeach-in-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8788-put-beforeeach-in-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8788-put-beforeeach-in-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

