### PR TITLE
feat(#6543): add back breadcrumbs for users with many facilities

### DIFF
--- a/admin/tests/unit/services/update-user.spec.js
+++ b/admin/tests/unit/services/update-user.spec.js
@@ -82,7 +82,7 @@ describe('CreateUser service', () => {
         chai.expect($http.callCount).to.equal(1);
         chai.expect($http.args[0][0]).to.deep.equal({
           method: 'POST',
-          url: '/api/v2/users',
+          url: '/api/v3/users',
           data: {username: 'user', some: 'updates'},
           headers: {
             'Accept': 'application/json',

--- a/admin/tests/unit/services/update-user.spec.js
+++ b/admin/tests/unit/services/update-user.spec.js
@@ -82,7 +82,7 @@ describe('CreateUser service', () => {
         chai.expect($http.callCount).to.equal(1);
         chai.expect($http.args[0][0]).to.deep.equal({
           method: 'POST',
-          url: '/api/v3/users',
+          url: '/api/v2/users',
           data: {username: 'user', some: 'updates'},
           headers: {
             'Accept': 'application/json',

--- a/tests/e2e/default/reports/breadcrumbs.wdio-spec.js
+++ b/tests/e2e/default/reports/breadcrumbs.wdio-spec.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const uuid = require('uuid').v4;
 
 const utils = require('@utils');
 const commonElements = require('@page-objects/default/common/common.wdio.page');
@@ -12,66 +13,96 @@ const reportFactory = require('@factories/cht/reports/generic-report');
 describe('Reports tab breadcrumbs', () => {
   const places = placeFactory.generateHierarchy();
   const clinic = places.get('clinic');
-  const health_center = places.get('health_center');
-  const district_hospital = places.get('district_hospital');
-  const contact = {
+  const healthCenter1 = places.get('health_center');
+  const districtHospital = places.get('district_hospital');
+  const healthCenter2 = placeFactory.place().build({
+    name: 'health_center_2',
+    type: 'health_center',
+    parent: { _id: districtHospital._id },
+  });
+  const offlineUserContact = {
     _id: 'fixture:user:user1',
     name: 'OfflineUser',
     phone: '+12068881234',
-    place: health_center._id,
+    place: healthCenter1._id,
     type: 'person',
-    parent: {
-      _id: health_center._id,
-      parent: health_center.parent
-    },
+    parent: { _id: healthCenter1._id, parent: healthCenter1.parent },
   };
-  const contact2 = {
+  const onlineUserContact = {
     _id: 'fixture:user:user2',
     name: 'OnlineUser',
     phone: '+12068881235',
-    place: district_hospital._id,
+    place: districtHospital._id,
     type: 'person',
-    parent: {
-      _id: district_hospital._id,
-    },
+    parent: { _id: districtHospital._id },
   };
   const offlineUser = userFactory.build({
     username: 'offlineuser_breadcrumbs',
     isOffline: true,
-    place: health_center._id,
-    contact: contact._id,
+    place: healthCenter1._id,
+    contact: offlineUserContact._id,
   });
   const onlineUser = userFactory.build({
     username: 'onlineuser_breadcrumbs',
     roles: [ 'program_officer' ],
-    place: district_hospital._id,
-    contact: contact2._id,
+    place: districtHospital._id,
+    contact: onlineUserContact._id,
   });
   const patient = personFactory.build({
     _id: 'patient1',
-    parent: { _id: clinic._id, parent: { _id: health_center._id, parent: { _id: district_hospital._id }}}
+    parent: { _id: clinic._id, parent: { _id: healthCenter1._id, parent: { _id: districtHospital._id } } },
   });
+  const contactWithManyPlaces = personFactory.build({
+    parent: { _id: healthCenter1._id, parent: { _id: districtHospital._id } },
+  });
+  const userWithManyPlaces = {
+    _id: 'org.couchdb.user:offline_many_facilities',
+    language: 'en',
+    known: true,
+    type: 'user-settings',
+    roles: [ 'chw' ],
+    facility_id: [ healthCenter1._id, healthCenter2._id ],
+    contact_id: contactWithManyPlaces._id,
+    name: 'offline_many_facilities'
+  };
+  const userWithManyPlacesPass = uuid();
 
   const today = moment();
-  const reports = [
-    reportFactory
-      .report()
-      .build(
-        {
-          form: 'P',
-          reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf(),
-          patient_id: 'patient1',
-        },
-        {
-          patient,
-          submitter: offlineUser.contact,
-          fields: { lmp_date: 'Feb 3, 2022', patient_id: 'patient1' },
-        },
-      ),
-  ];
+  const report1 = reportFactory
+    .report()
+    .build(
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf(),
+        patient_id: 'patient1',
+      },
+      { patient, submitter: offlineUser.contact, fields: { lmp_date: 'Feb 3, 2022', patient_id: 'patient1' } },
+    );
+  const report2 = reportFactory
+    .report()
+    .build(
+      {
+        form: 'P',
+        reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf(),
+        patient_id: 'patient1',
+      },
+      {
+        patient,
+        submitter: userWithManyPlaces.contact_id,
+        fields: { lmp_date: 'Feb 3, 2022', patient_id: 'patient1' },
+      },
+    );
 
   before(async () => {
-    await utils.saveDocs([ ...places.values(), contact, contact2, patient, ...reports ]);
+    await utils.saveDocs([
+      ...places.values(), healthCenter2, offlineUserContact, onlineUserContact,
+      contactWithManyPlaces, userWithManyPlaces, patient, report1, report2,
+    ]);
+    await utils.request({
+      path: `/_users/${userWithManyPlaces._id}`,
+      method: 'PUT',
+      body: { ...userWithManyPlaces, password: userWithManyPlacesPass, type: 'user' },
+    });
     await utils.createUsers([ onlineUser, offlineUser ]);
   });
 
@@ -84,8 +115,21 @@ describe('Reports tab breadcrumbs', () => {
     await (await reportsPage.firstReport()).waitForDisplayed();
     await commonElements.waitForPageLoaded();
 
-    const reportLineages =  await reportsPage.reportsListDetails();
-    const expectedLineage = clinic.name.concat(health_center.name, district_hospital.name);
+    const reportLineages = await reportsPage.reportsListDetails();
+    const expectedLineage = clinic.name.concat(healthCenter1.name, districtHospital.name);
+
+    expect(reportLineages[0].lineage).to.equal(expectedLineage);
+  });
+
+  it('should not remove facility from breadcrumbs when offline user has many facilities associated', async () => {
+    await loginPage.login({ password: userWithManyPlacesPass, username: userWithManyPlaces.name });
+    await commonElements.waitForPageLoaded();
+    await commonElements.goToReports();
+    await (await reportsPage.firstReport()).waitForDisplayed();
+    await commonElements.waitForPageLoaded();
+
+    const reportLineages = await reportsPage.reportsListDetails();
+    const expectedLineage = clinic.name.concat(healthCenter1.name);
 
     expect(reportLineages[0].lineage).to.equal(expectedLineage);
   });
@@ -97,7 +141,7 @@ describe('Reports tab breadcrumbs', () => {
     await (await reportsPage.firstReport()).waitForDisplayed();
     await commonElements.waitForPageLoaded();
 
-    const reportLineages =  await reportsPage.reportsListDetails();
+    const reportLineages = await reportsPage.reportsListDetails();
     const expectedLineage = clinic.name;
 
     expect(reportLineages[0].lineage).to.equal(expectedLineage);

--- a/webapp/src/ts/modules/messages/messages.component.ts
+++ b/webapp/src/ts/modules/messages/messages.component.ts
@@ -184,7 +184,10 @@ export class MessagesComponent implements OnInit, OnDestroy {
       .all([ this.messageContactService.getList(), this.userLineageLevel ])
       .then(([ conversations, userLineageLevel ]) => {
         conversations?.forEach(conversation => {
-          conversation.lineage = this.extractLineageService.removeUserFacility(conversation.lineage, userLineageLevel);
+          const lineage = this.extractLineageService.removeUserFacility(conversation.lineage, userLineageLevel);
+          if (lineage) {
+            conversation.lineage = lineage;
+          }
         });
         this.setConversations(conversations, { merge });
         this.loading = false;

--- a/webapp/src/ts/modules/messages/messages.component.ts
+++ b/webapp/src/ts/modules/messages/messages.component.ts
@@ -13,10 +13,9 @@ import { ExportService } from '@mm-services/export.service';
 import { ModalService } from '@mm-services/modal.service';
 import { SendMessageComponent } from '@mm-modals/send-message/send-message.component';
 import { ResponsiveService } from '@mm-services/responsive.service';
-import { UserContactService } from '@mm-services/user-contact.service';
-import { AuthService } from '@mm-services/auth.service';
 import { FastAction, FastActionButtonService } from '@mm-services/fast-action-button.service';
 import { PerformanceService } from '@mm-services/performance.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 @Component({
   templateUrl: './messages.component.html'
@@ -33,7 +32,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
   conversations: Record<string, any>[] = [];
   error = false;
   trackPerformance;
-  currentLevel;
+  userLineageLevel;
 
   constructor(
     private router: Router,
@@ -44,9 +43,8 @@ export class MessagesComponent implements OnInit, OnDestroy {
     private exportService: ExportService,
     private modalService: ModalService,
     private responsiveService: ResponsiveService,
-    private userContactService: UserContactService,
-    private authService: AuthService,
-    private performanceService: PerformanceService
+    private performanceService: PerformanceService,
+    private extractLineageService: ExtractLineageService,
   ) {
     this.globalActions = new GlobalActions(store);
     this.messagesActions = new MessagesActions(store);
@@ -54,10 +52,8 @@ export class MessagesComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.trackPerformance = this.performanceService.track();
+    this.userLineageLevel = this.extractLineageService.getUserLineageToRemove();
     this.subscribeToStore();
-
-    this.currentLevel = this.authService.online(true) ? Promise.resolve() : this.getCurrentLineageLevel();
-
     this.updateConversations().then(() => this.displayFirstConversation(this.conversations));
     this.watchForChanges();
   }
@@ -185,20 +181,11 @@ export class MessagesComponent implements OnInit, OnDestroy {
 
   updateConversations({ merge = false } = {}) {
     return Promise
-      .all([ this.messageContactService.getList(), this.currentLevel ])
-      .then(([ conversations, currentLevel ]) => {
-        // Remove the lineage level that belongs to the offline logged-in user.
-        if (currentLevel) {
-          conversations?.forEach(conversation => {
-            if (!conversation.lineage?.length) {
-              return;
-            }
-            conversation.lineage = conversation.lineage.filter(level => level);
-            if (conversation.lineage[conversation.lineage.length -1] === currentLevel){
-              conversation.lineage.pop();
-            }
-          });
-        }
+      .all([ this.messageContactService.getList(), this.userLineageLevel ])
+      .then(([ conversations, userLineageLevel ]) => {
+        conversations?.forEach(conversation => {
+          conversation.lineage = this.extractLineageService.removeUserFacility(conversation.lineage, userLineageLevel);
+        });
         this.setConversations(conversations, { merge });
         this.loading = false;
       });
@@ -236,10 +223,6 @@ export class MessagesComponent implements OnInit, OnDestroy {
   listTrackBy(index, message) {
     const identifier = message.doc ? message.doc.id + message.doc._rev : message.id;
     return message.key + identifier;
-  }
-
-  private getCurrentLineageLevel() {
-    return this.userContactService.get().then(user => user?.parent?.name);
   }
 
   exportMessages() {

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -64,6 +64,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   isExporting = false;
   userParentPlace;
   fastActionList?: FastAction[];
+  userLineageLevel;
 
   LIMIT_SELECT_ALL_REPORTS = 500;
 

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -110,7 +110,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
     this.userLineageLevel = await this.extractLineageService.getUserLineageToRemove();
     await this.checkPermissions();
     this.subscribeSidebarFilter();
-    await this.doInitialSearch();
+    this.doInitialSearch();
   }
 
   ngOnDestroy() {
@@ -253,7 +253,9 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
       report.heading = this.getReportHeading(form, report);
       report.lineage = report.subject && report.subject.lineage || report.lineage;
       report.unread = !report.read;
-      report.lineage = this.extractLineageService.removeUserFacility(report.lineage, this.userLineageLevel);
+      if (Array.isArray(report.lineage)) {
+        report.lineage = this.extractLineageService.removeUserFacility(report.lineage, this.userLineageLevel);
+      }
 
       return report;
     });
@@ -346,7 +348,11 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private async doInitialSearch() {
-    const userParentPlace = this.canDefaultFilter && await this.getUserParentPlace();
+    let userParentPlace;
+    if (this.canDefaultFilter) {
+      userParentPlace = await this.getUserParentPlace();
+    }
+
     if (userParentPlace?._id) {
       // The facility filter will trigger the search.
       this.reportsSidebarFilter?.setDefaultFacilityFilter({ facility: this.userParentPlace });
@@ -465,8 +471,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
         this.filters,
         { limit: this.LIMIT_SELECT_ALL_REPORTS, hydrateContactNames: true }
       );
-
-      const preparedReports = await this.prepareReports(reports, true);
+      const preparedReports = this.prepareReports(reports, true);
       this.reportsActions.setSelectedReports(preparedReports);
       this.globalActions.unsetComponents();
 

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -350,12 +350,11 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private async doInitialSearch() {
-    let userParentPlace;
     if (this.canDefaultFilter) {
-      userParentPlace = await this.getUserParentPlace();
+      this.userParentPlace = await this.getUserParentPlace();
     }
 
-    if (userParentPlace?._id) {
+    if (this.userParentPlace?._id) {
       // The facility filter will trigger the search.
       this.reportsSidebarFilter?.setDefaultFacilityFilter({ facility: this.userParentPlace });
       return;

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -107,7 +107,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   async ngAfterViewInit() {
-    this.userLineageLevel = await this.extractLineageService.getUserLineageToRemove();
+    this.userLineageLevel = this.extractLineageService.getUserLineageToRemove();
     await this.checkPermissions();
     this.subscribeSidebarFilter();
     this.doInitialSearch();
@@ -243,7 +243,8 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.translateService.instant('report.subject.unknown');
   }
 
-  private prepareReports(reports, isContent=false) {
+  private async prepareReports(reports, isContent=false) {
+    const userLineageLevel = await this.userLineageLevel;
     return reports.map(report => {
       const form = _find(this.forms, { code: report.form });
       const subTitle = form ? form.title : report.form;
@@ -254,7 +255,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
       report.lineage = report.subject && report.subject.lineage || report.lineage;
       report.unread = !report.read;
       if (Array.isArray(report.lineage)) {
-        report.lineage = this.extractLineageService.removeUserFacility(report.lineage, this.userLineageLevel);
+        report.lineage = this.extractLineageService.removeUserFacility(report.lineage, userLineageLevel);
       }
 
       return report;
@@ -471,7 +472,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
         this.filters,
         { limit: this.LIMIT_SELECT_ALL_REPORTS, hydrateContactNames: true }
       );
-      const preparedReports = this.prepareReports(reports, true);
+      const preparedReports = await this.prepareReports(reports, true);
       this.reportsActions.setSelectedReports(preparedReports);
       this.globalActions.unsetComponents();
 

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -24,6 +24,7 @@ import { ModalService } from '@mm-services/modal.service';
 import { FastAction, FastActionButtonService } from '@mm-services/fast-action-button.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
 import { PerformanceService } from '@mm-services/performance.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 const PAGE_SIZE = 50;
 const CAN_DEFAULT_FACILITY_FILTER = 'can_default_facility_filter';
@@ -85,6 +86,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
     private fastActionButtonService:FastActionButtonService,
     private xmlFormsService:XmlFormsService,
     private performanceService: PerformanceService,
+    private extractLineageService: ExtractLineageService,
   ) {
     this.globalActions = new GlobalActions(store);
     this.reportsActions = new ReportsActions(store);
@@ -105,10 +107,10 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   async ngAfterViewInit() {
-    this.userParentPlace = await this.getUserParentPlace();
+    this.userLineageLevel = await this.extractLineageService.getUserLineageToRemove();
     await this.checkPermissions();
     this.subscribeSidebarFilter();
-    this.doInitialSearch();
+    await this.doInitialSearch();
   }
 
   ngOnDestroy() {
@@ -251,15 +253,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
       report.heading = this.getReportHeading(form, report);
       report.lineage = report.subject && report.subject.lineage || report.lineage;
       report.unread = !report.read;
-
-      // Remove the lineage level that belongs to the offline logged-in user
-      if (!this.isOnlineOnly && this.userParentPlace?.name && report?.lineage?.length) {
-        report.lineage = report.lineage.filter(level => level);
-        const item = report.lineage[report.lineage.length -1];
-        if (item === this.userParentPlace.name) {
-          report.lineage.pop();
-        }
-      }
+      report.lineage = this.extractLineageService.removeUserFacility(report.lineage, this.userLineageLevel);
 
       return report;
     });
@@ -351,8 +345,9 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  private doInitialSearch() {
-    if (this.canDefaultFilter && this.userParentPlace?._id) {
+  private async doInitialSearch() {
+    const userParentPlace = this.canDefaultFilter && await this.getUserParentPlace();
+    if (userParentPlace?._id) {
       // The facility filter will trigger the search.
       this.reportsSidebarFilter?.setDefaultFacilityFilter({ facility: this.userParentPlace });
       return;

--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -10,9 +10,8 @@ import { TasksActions } from '@mm-actions/tasks';
 import { Selectors } from '@mm-selectors/index';
 import { GlobalActions } from '@mm-actions/global';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
-import { UserContactService } from '@mm-services/user-contact.service';
-import { SessionService } from '@mm-services/session.service';
 import { PerformanceService } from '@mm-services/performance.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 @Component({
   templateUrl: './tasks.component.html',
@@ -25,8 +24,7 @@ export class TasksComponent implements OnInit, OnDestroy {
     private rulesEngineService: RulesEngineService,
     private performanceService: PerformanceService,
     private lineageModelGeneratorService: LineageModelGeneratorService,
-    private userContactService: UserContactService,
-    private sessionService: SessionService,
+    private extractLineageService: ExtractLineageService,
   ) {
     this.tasksActions = new TasksActions(store);
     this.globalActions = new GlobalActions(store);
@@ -43,7 +41,7 @@ export class TasksComponent implements OnInit, OnDestroy {
   hasTasks;
   loading;
   tasksDisabled;
-  currentLevel;
+  userLineageLevel;
 
   private tasksLoaded;
   private debouncedReload;
@@ -102,8 +100,7 @@ export class TasksComponent implements OnInit, OnDestroy {
     this.hasTasks = false;
     this.loading = true;
     this.debouncedReload = _debounce(this.refreshTasks.bind(this), 1000, { maxWait: 10 * 1000 });
-
-    this.currentLevel = this.sessionService.isOnlineOnly() ? Promise.resolve() : this.getCurrentLineageLevel();
+    this.userLineageLevel = this.extractLineageService.getUserLineageToRemove();
     this.refreshTasks();
   }
 
@@ -126,9 +123,17 @@ export class TasksComponent implements OnInit, OnDestroy {
       this.tasksDisabled = !(await this.rulesEngineService.isEnabled());
       const taskDocs = this.tasksDisabled ? [] : await this.rulesEngineService.fetchTaskDocsForAllContacts() || [];
       this.hasTasks = taskDocs.length > 0;
-      const userLineageLevel = await this.currentLevel;
-      const taskEmissions = await this.getTasksWithLineage(taskDocs, userLineageLevel);
-      this.tasksActions.setTasksList(taskEmissions);
+
+      const hydratedTasks = await this.hydrateEmissions(taskDocs) || [];
+      const subjects = await this.getLineagesFromTaskDocs(hydratedTasks);
+      if (subjects?.size) {
+        const userLineageLevel = await this.userLineageLevel;
+        hydratedTasks.forEach(task => {
+          task.lineage = this.getTaskLineage(subjects, task, userLineageLevel);
+        });
+      }
+
+      this.tasksActions.setTasksList(hydratedTasks);
 
     } catch (exception) {
       console.error('Error getting tasks for all contacts', exception);
@@ -152,42 +157,17 @@ export class TasksComponent implements OnInit, OnDestroy {
     return task?._id;
   }
 
-  private getCurrentLineageLevel() {
-    return this.userContactService.get().then(user => user?.parent?.name);
+  private getLineagesFromTaskDocs(taskDocs) {
+    const ids = [ ...new Set(taskDocs.map(task => task.owner)) ];
+    return this.lineageModelGeneratorService
+      .reportSubjects(ids)
+      .then(subjects => new Map(subjects.map(subject => [subject._id, subject.lineage])));
   }
 
-  private async getTasksWithLineage(taskDocs, userLineageLevel) {
-    const ownerIds = [ ...new Set(taskDocs.map(task => task.owner)) ];
-    const subjects = await this.lineageModelGeneratorService.reportSubjects(ownerIds);
-    const subjectLineageMap = new Map();
-    subjects.forEach(subject => {
-      const taskLineage = subject.lineage
-        ?.filter(level => level?.name)
-        .map(level => level.name);
-
-      if (taskLineage?.length) {
-        subjectLineageMap.set(subject._id, taskLineage);
-      }
-    });
-
-    return taskDocs.map(task => {
-      return {
-        ...task.emission,
-        lineage: this.removeCurrentLineage(subjectLineageMap.get(task.owner), userLineageLevel),
-      };
-    });
-  }
-
-  private removeCurrentLineage(taskLineage, userLineageLevel) {
-    if (!taskLineage?.length) {
-      return;
-    }
-
-    const lastLevel = taskLineage[taskLineage.length - 1];
-    if (lastLevel === userLineageLevel) {
-      taskLineage.pop();
-    }
-
-    return taskLineage;
+  private getTaskLineage(subjects, task, userLineageLevel) {
+    const lineage = subjects
+      .get(task.owner)
+      ?.map(lineage => lineage?.name);
+    return this.extractLineageService.removeUserFacility(lineage, userLineageLevel);
   }
 }

--- a/webapp/src/ts/services/extract-lineage.service.ts
+++ b/webapp/src/ts/services/extract-lineage.service.ts
@@ -1,11 +1,19 @@
 import { Injectable } from '@angular/core';
 
+import { UserSettingsService } from '@mm-services/user-settings.service';
+import { UserContactService } from '@mm-services/user-contact.service';
+import { AuthService } from '@mm-services/auth.service';
+
 @Injectable({
   providedIn: 'root'
 })
 export class ExtractLineageService {
 
-  constructor() { }
+  constructor(
+    private userSettingsService: UserSettingsService,
+    private userContactService: UserContactService,
+    private authService: AuthService,
+  ) { }
 
   extract(contact) {
     if (!contact) {
@@ -22,5 +30,37 @@ export class ExtractLineageService {
     }
 
     return result;
+  }
+
+  async getUserLineageToRemove(): Promise<string | undefined> {
+    if (this.authService.online(true)) {
+      return;
+    }
+
+    const { facility_id }:any = await this.userSettingsService.get();
+    console.warn('facility_id', facility_id);
+    if (!facility_id || Array.isArray(facility_id)) {
+      return;
+    }
+
+    const user = await this.userContactService.get();
+    return user?.parent?.name;
+  }
+
+  removeUserFacility(lineage: string[], userLineageLevel: string): string[] | undefined {
+    if (!lineage?.length) {
+      return;
+    }
+
+    lineage = lineage.filter(level => level);
+    if (!userLineageLevel) {
+      return lineage;
+    }
+
+    if (lineage[lineage.length - 1] === userLineageLevel) {
+      lineage.pop();
+    }
+
+    return lineage;
   }
 }

--- a/webapp/src/ts/services/extract-lineage.service.ts
+++ b/webapp/src/ts/services/extract-lineage.service.ts
@@ -38,8 +38,7 @@ export class ExtractLineageService {
     }
 
     const { facility_id }:any = await this.userSettingsService.get();
-    console.warn('facility_id', facility_id);
-    if (!facility_id || Array.isArray(facility_id)) {
+    if (!facility_id || (Array.isArray(facility_id) && facility_id.length > 1)) {
       return;
     }
 

--- a/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
@@ -940,7 +940,7 @@ describe('Reports Component', () => {
 
       flush();
 
-      expect(setSelectMode.calledOnce).to.be.true;
+      expect(setSelectMode.callCount).to.equal(1);
       expect(setSelectMode.args).to.deep.equal([[true]]);
       expect(unsetComponents.calledOnce).to.be.true;
       expect(router.navigate.calledOnce).to.be.true;

--- a/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
@@ -940,10 +940,10 @@ describe('Reports Component', () => {
 
       flush();
 
-      expect(setSelectMode.calledTwice).to.be.true;
-      expect(setSelectMode.args).to.deep.equal([[true], [true]]);
-      expect(unsetComponents.calledTwice).to.be.true;
-      expect(router.navigate.calledTwice).to.be.true;
+      expect(setSelectMode.calledOnce).to.be.true;
+      expect(setSelectMode.args).to.deep.equal([[true]]);
+      expect(unsetComponents.calledOnce).to.be.true;
+      expect(router.navigate.calledOnce).to.be.true;
       expect(router.navigate.args[0]).to.deep.equal([['/reports']]);
     }));
 

--- a/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
@@ -301,7 +301,7 @@ describe('Reports Component', () => {
       await component.ngAfterViewInit();
       flush();
 
-      expect(setDefaultFacilityFilter.callCount).to.equal(1);
+      expect(setDefaultFacilityFilter.calledOnce).to.be.true;
       expect(setDefaultFacilityFilter.args[0][0]).to.deep.equal({
         facility: { _id: 'parent', name: 'parent', parent: { _id: 'grandparent' } }
       });
@@ -856,7 +856,6 @@ describe('Reports Component', () => {
       component.ngAfterViewInit();
       flush();
 
-      expect(component.userLineageLevel).to.be.undefined;
       expect(updateReportsListStub.calledOnce).to.be.true;
       expect(updateReportsListStub.args[0]).to.deep.equal([ expectedReports ]);
     }));
@@ -924,7 +923,6 @@ describe('Reports Component', () => {
       component.ngAfterViewInit();
       flush();
 
-      expect(component.userLineageLevel).to.equal('CHW Bettys Area');
       expect(updateReportsListStub.calledOnce).to.be.true;
       expect(updateReportsListStub.args[0]).to.deep.equal([ expectedReports ]);
     }));

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -14,9 +14,8 @@ import { TasksComponent } from '@mm-modules/tasks/tasks.component';
 import { NavigationComponent } from '@mm-components/navigation/navigation.component';
 import { Selectors } from '@mm-selectors/index';
 import { NavigationService } from '@mm-services/navigation.service';
-import { UserContactService } from '@mm-services/user-contact.service';
-import { SessionService } from '@mm-services/session.service';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 describe('TasksComponent', () => {
   let getComponent;
@@ -25,21 +24,13 @@ describe('TasksComponent', () => {
   let performanceService;
   let stopPerformanceTrackStub;
   let contactTypesService;
+  let extractLineageService;
+  let clock;
   let store;
-  let sessionService;
-  let userContactService;
   let lineageModelGeneratorService;
 
   let component: TasksComponent;
   let fixture: ComponentFixture<TasksComponent>;
-
-  const userContactDoc = {
-    _id: 'user',
-    parent: {
-      _id: 'parent',
-      name: 'parent',
-    },
-  };
 
   beforeEach(async () => {
     changesService = { subscribe: sinon.stub().returns({ unsubscribe: sinon.stub() }) };
@@ -53,14 +44,11 @@ describe('TasksComponent', () => {
     contactTypesService = {
       includes: sinon.stub(),
     };
-    sessionService = {
-      isOnlineOnly: sinon.stub().returns(false),
-      userCtx: sinon.stub()
-    };
-    userContactService = {
-      get: sinon.stub().resolves(),
-    };
     lineageModelGeneratorService = { reportSubjects: sinon.stub().resolves([]) };
+    extractLineageService = {
+      getUserLineageToRemove: sinon.stub(),
+      removeUserFacility: ExtractLineageService.prototype.removeUserFacility,
+    };
 
     TestBed.configureTestingModule({
       imports: [
@@ -74,8 +62,7 @@ describe('TasksComponent', () => {
         { provide: PerformanceService, useValue: performanceService },
         { provide: ContactTypesService, useValue: contactTypesService },
         { provide: NavigationService, useValue: {} },
-        { provide: SessionService, useValue: sessionService },
-        { provide: UserContactService, useValue: userContactService },
+        { provide: ExtractLineageService, useValue: extractLineageService },
         { provide: LineageModelGeneratorService, useValue: lineageModelGeneratorService },
       ],
       declarations: [
@@ -322,39 +309,6 @@ describe('TasksComponent', () => {
   });
 
   describe('lineage and breadcrumbs', () => {
-    const bettysContactDoc = {
-      _id: 'user',
-      parent: {
-        _id: 'parent',
-        name: 'CHW Bettys Area',
-      },
-    };
-    const taskDocs = [
-      {
-        _id: '1',
-        forId: 'a',
-        owner: 'a',
-        emission: {
-          _id: 'e1',
-          dueDate: '2020-10-20',
-          date: new Date('2020-10-20T17:00:00.000Z'),
-          overdue: true,
-          owner: 'a',
-        },
-      },
-      {
-        _id: '2',
-        forId: 'b',
-        owner: 'b',
-        emission: {
-          _id: 'e2',
-          dueDate: '2020-10-20',
-          date: new Date('2020-10-20T17:00:00.000Z'),
-          overdue: true,
-          owner: 'b',
-        },
-      },
-    ];
     const taskLineages = [
       {
         _id: 'a',
@@ -377,8 +331,12 @@ describe('TasksComponent', () => {
         ],
       },
     ];
+    const taskDocs = [
+      { _id: '1', emission: { _id: 'e1', dueDate: '2020-10-20' }, forId: 'a', owner: 'a' },
+      { _id: '2', emission: { _id: 'e2', dueDate: '2020-10-20' }, forId: 'b', owner: 'b' },
+    ];
 
-    it('should not alter tasks lineage if user is online only', async () => {
+    it('should not remove the lineage when user lineage level is undefined', async () => {
       const expectedTasks = [
         {
           _id: 'e1',
@@ -397,8 +355,7 @@ describe('TasksComponent', () => {
           owner: 'b',
         },
       ];
-      userContactService.get.resolves(bettysContactDoc);
-      sessionService.isOnlineOnly.returns(true);
+      extractLineageService.getUserLineageToRemove.resolves(undefined);
       rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
       lineageModelGeneratorService.reportSubjects.resolves(taskLineages);
 
@@ -407,44 +364,11 @@ describe('TasksComponent', () => {
         getComponent();
       });
 
-      expect(await component.currentLevel).to.be.undefined;
+      expect(await component.userLineageLevel).to.be.undefined;
       expect((<any>TasksActions.prototype.setTasksList).args).to.deep.equal([[expectedTasks]]);
     });
 
-    it('should not change the tasks lineage if user is offline with unrelated lineage', async () => {
-      const expectedTasks = [
-        {
-          _id: 'e1',
-          date: new Date('2020-10-20T17:00:00.000Z'),
-          dueDate: '2020-10-20',
-          lineage: [ 'Amy Johnsons Household', 'St Elmos Concession', 'Chattanooga Village', 'CHW Bettys Area' ],
-          overdue: true,
-          owner: 'a',
-        },
-        {
-          _id: 'e2',
-          dueDate: '2020-10-20',
-          date: new Date('2020-10-20T17:00:00.000Z'),
-          lineage: [ 'Amy Johnsons Household', 'St Elmos Concession', 'Chattanooga Village' ],
-          overdue: true,
-          owner: 'b',
-        },
-      ];
-      userContactService.get.resolves(userContactDoc);
-      sessionService.isOnlineOnly.returns(false);
-      rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
-      lineageModelGeneratorService.reportSubjects.resolves(taskLineages);
-
-      await new Promise(resolve => {
-        sinon.stub(TasksActions.prototype, 'setTasksList').callsFake(resolve);
-        getComponent();
-      });
-
-      expect(await component.currentLevel).to.equal('parent');
-      expect((<any>TasksActions.prototype.setTasksList).args).to.deep.equal([[expectedTasks]]);
-    });
-
-    it('should update the tasks lineage if user is offline with related place to lineage', async () => {
+    it('should remove lineage when user lineage level is defined', async () => {
       const expectedTasks = [
         {
           _id: 'e1',
@@ -463,8 +387,7 @@ describe('TasksComponent', () => {
           owner: 'b',
         },
       ];
-      userContactService.get.resolves(bettysContactDoc);
-      sessionService.isOnlineOnly.returns(false);
+      extractLineageService.getUserLineageToRemove.resolves('CHW Bettys Area');
       rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
       lineageModelGeneratorService.reportSubjects.resolves(taskLineages);
 
@@ -473,7 +396,7 @@ describe('TasksComponent', () => {
         getComponent();
       });
 
-      expect(await component.currentLevel).to.equal('CHW Bettys Area');
+      expect(await component.userLineageLevel).to.equal('CHW Bettys Area');
       expect((<any>TasksActions.prototype.setTasksList).args).to.deep.equal([[expectedTasks]]);
     });
   });

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -3,6 +3,7 @@ import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { expect } from 'chai';
+import * as moment from 'moment';
 import sinon from 'sinon';
 
 import { ChangesService } from '@mm-services/changes.service';
@@ -84,6 +85,7 @@ describe('TasksComponent', () => {
   afterEach(() => {
     store.resetSelectors();
     sinon.restore();
+    clock?.restore();
   });
 
   it('should ngOnDestroy should unsubscribe and clear state', async () => {
@@ -147,54 +149,32 @@ describe('TasksComponent', () => {
   });
 
   it('tasks render', async () => {
+    const now = moment('2020-10-20');
+    const futureDate = now.clone().add(3, 'days');
+    const pastDate = now.clone().subtract(3, 'days');
+    clock = sinon.useFakeTimers(now.valueOf());
     const taskDocs = [
-      {
-        _id: '1',
-        owner: 'a',
-        emission: {
-          _id: 'e1',
-          dueDate: '2030-10-24',
-          date: new Date('2023-10-24T17:00:00.000Z'),
-          overdue: false,
-          owner: 'a',
-        },
-      },
-      {
-        _id: '2',
-        owner: 'b',
-        emission: {
-          _id: 'e2',
-          dueDate: '2023-10-24',
-          date: new Date('2023-10-24T17:00:00.000Z'),
-          overdue: true,
-          owner: 'b',
-        },
-      },
+      { _id: '1', emission: { _id: 'e1', dueDate: futureDate.format('YYYY-MM-DD') }, owner: 'a' },
+      { _id: '2', emission: { _id: 'e2', dueDate: pastDate.format('YYYY-MM-DD') }, owner: 'b' },
     ];
     const expectedTasks = [
       {
         _id: 'e1',
-        dueDate: '2030-10-24',
-        date: new Date('2023-10-24T17:00:00.000Z'),
+        dueDate: futureDate.format('YYYY-MM-DD'),
         overdue: false,
+        date: new Date(futureDate.valueOf()),
         owner: 'a',
-        lineage: [ 'lineage-a' ]
       },
       {
         _id: 'e2',
-        dueDate: '2023-10-24',
-        date: new Date('2023-10-24T17:00:00.000Z'),
+        dueDate: pastDate.format('YYYY-MM-DD'),
         overdue: true,
+        date: new Date(pastDate.valueOf()),
         owner: 'b',
-        lineage: [ 'lineage-b' ]
       },
     ];
-    rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
-    lineageModelGeneratorService.reportSubjects.resolves([
-      { _id: 'a', lineage: [ { name: 'lineage-a' } ] },
-      { _id: 'b', lineage: [ { name: 'lineage-b' } ] },
-    ]);
 
+    rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
     await new Promise(resolve => {
       sinon.stub(TasksActions.prototype, 'setTasksList').callsFake(resolve);
       getComponent();
@@ -340,7 +320,7 @@ describe('TasksComponent', () => {
       const expectedTasks = [
         {
           _id: 'e1',
-          date: new Date('2020-10-20T17:00:00.000Z'),
+          date: moment('2020-10-20').toDate(),
           dueDate: '2020-10-20',
           lineage: [ 'Amy Johnsons Household', 'St Elmos Concession', 'Chattanooga Village', 'CHW Bettys Area' ],
           overdue: true,
@@ -348,8 +328,8 @@ describe('TasksComponent', () => {
         },
         {
           _id: 'e2',
+          date: moment('2020-10-20').toDate(),
           dueDate: '2020-10-20',
-          date: new Date('2020-10-20T17:00:00.000Z'),
           lineage: [ 'Amy Johnsons Household', 'St Elmos Concession', 'Chattanooga Village' ],
           overdue: true,
           owner: 'b',
@@ -372,7 +352,7 @@ describe('TasksComponent', () => {
       const expectedTasks = [
         {
           _id: 'e1',
-          date: new Date('2020-10-20T17:00:00.000Z'),
+          date: moment('2020-10-20').toDate(),
           dueDate: '2020-10-20',
           lineage: [ 'Amy Johnsons Household', 'St Elmos Concession', 'Chattanooga Village' ],
           overdue: true,
@@ -380,8 +360,8 @@ describe('TasksComponent', () => {
         },
         {
           _id: 'e2',
+          date: moment('2020-10-20').toDate(),
           dueDate: '2020-10-20',
-          date: new Date('2020-10-20T17:00:00.000Z'),
           lineage: [ 'Amy Johnsons Household', 'St Elmos Concession', 'Chattanooga Village' ],
           overdue: true,
           owner: 'b',

--- a/webapp/tests/karma/ts/services/delete-docs.service.spec.ts
+++ b/webapp/tests/karma/ts/services/delete-docs.service.spec.ts
@@ -6,6 +6,7 @@ import { DbService } from '@mm-services/db.service';
 import { SessionService } from '@mm-services/session.service';
 import { ChangesService } from '@mm-services/changes.service';
 import { DeleteDocsService } from '@mm-services/delete-docs.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 describe('DeleteDocs service', () => {
 
@@ -14,6 +15,7 @@ describe('DeleteDocs service', () => {
   let bulkDocs;
   let isOnlineOnly;
   let server;
+  let extractLineageService;
 
   beforeEach(() => {
     get = sinon.stub();
@@ -21,12 +23,14 @@ describe('DeleteDocs service', () => {
     isOnlineOnly = sinon.stub().returns(false);
     const Changes = () => undefined;
     Changes.killWatchers = () => undefined;
+    extractLineageService = { extract: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: DbService, useValue: { get: () => ({ bulkDocs, get }) } },
         { provide: SessionService, useValue: { isOnlineOnly } },
         { provide: ChangesService, useValue: Changes },
+        { provide: ExtractLineageService, useValue: extractLineageService },
       ]
     });
     service = TestBed.inject(DeleteDocsService);

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -10,6 +10,7 @@ import { EnketoPrepopulationDataService } from '@mm-services/enketo-prepopulatio
 import { AttachmentService } from '@mm-services/attachment.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 describe('Enketo service', () => {
   // return a mock form ready for putting in #dbContent
@@ -39,6 +40,7 @@ describe('Enketo service', () => {
   let EnketoForm;
   let EnketoPrepopulationData;
   let translateService;
+  let extractLineageService;
 
   beforeEach(() => {
     enketoInit = sinon.stub();
@@ -73,6 +75,7 @@ describe('Enketo service', () => {
       instant: sinon.stub().returnsArg(0),
       get: sinon.stub(),
     };
+    extractLineageService = { extract: ExtractLineageService.prototype.extract };
 
     TestBed.configureTestingModule({
       providers: [
@@ -87,6 +90,7 @@ describe('Enketo service', () => {
         { provide: EnketoPrepopulationDataService, useValue: { get: EnketoPrepopulationData } },
         { provide: AttachmentService, useValue: { add: AddAttachment, remove: removeAttachment } },
         { provide: TranslateService, useValue: translateService },
+        { provide: ExtractLineageService, useValue: extractLineageService },
       ],
     });
 

--- a/webapp/tests/karma/ts/services/extract-lineage.service.spec.ts
+++ b/webapp/tests/karma/ts/services/extract-lineage.service.spec.ts
@@ -1,62 +1,156 @@
 import { TestBed } from '@angular/core/testing';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
+import { UserSettingsService } from '@mm-services/user-settings.service';
+import { UserContactService } from '@mm-services/user-contact.service';
+import { AuthService } from '@mm-services/auth.service';
 
 describe('ExtractLineageService', () => {
   let service: ExtractLineageService;
+  let userSettingsService;
+  let userContactService;
+  let authService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    userSettingsService = { get: sinon.stub() };
+    userContactService = { get: sinon.stub() };
+    authService = { online: sinon.stub() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserContactService, useValue: userContactService },
+        { provide: UserSettingsService, useValue: userSettingsService },
+        { provide: AuthService, useValue: authService },
+      ]
+    });
     service = TestBed.inject(ExtractLineageService);
   });
+
+  afterEach(() => sinon.restore());
 
   it('should be created', () => {
     expect(service).to.exist;
   });
 
-  it('returns nothing when given nothing', () => {
-    expect(service.extract(null)).to.equal(null);
-  });
+  describe('extract()', () => {
+    it('returns nothing when given nothing', () => {
+      expect(service.extract(null)).to.equal(null);
+    });
 
-  it('extracts orphan', () => {
-    const contact = { _id: 'a', name: 'jim' };
-    const expected = { _id: 'a' };
+    it('extracts orphan', () => {
+      const contact = { _id: 'a', name: 'jim' };
+      const expected = { _id: 'a' };
 
-    expect(service.extract(contact)).to.deep.equal(expected);
-  });
+      expect(service.extract(contact)).to.deep.equal(expected);
+    });
 
-  it('extracts lineage', () => {
-    const contact = {
-      _id: 'a',
-      name: 'jim',
-      parent: {
-        _id: 'b',
-        age: 55,
+    it('extracts lineage', () => {
+      const contact = {
+        _id: 'a',
+        name: 'jim',
         parent: {
-          _id: 'c',
-          sex: true,
+          _id: 'b',
+          age: 55,
           parent: {
-            _id: 'd'
+            _id: 'c',
+            sex: true,
+            parent: {
+              _id: 'd'
+            }
           }
         }
-      }
-    };
-    const expected = {
-      _id: 'a',
-      parent: {
-        _id: 'b',
+      };
+      const expected = {
+        _id: 'a',
         parent: {
-          _id: 'c',
+          _id: 'b',
           parent: {
-            _id: 'd'
+            _id: 'c',
+            parent: {
+              _id: 'd'
+            }
           }
         }
-      }
-    };
+      };
 
-    expect(service.extract(contact)).to.deep.equal(expected);
-    // ensure the original contact is unchanged
-    expect(contact.parent.age).to.equal(55);
+      expect(service.extract(contact)).to.deep.equal(expected);
+      // ensure the original contact is unchanged
+      expect(contact.parent.age).to.equal(55);
+    });
+  });
+
+  describe('getUserLineageToRemove()', () => {
+    it('should return undefined when user is type online', async () => {
+      authService.online.returns(true);
+
+      const result = await service.getUserLineageToRemove();
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when user has more than one assigned facility', async () => {
+      authService.online.returns(false);
+      userSettingsService.get.resolves({ facility_id: [ 'id-1', 'id-2' ] });
+
+      const result = await service.getUserLineageToRemove();
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when parent is not defined', async () => {
+      authService.online.returns(false);
+      userSettingsService.get.resolves({ facility_id: [ 'id-1', 'id-2' ] });
+      userContactService.get.resolves({ parent: undefined });
+
+      const result = await service.getUserLineageToRemove();
+
+      expect(result).to.be.undefined;
+    });
+
+    it('should return facility name when user is type offline and has only one assigned facility', async () => {
+      authService.online.returns(false);
+      userSettingsService.get.resolves({ facility_id: 'id-1' });
+      userContactService.get.resolves({ parent: { name: 'Kisumu Area' } });
+
+      const resultWithString = await service.getUserLineageToRemove();
+
+      expect(resultWithString).to.equal('Kisumu Area');
+
+      userSettingsService.get.resolves({ facility_id: [ 'id-5' ] });
+      userContactService.get.resolves({ parent: { name: 'Kakamega Area' } });
+
+      const resultWithArray = await service.getUserLineageToRemove();
+
+      expect(resultWithArray).to.equal('Kakamega Area');
+    });
+  });
+
+  describe('removeUserFacility()', () => {
+    it('should return undefined when lineage is empty or undefined', () => {
+      const resultWithUndefined = service.removeUserFacility(undefined as any, 'Kakamega Area');
+
+      expect(resultWithUndefined).to.be.undefined;
+
+      const resultWithEmpty = service.removeUserFacility([], 'Kakamega Area');
+
+      expect(resultWithEmpty).to.be.undefined;
+    });
+
+    it('should filter empty strings when no need to remove facility associated to user', () => {
+      const resultWithEmpty = service.removeUserFacility([ '', 'place-1', '', 'place-2', '' ], 'Kakamega Area');
+
+      expect(resultWithEmpty).to.have.members([ 'place-1', 'place-2' ]);
+    });
+
+    it('should filter empty strings and remove facility associated to user', () => {
+      const resultWithEmpty = service.removeUserFacility(
+        [ '', 'place-1', '', 'place-2', '', 'Kakamega Area' ],
+        'Kakamega Area'
+      );
+
+      expect(resultWithEmpty).to.have.members([ 'place-1', 'place-2' ]);
+    });
   });
 });

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -88,7 +88,7 @@ describe('Form service', () => {
   let consoleErrorMock;
   let consoleWarnMock;
   let feedbackService;
-  let extractLineageService
+  let extractLineageService;
 
   beforeEach(() => {
     enketoInit = sinon.stub();

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -88,6 +88,7 @@ describe('Form service', () => {
   let consoleErrorMock;
   let consoleWarnMock;
   let feedbackService;
+  let extractLineageService
 
   beforeEach(() => {
     enketoInit = sinon.stub();
@@ -153,6 +154,7 @@ describe('Form service', () => {
     consoleErrorMock = sinon.stub(console, 'error');
     consoleWarnMock = sinon.stub(console, 'warn');
     feedbackService = { submit: sinon.stub() };
+    extractLineageService = { extract: ExtractLineageService.prototype.extract };
 
     TestBed.configureTestingModule({
       providers: [
@@ -181,6 +183,7 @@ describe('Form service', () => {
         { provide: TranslateService, useValue: translateService },
         { provide: TrainingCardsService, useValue: trainingCardsService },
         { provide: FeedbackService, useValue: feedbackService },
+        { provide: ExtractLineageService, useValue: extractLineageService },
       ],
     });
 

--- a/webapp/tests/karma/ts/services/send-message.service.spec.ts
+++ b/webapp/tests/karma/ts/services/send-message.service.spec.ts
@@ -20,6 +20,7 @@ describe('SendMessageService', () => {
   let markReadService;
   let settingsService;
   let userSettingsService;
+  let extractLineageService;
 
   beforeEach(() => {
     const store = { dispatch: sinon.stub() };
@@ -32,6 +33,7 @@ describe('SendMessageService', () => {
     markReadService = { markAsRead: sinon.stub() };
     settingsService = { get: sinon.stub().resolves() };
     userSettingsService = { get: sinon.stub().resolves({ phone: '+5551', name: 'jack' }) };
+    extractLineageService = { extract: ExtractLineageService.prototype.extract };
 
     TestBed.configureTestingModule({
       providers: [
@@ -41,6 +43,7 @@ describe('SendMessageService', () => {
         { provide: MarkReadService, useValue: markReadService },
         { provide: SettingsService, useValue: settingsService },
         { provide: UserSettingsService, useValue: userSettingsService },
+        { provide: ExtractLineageService, useValue: extractLineageService },
       ]
     });
 

--- a/webapp/tests/karma/ts/services/transitions/create-user-for-contacts.transition.spec.ts
+++ b/webapp/tests/karma/ts/services/transitions/create-user-for-contacts.transition.spec.ts
@@ -6,6 +6,7 @@ import { CreateUserForContactsTransition } from '@mm-services/transitions/create
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { UserContactService } from '@mm-services/user-contact.service';
+import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 const deepFreeze = obj => {
   Object
@@ -67,6 +68,7 @@ describe('Create User for Contacts Transition', () => {
   let dbService;
   let createUserForContactsService;
   let userContactService;
+  let extractLineageService;
   let transition;
 
   beforeEach(() => {
@@ -82,6 +84,7 @@ describe('Create User for Contacts Transition', () => {
       getReplacedBy: sinon.stub(),
     };
     userContactService = { get: sinon.stub() };
+    extractLineageService = { extract: ExtractLineageService.prototype.extract };
 
     TestBed.configureTestingModule({
       providers: [
@@ -89,6 +92,7 @@ describe('Create User for Contacts Transition', () => {
         { provide: DbService, useValue: dbService },
         { provide: CreateUserForContactsService, useValue: createUserForContactsService },
         { provide: UserContactService, useValue: userContactService },
+        { provide: ExtractLineageService, useValue: extractLineageService },
       ]
     });
 

--- a/webapp/tests/karma/ts/services/update-facility.service.spec.ts
+++ b/webapp/tests/karma/ts/services/update-facility.service.spec.ts
@@ -8,16 +8,18 @@ import { UpdateFacilityService } from '@mm-services/update-facility.service';
 
 describe('UpdateFacility service', () => {
   let service;
+  let extractLineageService;
   let get;
   let put;
 
   beforeEach(() => {
     get = sinon.stub();
     put = sinon.stub();
+    extractLineageService = { extract: ExtractLineageService.prototype.extract };
 
     TestBed.configureTestingModule({
       providers: [
-        ExtractLineageService,
+        { provide: ExtractLineageService, useValue: extractLineageService },
         { provide: DbService, useValue: { get: () => ({ get, put }) } },
       ],
     });

--- a/webapp/web-components/cht-form/src/app.module.ts
+++ b/webapp/web-components/cht-form/src/app.module.ts
@@ -7,11 +7,15 @@ import { DoBootstrap, Injector, NgModule } from '@angular/core';
 import { createCustomElement } from '@angular/elements';
 import { AppComponent } from './app.component';
 import { TranslateService } from '@mm-services/translate.service';
+import { HttpClientModule } from '@angular/common/http';
+import { StoreModule } from '@ngrx/store';
 
 @NgModule({
   declarations: [AppComponent],
   imports: [
     BrowserModule,
+    HttpClientModule,
+    StoreModule.forRoot(),
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,

--- a/webapp/web-components/cht-form/src/stubs/db.service.ts
+++ b/webapp/web-components/cht-form/src/stubs/db.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class DbService {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public get(context?: { meta?: boolean; remote?: boolean }): any {
     return {
       get: () => Promise.resolve(),

--- a/webapp/web-components/cht-form/src/stubs/db.service.ts
+++ b/webapp/web-components/cht-form/src/stubs/db.service.ts
@@ -8,6 +8,7 @@ export class DbService {
   public get(context?: { meta?: boolean; remote?: boolean }): any {
     return {
       get: () => Promise.resolve(),
+      info: () => Promise.resolve(),
       query: async (selector, options) => {
         if (selector === 'medic-client/contacts_by_phone') {
           // Used by phone-widget to look for contacts with same phone number

--- a/webapp/web-components/cht-form/src/stubs/db.service.ts
+++ b/webapp/web-components/cht-form/src/stubs/db.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class DbService {
-  public get(): any {
+  public get(context?: { meta?: boolean; remote?: boolean }): any {
     return {
       get: () => Promise.resolve(),
       query: async (selector, options) => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

- The scope of this work is breadcrumbs in Reports, Message and Tasks pages. 
- This PR implements the support for when a user has many facility IDs assigned. The rules are:
  - If the user is online, leave breadcrumbs as they are. 
  - If the user is offline but has multiple facilities, leave breadcrumbs as they are. 
  - If the user is offline but only 1 facility is assigned, remove the last piece of the breadcrumb if the name is the same as the user's facility. 
- To assign more than one facility to a user:
  - Go to couchdb, find the `_users` database, find the offline user `org.couchdb:<username>`
  - Make `facility_id` an array and add the IDs: `"facility_id: [ "id-1", "id-2" ]`
      - the facility should be at the same level in the hierarchy. 
  - Go find the `medic` database, find the offline user `org.couchdb:<username>`
  -  Make `facility_id` an array and add the IDs: `"facility_id: [ "id-1", "id-2" ]`. It should match with the one in `_users` db. 

Videos: 
- user with 1 facility (Maggiocester's CHU)
https://github.com/medic/cht-core/assets/66472237/dde98e55-b4fe-4385-8436-5a107f9b8e25


- user with multiple facilities (Maggiocester's CHU, Hodkiewiczland's CHU)
https://github.com/medic/cht-core/assets/66472237/85382e57-d4c7-49e4-baa4-7d29efe55874



#6543

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:breadcrumbs-multi-facility/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:breadcrumbs-multi-facility/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:breadcrumbs-multi-facility/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

