### PR TITLE
fix(#8985): remove extra validation for parent place contact (#9027)

### DIFF
--- a/shared-libs/contacts/src/places.js
+++ b/shared-libs/contacts/src/places.js
@@ -25,6 +25,12 @@ const getPlace = id => {
 
 const isAPlace = place => place && contactTypesUtils.isPlace(config.get(), place);
 const getContactType = place => place && contactTypesUtils.getContactType(config.get(), place);
+const err = (msg, code) => {
+  return Promise.reject({
+    code: code || 400,
+    message: msg
+  });
+};
 
 /*
  * Validate the basic data structure for a place.  Not checking against the
@@ -36,12 +42,6 @@ const getContactType = place => place && contactTypesUtils.getContactType(config
  *     fetchHydratedDoc().
  */
 const validatePlace = place => {
-  const err = (msg, code) => {
-    return Promise.reject({
-      code: code || 400,
-      message: msg
-    });
-  };
   if (!_.isObject(place)) {
     return err('Place must be an object.');
   }
@@ -75,12 +75,6 @@ const validatePlace = place => {
     if (!_.isString(place.contact) && !_.isObject(place.contact)) {
       return err(`Property "contact" on place ${placeId} must be an object or string.`);
     }
-    if (_.isObject(place.contact)) {
-      const errStr = people._validatePerson(place.contact);
-      if (errStr) {
-        return err(errStr);
-      }
-    }
   }
   if (place.parent && !_.isEmpty(place.parent)) {
     // validate parents
@@ -89,30 +83,46 @@ const validatePlace = place => {
   return Promise.resolve();
 };
 
-const createPlace = async (place) => {
-  if (place.contact && !place.contact.type) {
-    place.contact.type = people._getDefaultPersonType();
+const preparePlaceContact = async contact => {
+  if (!contact) {
+    return {};
   }
+  if (_.isString(contact)) {
+    const person = await people.getOrCreatePerson(contact);
+    return { exists: true, contact: person };
+  }
+  if (!_.isObject(contact)) {
+    return err();
+  }
+  contact.type = contact.type ?? people._getDefaultPersonType();
+  const errStr = people._validatePerson(contact);
+  if (errStr) {
+    return err(errStr);
+  }
+  return { exists: false, contact: contact };
+};
+
+const createPlace = async (place) => {
   await module.exports._validatePlace(place);
-
-  const contact = place.contact;
+  const { exists: contactExists, contact } = await preparePlaceContact(place.contact);
   delete place.contact;
-
   const date = place.reported_date ? utils.parseDate(place.reported_date) : new Date();
   place.reported_date = date.valueOf();
   if (place.parent) {
     place.parent = lineage.minifyLineage(place.parent);
   }
-
-  const response = await db.medic.post(place);
   if (!contact) {
-    return response;
+    return await db.medic.post(place);
   }
-  const placeUUID = response.id;
-
-  contact.place = placeUUID;
+  if (contactExists) {
+    place.contact = contact._id;
+    const resp = await db.medic.post(place);
+    return { ...resp, contact: { id: contact._id } };
+  }
+  const placeResponse = await db.medic.post(place);
+  contact.place = placeResponse.id;
   const person = await people.getOrCreatePerson(contact);
-  const result = await updatePlace(placeUUID, { contact: person._id });
+  const result = await updatePlace(placeResponse.id, { contact: person._id });
   return { ...result, contact: { id: person._id } };
 };
 
@@ -220,6 +230,7 @@ module.exports = {
   _createPlaces: createPlaces,
   _updateFields: updateFields,
   _validatePlace: validatePlace,
+  _preparePlaceContact: preparePlaceContact,
   createPlace: createPlaces,
   getPlace: getPlace,
   updatePlace: updatePlace,

--- a/shared-libs/contacts/test/unit/places.spec.js
+++ b/shared-libs/contacts/test/unit/places.spec.js
@@ -404,6 +404,23 @@ describe('places controller', () => {
       });
     });
 
+    it('returns err if contact does not exist', async () => {
+      const place = {
+        name: 'HC',
+        type: 'district_hospital',
+        contact: 'person'
+      };
+      fetchHydratedDoc.rejects({ status: 404 });
+      const post = db.medic.post;
+      try {
+        await controller._createPlaces(place);
+        chai.expect.fail('Call should throw');
+      } catch (err) {
+        chai.expect(err.message).to.equal('Failed to find person.');
+        chai.expect(post.callCount).to.equal(0);
+      }
+    });
+
     it('rejects contacts with wrong type', done => {
       const place = {
         name: 'HC',
@@ -559,6 +576,26 @@ describe('places controller', () => {
       });
     });
 
+  });
+
+  describe('preparePlaceContact', () => {
+    it('adds default person type', () => {
+      return controller._preparePlaceContact({ name: 'test' }).then(({ exists, contact }) => {
+        chai.expect(exists).to.equal(false);
+        chai.expect(contact).to.have.property('type');
+        chai.expect(contact).property('type').equal('person');
+      });
+    });
+
+    it('rejects if contact does not exist', async () => {
+      fetchHydratedDoc.rejects({ status: 404 });
+      try {
+        await controller._preparePlaceContact('test');
+        chai.expect.fail('Call should throw');
+      } catch (err) {
+        chai.expect(err.message).to.equal('Failed to find person.');
+      }
+    });
   });
 
 });

--- a/tests/integration/api/controllers/places.spec.js
+++ b/tests/integration/api/controllers/places.spec.js
@@ -97,6 +97,40 @@ describe('Places API', () => {
         });
     });
 
+    it('#8985 should create place if parent has invalid contact', () => {
+      const parentDoc = {
+        _id: 'parent',
+        type: 'district_hospital',
+        name: 'A Place',
+        contact: {
+          _id: ''
+        }
+      };
+      return utils.saveDoc(parentDoc).then(() => {
+        onlineRequestOptions.body = {
+          name: 'CHP Area One',
+          type: 'health_center',
+          parent: parentDoc._id
+        };
+        return utils.request(onlineRequestOptions);
+      })
+        .then(result => {
+          chai.expect(result.id).to.not.be.undefined;
+          return utils.getDoc(result.id);
+        })
+        .then((place) => {
+          chai.expect(place).to.deep.include({
+            name: 'CHP Area One',
+            type: 'health_center',
+          });
+          expect(place.parent._id).to.be.a('string');
+          return utils.getDoc(place.parent._id);
+        })
+        .then((parent) => {
+          chai.expect(parent).to.deep.include(parentDoc);
+        });
+    });
+
     it('should create place with contact', () => {
       onlineRequestOptions.body = {
         name: 'CHP Area One',
@@ -152,7 +186,7 @@ describe('Places API', () => {
           chai.expect(place).to.deep.include({
             name: 'DS',
             type: 'district_hospital',
-            contact: { _id: contact._id, parent: { _id: contact.parent._id } }
+            contact: 'fixture:user:online'
           });
         });
     });


### PR DESCRIPTION


<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description
Primary contacts of ancestors are no longer validated when creating a new place.

#8985

(cherry picked from commit 6bb7f6963aad9454c22d6836f5c4c7cff33398b9)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8985-4.7.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8985-4.7.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8985-4.7.x/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

