### PR TITLE
feat(#6543): disable aggregate targets for users with multiple facility_ids

### DIFF
--- a/api/src/services/authorization.js
+++ b/api/src/services/authorization.js
@@ -187,13 +187,14 @@ const alwaysAllowCreate = doc => {
 
 const getContactsByDepthKeys = (userCtx, depth) => {
   const keys = [];
-  if (depth >= 0) {
-    for (let i = 0; i <= depth; i++) {
-      keys.push([ userCtx.facility_id, i ]);
+  const facilityIds = Array.isArray(userCtx.facility_id) ? userCtx.facility_id : [userCtx.facility_id];
+  for (const facilityId of facilityIds) {
+    if (depth >= 0) {
+      keys.push(...Array.from({ length: depth + 1 }).map((_, i) => [facilityId, i]));
+    } else {
+      // no configured depth limit
+      keys.push([ facilityId ]);
     }
-  } else {
-    // no configured depth limit
-    keys.push([ userCtx.facility_id ]);
   }
 
   return keys;

--- a/webapp/src/ts/components/filters/analytics-filter/analytics-filter.component.ts
+++ b/webapp/src/ts/components/filters/analytics-filter/analytics-filter.component.ts
@@ -1,5 +1,5 @@
 import { AfterContentChecked, AfterContentInit, Component, Input, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -12,8 +12,7 @@ export class AnalyticsFilterComponent implements AfterContentInit, AfterContentC
   subscriptions: Subscription = new Subscription();
 
   constructor(
-    private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
   ) { }
 
   ngAfterContentInit() {

--- a/webapp/src/ts/services/analytics-modules.service.ts
+++ b/webapp/src/ts/services/analytics-modules.service.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@angular/core';
+
 import { SettingsService } from '@mm-services/settings.service';
-import { AuthService } from '@mm-services/auth.service';
+import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AnalyticsModulesService {
   constructor(
-    private authService:AuthService,
-    private settingsService:SettingsService,
+    private settingsService: SettingsService,
+    private targetAggregatesService: TargetAggregatesService,
   ) { }
 
   private getTargetsModule(settings) {
@@ -20,19 +21,19 @@ export class AnalyticsModulesService {
     };
   }
 
-  private getTargetAggregatesModule (settings, canAggregateTargets) {
+  private getTargetAggregatesModule (settings, isAggregateEnabled) {
     return {
       id: 'target-aggregates',
       label: 'analytics.target.aggregates',
       route: ['/', 'analytics', 'target-aggregates'],
-      available: () => !!(settings.tasks && settings.tasks.targets && canAggregateTargets)
+      available: () => !!(settings.tasks && settings.tasks.targets && isAggregateEnabled)
     };
   }
 
-  private getModules(settings, canAggregateTargets) {
+  private getModules(settings, isAggregateEnabled) {
     return [
       this.getTargetsModule(settings),
-      this.getTargetAggregatesModule(settings, canAggregateTargets),
+      this.getTargetAggregatesModule(settings, isAggregateEnabled),
     ].filter(module => module.available());
   }
 
@@ -40,10 +41,10 @@ export class AnalyticsModulesService {
     return Promise
       .all([
         this.settingsService.get(),
-        this.authService.has('can_aggregate_targets')
+        this.targetAggregatesService.isEnabled(),
       ])
-      .then(([settings, canAggregateTargets]) => {
-        const modules = this.getModules(settings, canAggregateTargets);
+      .then(([settings, isAggregateEnabled]) => {
+        const modules = this.getModules(settings, isAggregateEnabled);
         console.debug('AnalyticsModules. Enabled modules: ', modules.map(module => module.label));
         return modules;
       });

--- a/webapp/src/ts/services/target-aggregates.service.ts
+++ b/webapp/src/ts/services/target-aggregates.service.ts
@@ -228,13 +228,20 @@ export class TargetAggregatesService {
       });
   }
 
-  private async getHomePlace() {
+  private async getUserFacilityIds(): Promise<string[] | undefined> {
     const { facility_id }:any = await this.userSettingsService.get();
-    if (!facility_id) {
+    if (!facility_id?.length) {
       return;
     }
+    return Array.isArray(facility_id) ? facility_id : [ facility_id ];
+  }
 
-    const places = await this.getDataRecordsService.get([ facility_id ]);
+  private async getHomePlace() {
+    const facilityIds = await this.getUserFacilityIds();
+    if (!facilityIds?.length) {
+      return;
+    }
+    const places = await this.getDataRecordsService.get(facilityIds);
     return places?.length ? places[0] : undefined;
   }
 
@@ -269,8 +276,14 @@ export class TargetAggregatesService {
       });
   }
 
-  isEnabled() {
-    return this.authService.has('can_aggregate_targets');
+  async isEnabled() {
+    const canSeeAggregates = await this.authService.has('can_aggregate_targets');
+    if (!canSeeAggregates) {
+      return false;
+    }
+
+    const facilityIds = await this.getUserFacilityIds();
+    return !!facilityIds && facilityIds.length <= 1;
   }
 
   getAggregates() {

--- a/webapp/tests/karma/ts/services/analytics-modules.service.spec.ts
+++ b/webapp/tests/karma/ts/services/analytics-modules.service.spec.ts
@@ -3,23 +3,23 @@ import sinon from 'sinon';
 import { expect, assert } from 'chai';
 
 import { AnalyticsModulesService } from '@mm-services/analytics-modules.service';
-import { AuthService } from '@mm-services/auth.service';
 import { SettingsService } from '@mm-services/settings.service';
+import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 
 describe('AnalyticsModulesService', () => {
   let service: AnalyticsModulesService;
-  let authService;
+  let targetAggregatesService;
   let settingsService;
 
   beforeEach(() => {
-    authService = { has: sinon.stub() };
+    targetAggregatesService = { isEnabled: sinon.stub() };
     settingsService = { get: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
-        { provide: AuthService, useValue: authService },
+        { provide: TargetAggregatesService, useValue: targetAggregatesService },
         { provide: SettingsService, useValue: settingsService },
-      ]
+      ],
     });
 
     service = TestBed.inject(AnalyticsModulesService);
@@ -31,7 +31,7 @@ describe('AnalyticsModulesService', () => {
 
   it('should throw an error when settings fails', () => {
     settingsService.get.rejects({ some: 'err' });
-    authService.has.resolves(true);
+    targetAggregatesService.isEnabled.resolves(true);
 
     return service
       .get()
@@ -41,7 +41,7 @@ describe('AnalyticsModulesService', () => {
 
   it('should enable targets when configured', () => {
     settingsService.get.resolves({ tasks: { targets: { enabled: true } } });
-    authService.has.resolves(false);
+    targetAggregatesService.isEnabled.resolves(false);
 
     return service
       .get()
@@ -57,7 +57,7 @@ describe('AnalyticsModulesService', () => {
 
   it('should enable target aggregates when configured', () => {
     settingsService.get.resolves({ tasks: { targets: { enabled: true } } });
-    authService.has.resolves(true);
+    targetAggregatesService.isEnabled.resolves(true);
 
     return service
       .get()

--- a/webapp/tests/karma/ts/services/target-aggregates.service.spec.ts
+++ b/webapp/tests/karma/ts/services/target-aggregates.service.spec.ts
@@ -84,22 +84,48 @@ describe('TargetAggregatesService', () => {
   });
 
   describe('isEnabled', () => {
-    it('should return false when user does not have permission', async () => {
-      authService.has.resolves(false);
-
-      const result = await service.isEnabled();
-
-      expect(result).to.equal(false);
-    });
-
-    it('should return true when user has permission', async () => {
+    it('should return true when user has permission and user has one facility assigned as array', async () => {
       authService.has.resolves(true);
+      userSettingsService.get.resolves({ facility_id: [ 'facility-1' ] });
 
       const result = await service.isEnabled();
 
       expect(result).to.equal(true);
       expect(authService.has.callCount).to.equal(1);
       expect(authService.has.args[0]).to.deep.equal(['can_aggregate_targets']);
+      expect(userSettingsService.get.calledOnce).to.be.true;
+    });
+
+    it('should return true when user has permission and user has one facility assigned as string', async () => {
+      authService.has.resolves(true);
+      userSettingsService.get.resolves({ facility_id: 'facility-1' });
+
+      const result = await service.isEnabled();
+
+      expect(result).to.equal(true);
+      expect(authService.has.callCount).to.equal(1);
+      expect(authService.has.args[0]).to.deep.equal(['can_aggregate_targets']);
+      expect(userSettingsService.get.calledOnce).to.be.true;
+    });
+
+    it('should return false when user does not have permission', async () => {
+      authService.has.resolves(false);
+      userSettingsService.get.resolves({ facility_id: [ 'facility-1' ] });
+
+      const result = await service.isEnabled();
+
+      expect(result).to.equal(false);
+      expect(userSettingsService.get.notCalled).to.be.true;
+    });
+
+    it('should return false when user has more than one facility assigned', async () => {
+      authService.has.resolves(true);
+      userSettingsService.get.resolves({ facility_id: [ 'facility-1', 'facility-2' ] });
+
+      const result = await service.isEnabled();
+
+      expect(result).to.equal(false);
+      expect(userSettingsService.get.calledOnce).to.be.true;
     });
   });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

- Users with many associated facilities cannot see target aggregates 

- To assign more than one facility to a user:
  - Go to couchdb, find the `_users` database, find the offline user `org.couchdb:<username>`
  - Make `facility_id` an array and add the IDs: `"facility_id: [ "id-1", "id-2" ]`
      - the facility should be at the same level in the hierarchy. 
  - Go find the `medic` database, find the offline user `org.couchdb:<username>`
  -  Make `facility_id` an array and add the IDs: `"facility_id: [ "id-1", "id-2" ]`. It should match with the one in `_users` db. 

Videos:

- The `can_aggregate_targets` is disabled. Users with 1 and with many associated facilities cannot see the aggregate targets page. 

Uploading permission-disabled.mov…


- The `can_aggregate_targets` is enabled. Users with 1 associated facility can see the page, but those with many associated facilities cannot see the aggregate targets page. 

Uploading permission-enabled.mov…



#6543

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

