### PR TITLE
fix(#9117): use correct _users database name

### DIFF
--- a/api/src/services/setup/databases.js
+++ b/api/src/services/setup/databases.js
@@ -34,7 +34,7 @@ const DATABASES = [
     jsonFileName: 'users-meta.json',
   },
   {
-    name: `${environment.db}-users`,
+    name: `_users`,
     db: db.users,
     jsonFileName: 'users.json',
   },

--- a/api/tests/mocha/services/setup/databases.spec.js
+++ b/api/tests/mocha/services/setup/databases.spec.js
@@ -40,7 +40,7 @@ describe('databases', () => {
         jsonFileName: 'users-meta.json',
       },
       {
-        name: `thedb-users`,
+        name: `_users`,
         db: db.users,
         jsonFileName: 'users.json',
       },


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

#9117 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9117-fix-users-ddoc-setting/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9117-fix-users-ddoc-setting/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9117-fix-users-ddoc-setting/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

