### PR TITLE
fix(#9122): detect unsafe redirection on login

### DIFF
--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -79,7 +79,7 @@ const resolveUrl = (requested) => {
     // invalid url
     return;
   }
-}
+};
 
 const sanitizeRequestedRedirect = (requested) => {
   const resolved = resolveUrl(requested);

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -96,6 +96,14 @@ describe('login controller', () => {
         given: '/lg/_design/medic/_rewrite/../../../../../.htpasswd',
         expected: '/.htpasswd'
       },
+      {
+        given: 'https://demo-cht.dev.medicmobile.org//MYFAKESITE.com/phishing-example/login/',
+        expected: '/'
+      },
+      {
+        given: 'https://demo-cht.dev.medicmobile.org/%2F%61%6C%78%6E%64%72%73%6E%2E%67%69%74%68%75%62%2E%69%6F%2F%70%68%69%73%68%69%6E%67%2D%65%78%61%6D%70%6C%65%2F%6C%6F%67%69%6E%26%75%73%65%72%6E%61%6D%65%3D%67%61%72%65%74%68',
+        expected: '/'
+      },
     ].forEach(({given, expected}) => {
       it(`Bad URL "${given}" should redirect to root`, () => {
         chai.expect(controller.__get__('getRedirectUrl')({}, given)).to.equal(expected);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->
#9122

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9122-detect-double-slash-redirection/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9122-detect-double-slash-redirection/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9122-detect-double-slash-redirection/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

