### PR TITLE
fix(#9166): backwards compatible couchdb views (4.8.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -390,9 +390,16 @@ jobs:
 
   upgrade:
     needs: [publish]
-    name: Upgrade from latest release
+    name: Upgrade from ${{ matrix.version }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
+
     if: ${{ github.event_name != 'pull_request' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ '4.2.4', 'latest' ]
 
     steps:
       - name: Configure AWS credentials Public
@@ -413,6 +420,7 @@ jobs:
       - name: Set ENV
         run: |
           echo "BUILDS_SERVER=$STAGING_SERVER" >> $GITHUB_ENV
+          echo "BASE_VERSION=${{ matrix.version }}" >> $GITHUB_ENV
       - run: npm ci
       - name: Create logs directory
         run: mkdir tests/logs
@@ -422,7 +430,7 @@ jobs:
       - name: Archive Results
         uses: actions/upload-artifact@v4
         with:
-          name: Upgrade
+          name: upgrade-${{ matrix.version }}
           path: |
             allure-results
             allure-report

--- a/ddocs/.eslintrc
+++ b/ddocs/.eslintrc
@@ -7,6 +7,6 @@
     "no-var": "off"
   },
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 5
   }
 }

--- a/ddocs/users-meta-db/users-meta/views/device_by_user/map.js
+++ b/ddocs/users-meta-db/users-meta/views/device_by_user/map.js
@@ -8,9 +8,12 @@ function(doc) {
     doc.metadata.month &&
     doc.metadata.day
   ) {
-    const pad = number => number.toString().padStart(2, '0');
+    var pad = function (number) {
+      return number.toString().padStart(2, '0');
+    };
+
     emit([doc.metadata.user, doc.metadata.deviceId], {
-      date: `${doc.metadata.year}-${pad(doc.metadata.month)}-${pad(doc.metadata.day)}`,
+      date: doc.metadata.year + '-' + pad(doc.metadata.month) + '-' + pad(doc.metadata.day),
       id: doc._id,
       device: {
         userAgent: doc.device && doc.device.userAgent,

--- a/ddocs/users-meta-db/users-meta/views/device_by_user/reduce.js
+++ b/ddocs/users-meta-db/users-meta/views/device_by_user/reduce.js
@@ -1,6 +1,6 @@
 function (keys, values) {
-  let latest = { date: '1970-01-01' };
-  values.forEach(function (value) {
+  var latest = { date: '1970-01-01' };
+  values.forEach(function(value) {
     if (value.date > latest.date) {
       latest = value;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medic",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "medic",
-      "version": "4.8.0",
+      "version": "4.8.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medic",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {

--- a/tests/e2e/upgrade/wdio.conf.js
+++ b/tests/e2e/upgrade/wdio.conf.js
@@ -13,7 +13,7 @@ const rpn = require('request-promise-native');
 const utils = require('@utils');
 const wdioBaseConfig = require('../../wdio.conf');
 
-const { MARKET_URL_READ, STAGING_SERVER, HAPROXY_PORT } = process.env;
+const { MARKET_URL_READ, STAGING_SERVER, HAPROXY_PORT, BASE_VERSION } = process.env;
 const CHT_COMPOSE_PROJECT_NAME = 'cht-upgrade';
 
 const UPGRADE_SERVICE_DOCKER_COMPOSE_FOLDER = utils.makeTempDir('upgrade-service-');
@@ -28,7 +28,11 @@ const getUpgradeServiceDockerCompose = async () => {
   await fs.promises.writeFile(UPGRADE_SERVICE_DC, contents);
 };
 
-const getLatestRelease = async () => {
+const getRelease = async () => {
+  if (BASE_VERSION !== 'latest') {
+    return `medic:medic:${BASE_VERSION}`;
+  }
+
   const url = `${MARKET_URL_READ}/${STAGING_SERVER}/_design/builds/_view/releases`;
   const query = {
     startKey: ['release', 'medic', 'medic', {}],
@@ -43,9 +47,9 @@ const getLatestRelease = async () => {
 };
 
 const getMainCHTDockerCompose = async () => {
-  const latestRelease = await getLatestRelease();
+  const release = await getRelease();
   for (const composeFile of COMPOSE_FILES) {
-    const composeFileUrl = `${MARKET_URL_READ}/${STAGING_SERVER}/${latestRelease}/docker-compose/${composeFile}.yml`;
+    const composeFileUrl = `${MARKET_URL_READ}/${STAGING_SERVER}/${release}/docker-compose/${composeFile}.yml`;
     const contents = await rpn.get(composeFileUrl);
     const filePath = path.join(CHT_DOCKER_COMPOSE_FOLDER, `${composeFile}.yml`);
     await fs.promises.writeFile(filePath, contents);

--- a/tests/factories/cht/reports/pregnancy.js
+++ b/tests/factories/cht/reports/pregnancy.js
@@ -18,7 +18,7 @@ const defaultSubmitter = {
 };
 
 const nextANCVisit = moment().add(2, 'day');
-const lmp = moment().subtract(3, 'months');
+const lmp = moment().subtract(90, 'days');
 
 const defaultFields = {
   'inputs': {

--- a/tests/integration/couchdb/couch_chttpd.spec.js
+++ b/tests/integration/couchdb/couch_chttpd.spec.js
@@ -21,8 +21,13 @@ const startContainer = async (useAuthentication) => {
   if (useAuthentication) {
     env.COUCH_AUTH = `${constants.USERNAME}:${constants.PASSWORD}`;
   }
-  return await runDockerCommand('docker-compose', ['up', '--build', '--force-recreate'], env);
+  await runDockerCommand('docker-compose', ['up', '--build', '--force-recreate'], env);
 };
+
+const stopContainer = async () => {
+  await runDockerCommand('docker-compose', ['down', '--remove-orphans']);
+};
+
 const getLogs = async () => {
   const containerName = (await runDockerCommand('docker-compose', ['ps', '-q', '-a']))[0];
   const logs = await runDockerCommand('docker', ['logs', containerName]);
@@ -46,6 +51,10 @@ const expectCorrectMetadata = (metadata) => {
 };
 
 describe('accessing couch clustering endpoint', () => {
+  afterEach(async () => {
+    await stopContainer();
+  });
+
   it('should block unauthenticated access through the host network', async () => {
     await expect(
       utils.request({ uri: `https://${constants.API_HOST}/_node/_local/_dbs/${constants.DB_NAME}`, noAuth: true })

--- a/tests/integration/couchdb/couch_httpd_script/docker-compose.yml
+++ b/tests/integration/couchdb/couch_httpd_script/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   chttpd_call:
     build: .
@@ -11,3 +9,4 @@ services:
 networks:
   net:
     name: cht-net-e2e
+    external: true


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

#9166

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9166-4.8.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9166-4.8.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9166-4.8.x/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

