### PR TITLE
fix(#9187): fix haproxy version to 2.6.17

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.6
+FROM haproxy:2.6.17
 
 USER root
 RUN apt-get update && apt-get install luarocks gettext jq curl -y

--- a/haproxy/tests/compose.yml
+++ b/haproxy/tests/compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   haproxy:
     build:

--- a/haproxy/tests/with_mock.bats
+++ b/haproxy/tests/with_mock.bats
@@ -24,7 +24,8 @@ setup() {
 }
 
 @test "should return json with on connection drop" {
-	run bash -c "curl -ksm5 http://127.0.0.1:5984/error/drop | jq .error"
+	run bash -c "curl -ksm5 http://127.0.0.1:5984/error/drop"
 	assert_success
+	echo "output = ${output}"
 	assert_output '"502 Bad Gateway"'
 }

--- a/haproxy/tests/with_mock.bats
+++ b/haproxy/tests/with_mock.bats
@@ -24,8 +24,7 @@ setup() {
 }
 
 @test "should return json with on connection drop" {
-	run bash -c "curl http://127.0.0.1:5984/error/drop"
-	# assert_success
-	echo "output = ${output}"
+	run bash -c "curl -ksm5 http://127.0.0.1:5984/error/drop | jq .error"
+	assert_success
 	assert_output '"502 Bad Gateway"'
 }

--- a/haproxy/tests/with_mock.bats
+++ b/haproxy/tests/with_mock.bats
@@ -24,7 +24,7 @@ setup() {
 }
 
 @test "should return json with on connection drop" {
-	run bash -c "curl -ksm5 http://127.0.0.1:5984/error/drop"
+	run bash -c "curl http://127.0.0.1:5984/error/drop"
 	# assert_success
 	echo "output = ${output}"
 	assert_output '"502 Bad Gateway"'

--- a/haproxy/tests/with_mock.bats
+++ b/haproxy/tests/with_mock.bats
@@ -25,7 +25,7 @@ setup() {
 
 @test "should return json with on connection drop" {
 	run bash -c "curl -ksm5 http://127.0.0.1:5984/error/drop"
-	assert_success
+	# assert_success
 	echo "output = ${output}"
 	assert_output '"502 Bad Gateway"'
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "wdio-local": "export VERSION=$(node ./scripts/build/get-version.js) && ./scripts/build/build-service-images.sh && wdio run ./tests/e2e/default/wdio.conf.js",
     "-- CI SCRIPTS ": "-----------------------------------------------------------------------------------------------",
     "build": "./scripts/build/build-ci.sh",
-    "ci-compile": "node scripts/ci/check-versions.js && node scripts/build/cli npmCiModules && npm run lint && npm run build && npm run integration-api && npm run unit && npm run unit-nginx && npm run unit-haproxy && npm run unit-haproxy-healthcheck",
+    "ci-compile": "node scripts/ci/check-versions.js && node scripts/build/cli npmCiModules && npm run lint && npm run unit-nginx && npm run unit-haproxy && npm run unit-haproxy-healthcheck && npm run build && npm run integration-api && npm run unit",
     "ci-integration-all": "mocha --config tests/integration/.mocharc-all.js",
     "ci-integration-all-k3d": "mocha --config tests/integration/.mocharc-k3d.js",
     "ci-integration-sentinel": "mocha --config tests/integration/.mocharc-sentinel.js",


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Haproxy published a new 2.6.18 image today, which breaks one of our unit tests. It might also break behavior.
Fixing the image version to `2.6.17` resolves the issue and makes sure we're having expected behavior. 

#9187 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9187-fix-haproxy-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9187-fix-haproxy-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9187-fix-haproxy-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

