### PR TITLE
docs(#9127): document cht-datasource

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,7 +398,7 @@ jobs:
 
 
   publish-generated-docs:
-    #    needs: [publish]
+    needs: [publish]
     name: Publish generated docs
     runs-on: ubuntu-22.04
     timeout-minutes: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
 #    needs: [publish]
     name: Publish generated docs
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 5
 
 #    if: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -417,7 +417,7 @@ jobs:
       - name: Main Branch Only - Deploy to GH pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.DEPOLY_TO_SITE }}
+          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
           external_repository: medic/medic.github.io
           publish_dir: ./shared-libs/cht-datasource/docs
           user_name: medic-ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
     #    needs: [publish]
     name: Publish generated docs
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 5
 
     if: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,7 @@ jobs:
           personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
           external_repository: medic/cht-datasource
           publish_dir: ./shared-libs/cht-datasource/docs
-          user_name: medic-ci
+          user_name: medic-ci-test
           user_email: medic-ci@github
           publish_branch: main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,10 +402,8 @@ jobs:
     name: Publish generated docs
     runs-on: ubuntu-22.04
     timeout-minutes: 15
-    permissions:
-      contents: write
 
-#    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -419,7 +417,7 @@ jobs:
       - name: Main Branch Only - Deploy to GH pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES_FAIL }}
+          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
           external_repository: medic/cht-datasource
           publish_dir: ./shared-libs/cht-datasource/docs
           user_name: medic-ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
 #    needs: [publish]
     name: Publish generated docs
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 15
 
 #    if: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,7 +419,7 @@ jobs:
       - name: Main Branch Only - Deploy to GH pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
+          personal_token: ${{ secrets.TEST_DEPLOY }}
           external_repository: medic/cht-datasource
           publish_dir: ./shared-libs/cht-datasource/docs
           user_name: medic-ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,7 +419,7 @@ jobs:
       - name: Main Branch Only - Deploy to GH pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.TEST_DEPLOY }}
+          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
           external_repository: medic/cht-datasource
           publish_dir: ./shared-libs/cht-datasource/docs
           user_name: medic-ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,10 +419,10 @@ jobs:
       - name: Main Branch Only - Deploy to GH pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
+          personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES_FAIL }}
           external_repository: medic/cht-datasource
           publish_dir: ./shared-libs/cht-datasource/docs
-          user_name: medic-ci-test
+          user_name: medic-ci
           user_email: medic-ci@github
           publish_branch: main
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,10 +398,12 @@ jobs:
 
 
   publish-generated-docs:
-#    needs: [publish]
+    #    needs: [publish]
     name: Publish generated docs
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    permissions:
+      contents: write
 
 #    if: ${{ github.event_name != 'pull_request' }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,12 +398,12 @@ jobs:
 
 
   publish-generated-docs:
-    needs: [publish]
+#    needs: [publish]
     name: Publish generated docs
     runs-on: ubuntu-22.04
     timeout-minutes: 5
 
-    if: ${{ github.event_name != 'pull_request' }}
+#    if: ${{ github.event_name != 'pull_request' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -418,12 +418,11 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.DEPLOY_TO_GITHUB_PAGES }}
-          external_repository: medic/medic.github.io
+          external_repository: medic/cht-datasource
           publish_dir: ./shared-libs/cht-datasource/docs
           user_name: medic-ci
           user_email: medic-ci@github
           publish_branch: main
-          destination_dir: ./cht-datasource
 
   upgrade:
     needs: [publish]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,6 +396,35 @@ jobs:
         node ./publish.js
         node ./tag-docker-images.js
 
+
+  publish-generated-docs:
+    needs: [publish]
+    name: Publish generated docs
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    if: ${{ github.event_name != 'pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm ci
+      - name: Generate TypeDoc
+        run: npm run --prefix shared-libs/cht-datasource gen-docs
+      - name: Main Branch Only - Deploy to GH pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.DEPOLY_TO_SITE }}
+          external_repository: medic/medic.github.io
+          publish_dir: ./shared-libs/cht-datasource/docs
+          user_name: medic-ci
+          user_email: medic-ci@github
+          publish_branch: main
+          destination_dir: ./cht-datasource
+
   upgrade:
     needs: [publish]
     name: Upgrade from ${{ matrix.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ dist
 api/**/extracted-resources/**/*
 api/build/**/*
 jsdocs
+shared-libs/**/docs
 config/*/.gdrive.*.json
 config/*/.snapshots/*
 config/*/backups/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -9545,6 +9545,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "dev": true,
@@ -10373,7 +10378,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base": {
@@ -21934,8 +21938,7 @@
     "node_modules/jsonc-parser": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -23535,6 +23538,11 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "dev": true
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "node_modules/magic-string": {
       "version": "0.30.8",
@@ -30265,6 +30273,17 @@
         "node": ">=0.11.0"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -32292,11 +32311,63 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33501,6 +33572,16 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "node_modules/vscode-uri": {
       "version": "3.0.2",
@@ -35935,7 +36016,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@medic/contact-types-utils": "file:../contact-types-utils",
-        "@medic/logger": "file:../logger"
+        "@medic/logger": "file:../logger",
+        "typedoc": "^0.25.13"
       }
     },
     "shared-libs/cht-datasource2": {
@@ -39733,7 +39815,8 @@
       "version": "file:shared-libs/cht-datasource",
       "requires": {
         "@medic/contact-types-utils": "file:../contact-types-utils",
-        "@medic/logger": "file:../logger"
+        "@medic/logger": "file:../logger",
+        "typedoc": "^0.25.13"
       }
     },
     "@medic/contact-types-utils": {
@@ -42943,6 +43026,11 @@
       "version": "2.1.1",
       "dev": true
     },
+    "ansi-sequence-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
+      "integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg=="
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "dev": true,
@@ -43537,8 +43625,7 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "1.0.2",
-      "dev": true
+      "version": "1.0.2"
     },
     "base": {
       "version": "0.11.2",
@@ -51836,8 +51923,7 @@
     "jsonc-parser": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
-      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==",
-      "dev": true
+      "integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -53065,6 +53151,11 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
       "dev": true
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
     },
     "magic-string": {
       "version": "0.30.8",
@@ -58084,6 +58175,17 @@
         "rechoir": "^0.6.2"
       }
     },
+    "shiki": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -59592,11 +59694,44 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "marked": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+          "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
     "typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
     },
     "typify-parser": {
       "version": "1.1.0",
@@ -60312,6 +60447,16 @@
     "vscode-nls": {
       "version": "5.0.0",
       "dev": true
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "vscode-uri": {
       "version": "3.0.2",

--- a/shared-libs/cht-datasource/package.json
+++ b/shared-libs/cht-datasource/package.json
@@ -3,17 +3,21 @@
   "version": "1.0.0",
   "description": "Provides an API for the CHT data model",
   "main": "dist/index.js",
-  "files": [ "/dist" ],
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "postinstall": "rm -rf dist && npm run build",
     "build": "tsc -p tsconfig.build.json",
     "build-watch": "tsc --watch -p tsconfig.build.json",
-    "test": "nyc --nycrcPath='../nyc.config.js' mocha \"test/**/*\""
+    "test": "nyc --nycrcPath='../nyc.config.js' mocha \"test/**/*\"",
+    "gen-docs": "typedoc ./src/index.ts"
   },
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
     "@medic/contact-types-utils": "file:../contact-types-utils",
-    "@medic/logger": "file:../logger"
+    "@medic/logger": "file:../logger",
+    "typedoc": "^0.25.13"
   }
 }


### PR DESCRIPTION
# Description

Fixes #9127

Generate [TypeDoc](https://typedoc.org/) from the commented source code and push it to [medic/cht-datasource](https://github.com/medic/cht-datasource) to live at https://docs.communityhealthtoolkit.org/cht-datasource.
So once this PR gets merged to master, CI will publish the generated docs every time a PR gets merged to master and a branch build gets published.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9127-document-cht-datasource/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9127-document-cht-datasource/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9127-document-cht-datasource/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

