### PR TITLE
fix(#9203): add facility_id backward compatibility in admin app

### DIFF
--- a/admin/src/js/controllers/edit-user.js
+++ b/admin/src/js/controllers/edit-user.js
@@ -63,10 +63,9 @@ angular
     const allowTokenLogin = settings => settings.token_login && settings.token_login.enabled;
 
     /**
-     * * Ensures that facility_id is an array for backward compatibility.
-     * *
-     * * @returns {Array} The normalized facility_id as an array.
-     * */
+     * Ensures that facility_id is an array for backward compatibility.
+     * @returns {Array} The normalized facility_id as an array.
+     */
     const getFacilityId = function () {
       if (!$scope.model.facility_id) {
         $scope.model.facility_id = [];
@@ -75,6 +74,7 @@ angular
       if (!Array.isArray($scope.model.facility_id)) {
         $scope.model.facility_id = [$scope.model.facility_id];
       }
+
       return $scope.model.facility_id;
     };
 

--- a/admin/src/js/controllers/edit-user.js
+++ b/admin/src/js/controllers/edit-user.js
@@ -62,6 +62,22 @@ angular
 
     const allowTokenLogin = settings => settings.token_login && settings.token_login.enabled;
 
+    /**
+     * * Ensures that facility_id is an array for backward compatibility.
+     * *
+     * * @returns {Array} The normalized facility_id as an array.
+     * */
+    const getFacilityId = function () {
+      if (!$scope.model.facility_id) {
+        $scope.model.facility_id = [];
+      }
+
+      if (!Array.isArray($scope.model.facility_id)) {
+        $scope.model.facility_id = [$scope.model.facility_id];
+      }
+      return $scope.model.facility_id;
+    };
+
     const determineEditUserModel = function() {
       // Edit a user that's not the current user.
       // $scope.model is the user object passed in by controller creating the Modal.
@@ -75,6 +91,7 @@ angular
             return $q.resolve({});
           }
 
+          const facilityId = getFacilityId();
           const tokenLoginData = $scope.model.token_login;
           const tokenLoginEnabled = tokenLoginData &&
             {
@@ -92,8 +109,8 @@ angular
             phone: $scope.model.phone,
             // FacilitySelect is what binds to the select, place is there to
             // compare to later to see if it's changed once we've run computeFields();
-            facilitySelect: $scope.model.facility_id || [],
-            place: $scope.model.facility_id,
+            facilitySelect: facilityId,
+            place: facilityId,
             roles: getRoles($scope.model.roles),
             // ^ Same with contactSelect vs. contact
             contactSelect: $scope.model.contact_id,

--- a/admin/tests/unit/controllers/edit-user.spec.js
+++ b/admin/tests/unit/controllers/edit-user.spec.js
@@ -16,6 +16,7 @@ describe('EditUserCtrl controller', () => {
   let Translate;
   let Settings;
   let userToEdit;
+  let user;
   let http;
 
   beforeEach(() => {
@@ -174,6 +175,27 @@ describe('EditUserCtrl controller', () => {
           contact: userToEdit.contact_id,
           tokenLoginEnabled: undefined,
         });
+      });
+    });
+  });
+
+  describe('Initializing existing users', () => {
+    user = {
+      _id: 'user.id',
+      name: 'user.name',
+      fullname: 'user.fullname',
+      email: 'user@email.com',
+      phone: 'user.phone',
+      facility_id: 'abc',
+      contact_id: 'xyz',
+      roles: ['supervisor'],
+      language: 'zz',
+    };
+
+    it('converts string facility_id to Array ', () => {
+      return mockEditAUser(user).setupPromise.then(() => {
+        chai.expect(scope.editUserModel.facilitySelect).to.deep.equal(['abc']);
+        chai.expect(scope.editUserModel.facilitySelect).to.be.an('array');
       });
     });
   });

--- a/config/default/app_settings.json
+++ b/config/default/app_settings.json
@@ -283,6 +283,7 @@
     "can_view_old_filter_and_search": [],
     "can_view_old_action_bar": [],
     "can_default_facility_filter": [],
+    "can_have_multiple_places": [],
     "can_export_devices_details": [
       "national_admin"
     ]

--- a/ddocs/medic-db/medic-client/validate_doc_update.js
+++ b/ddocs/medic-db/medic-client/validate_doc_update.js
@@ -112,7 +112,9 @@ function(newDoc, oldDoc, userCtx, secObj) {
   if (isDbAdmin(userCtx, secObj)) {
     return;
   }
-  if (userCtx.facility_id === newDoc._id) {
+  if (userCtx.facility_id === newDoc._id ||
+    (Array.isArray(userCtx.facility_id) && userCtx.facility_id.includes(newDoc._id ))
+  ) {
     _err('You are not authorized to edit your own place');
   }
   if (newDoc.type === 'form') {

--- a/ddocs/medic-db/medic/validate_doc_update.js
+++ b/ddocs/medic-db/medic/validate_doc_update.js
@@ -78,7 +78,9 @@ function(newDoc, oldDoc, userCtx, secObj) {
       _err('You are not authorized to edit admin only docs');
     }
 
-    if (userCtx.facility_id === newDoc._id) {
+    if (userCtx.facility_id === newDoc._id ||
+      (Array.isArray(userCtx.facility_id) && userCtx.facility_id.includes(newDoc._id ))
+    ) {
       _err('You are not authorized to edit your own place');
     }
   };

--- a/webapp/src/ts/modules/contacts/contacts-more-menu.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-more-menu.component.ts
@@ -116,7 +116,7 @@ export class ContactsMoreMenuComponent implements OnInit, OnDestroy {
       && !this.loadingContent
       && this.snapshotData?.name === 'contacts.detail'
       && this.hasEditPermission
-      && (this.isOnlineOnly || this.userSettings?.facility_id !== this.selectedContactDoc?._id);
+      && (this.isOnlineOnly || !this.isUserFacility);
   }
 
   displayDeleteOption() {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Type casts users with existing `string` `facility_id` to `Array`  `facility_id` that can be loaded in the edit form of the Admin app. 

Closes #9203 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:facility-backward-compatibility/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:facility-backward-compatibility/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:facility-backward-compatibility/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

