### PR TITLE
fix(#9065): block offline users from using api/v1/person endpoint

### DIFF
--- a/api/src/controllers/person.js
+++ b/api/src/controllers/person.js
@@ -12,7 +12,10 @@ const getPerson = ({ with_lineage }) => ctx.bind(
 module.exports = {
   v1: {
     get: serverUtils.doOrError(async (req, res) => {
-      await auth.check(req, 'can_view_contacts');
+      const userCtx = await auth.getUserCtx(req);
+      if (!auth.isOnlineOnly(userCtx) || !auth.hasAllPermissions(userCtx, 'can_view_contacts')) {
+        return Promise.reject({ code: 403, message: 'Insufficient privileges' });
+      }
       const { uuid } = req.params;
       const person = await getPerson(req.query)(Qualifier.byUuid(uuid));
       if (!person) {

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -5,7 +5,6 @@ import { UuidQualifier } from '../qualifier';
 import * as Person from '../person';
 import { getDocById, getDocsByIds } from './libs/doc';
 import { LocalDataContext, SettingsService } from './libs/data-context';
-import { isNormalizedParent } from '../libs/contact';
 import logger from '@medic/logger';
 import { getLineageDocsById, getPrimaryContactIds, hydrateLineage, hydratePrimaryContact } from './libs/lineage';
 
@@ -17,7 +16,7 @@ export namespace v1 {
       return false;
     }
     const hasPersonType = contactTypeUtils.isPerson(settings.getAll(), doc);
-    if (!hasPersonType || !isNormalizedParent(doc)) {
+    if (!hasPersonType) {
       logger.warn(`Document [${uuid}] is not a valid person.`);
       return false;
     }


### PR DESCRIPTION
# Description

Result of https://github.com/medic/cht-core/issues/9065#issuecomment-2186704076

Closes https://github.com/medic/cht-core/issues/9065

Basically this PR just adds a check to the REST api so that only online users (user with full DB access) can call the `person` endpoint. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9065_block_offline_users/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9065_block_offline_users/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9065_block_offline_users/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

