### PR TITLE
fix(#9156): fix duplicate name in reports

### DIFF
--- a/webapp/src/ts/components/sender/sender.component.html
+++ b/webapp/src/ts/components/sender/sender.component.html
@@ -9,7 +9,7 @@
 
     <a class="name" *ngIf="!sentBy && getId() && getName(); else noLinkLabel" [routerLink]="[ '/contacts', getId() ]">{{ getName() }}</a>
     <ng-template #noLinkLabel>
-      <span class="name">{{ getName() || ( 'messages.unknown.sender' | translate ) }}</span>
+      <span class="name" *ngIf="!sentBy">{{ getName() || ( 'messages.unknown.sender' | translate ) }}</span>
     </ng-template>
 
     <span class="phone" *ngIf="!(message.name && message.name === message.facility?.contact?.phone)">

--- a/webapp/src/ts/components/sender/sender.component.html
+++ b/webapp/src/ts/components/sender/sender.component.html
@@ -9,7 +9,7 @@
 
     <a class="name" *ngIf="!sentBy && getId() && getName(); else noLinkLabel" [routerLink]="[ '/contacts', getId() ]">{{ getName() }}</a>
     <ng-template #noLinkLabel>
-      <span class="name" *ngIf="!sentBy">{{ getName() || ( 'messages.unknown.sender' | translate ) }}</span>
+      <span class="name" *ngIf="!sentBy || !getName()">{{ getName() || ( 'messages.unknown.sender' | translate ) }}</span>
     </ng-template>
 
     <span class="phone" *ngIf="!(message.name && message.name === message.facility?.contact?.phone)">


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

The  problem was when `sentBy` is `true`, the `span` inside the `ng-template` with `#noLinkLabel` was being rendered yet it should render when `sentBy` is `false`. 

Closes #9156 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9156-duplicate-name/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9156-duplicate-name/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9156-duplicate-name/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

