### PR TITLE
chore(#9123): add scenario that update from build version to 'master'

### DIFF
--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -49,6 +49,24 @@ const deleteUpgradeLogs = async () => {
   await utils.logsDb.bulkDocs(logs);
 };
 
+const upgradeVersion = async (branchVersion) => {
+  await upgradePage.goToUpgradePage();
+  await upgradePage.expandPreReleasesAccordion();
+
+  await (await upgradePage.getInstallButton(branchVersion, TAG)).click();
+  await (await upgradePage.upgradeModalConfirm()).click();
+
+  await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
+  await (await upgradePage.deploymentInProgress()).waitForDisplayed();
+  await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
+
+  if (testFrontend) {
+    // https://github.com/medic/cht-core/issues/9186
+    // this is an unfortunate incompatibility between current API and admin app in the old version
+    await (await upgradePage.deploymentComplete()).waitForDisplayed();
+  }
+};
+
 describe('Performing an upgrade', () => {
   before(async () => {
     await utils.saveDocs([...docs.places, ...docs.clinics, ...docs.persons, ...docs.reports]);
@@ -87,24 +105,7 @@ describe('Performing an upgrade', () => {
   });
 
   it('should upgrade to current branch', async () => {
-    await upgradePage.goToUpgradePage();
-    await upgradePage.expandPreReleasesAccordion();
-
-    const installButton = await upgradePage.getInstallButton(BRANCH, TAG);
-    await installButton.click();
-
-    const confirm = await upgradePage.upgradeModalConfirm();
-    await confirm.click();
-
-    await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-    if (testFrontend) {
-      // https://github.com/medic/cht-core/issues/9186
-      // this is an unfortunate incompatibility between current API and admin app in the old version
-      await (await upgradePage.deploymentComplete()).waitForDisplayed();
-    }
+    await upgradeVersion(BRANCH);
 
     const currentVersion = await upgradePage.getCurrentVersion();
     expect(version.getVersion(true)).to.include(currentVersion);
@@ -156,21 +157,7 @@ describe('Performing an upgrade', () => {
       createUser: false
     });
 
-    await upgradePage.goToUpgradePage();
-    await upgradePage.expandPreReleasesAccordion();
-
-    await (upgradePage.getInstallButton('master', TAG)).click();
-    await (upgradePage.upgradeModalConfirm()).click();
-
-    await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-    if (testFrontend) {
-      // https://github.com/medic/cht-core/issues/9186
-      // this is an unfortunate incompatibility between current API and admin app in the old version
-      await (await upgradePage.deploymentComplete()).waitForDisplayed();
-    }
+    await upgradeVersion('master');
 
     expect(await upgradePage.getBuild()).to.include('alpha');
     await commonPage.goToAboutPage();

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -49,6 +49,27 @@ const deleteUpgradeLogs = async () => {
   await utils.logsDb.bulkDocs(logs);
 };
 
+const upgradeVersion = async (branchVersion) => {
+  await upgradePage.goToUpgradePage();
+  await upgradePage.expandPreReleasesAccordion();
+
+  const installButton = await upgradePage.getInstallButton(branchVersion, TAG);
+  await installButton.click();
+
+  const confirm = await upgradePage.upgradeModalConfirm();
+  await confirm.click();
+
+  await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
+  await (await upgradePage.deploymentInProgress()).waitForDisplayed();
+  await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
+
+  if (testFrontend) {
+    // https://github.com/medic/cht-core/issues/9186
+    // this is an unfortunate incompatibility between current API and admin app in the old version
+    await (await upgradePage.deploymentComplete()).waitForDisplayed();
+  }
+};
+
 describe('Performing an upgrade', () => {
   before(async () => {
     await utils.saveDocs([...docs.places, ...docs.clinics, ...docs.persons, ...docs.reports]);
@@ -86,25 +107,9 @@ describe('Performing an upgrade', () => {
     expect(semver.valid(deployInfo.version)).to.be.ok;
   });
 
-  it('should upgrade to current branch', async () => {
-    await upgradePage.goToUpgradePage();
-    await upgradePage.expandPreReleasesAccordion();
-
-    const installButton = await upgradePage.getInstallButton(BRANCH, TAG);
-    await installButton.click();
-
-    const confirm = await upgradePage.upgradeModalConfirm();
-    await confirm.click();
-
-    await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-    if (testFrontend) {
-      // https://github.com/medic/cht-core/issues/9186
-      // this is an unfortunate incompatibility between current API and admin app in the old version
-      await (await upgradePage.deploymentComplete()).waitForDisplayed();
-    }
+  // eslint-disable-next-line no-only-tests/no-only-tests
+  it.only('should upgrade to current branch', async () => {
+    await upgradeVersion(BRANCH);
 
     const currentVersion = await upgradePage.getCurrentVersion();
     expect(version.getVersion(true)).to.include(currentVersion);
@@ -154,27 +159,18 @@ describe('Performing an upgrade', () => {
       password: constants.PASSWORD,
       createUser: false
     });
-    await upgradePage.goToUpgradePage();
-    await upgradePage.expandPreReleasesAccordion();
 
-    await (await upgradePage.getInstallButton('master', TAG)).click();
-    await (await upgradePage.upgradeModalConfirm()).click();
-
-    await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-    await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-    if (testFrontend) {
-      // https://github.com/medic/cht-core/issues/9186
-      // this is an unfortunate incompatibility between current API and admin app in the old version
-      await (await upgradePage.deploymentComplete()).waitForDisplayed();
-    }
+    await upgradeVersion('master');
 
     expect(await upgradePage.getBuild()).to.include('alpha');
     await commonPage.goToAboutPage();
     await commonPage.waitForPageLoaded();
     await (await aboutPage.aboutCard()).waitForDisplayed();
     expect(await aboutPage.getVersion()).to.include('master');
+
+    // installing again the BRANCH version for further validations
+    await upgradeVersion(BRANCH);
+
     await commonPage.logout();
   });
 

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -49,27 +49,6 @@ const deleteUpgradeLogs = async () => {
   await utils.logsDb.bulkDocs(logs);
 };
 
-const upgradeVersion = async (branchVersion) => {
-  await upgradePage.goToUpgradePage();
-  await upgradePage.expandPreReleasesAccordion();
-
-  const installButton = await upgradePage.getInstallButton(branchVersion, TAG);
-  await installButton.click();
-
-  const confirm = await upgradePage.upgradeModalConfirm();
-  await confirm.click();
-
-  await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-  await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-  await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-  if (testFrontend) {
-    // https://github.com/medic/cht-core/issues/9186
-    // this is an unfortunate incompatibility between current API and admin app in the old version
-    await (await upgradePage.deploymentComplete()).waitForDisplayed();
-  }
-};
-
 describe('Performing an upgrade', () => {
   before(async () => {
     await utils.saveDocs([...docs.places, ...docs.clinics, ...docs.persons, ...docs.reports]);
@@ -108,7 +87,24 @@ describe('Performing an upgrade', () => {
   });
 
   it('should upgrade to current branch', async () => {
-    await upgradeVersion(BRANCH);
+    await upgradePage.goToUpgradePage();
+    await upgradePage.expandPreReleasesAccordion();
+
+    const installButton = await upgradePage.getInstallButton(BRANCH, TAG);
+    await installButton.click();
+
+    const confirm = await upgradePage.upgradeModalConfirm();
+    await confirm.click();
+
+    await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
+    await (await upgradePage.deploymentInProgress()).waitForDisplayed();
+    await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
+
+    if (testFrontend) {
+      // https://github.com/medic/cht-core/issues/9186
+      // this is an unfortunate incompatibility between current API and admin app in the old version
+      await (await upgradePage.deploymentComplete()).waitForDisplayed();
+    }
 
     const currentVersion = await upgradePage.getCurrentVersion();
     expect(version.getVersion(true)).to.include(currentVersion);
@@ -146,6 +142,7 @@ describe('Performing an upgrade', () => {
     await browser.refresh();
     await commonPage.waitForPageLoaded();
     await commonPage.goToAboutPage();
+    await (await aboutPage.aboutCard()).waitForDisplayed();
     const expected = TAG || `${utils.escapeBranchName(BRANCH)} (`;
     expect(await aboutPage.getVersion()).to.include(expected);
     await commonPage.logout();
@@ -159,16 +156,27 @@ describe('Performing an upgrade', () => {
       createUser: false
     });
 
-    await upgradeVersion('master');
+    await upgradePage.goToUpgradePage();
+    await upgradePage.expandPreReleasesAccordion();
+
+    await (upgradePage.getInstallButton('master', TAG)).click();
+    await (upgradePage.upgradeModalConfirm()).click();
+
+    await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
+    await (await upgradePage.deploymentInProgress()).waitForDisplayed();
+    await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
+
+    if (testFrontend) {
+      // https://github.com/medic/cht-core/issues/9186
+      // this is an unfortunate incompatibility between current API and admin app in the old version
+      await (await upgradePage.deploymentComplete()).waitForDisplayed();
+    }
 
     expect(await upgradePage.getBuild()).to.include('alpha');
     await commonPage.goToAboutPage();
     await commonPage.waitForPageLoaded();
     await (await aboutPage.aboutCard()).waitForDisplayed();
     expect(await aboutPage.getVersion()).to.include('master');
-
-    // installing again the BRANCH version for further validations
-    await upgradeVersion(BRANCH);
 
     await commonPage.logout();
   });

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -107,8 +107,7 @@ describe('Performing an upgrade', () => {
     expect(semver.valid(deployInfo.version)).to.be.ok;
   });
 
-  // eslint-disable-next-line no-only-tests/no-only-tests
-  it.only('should upgrade to current branch', async () => {
+  it('should upgrade to current branch', async () => {
     await upgradeVersion(BRANCH);
 
     const currentVersion = await upgradePage.getCurrentVersion();

--- a/tests/e2e/upgrade/wdio.conf.js
+++ b/tests/e2e/upgrade/wdio.conf.js
@@ -124,8 +124,7 @@ const servicesStartTimeout = () => {
 const upgradeConfig = Object.assign(wdioBaseConfig.config, {
   specs:
     [
-      'upgrade.wdio-spec.js',
-      '*.wdio-spec.js'
+      '*.wdio-spec.js',
     ],
   exclude: [],
 

--- a/tests/e2e/upgrade/webapp.wdio-spec.js
+++ b/tests/e2e/upgrade/webapp.wdio-spec.js
@@ -1,10 +1,7 @@
 const common = require('@page-objects/default/common/common.wdio.page');
 const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
 const peoplePage = require('@page-objects/default/contacts/contacts.wdio.page');
-const aboutPage = require('@page-objects/default/about/about.wdio.page');
 const utils = require('@utils');
-
-const { BRANCH, TAG } = process.env;
 
 const loginPage = require('@page-objects/default/login/login.wdio.page');
 const constants = require('@constants');

--- a/tests/e2e/upgrade/webapp.wdio-spec.js
+++ b/tests/e2e/upgrade/webapp.wdio-spec.js
@@ -55,9 +55,4 @@ describe('Webapp after upgrade', () => {
     expect(contacts).to.deep.equal(['DC']);
   });
 
-  it('should display correct version on the about page', async () => {
-    await common.goToAboutPage();
-    const expected = TAG || `${utils.escapeBranchName(BRANCH)} (`;
-    expect(await aboutPage.getVersion()).to.include(expected);
-  });
 });

--- a/tests/page-objects/default/about/about.wdio.page.js
+++ b/tests/page-objects/default/about/about.wdio.page.js
@@ -1,6 +1,7 @@
 const userName = () => $('label=User name');
 const partners = () => $('.partners');
 const version = () => $('[test-id="about-version"]');
+const aboutCard = () => $('div*=About');
 const RELOAD_BUTTON = '.about.page .mat-primary';
 
 const getPartnerImage = async (name) => {
@@ -21,5 +22,6 @@ module.exports = {
   partners,
   getPartnerImage,
   getVersion,
+  aboutCard,
   RELOAD_BUTTON,
 };


### PR DESCRIPTION
# Description

Add a scenario to the individual test `should upgrade to current branch` to verify that it is possible to update from a specific build version, `master` branch it is being used for this test.

Related to issue #9123 

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-from-build-version/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-from-build-version/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-from-build-version/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

