### PR TITLE
fix(#9218): fix upgrade e2e test for tags

### DIFF
--- a/tests/e2e/upgrade/upgrade-master.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade-master.wdio-spec.js
@@ -4,21 +4,6 @@ const commonPage = require('@page-objects/default/common/common.wdio.page');
 const aboutPage = require('@page-objects/default/about/about.wdio.page');
 const constants = require('@constants');
 
-const upgradeVersion = async () => {
-  await upgradePage.goToUpgradePage();
-  await upgradePage.expandPreReleasesAccordion();
-
-  await (await upgradePage.getInstallButton('master')).click();
-  await (await upgradePage.upgradeModalConfirm()).click();
-
-  await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-  await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-  await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-  await (await upgradePage.deploymentComplete()).waitForDisplayed();
-};
-
-
 describe('Performing an upgrade from current branch to master', () => {
   it('should upgrade from current version to master', async () => {
     await loginPage.cookieLogin({
@@ -27,7 +12,7 @@ describe('Performing an upgrade from current branch to master', () => {
       createUser: false
     });
 
-    await upgradeVersion('master');
+    await upgradePage.upgradeVersion('master', false, true);
 
     expect(await upgradePage.getBuild()).to.include('alpha');
     await commonPage.goToAboutPage();

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -49,24 +49,6 @@ const deleteUpgradeLogs = async () => {
   await utils.logsDb.bulkDocs(logs);
 };
 
-const upgradeVersion = async (branchVersion) => {
-  await upgradePage.goToUpgradePage();
-  await upgradePage.expandPreReleasesAccordion();
-
-  await (await upgradePage.getInstallButton(branchVersion, TAG)).click();
-  await (await upgradePage.upgradeModalConfirm()).click();
-
-  await (await upgradePage.cancelUpgradeButton()).waitForDisplayed();
-  await (await upgradePage.deploymentInProgress()).waitForDisplayed();
-  await (await upgradePage.deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
-
-  if (testFrontend) {
-    // https://github.com/medic/cht-core/issues/9186
-    // this is an unfortunate incompatibility between current API and admin app in the old version
-    await (await upgradePage.deploymentComplete()).waitForDisplayed();
-  }
-};
-
 describe('Performing an upgrade', () => {
   before(async () => {
     await utils.saveDocs([...docs.places, ...docs.clinics, ...docs.persons, ...docs.reports]);
@@ -105,7 +87,7 @@ describe('Performing an upgrade', () => {
   });
 
   it('should upgrade to current branch', async () => {
-    await upgradeVersion(BRANCH);
+    await upgradePage.upgradeVersion(BRANCH, TAG, testFrontend);
 
     const currentVersion = await upgradePage.getCurrentVersion();
     expect(version.getVersion(true)).to.include(currentVersion);

--- a/tests/page-objects/upgrade/upgrade.wdio.page.js
+++ b/tests/page-objects/upgrade/upgrade.wdio.page.js
@@ -50,6 +50,26 @@ const getBuild = async () => {
   return await (await version()).getText();
 };
 
+const upgradeVersion = async (branch, tag, testFrontend=true) => {
+  await goToUpgradePage();
+  await expandPreReleasesAccordion();
+
+  const installButton = await getInstallButton(branch, tag);
+  await installButton.scrollIntoView({ block: 'center', inline: 'center' });
+  await installButton.click();
+  await (await upgradeModalConfirm()).click();
+
+  await (await cancelUpgradeButton()).waitForDisplayed();
+  await (await deploymentInProgress()).waitForDisplayed();
+  await (await deploymentInProgress()).waitForDisplayed({ reverse: true, timeout: 100000 });
+
+  if (testFrontend) {
+    // https://github.com/medic/cht-core/issues/9186
+    // this is an unfortunate incompatibility between current API and admin app in the old version
+    await (await deploymentComplete()).waitForDisplayed();
+  }
+};
+
 module.exports = {
   cancelUpgradeButton,
   deploymentInProgress,
@@ -60,4 +80,5 @@ module.exports = {
   expandPreReleasesAccordion,
   upgradeModalConfirm,
   getBuild,
+  upgradeVersion,
 };


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fixes upgrade page hitting header instead of upgrade button when there are many releases to choose from. 
Changes how we select the "latest" release, so it's always the version that is released before the version we test. 

#9218 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9218-fix-upgrade-on-release-tag/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9218-fix-upgrade-on-release-tag/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9218-fix-upgrade-on-release-tag/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

