### PR TITLE
fix(#9264): telemetry granularity for contact details page

### DIFF
--- a/webapp/src/ts/effects/contacts.effects.ts
+++ b/webapp/src/ts/effects/contacts.effects.ts
@@ -14,6 +14,7 @@ import { TargetAggregatesService } from '@mm-services/target-aggregates.service'
 import { RouteSnapshotService } from '@mm-services/route-snapshot.service';
 import { TranslateService } from '@mm-services/translate.service';
 import { PerformanceService } from '@mm-services/performance.service';
+import { ContactTypesService } from '@mm-services/contact-types.service';
 
 @Injectable()
 export class ContactsEffects {
@@ -29,6 +30,7 @@ export class ContactsEffects {
     private performanceService: PerformanceService,
     private contactViewModelGeneratorService: ContactViewModelGeneratorService,
     private contactSummaryService: ContactSummaryService,
+    private contactTypesService: ContactTypesService,
     private tasksForContactService: TasksForContactService,
     private targetAggregateService: TargetAggregatesService,
     private translateService: TranslateService,
@@ -71,7 +73,7 @@ export class ContactsEffects {
         const loadContact = this
           .loadContact(id)
           .then(contact => {
-            const contactType = contact?.doc?.contact_type;
+            const contactType = this.contactTypesService.getTypeId(contact?.doc);
             if (contactType) {
               trackName = trackName.map(part => part === 'contact' ? contactType : part);
             }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Fixes bug and updates unit tests to verify default value, `contact_type` and `type`.

#9264

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-telemetry-granularity-contact-details/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-telemetry-granularity-contact-details/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-telemetry-granularity-contact-details/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

