### PR TITLE
fix(#9275): set targets' dropdown on navigation

### DIFF
--- a/webapp/tests/karma/ts/components/filters/analytics-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/analytics-filter.component.spec.ts
@@ -1,0 +1,80 @@
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+import { AnalyticsFilterComponent } from '@mm-components/filters/analytics-filter/analytics-filter.component';
+
+describe('Analytics Filter Component', () => {
+  let component: AnalyticsFilterComponent;
+  let fixture: ComponentFixture<AnalyticsFilterComponent>;
+  let route;
+  let router;
+  let routerEventSubject;
+
+  beforeEach(async () => {
+    route = {
+      snapshot: { queryParams: { query: '' }, firstChild: { data: { moduleId: 'some-module' } } },
+    };
+    routerEventSubject = new Subject();
+    router = {
+      events: { pipe: sinon.stub().returns(routerEventSubject) },
+      navigate: sinon.stub(),
+    };
+
+    await TestBed
+      .configureTestingModule({
+        imports: [
+          TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } })
+        ],
+        declarations: [
+          AnalyticsFilterComponent,
+        ],
+        providers: [
+          { provide: ActivatedRoute, useValue: route },
+          { provide: Router, useValue: router },
+        ]
+      })
+      .compileComponents()
+      .then(() => {
+        fixture = TestBed.createComponent(AnalyticsFilterComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should create AnalyticsFilterComponent', () => {
+    expect(component).to.exist;
+  });
+
+  it('should update the active module when route changes', fakeAsync(() => {
+    component.analyticsModules = [
+      { id: 'targets' },
+      { id: 'target-aggregates' },
+    ];
+
+    routerEventSubject.next({ snapshot: { data: { moduleId: 'random-module' } } });
+    flush();
+
+    expect(component.activeModule).to.be.undefined;
+
+    routerEventSubject.next({ snapshot: { data: { moduleId: 'targets' } } });
+    flush();
+
+    expect(component.activeModule).to.not.be.undefined;
+    expect(component.activeModule.id).to.equal('targets');
+
+    routerEventSubject.next({ snapshot: { data: { moduleId: 'target-aggregates' } } });
+    flush();
+
+    expect(component.activeModule).to.not.be.undefined;
+    expect(component.activeModule.id).to.equal('target-aggregates');
+  }));
+
+});


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

#9275

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-targets-dropdown/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-targets-dropdown/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-targets-dropdown/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

