### PR TITLE
chore(#9106): fix dependencies for e2e tests that runs in local environment

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update --no-cache \
 
 WORKDIR /service
 
-COPY shared-libs ./shared-libs
+COPY ../shared-libs ./shared-libs
 COPY node_modules/@medic ./node_modules/@medic
 COPY api ./api
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,6 +12,8 @@ RUN apk add --update --no-cache \
 
 WORKDIR /service
 
+COPY shared-libs ./shared-libs
+COPY node_modules/@medic ./node_modules/@medic
 COPY api ./api
 
 ENV NODE_PATH=/service/api/node_modules

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -244,8 +244,9 @@ const buildServiceImages = async () => {
 
   console.log('working directory', workingDir);
   for (const service of versions.SERVICES) {
-    await exec('cp', ['-r', `${workingDir}/node_modules`, service]);
-    await exec('cp', ['-r', './shared-libs', service]);
+    await exec('rsync', ['-r', '-p', './shared-libs', service]);
+    await exec('rsync', ['-r', '-p', `${workingDir}/node_modules`, service]);
+
 
     const tag = versions.getImageTag(service);
     if (INTERNAL_CONTRIBUTOR) {

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -244,7 +244,6 @@ const buildServiceImages = async () => {
 
   console.log('working directory', workingDir);
   for (const service of versions.SERVICES) {
-    await exec('rsync', ['-r', '-p', './shared-libs', service]);
     await exec('rsync', ['-r', '-p', `${workingDir}/node_modules`, service]);
 
     const tag = versions.getImageTag(service);

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -244,7 +244,7 @@ const buildServiceImages = async () => {
 
   console.log('working directory', workingDir);
   for (const service of versions.SERVICES) {
-    await exec('rsync', ['-r', '-p', `${workingDir}/node_modules`, service]);
+    await exec('cp', ['-a', `${workingDir}/node_modules`, service]);
 
     const tag = versions.getImageTag(service);
     if (INTERNAL_CONTRIBUTOR) {

--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -247,7 +247,6 @@ const buildServiceImages = async () => {
     await exec('rsync', ['-r', '-p', './shared-libs', service]);
     await exec('rsync', ['-r', '-p', `${workingDir}/node_modules`, service]);
 
-
     const tag = versions.getImageTag(service);
     if (INTERNAL_CONTRIBUTOR) {
       await buildMultiPlatformServiceImage(service, tag);

--- a/sentinel/Dockerfile
+++ b/sentinel/Dockerfile
@@ -11,6 +11,8 @@ RUN apk add --update --no-cache \
 
 WORKDIR /service
 
+COPY shared-libs ./shared-libs
+COPY node_modules/@medic ./node_modules/@medic
 COPY sentinel ./sentinel
 
 ENV NODE_PATH=/service/sentinel/node_modules

--- a/sentinel/Dockerfile
+++ b/sentinel/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --no-cache \
 
 WORKDIR /service
 
-COPY shared-libs ./shared-libs
+COPY ../shared-libs ./shared-libs
 COPY node_modules/@medic ./node_modules/@medic
 COPY sentinel ./sentinel
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

1. The problem is that the `cp -r` doesn't preserve symbolic links. So I changed to this `await exec('cp', ['-a', '${workingDir}/node_modules', service]);`

2. Then, the docker files still need the node-modules and the shared-libs folders to find the dependencies during run time. I'm copying those folders into the working directory of the container. 

#9106

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fixes-e2e-for-local-run/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fixes-e2e-for-local-run/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fixes-e2e-for-local-run/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

