### PR TITLE
fix(#8781):  docker helper to use docker compose v2x

### DIFF
--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -155,6 +155,20 @@ required_apps_installed(){
   echo "${error}"
 }
 
+docker_installed(){
+  # special check for docker.  We want to be sure both "docker" is installed AND
+  # that "docker compose" is installed.  We deprecated "docker-compose" in CHT Core #8781
+  if [ -n "$(required_apps_installed "docker")" ];then
+    echo "Docker not installed"
+  else
+    docker compose &>/dev/null # sending output to /dev/null because we don't want it printed
+
+    if [ ! $? -eq 0 ]; then
+        echo "Docker Compose not installed"
+    fi
+  fi
+}
+
 get_nginx_container_id() {
   docker ps --all --filter "publish=${NGINX_HTTPS_PORT}" --filter "name=${projectName}" --quiet  2>/dev/null
 }
@@ -256,9 +270,9 @@ get_system_and_docker_info(){
   echo $"$info" | column -t
 }
 
-if [ -n "$(required_apps_installed "docker-compose")" ];then
+if [ -n "$(required_apps_installed "docker")" ];then
   echo ""
-  echo -e "${red}\"docker-compose\" is not installed or could not be found. Please install and try again!${noColor}"
+  echo -e "${red}\"docker\" or \"docker compose\" is not installed or could not be found. Please install and try again!${noColor}"
   show_help_existing_stop_and_destroy
   exit 0
 fi
@@ -421,7 +435,7 @@ projectURL=$(get_local_ip_url "$(get_lan_ip)")
 if [[ -n ${DEBUG+x} ]];then get_system_and_docker_info; fi
 
 echo "";echo "homedir: $homeDir"
-docker-compose --env-file "./$projectFile" --file "$homeDir/upgrade-service.yml" up --detach
+docker compose --env-file "./$projectFile" --file "$homeDir/upgrade-service.yml" up --detach
 if [[ -n ${DEBUG+x} ]];then get_system_and_docker_info; fi
 
 set +e

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -155,17 +155,13 @@ required_apps_installed(){
   echo "${error}"
 }
 
-docker_installed(){
+docker_not_installed(){
   # special check for docker.  We want to be sure both "docker" is installed AND
   # that "docker compose" is installed.  We deprecated "docker-compose" in CHT Core #8781
   if [ -n "$(required_apps_installed "docker")" ];then
     echo "Docker not installed"
   else
-    docker compose &>/dev/null # sending output to /dev/null because we don't want it printed
-
-    if [ ! $? -eq 0 ]; then
-        echo "Docker Compose not installed"
-    fi
+    docker compose &>/dev/null || echo "Docker Compose not installed"
   fi
 }
 
@@ -270,7 +266,7 @@ get_system_and_docker_info(){
   echo $"$info" | column -t
 }
 
-if [ -n "$(required_apps_installed "docker")" ];then
+if [ "$(docker_not_installed)" ];then
   echo ""
   echo -e "${red}\"docker\" or \"docker compose\" is not installed or could not be found. Please install and try again!${noColor}"
   show_help_existing_stop_and_destroy


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR:
* updates docker helper to use `docker compose` instead of `docker-compose`
* helps users by defending against `docker compose` not being installed

per #8781

Testing:
* I tested this by spinning up an ubuntu 18 VM and running `apt install docker.io docker-compose` which installed it like this:

```
$ docker version
Client:
 Version:           24.0.7
[SNIP]

$ docker-compose version
docker-compose version 1.25.0, build unknown
[SNIP]

$ docker compose version
docker: 'compose' is not a docker command.
```
* then I tested this branch on that old VM to make sure it failed to run (as expected)
* I also tested this branch on Fedora 39 bluefin which had modern docker 2.x  and it succeeded (as expected)
 
# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8781-docker-helper-composev2/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8781-docker-helper-composev2/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8781-docker-helper-composev2/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

