### PR TITLE
fix(#9294): adds deploy-info to service worker

### DIFF
--- a/api/src/generate-service-worker.js
+++ b/api/src/generate-service-worker.js
@@ -80,6 +80,7 @@ const writeServiceWorkerFile = async () => {
 
       // webapp
       'webapp/manifest.json',
+      'webapp/deploy-info.json',
       'webapp/audio/*',
       'webapp/img/*',
       'webapp/*.js',

--- a/api/src/services/config-watcher.js
+++ b/api/src/services/config-watcher.js
@@ -16,6 +16,7 @@ const config = require('../config');
 const environment = require('@medic/environment');
 const dataContext = require('./data-context');
 const extensionLibs = require('./extension-libs');
+const deployInfo = require('./deploy-info');
 
 const MEDIC_DDOC_ID = '_design/medic';
 
@@ -148,7 +149,8 @@ const load = () => {
     .then(() => loadSettings())
     .then(() => addUserRolesToDb())
     .then(() => initTransitionLib())
-    .then(() => db.createVault());
+    .then(() => db.createVault())
+    .then(() => deployInfo.store());
 };
 
 const listen = () => {

--- a/api/src/services/deploy-info.js
+++ b/api/src/services/deploy-info.js
@@ -3,8 +3,13 @@ const environment = require('@medic/environment');
 const ddocs = require('./setup/ddocs');
 const logger = require('@medic/logger');
 const semver = require('semver');
+const fs = require('fs');
+const path = require('path');
+const resources = require('../resources');
 
 let deployInfoCache;
+const webappPath = resources.webappPath;
+const DEPLOY_INFO_OUTPUT_PATH = path.join(webappPath, 'deploy-info.json');
 
 const getVersion = (ddoc) => {
   return semver.valid(ddoc.build_info?.version) || semver.valid(ddoc.deploy_info?.build) || ddoc.version;
@@ -26,6 +31,12 @@ const getDeployInfo = async () => {
   }
 };
 
+const store = async () => {
+  const deployInfo = await getDeployInfo();
+  return await fs.promises.writeFile(DEPLOY_INFO_OUTPUT_PATH, JSON.stringify(deployInfo));
+};
+
 module.exports = {
   get: getDeployInfo,
+  store,
 };

--- a/api/tests/mocha/generate-service-worker.spec.js
+++ b/api/tests/mocha/generate-service-worker.spec.js
@@ -67,6 +67,7 @@ describe('generate service worker', () => {
       globPatterns: [
         '!webapp/service-worker.js',
         'webapp/manifest.json',
+        'webapp/deploy-info.json',
         'webapp/audio/*',
         'webapp/img/*',
         'webapp/*.js',

--- a/api/tests/mocha/services/config-watcher.spec.js
+++ b/api/tests/mocha/services/config-watcher.spec.js
@@ -14,6 +14,7 @@ const config = require('../../../src/config');
 const bootstrap = require('../../../src/services/config-watcher');
 const manifest = require('../../../src/services/manifest');
 const environment = require('@medic/environment');
+const deployInfo = require('../../../src/services/deploy-info');
 
 describe('Configuration', () => {
   beforeEach(() => {
@@ -32,6 +33,7 @@ describe('Configuration', () => {
     sinon.stub(fs, 'watch');
     sinon.stub(translations, 'getTranslationDocs');
     sinon.stub(dbWatcher, 'listen');
+    sinon.stub(deployInfo, 'store');
   });
 
   afterEach(() => {
@@ -67,6 +69,7 @@ describe('Configuration', () => {
         chai.expect(config.setTranslationCache.callCount).to.equal(1);
         chai.expect(config.setTranslationCache.args[0]).to.deep.equal([{}]);
 
+        chai.expect(deployInfo.store.calledOnce).to.equal(true);
         chai.expect(db.createVault.callCount).to.equal(1);
       });
     });

--- a/tests/e2e/default/service-worker/service-worker.wdio-spec.js
+++ b/tests/e2e/default/service-worker/service-worker.wdio-spec.js
@@ -131,6 +131,7 @@ describe('Service worker cache', () => {
       '/login/images/hide-password.svg',
       '/login/images/show-password.svg',
       '/main.js',
+      '/deploy-info.json',
       '/manifest.json',
       '/medic/_design/medic/_rewrite/',
       '/medic/login',

--- a/webapp/src/ts/services/feedback.service.ts
+++ b/webapp/src/ts/services/feedback.service.ts
@@ -20,7 +20,7 @@ export class FeedbackService {
     private versionService:VersionService,
     private debugService: DebugService,
     private languageService: LanguageService,
-    private telemetryService : TelemetryService,
+    private telemetryService : TelemetryService
   ) {
   }
 
@@ -191,7 +191,7 @@ export class FeedbackService {
   }
 
   private async create(info, isManual?) {
-    const { version } = await this.versionService.getLocal();
+    const { version } = await this.versionService.getServiceWorker();
     const language = await this.languageService.get();
 
     const time = new Date().toISOString();

--- a/webapp/src/ts/services/version.service.ts
+++ b/webapp/src/ts/services/version.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 
 import { DbService } from '@mm-services/db.service';
 
@@ -6,8 +7,10 @@ import { DbService } from '@mm-services/db.service';
   providedIn: 'root'
 })
 export class VersionService {
-  constructor(private dbService: DbService) {
-  }
+  constructor(
+    private dbService: DbService,
+    private http: HttpClient,
+  ) {}
 
   private formatRev(rev) {
     return rev.split('-')[0];
@@ -33,6 +36,19 @@ export class VersionService {
           rev: this.formatRev(ddoc._rev)
         };
       });
+  }
+
+  getServiceWorker ():Promise<{ version }> {
+    return new Promise((resolve, reject) => {
+      this.http
+        .get('/deploy-info.json')
+        .subscribe({
+          next: response => resolve({
+            version: this.getDeployVersion(response),
+          }),
+          error: error => reject(error),
+        });
+    });
   }
 
   getRemoteRev() {

--- a/webapp/src/ts/services/version.service.ts
+++ b/webapp/src/ts/services/version.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 
 import { DbService } from '@mm-services/db.service';
 
@@ -38,17 +39,12 @@ export class VersionService {
       });
   }
 
-  getServiceWorker ():Promise<{ version }> {
-    return new Promise((resolve, reject) => {
-      this.http
-        .get('/deploy-info.json')
-        .subscribe({
-          next: response => resolve({
-            version: this.getDeployVersion(response),
-          }),
-          error: error => reject(error),
-        });
-    });
+  async getServiceWorker():Promise<{ version }> {
+    const obs = this.http.get('/deploy-info.json');
+    const response = await firstValueFrom(obs);
+    return {
+      version: this.getDeployVersion(response),
+    };
   }
 
   getRemoteRev() {

--- a/webapp/tests/karma/ts/services/feedback.service.spec.ts
+++ b/webapp/tests/karma/ts/services/feedback.service.spec.ts
@@ -14,7 +14,7 @@ describe('Feedback service', () => {
   let mockConsole;
   let mockWindow;
   let mockDocument;
-  let getLocal;
+  let getServiceWorker;
   let service:FeedbackService;
   let languageService;
 
@@ -30,19 +30,18 @@ describe('Feedback service', () => {
       info: sinon.stub(),
       log: sinon.stub()
     };
-    getLocal = sinon.stub();
+    getServiceWorker = sinon.stub();
     mockWindow = sinon.stub();
     languageService = { get: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: DbService, useValue: { get: () => metaDb } },
-        { provide: VersionService, useValue: { getLocal } },
+        { provide: VersionService, useValue: { getServiceWorker } },
         { provide: SessionService, useValue: { userCtx: () => ({ name: 'fred' }) } },
         { provide: LanguageService, useValue: languageService }
       ]
     });
-
     service = TestBed.inject(FeedbackService);
   });
 
@@ -54,7 +53,7 @@ describe('Feedback service', () => {
   it('should submit feedback when there is an unhandled error', fakeAsync(() => {
     metaDb.post.resolves();
     metaDb.allDocs.resolves({ rows: [] });
-    getLocal.resolves(({ version: '0.5.0' }));
+    getServiceWorker.resolves(({ version: '0.5.0' }));
     languageService.get.resolves('es');
     service._setOptions({
       console: mockConsole,
@@ -103,7 +102,7 @@ describe('Feedback service', () => {
   it('should log history restricted to 20 lines', async () => {
     metaDb.post.resolves();
     metaDb.allDocs.resolves({ rows: [] });
-    getLocal.resolves(({ version: '0.5.0' }));
+    getServiceWorker.resolves(({ version: '0.5.0' }));
     languageService.get.resolves('en');
     service.init();
     service._setOptions({
@@ -132,7 +131,7 @@ describe('Feedback service', () => {
     clock = sinon.useFakeTimers();
     metaDb.post.resolves();
     metaDb.allDocs.resolves({ rows: [] });
-    getLocal.resolves(({ version: '0.5.0' }));
+    getServiceWorker.resolves(({ version: '0.5.0' }));
     mockDocument.URL = 'http://gareth:SUPERSECRET!@somewhere.com';
     languageService.get.resolves('en');
     service.init();
@@ -155,7 +154,7 @@ describe('Feedback service', () => {
   it('should record device id in feedback doc', async () => {
     metaDb.post.resolves();
     metaDb.allDocs.resolves({ rows: [] });
-    getLocal.resolves(({ version: '0.5.0' }));
+    getServiceWorker.resolves(({ version: '0.5.0' }));
     languageService.get.resolves('en');
     service._setOptions({
       console: mockConsole,


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Uses service worker deploy-info to get version in feedback service. 

#9294 
#8645

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9294-feedback-doc-on-couch-crash/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9294-feedback-doc-on-couch-crash/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9294-feedback-doc-on-couch-crash/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

