### PR TITLE
chore(#9315): fix test to use promises not callbacks

### DIFF
--- a/shared-libs/validation/test/validations.js
+++ b/shared-libs/validation/test/validations.js
@@ -136,7 +136,7 @@ describe('validations', () => {
     const view = sinon.stub(db.medic, 'query').resolves({
       rows: [{ id: 'different' }],
     });
-    const allDocs = sinon.stub(db.medic, 'allDocs').callsArgWith(1, null, {
+    const allDocs = sinon.stub(db.medic, 'allDocs').resolves({
       rows: [
         {
           id: 'different',

--- a/shared-libs/validation/test/validations.js
+++ b/shared-libs/validation/test/validations.js
@@ -24,6 +24,7 @@ describe('validations', () => {
     config = {};
     translate = sinon.stub().returnsArg(0);
     sinon.stub(logger, 'debug');
+    sinon.stub(logger, 'error');
 
     validation.init({ db, config, translate });
   });
@@ -155,6 +156,7 @@ describe('validations', () => {
       patient_id: '111',
     };
     return validation.validate(doc, validations).then(errors => {
+      assert.equal(logger.error.callCount, 0);
       assert.equal(view.callCount, 1);
       assert.equal(view.args[0][0], 'medic-client/reports_by_freetext');
       assert.deepEqual(view.args[0][1], { key: ['patient_id:111'] });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->
#9315

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9315-fix-badly-mocked-unit-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9315-fix-badly-mocked-unit-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9315-fix-badly-mocked-unit-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

