### PR TITLE
feat(#8181): add automation tests for report's filter

### DIFF
--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -37,6 +37,7 @@ describe('Reports Sidebar Filter', () => {
     .build(
       {
         form: 'pregnancy',
+        verified: true,
         reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf()
       },
       { patient, submitter: healthCenterContact, fields: { lmp_date: 'Feb 3, 2022' }}
@@ -55,6 +56,7 @@ describe('Reports Sidebar Filter', () => {
     .build(
       {
         form: 'pregnancy_home_visit',
+        verified: false,
         reported_date: moment([today.year(), today.month(), 15, 0, 30]).subtract(5, 'month').valueOf()
       },
       { patient, submitter: healthCenterContact, fields: { ok: 'Yes!' }}
@@ -64,6 +66,7 @@ describe('Reports Sidebar Filter', () => {
     .build(
       {
         form: 'pregnancy_home_visit',
+        verified: true,
         reported_date: moment([today.year(), today.month(), 16, 9, 10]).subtract(1, 'month').valueOf()
       },
       { patient, submitter: districtHospitalContact, fields: { ok: 'Yes!' }}
@@ -138,6 +141,23 @@ describe('Reports Sidebar Filter', () => {
     expect((await reportsPage.allReports()).length).to.equal(2);
     expect(await (await reportsPage.reportByUUID(visitHealthCenter._id)).isDisplayed()).to.be.true;
     expect(await (await reportsPage.reportByUUID(pregnancyHealthCenter._id)).isDisplayed()).to.be.true;
+  });
+
+  it('should filter by status', async () => {
+    await loginPage.login(districtHospitalUser);
+    await commonPage.waitForPageLoaded();
+
+    await commonPage.goToReports();
+    await (await reportsPage.firstReport()).waitForDisplayed();
+    expect((await reportsPage.allReports()).length).to.equal(reports.length);
+
+    await reportsPage.openSidebarFilter();
+    await reportsPage.filterByStatus('Reviewed: correct');
+    await commonPage.waitForPageLoaded();
+
+    expect((await reportsPage.allReports()).length).to.equal(2);
+    expect(await (await reportsPage.reportByUUID(pregnancyHealthCenter._id)).isDisplayed()).to.be.true;
+    expect(await (await reportsPage.reportByUUID(visitDistrictHospital._id)).isDisplayed()).to.be.true;
   });
 
   it('should filter by user associated place when the permission to default filter is enabled', async () => {

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -123,6 +123,23 @@ describe('Reports Sidebar Filter', () => {
     expect(await (await reportsPage.reportByUUID(visitDistrictHospital._id)).isDisplayed()).to.be.true;
   });
 
+  it('should filter by place', async () => {
+    await loginPage.login(districtHospitalUser);
+    await commonPage.waitForPageLoaded();
+
+    await commonPage.goToReports();
+    await (await reportsPage.firstReport()).waitForDisplayed();
+    expect((await reportsPage.allReports()).length).to.equal(reports.length);
+
+    await reportsPage.openSidebarFilter();
+    await reportsPage.filterByFacility(districtHospital.name, healthCenter.name);
+    await commonPage.waitForPageLoaded();
+
+    expect((await reportsPage.allReports()).length).to.equal(2);
+    expect(await (await reportsPage.reportByUUID(visitHealthCenter._id)).isDisplayed()).to.be.true;
+    expect(await (await reportsPage.reportByUUID(pregnancyHealthCenter._id)).isDisplayed()).to.be.true;
+  });
+
   it('should filter by user associated place when the permission to default filter is enabled', async () => {
     await loginPage.login(healthCenterUser);
     await commonPage.waitForPageLoaded();

--- a/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
+++ b/tests/e2e/default/reports/sidebar-filter.wdio-spec.js
@@ -40,7 +40,7 @@ describe('Reports Sidebar Filter', () => {
         verified: true,
         reported_date: moment([today.year(), today.month(), 1, 23, 30]).subtract(4, 'month').valueOf()
       },
-      { patient, submitter: healthCenterContact, fields: { lmp_date: 'Feb 3, 2022' }}
+      { patient, submitter: healthCenterContact, fields: { lmp_date: 'Feb 3, 2022' } }
     );
   const pregnancyDistrictHospital = reportFactory
     .report()
@@ -49,7 +49,7 @@ describe('Reports Sidebar Filter', () => {
         form: 'pregnancy',
         reported_date: moment([today.year(), today.month(), 12, 10, 30]).subtract(1, 'month').valueOf()
       },
-      { patient, submitter: districtHospitalContact, fields: { lmp_date: 'Feb 16, 2022' }}
+      { patient, submitter: districtHospitalContact, fields: { lmp_date: 'Feb 16, 2022' } }
     );
   const visitHealthCenter = reportFactory
     .report()
@@ -59,7 +59,7 @@ describe('Reports Sidebar Filter', () => {
         verified: false,
         reported_date: moment([today.year(), today.month(), 15, 0, 30]).subtract(5, 'month').valueOf()
       },
-      { patient, submitter: healthCenterContact, fields: { ok: 'Yes!' }}
+      { patient, submitter: healthCenterContact, fields: { ok: 'Yes!' } }
     );
   const visitDistrictHospital = reportFactory
     .report()
@@ -69,7 +69,7 @@ describe('Reports Sidebar Filter', () => {
         verified: true,
         reported_date: moment([today.year(), today.month(), 16, 9, 10]).subtract(1, 'month').valueOf()
       },
-      { patient, submitter: districtHospitalContact, fields: { ok: 'Yes!' }}
+      { patient, submitter: districtHospitalContact, fields: { ok: 'Yes!' } }
     );
   const reports = [
     pregnancyHealthCenter,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -34,6 +34,8 @@ const reviewReportCloseButton = () => $(`${REVIEW_REPORT_CONTAINER} .panel-heade
 
 const sidebarFilterDateAccordionHeader = () => $('#date-filter-accordion mat-expansion-panel-header');
 const sidebarFilterDateAccordionBody = () => $('#date-filter-accordion mat-panel-description');
+const sidebarFilterFormAccordionHeader = () => $('#form-filter-accordion mat-expansion-panel-header');
+const sidebarFilterFormAccordionBody = () => $('#form-filter-accordion mat-panel-description');
 const sidebarFilterToDate = () => $('#toDateFilter');
 const sidebarFilterFromDate = () => $('#fromDateFilter');
 const sidebarFilterOpenBtn = () => $('mm-search-bar .open-filter');
@@ -252,6 +254,13 @@ const openSidebarFilterDateAccordion = async () => {
   return (await sidebarFilterDateAccordionBody()).waitForDisplayed();
 };
 
+const filterByForm = async (formName) => {
+  await (await sidebarFilterFormAccordionHeader()).click();
+  await (await sidebarFilterFormAccordionBody()).waitForDisplayed();
+  const option = sidebarFilterFormAccordionBody().$(`a*=${formName}`);
+  await (await option).click();
+};
+
 const setSidebarFilterDate = async (fieldPromise, calendarIdx, date) => {
   await (await fieldPromise).waitForDisplayed();
   await (await fieldPromise).click();
@@ -464,6 +473,7 @@ module.exports = {
   openSidebarFilterDateAccordion,
   setSidebarFilterFromDate,
   setSidebarFilterToDate,
+  filterByForm,
   setDateInput,
   getFieldValue,
   setBikDateInput,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -262,7 +262,7 @@ const filterByForm = async (formName) => {
   await (await sidebarFilterFormAccordionHeader()).click();
   await (await sidebarFilterFormAccordionBody()).waitForDisplayed();
   const option = sidebarFilterFormAccordionBody().$(`a*=${formName}`);
-  await (await option).waitForDisplayed();
+  await (await option).waitForClickable();
   await (await option).click();
 };
 
@@ -270,7 +270,7 @@ const filterByStatus = async (statusOption) => {
   await (await sidebarFilterStatusAccordionHeader()).click();
   await (await sidebarFilterStatusAccordionBody()).waitForDisplayed();
   const option = sidebarFilterStatusAccordionBody().$(`a*=${statusOption}`);
-  await (await option).waitForDisplayed();
+  await (await option).waitForClickable();
   await (await option).click();
 };
 
@@ -279,11 +279,12 @@ const filterByFacility = async (parentFacility, reportFacility) => {
   await (await sidebarFilterFacilityAccordionBody()).waitForDisplayed();
 
   const parent = sidebarFilterFacilityAccordionBody().$(`a*=${parentFacility}`);
-  parent.waitForDisplayed();
+  await parent.waitForDisplayed();
+  await parent.waitForClickable();
   await (await parent).click();
 
   const facility = await sidebarFilterFacilityAccordionBody().$('.mm-dropdown-submenu').$(`a*=${reportFacility}`);
-  await facility.waitForDisplayed();
+  await facility.waitForClickable();
   const checkbox = facility.previousElement();
   await (await checkbox).click();
 };

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -262,6 +262,7 @@ const filterByForm = async (formName) => {
   await (await sidebarFilterFormAccordionHeader()).click();
   await (await sidebarFilterFormAccordionBody()).waitForDisplayed();
   const option = sidebarFilterFormAccordionBody().$(`a*=${formName}`);
+  await (await option).waitForDisplayed();
   await (await option).waitForClickable();
   await (await option).click();
 };
@@ -270,6 +271,7 @@ const filterByStatus = async (statusOption) => {
   await (await sidebarFilterStatusAccordionHeader()).click();
   await (await sidebarFilterStatusAccordionBody()).waitForDisplayed();
   const option = sidebarFilterStatusAccordionBody().$(`a*=${statusOption}`);
+  await (await option).waitForDisplayed();
   await (await option).waitForClickable();
   await (await option).click();
 };
@@ -284,6 +286,7 @@ const filterByFacility = async (parentFacility, reportFacility) => {
   await (await parent).click();
 
   const facility = await sidebarFilterFacilityAccordionBody().$('.mm-dropdown-submenu').$(`a*=${reportFacility}`);
+  await facility.waitForDisplayed();
   await facility.waitForClickable();
   const checkbox = facility.previousElement();
   await (await checkbox).click();
@@ -291,6 +294,7 @@ const filterByFacility = async (parentFacility, reportFacility) => {
 
 const setSidebarFilterDate = async (fieldPromise, calendarIdx, date) => {
   await (await fieldPromise).waitForDisplayed();
+  await (await fieldPromise).waitForClickable();
   await (await fieldPromise).click();
 
   const dateRangePicker = `.daterangepicker:nth-of-type(${calendarIdx})`;

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -36,6 +36,8 @@ const sidebarFilterDateAccordionHeader = () => $('#date-filter-accordion mat-exp
 const sidebarFilterDateAccordionBody = () => $('#date-filter-accordion mat-panel-description');
 const sidebarFilterFormAccordionHeader = () => $('#form-filter-accordion mat-expansion-panel-header');
 const sidebarFilterFormAccordionBody = () => $('#form-filter-accordion mat-panel-description');
+const sidebarFilterFacilityAccordionHeader = () => $('#place-filter-accordion mat-expansion-panel-header');
+const sidebarFilterFacilityAccordionBody = () => $('#place-filter-accordion mat-panel-description');
 const sidebarFilterToDate = () => $('#toDateFilter');
 const sidebarFilterFromDate = () => $('#fromDateFilter');
 const sidebarFilterOpenBtn = () => $('mm-search-bar .open-filter');
@@ -258,7 +260,22 @@ const filterByForm = async (formName) => {
   await (await sidebarFilterFormAccordionHeader()).click();
   await (await sidebarFilterFormAccordionBody()).waitForDisplayed();
   const option = sidebarFilterFormAccordionBody().$(`a*=${formName}`);
+  await (await option).waitForDisplayed();
   await (await option).click();
+};
+
+const filterByFacility = async (parentFacility, reportFacility) => {
+  await (await sidebarFilterFacilityAccordionHeader()).click();
+  await (await sidebarFilterFacilityAccordionBody()).waitForDisplayed();
+
+  const parent = sidebarFilterFacilityAccordionBody().$(`a*=${parentFacility}`);
+  parent.waitForDisplayed();
+  await (await parent).click();
+
+  const facility = await sidebarFilterFacilityAccordionBody().$('.mm-dropdown-submenu').$(`a*=${reportFacility}`);
+  await facility.waitForDisplayed();
+  const checkbox = facility.previousElement();
+  await (await checkbox).click();
 };
 
 const setSidebarFilterDate = async (fieldPromise, calendarIdx, date) => {
@@ -474,6 +491,7 @@ module.exports = {
   setSidebarFilterFromDate,
   setSidebarFilterToDate,
   filterByForm,
+  filterByFacility,
   setDateInput,
   getFieldValue,
   setBikDateInput,

--- a/tests/page-objects/default/reports/reports.wdio.page.js
+++ b/tests/page-objects/default/reports/reports.wdio.page.js
@@ -38,6 +38,8 @@ const sidebarFilterFormAccordionHeader = () => $('#form-filter-accordion mat-exp
 const sidebarFilterFormAccordionBody = () => $('#form-filter-accordion mat-panel-description');
 const sidebarFilterFacilityAccordionHeader = () => $('#place-filter-accordion mat-expansion-panel-header');
 const sidebarFilterFacilityAccordionBody = () => $('#place-filter-accordion mat-panel-description');
+const sidebarFilterStatusAccordionHeader = () => $('#status-filter-accordion mat-expansion-panel-header');
+const sidebarFilterStatusAccordionBody = () => $('#status-filter-accordion mat-panel-description');
 const sidebarFilterToDate = () => $('#toDateFilter');
 const sidebarFilterFromDate = () => $('#fromDateFilter');
 const sidebarFilterOpenBtn = () => $('mm-search-bar .open-filter');
@@ -260,6 +262,14 @@ const filterByForm = async (formName) => {
   await (await sidebarFilterFormAccordionHeader()).click();
   await (await sidebarFilterFormAccordionBody()).waitForDisplayed();
   const option = sidebarFilterFormAccordionBody().$(`a*=${formName}`);
+  await (await option).waitForDisplayed();
+  await (await option).click();
+};
+
+const filterByStatus = async (statusOption) => {
+  await (await sidebarFilterStatusAccordionHeader()).click();
+  await (await sidebarFilterStatusAccordionBody()).waitForDisplayed();
+  const option = sidebarFilterStatusAccordionBody().$(`a*=${statusOption}`);
   await (await option).waitForDisplayed();
   await (await option).click();
 };
@@ -492,6 +502,7 @@ module.exports = {
   setSidebarFilterToDate,
   filterByForm,
   filterByFacility,
+  filterByStatus,
   setDateInput,
   getFieldValue,
   setBikDateInput,


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

[We removed the old search and filters](https://github.com/medic/cht-core/pull/9326). These features are well covered with unit tests, but we need automation tests for form, facility, and status filters. This PR adds basic test cases for those three filters.  

- There are already automation for [Reports' search](https://github.com/medic/cht-core/blob/master/tests/e2e/default/reports/search-reports.wdio-spec.js) and [Contacts' search](https://github.com/medic/cht-core/blob/master/tests/e2e/default/contacts/search-contacts.wdio-spec.js)
- There is already automation [for the date filter](https://github.com/medic/cht-core/blob/master/tests/e2e/default/reports/sidebar-filter.wdio-spec.js)

#8181
https://github.com/medic/care-teams/issues/148

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8181-e2e-remove-old-design-filter/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8181-e2e-remove-old-design-filter/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8181-e2e-remove-old-design-filter/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

