### PR TITLE
fix(#9291): align fab icon in mobile view

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1391,7 +1391,6 @@ mm-search-bar {
   overflow-y: auto;
   .mdc-list-item.mdc-list-item--with-one-line {
     height: 60px;
-    border: 1px solid red;
     &:not(:last-child) {
       border-bottom: 1px solid @separator-color;
     }
@@ -1402,7 +1401,6 @@ mm-search-bar {
     justify-content: flex-start;
     text-decoration: none;
     color: @mat-font-color;
-    display: flex;
     .fast-action-item-icon {
       margin-right: 20px;
       display: flex;
@@ -1427,7 +1425,6 @@ mm-search-bar {
 
       .resource-icon {
         display: block;
-        border: 1px solid black;
       }
     }
 

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1391,6 +1391,7 @@ mm-search-bar {
   overflow-y: auto;
   .mdc-list-item.mdc-list-item--with-one-line {
     height: 60px;
+    border: 1px solid red;
     &:not(:last-child) {
       border-bottom: 1px solid @separator-color;
     }
@@ -1401,8 +1402,11 @@ mm-search-bar {
     justify-content: flex-start;
     text-decoration: none;
     color: @mat-font-color;
+    display: flex;
     .fast-action-item-icon {
       margin-right: 20px;
+      display: flex;
+      align-items: center;
 
       mat-icon,
       .fast-action-resource-icon img,
@@ -1423,6 +1427,7 @@ mm-search-bar {
 
       .resource-icon {
         display: block;
+        border: 1px solid black;
       }
     }
 
@@ -1436,6 +1441,7 @@ mm-search-bar {
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       white-space: normal;
+      border: 1px solid black;
     }
   }
 }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1420,10 +1420,6 @@ mm-search-bar {
         color: @mm-mat-primary;
         font-size: @font-extra-extra-large;
       }
-
-      .fast-action-resource-icon {
-        line-height: 60px;
-      }
     }
 
     .fast-action-item-label {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1438,7 +1438,6 @@ mm-search-bar {
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       white-space: normal;
-      border: 1px solid black;
     }
   }
 }

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1420,6 +1420,10 @@ mm-search-bar {
         color: @mm-mat-primary;
         font-size: @font-extra-extra-large;
       }
+
+      .resource-icon {
+        display: block;
+      }
     }
 
     .fast-action-item-label {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Removing the line-height seems to fix it 


https://github.com/user-attachments/assets/2585d0a1-a73d-403f-b287-fb3f87ff4b76



Closes #9291 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9291-align-icon/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9291-align-icon/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9291-align-icon/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

