### PR TITLE
fix(#9389): update api/v1/person query param from personType to type

### DIFF
--- a/api/src/controllers/person.js
+++ b/api/src/controllers/person.js
@@ -31,7 +31,7 @@ module.exports = {
     getAll: serverUtils.doOrError(async (req, res) => {
       await checkUserPermissions(req);
 
-      const personType  = Qualifier.byContactType(req.query.personType);
+      const personType  = Qualifier.byContactType(req.query.type);
       const limit = req.query.limit ? Number(req.query.limit) : req.query.limit;
 
       const docs = await getPageByType()( personType, req.query.cursor, limit );

--- a/api/tests/mocha/controllers/person.spec.js
+++ b/api/tests/mocha/controllers/person.spec.js
@@ -169,7 +169,7 @@ describe('Person Controller', () => {
       beforeEach(() => {
         req = {
           query: {
-            personType,
+            type: personType,
             cursor,
             limit,
           }
@@ -193,7 +193,7 @@ describe('Person Controller', () => {
         await controller.v1.getAll(req, res);
 
         expect(hasAllPermissions.calledOnceWithExactly(userCtx, 'can_view_contacts')).to.be.true;
-        expect(qualifierByContactType.calledOnceWithExactly(req.query.personType)).to.be.true;
+        expect(qualifierByContactType.calledOnceWithExactly(req.query.type)).to.be.true;
         expect(dataContextBind.calledOnceWithExactly(Person.v1.getPage)).to.be.true;
         expect(personGetPageByType.calledOnceWithExactly(personTypeQualifier, cursor, limit)).to.be.true;
         expect(res.json.calledOnceWithExactly(people)).to.be.true;
@@ -238,7 +238,7 @@ describe('Person Controller', () => {
         await controller.v1.getAll(req, res);
 
         expect(hasAllPermissions.calledOnceWithExactly(userCtx, 'can_view_contacts')).to.be.true;
-        expect(qualifierByContactType.calledOnceWithExactly(req.query.personType)).to.be.true;
+        expect(qualifierByContactType.calledOnceWithExactly(req.query.type)).to.be.true;
         expect(dataContextBind.calledOnceWithExactly(Person.v1.getPage)).to.be.true;
         expect(personGetPageByType.calledOnceWithExactly(personTypeQualifier, cursor, limit)).to.be.true;
         expect(res.json.notCalled).to.be.true;
@@ -254,7 +254,7 @@ describe('Person Controller', () => {
         await controller.v1.getAll(req, res);
 
         expect(hasAllPermissions.calledOnceWithExactly(userCtx, 'can_view_contacts')).to.be.true;
-        expect(qualifierByContactType.calledOnceWithExactly(req.query.personType)).to.be.true;
+        expect(qualifierByContactType.calledOnceWithExactly(req.query.type)).to.be.true;
         expect(dataContextBind.calledOnceWithExactly(Person.v1.getPage)).to.be.true;
         expect(personGetPageByType.calledOnceWithExactly(personTypeQualifier, cursor, limit)).to.be.true;
         expect(res.json.notCalled).to.be.true;

--- a/shared-libs/cht-datasource/src/remote/person.ts
+++ b/shared-libs/cht-datasource/src/remote/person.ts
@@ -30,7 +30,7 @@ export namespace v1 {
   ): Promise<Page<Person.v1.Person>> => {
     const queryParams = {
       'limit': limit.toString(),
-      'personType': personType.contactType,
+      'type': personType.contactType,
       ...(cursor ? { cursor } : {})
     };
     return getPeople(remoteContext)(queryParams);

--- a/shared-libs/cht-datasource/test/remote/person.spec.ts
+++ b/shared-libs/cht-datasource/test/remote/person.spec.ts
@@ -76,7 +76,7 @@ describe('remote person', () => {
       const personTypeQualifier = {contactType: personType};
       const queryParam = {
         limit: limit.toString(),
-        personType,
+        type: personType,
         cursor,
       };
 

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -188,7 +188,7 @@ describe('Person API', () => {
 
     it('throws 400 error when personType is invalid', async () => {
       const queryParams = {
-        'personType': invalidContactType
+        type: invalidContactType
       };
       const queryString = new URLSearchParams(queryParams).toString();
       const opts = {
@@ -201,7 +201,7 @@ describe('Person API', () => {
 
     it('throws 400 error when limit is invalid', async () => {
       const queryParams = {
-        personType,
+        type: personType,
         limit: -1
       };
       const queryString = new URLSearchParams(queryParams).toString();
@@ -215,7 +215,7 @@ describe('Person API', () => {
 
     it('throws 400 error when cursor is invalid', async () => {
       const queryParams = {
-        personType,
+        type: personType,
         cursor: '-1'
       };
       const queryString = new URLSearchParams(queryParams).toString();


### PR DESCRIPTION
# Description

Closes #9389 

https://github.com/medic/cht-docs/pull/1509

Simple change to update the `personType` query parameter name on the `api/v1/person` endpoint to just be `type`.  

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9389_fix_person_type_param/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9389_fix_person_type_param/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9389_fix_person_type_param/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

