### PR TITLE
chore(#9327): adjust new nav styles after manual testing

### DIFF
--- a/webapp/src/css/badge.less
+++ b/webapp/src/css/badge.less
@@ -1,7 +1,7 @@
 @import "variables";
 
 .mm-badge-border {
-  border: solid 1px #fff;
+  border: none;
 }
 
 .mm-badge {

--- a/webapp/src/css/icon.less
+++ b/webapp/src/css/icon.less
@@ -10,6 +10,7 @@
   position: relative;
   &, &:focus {
     .button-text(@white);
+    text-shadow: none;
   }
   &:hover, &.active {
     .button-text-hover;

--- a/webapp/src/css/icon.less
+++ b/webapp/src/css/icon.less
@@ -19,7 +19,7 @@
 
 .mm-icon-inverse {
   &, &:focus {
-    .button-text-inverse(@gray-medium);
+    .button-text-inverse(@nav-icon-gray);
   }
 }
 

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -632,7 +632,7 @@ body {
 }
 
 .loading-status {
-  margin: 10px 10px @bottom-navbar-height;
+  margin: 10px 10px calc(@bottom-navbar-height + 10px);
   text-align: center;
   font-size: @font-small;
   color: @label-color;

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -107,7 +107,7 @@ body {
   }
 
   a {
-    .button-text-inverse(@gray-medium);
+    .button-text-inverse(@nav-icon-gray);
     outline: 0;
     padding-top: 3px;
   }
@@ -223,6 +223,7 @@ body {
       position: relative;
       overflow: hidden;
       word-wrap: break-word;
+      color: @nav-icon-gray;
     }
 
     a {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -107,7 +107,7 @@ body {
   }
 
   a {
-    .button-text-inverse;
+    .button-text-inverse(@gray-medium);
     outline: 0;
     padding-top: 3px;
   }
@@ -248,10 +248,12 @@ body {
       }
 
       &.selected {
+        text-shadow: none;
         .button-label,
         .mm-icon:hover,
         .resource-icon {
           .button-text(@white);
+          text-shadow: none;
         }
       }
 
@@ -1391,7 +1393,7 @@ mm-sidebar-menu .mat-sidenav-container {
           padding-top: 5px;
         }
         a {
-          min-width: 0;
+          min-width: 65px;
           .mm-icon {
             padding: 8px 0;
           }
@@ -1598,7 +1600,7 @@ mm-sidebar-menu .mat-sidenav-container {
       left: 0;
     }
     .fast-action-trigger:not(.embed-fast-action) {
-      bottom: 17px;
+      bottom: @fab-bottom-padding;
     }
   }
 

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1057,7 +1057,7 @@ mm-search-bar {
 
       .filter-counter {
         color: @chip-text-color;
-        font-size: @font-extra-extra-small;
+        font-size: @font-XXXS;
         background: @chip-background-color;
         border-radius: 50%;
         padding: 1px 5px;
@@ -1390,7 +1390,7 @@ mm-sidebar-menu .mat-sidenav-container {
       .tabs {
         .button-label {
           top: 0;
-          font-size: @font-extra-smaller;
+          font-size: @font-XXS;
           padding-top: 5px;
         }
         a {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -236,6 +236,8 @@ body {
       .mm-icon {
         display: block;
         padding: 5px 0;
+        height: 34px;
+        width: 54px;
 
         svg, span:not(.mm-badge-overlay):not(.mm-badge), img {
           &, &:before {

--- a/webapp/src/css/material.less
+++ b/webapp/src/css/material.less
@@ -279,6 +279,11 @@ mm-panel-header {
       border-radius: @radius-size;
     }
   }
+
+  .app-root.show-content:not(.old-nav) #snackbar {
+    bottom: calc(@fab-height + @fab-bottom-padding + @snackbar-fab-gap);
+  }
+
   .material {
     .card:not(.compact-card) {
       border-radius: 0;

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -102,6 +102,10 @@
   .loading-status {
     margin: 10px;
   }
+
+  .mm-badge-border {
+    border: solid 1px #fff;
+  }
 }
 
 @media (max-width: @media-mobile) {

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -104,7 +104,7 @@
   }
 
   .mm-badge-border {
-    border: solid 1px #fff;
+    border: solid 1px @white;
   }
 }
 
@@ -170,7 +170,7 @@
         a {
           min-width: 40px;
           .button-label {
-            font-size: @font-extra-extra-small;
+            font-size: @font-XXXS;
           }
         }
 

--- a/webapp/src/css/private-vars.less
+++ b/webapp/src/css/private-vars.less
@@ -15,7 +15,7 @@
 @gray-ultra-dark: #333333;
 @gray-ultra-darker: #262626;
 @gray-disabled: #999999;
-@nav-icon-gray:#A7A9AC;
+@silver-gray:#A7A9AC;
 @black: #000000;
 @medium-black: #1A1A1A;
 @blue: #63A2C6;

--- a/webapp/src/css/private-vars.less
+++ b/webapp/src/css/private-vars.less
@@ -15,6 +15,7 @@
 @gray-ultra-dark: #333333;
 @gray-ultra-darker: #262626;
 @gray-disabled: #999999;
+@nav-icon-gray:#A7A9AC;
 @black: #000000;
 @medium-black: #1A1A1A;
 @blue: #63A2C6;

--- a/webapp/src/css/variables.less
+++ b/webapp/src/css/variables.less
@@ -57,6 +57,7 @@
 @tooltip-text: @gray-light;
 @target-progress-bar-border-color: @white;
 @targets-progress-bar-background-color: @gray-medium-dark;
+@nav-icon-gray: @silver-gray;
 
 /* tab colors */
 @messages-color: @blue;
@@ -126,8 +127,8 @@
 @font-medium: 1rem;
 @font-small: 0.875rem;
 @font-extra-small: 0.8125rem;
-@font-extra-smaller: 0.75rem;
-@font-extra-extra-small: 0.625rem;
+@font-XXS: 0.75rem;
+@font-XXXS: 0.625rem;
 
 @icon-large: 60px;
 @icon-small: 30px;

--- a/webapp/src/css/variables.less
+++ b/webapp/src/css/variables.less
@@ -126,7 +126,7 @@
 @font-medium: 1rem;
 @font-small: 0.875rem;
 @font-extra-small: 0.8125rem;
-@font-extra-smaller: 0.6875rem;
+@font-extra-smaller: 0.75rem;
 @font-extra-extra-small: 0.625rem;
 
 @icon-large: 60px;


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description
 
<details>
<summary>selected icon and label have color #FFFFFF</summary>

![Screenshot 2024-09-04 at 15 13 38](https://github.com/user-attachments/assets/560f89ae-7216-48d8-9749-0791f2cb6151)

</details>

<details>
<summary>Unselected icon and label have color #A7A9AC </summary>

![Screenshot 2024-09-04 at 15 13 20](https://github.com/user-attachments/assets/df4d6753-368d-40f7-bb2e-6acc122ef1c7)

</details>

<details>
<summary>Snackbar is above FAB and adjusts when Tab navigation is not present</summary>

https://github.com/user-attachments/assets/3207e6d7-3ad9-4b76-af6a-66d3c890a901

</details>

<details>
<summary>Removed the white outline for the notification dot </summary>

![Screenshot 2024-09-04 at 15 23 24](https://github.com/user-attachments/assets/c52ed9b0-0fde-4b60-bcd4-71b38971ba59)


</details>

<details>
<summary>Made the highlight pill consistent size </summary>

![Screenshot 2024-09-04 at 15 19 55](https://github.com/user-attachments/assets/d9620ef4-ed65-42bb-b2d9-6c1731ad5382)

</details>
<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:move-nav-feedback/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:move-nav-feedback/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:move-nav-feedback/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

