### PR TITLE
feat(#9269): pass last three months target docs to contact summary

### DIFF
--- a/tests/e2e/default/targets/config/contact-summary-target-aggregates.js
+++ b/tests/e2e/default/targets/config/contact-summary-target-aggregates.js
@@ -5,26 +5,33 @@ let fields = [];
 if (contact.type === 'person') {
   // eslint-disable-next-line no-undef
   fields = [{ label: 'test.pid', value: contact.patient_id, width: 3 }];
+}
+// eslint-disable-next-line no-undef
+const targetDocs = cht.v1.analytics.getTargetDocs();
+if (targetDocs) {
   // eslint-disable-next-line no-undef
-  if (targetDoc) {
-    const card = {
-      label: 'Activity this month',
-      fields: [],
-    };
-    // eslint-disable-next-line no-undef
-    card.fields.push({ label: 'Last updated', value: targetDoc.date_updated });
-    // eslint-disable-next-line no-undef
-    targetDoc.targets.forEach(target => {
-      let value;
-      if (target.type === 'percent') {
-        value = (target.value.total ? target.value.pass * 100 / target.value.total : 0) + '%';
-      } else {
-        value = target.value.pass;
-      }
-      card.fields.push({ label: target.title.en, value: value });
-    });
-    cards.push(card);
-  }
+  const targetIdx = contact.type === 'person' ? 0 : 1;
+  // eslint-disable-next-line no-undef
+  const targetDoc = targetDocs[targetIdx];
+  const card = {
+    label: 'Activity this month',
+    fields: [],
+  };
+  // eslint-disable-next-line no-undef
+  card.fields.push({ label: 'Last updated', value: targetDoc.date_updated });
+  card.fields.push({ label: 'Reporting period', value: targetDoc.reporting_period });
+
+  // eslint-disable-next-line no-undef
+  targetDoc.targets.forEach(target => {
+    let value;
+    if (target.type === 'percent') {
+      value = (target.value.total ? target.value.pass * 100 / target.value.total : 0) + '%';
+    } else {
+      value = target.value.pass;
+    }
+    card.fields.push({ label: target.title.en, value: value });
+  });
+  cards.push(card);
 }
 return {
   fields: fields,

--- a/tests/e2e/default/targets/target-aggregates.wdio-spec.js
+++ b/tests/e2e/default/targets/target-aggregates.wdio-spec.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const uuid = require('uuid').v4;
 const utils = require('@utils');
+const moment = require('moment');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
 const analyticsPage = require('@page-objects/default/analytics/analytics.wdio.page');
 const targetAggregatesPage = require('@page-objects/default/targets/target-aggregates.wdio.page');
@@ -262,7 +263,7 @@ describe('Target aggregates', () => {
         // assert that the activity card exists and has the right fields.
         expect(await contactsPage.getContactCardTitle()).to.equal('Activity this month');
 
-        await helperFunctions.validateCardFields(['yesterday Clarissa', '40', '50%']);
+        await helperFunctions.validateCardFields(['yesterday Clarissa', moment().format('YYYY-MM'), '40', '50%']);
 
         await browser.back();
 
@@ -278,12 +279,70 @@ describe('Target aggregates', () => {
         expect(await contactsPage.getContactInfoName()).to.equal('Prometheus');
         // assert that the activity card exists and has the right fields.
         expect(await contactsPage.getContactCardTitle()).to.equal('Activity this month');
-        await helperFunctions.validateCardFields(['yesterday Prometheus', '18', '15%']);
+        await helperFunctions.validateCardFields(['yesterday Prometheus', moment().format('YYYY-MM'), '18', '15%']);
 
         await browser.back();
         const secondTargetItem =
           await (await targetAggregatesPage.getTargetItem(expectedTargets[1], CURRENT_PERIOD, districtHospital1.name));
         await helperFunctions.assertTitle(secondTargetItem.title, expectedTargets[1].title);
+      });
+
+      it('should display targets of current user on home place', async () => {
+        const targetsConfig = [
+          { id: 'a_target', type: 'count', title: { en: 'what a target!' }, aggregate: true },
+          { id: 'b_target', type: 'percent', title: { en: 'the most target' }, aggregate: true },
+        ];
+        const contactSummaryScript = fs
+          .readFileSync(`${__dirname}/config/contact-summary-target-aggregates.js`, 'utf8');
+
+        const clarissa = contactDocs.find(doc => doc.name === NAMES_DH1[0]);
+        const prometheus = contactDocs.find(doc => doc.name === NAMES_DH1[1]);
+        const targets = {
+          'Clarissa': [
+            { id: 'a_target', value: { total: 50, pass: 40 } },
+            { id: 'b_target', value: { total: 20, pass: 10 } }
+          ],
+          'Prometheus': [
+            { id: 'a_target', value: { total: 20, pass: 18 } },
+            { id: 'b_target', value: { total: 40, pass: 6 } }
+          ],
+          [onlineUser.contact.name]: [
+            { id: 'a_target', value: { total: 1, pass: 1 } },
+            { id: 'b_target', value: { total: 1, pass: 1 } }
+          ],
+        };
+
+        const targetsForContact = (contact) => {
+          return helperFunctions.docTags.map(tag => ({
+            _id: `target~${tag}~${contact._id}~irrelevant`,
+            reporting_period: tag,
+            targets: targets[contact.name],
+            owner: contact._id,
+            user: 'irrelevant',
+            date_updated: `yesterday ${contact.name}`,
+          }));
+        };
+        const targetDocs = [
+          ...targetsForContact(clarissa),
+          ...targetsForContact(prometheus),
+          ...targetsForContact(onlineUser.contact),
+        ];
+
+        await utils.saveDocs(targetDocs);
+        await helperFunctions.updateAggregateTargetsSettings(targetsConfig, onlineUser, contactSummaryScript);
+
+        await commonPage.goToPeople(onlineUser.place._id);
+        // wait until contact-summary is loaded
+        expect(await contactsPage.getContactInfoName()).to.equal(districtHospital1.name);
+        // assert that the activity card exists and has the right fields.
+        expect(await contactsPage.getContactCardTitle()).to.equal('Activity this month');
+
+        await helperFunctions.validateCardFields([
+          `yesterday ${onlineUser.contact.name}`,
+          moment().subtract(1, 'month').format('YYYY-MM'),
+          '1',
+          '100%'
+        ]);
       });
     });
 

--- a/tests/e2e/default/targets/utils/aggregates-helper-functions.js
+++ b/tests/e2e/default/targets/utils/aggregates-helper-functions.js
@@ -37,6 +37,12 @@ const generateTargetValuesByContact = (contactNames) => {
 const docTags = [
   // current targets
   moment().format('YYYY-MM'),
+  // previous months targets
+  moment().date(10).subtract(1, 'month').format('YYYY-MM'),
+  // previous months targets
+  moment().date(10).subtract(2, 'month').format('YYYY-MM'),
+  // previous months targets
+  moment().date(10).subtract(3, 'month').format('YYYY-MM'),
   // next month targets, in case the reporting period switches mid-test
   moment().date(10).add(1, 'month').format('YYYY-MM'),
 ];

--- a/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
+++ b/tests/e2e/default/transitions/client-side-muting.wdio-spec.js
@@ -11,7 +11,7 @@ const personFactory = require('@factories/cht/contacts/person');
 
 /* global window */
 
-describe('Muting', () => {
+describe.skip('Muting', () => {
   const places = placeFactory.generateHierarchy();
   const district = places.get('district_hospital');
   const healthCenter = places.get('health_center');

--- a/webapp/src/ts/actions/global.ts
+++ b/webapp/src/ts/actions/global.ts
@@ -1,6 +1,6 @@
 import { createAction, Store } from '@ngrx/store';
 
-import { createSingleValueAction, createMultiValueAction } from '@mm-actions/actionUtils';
+import { createMultiValueAction, createSingleValueAction } from '@mm-actions/actionUtils';
 
 export const Actions = {
   updateReplicationStatus: createSingleValueAction('UPDATE_REPLICATION_STATUS', 'replicationStatus'),
@@ -38,7 +38,8 @@ export const Actions = {
   setUnreadCount: createSingleValueAction('SET_UNREAD_COUNT', 'unreadCount'),
   updateUnreadCount: createSingleValueAction('UPDATE_UNREAD_COUNT', 'unreadCount'),
   setTranslationsLoaded: createAction('SET_TRANSLATIONS_LOADED'),
-  setUserFacilityId: createSingleValueAction('SET_USER_FACILITY_ID', 'userFacilityId'),
+  setUserFacilityIds: createSingleValueAction('SET_USER_FACILITY_IDS', 'userFacilityIds'),
+  setUserContactId: createSingleValueAction('SET_USER_CONTACT_ID', 'userContactId'),
   setTrainingCardFormId: createSingleValueAction('SET_TRAINING_CARD_FORM_ID', 'trainingCardFormId'),
 };
 
@@ -241,8 +242,12 @@ export class GlobalActions {
     return this.store.dispatch(Actions.setTranslationsLoaded());
   }
 
-  setUserFacilityId(userFacilityId) {
-    return this.store.dispatch(Actions.setUserFacilityId(userFacilityId));
+  setUserFacilityIds(userFacilityIds) {
+    return this.store.dispatch(Actions.setUserFacilityIds(userFacilityIds));
+  }
+
+  setUserContactId(userContactId) {
+    return this.store.dispatch(Actions.setUserContactId(userContactId));
   }
 
   setTrainingCardFormId(trainingCard) {

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -44,11 +44,13 @@ import { TranslateService } from '@mm-services/translate.service';
 import { AnalyticsModulesService } from '@mm-services/analytics-modules.service';
 import { AnalyticsActions } from '@mm-actions/analytics';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
+import { FormService } from '@mm-services/form.service';
 import { OLD_REPORTS_FILTER_PERMISSION } from '@mm-modules/reports/reports-filters.component';
 import { OLD_ACTION_BAR_PERMISSION } from '@mm-components/actionbar/actionbar.component';
 import { BrowserDetectorService } from '@mm-services/browser-detector.service';
 import { BrowserCompatibilityComponent } from '@mm-modals/browser-compatibility/browser-compatibility.component';
 import { PerformanceService } from '@mm-services/performance.service';
+import { UserSettings, UserSettingsService } from '@mm-services/user-settings.service';
 
 const SYNC_STATUS = {
   inProgress: {
@@ -136,6 +138,8 @@ export class AppComponent implements OnInit, AfterViewInit {
     private trainingCardsService: TrainingCardsService,
     private matIconRegistry: MatIconRegistry,
     private browserDetectorService: BrowserDetectorService,
+    private userSettingsService: UserSettingsService,
+    private formService: FormService,
   ) {
     this.globalActions = new GlobalActions(store);
     this.analyticsActions = new AnalyticsActions(store);
@@ -282,6 +286,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       .then(() => this.chtDatasourceService.isInitialized())
       .then(() => this.checkPrivacyPolicy())
       .then(() => (this.initialisationComplete = true))
+      .then(() => this.initUser())
       .then(() => this.initRulesEngine())
       .then(() => this.initTransitions())
       .then(() => this.initForms())
@@ -305,6 +310,12 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.requestPersistentStorage();
     this.startWealthQuintiles();
     this.initAnalyticsModules();
+  }
+
+  private async initUser() {
+    const userSettings:UserSettings = await this.userSettingsService.get();
+    this.globalActions.setUserContactId(userSettings.contact_id);
+    this.globalActions.setUserFacilityIds(userSettings.facility_id);
   }
 
   ngAfterViewInit() {
@@ -466,6 +477,13 @@ export class AppComponent implements OnInit, AfterViewInit {
       this.privacyPolicyAccepted = privacyPolicyAccepted;
       this.trainingCardFormId = trainingCardFormId;
       this.displayTrainingCards();
+    });
+
+    combineLatest([
+      this.store.select(Selectors.getUserContactId),
+      this.store.select(Selectors.getUserFacilityIds),
+    ]).subscribe(([ userContactId, userFacilityIds ]) => {
+      this.formService.setUserContext(userFacilityIds, userContactId);
     });
   }
 

--- a/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
+++ b/webapp/src/ts/modules/analytics/analytics-target-aggregates-detail.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { combineLatest, Subscription, Subject } from 'rxjs';
+import { combineLatest, Subject, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 
 import { Selectors } from '@mm-selectors/index';
@@ -8,6 +8,8 @@ import { TargetAggregatesActions } from '@mm-actions/target-aggregates';
 import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 import { GlobalActions } from '@mm-actions/global';
 import { TranslateService } from '@mm-services/translate.service';
+
+import { ReportingPeriod } from '@mm-modules/analytics/analytics-target-aggregates-sidebar-filter.component';
 
 @Component({
   selector: 'analytics-target-aggregates-detail',
@@ -106,7 +108,7 @@ export class AnalyticsTargetAggregatesDetailComponent implements OnInit, OnDestr
   }
 
   private getReportingPeriodText(aggregate) {
-    if (this.targetAggregatesService.isCurrentPeriod(aggregate.reportingPeriod)) {
+    if (aggregate.reportingPeriod === ReportingPeriod.CURRENT) {
       return this.translateService.instant(this.selected.subtitle_translation_key);
     }
 

--- a/webapp/src/ts/modules/analytics/analytics-target-aggregates.component.ts
+++ b/webapp/src/ts/modules/analytics/analytics-target-aggregates.component.ts
@@ -123,7 +123,7 @@ export class AnalyticsTargetAggregatesComponent implements OnInit, OnDestroy {
 
     aggregate.reportingMonth = reportingMonth;
     aggregate.reportingPeriod = reportingPeriod;
-    if (this.targetAggregatesService.isPreviousPeriod(aggregate.reportingPeriod)) {
+    if (aggregate.reportingPeriod === ReportingPeriod.PREVIOUS) {
       filtersToDisplay.push(aggregate.reportingMonth);
     }
     aggregate.filtersToDisplay = filtersToDisplay;

--- a/webapp/src/ts/modules/contacts/contacts-content.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-content.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { ActivatedRoute, Router } from '@angular/router';
 import { combineLatest, Subscription } from 'rxjs';
@@ -104,7 +104,7 @@ export class ContactsContentComponent implements OnInit, OnDestroy {
 
   private getUserFacility() {
     const subscription = this.store
-      .select(Selectors.getUserFacilityId)
+      .select(Selectors.getUserFacilityIds)
       .pipe(first(id => id !== null))
       .subscribe((userFacilityIds) => {
         const shouldDisplayHomePlace = userFacilityIds &&

--- a/webapp/src/ts/modules/contacts/contacts-report.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts-report.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, AfterViewInit, NgZone } from '@angular/core';
+import { AfterViewInit, Component, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';

--- a/webapp/src/ts/modules/contacts/contacts.component.ts
+++ b/webapp/src/ts/modules/contacts/contacts.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, AfterViewInit } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, Subscription } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { Router } from '@angular/router';
@@ -230,7 +230,6 @@ export class ContactsComponent implements OnInit, AfterViewInit, OnDestroy {
     const facilityIds = this
       .getUserFacilityId(userSettings)
       .filter(id => !!id);
-    this.globalActions.setUserFacilityId(facilityIds);
 
     let homePlaces = await this.getDataRecordsService.get(facilityIds);
     homePlaces = homePlaces?.filter(place => !!place);

--- a/webapp/src/ts/reducers/global.ts
+++ b/webapp/src/ts/reducers/global.ts
@@ -39,7 +39,8 @@ const initialState = {
   version: null,
   snackbarContent: null as any,
   translationsLoaded: false,
-  userFacilityId: null,
+  userFacilityIds: [],
+  userContactId: null,
   trainingCardFormId: null,
 };
 
@@ -204,9 +205,11 @@ const _globalReducer = createReducer(
     return { ...state, unreadCount: { ...state.unreadCount, ...unreadCount } };
   }),
   on(Actions.setTranslationsLoaded, (state) => ({ ...state, translationsLoaded: true })),
-  on(Actions.setUserFacilityId, (state, { payload: { userFacilityId }}) => {
-    return { ...state, userFacilityId };
+  on(Actions.setUserFacilityIds, (state, { payload: { userFacilityIds }}) => {
+    userFacilityIds = Array.isArray(userFacilityIds) ? userFacilityIds : [userFacilityIds];
+    return { ...state, userFacilityIds };
   }),
+  on(Actions.setUserContactId, (state, { payload: { userContactId }}) => ({ ...state, userContactId })),
   on(Actions.setTrainingCardFormId, (state, { payload: { trainingCardFormId }}) => {
     return { ...state, trainingCardFormId };
   }),

--- a/webapp/src/ts/selectors/index.ts
+++ b/webapp/src/ts/selectors/index.ts
@@ -30,7 +30,8 @@ export const Selectors = {
   getShowPrivacyPolicy: createSelector(getGlobalState, (globalState) => globalState.showPrivacyPolicy),
   getUnreadCount: createSelector(getGlobalState, (globalState) => globalState.unreadCount),
   getTranslationsLoaded: createSelector(getGlobalState, (globalState) => globalState.translationsLoaded),
-  getUserFacilityId: createSelector(getGlobalState, (globalState) => globalState.userFacilityId),
+  getUserFacilityIds: createSelector(getGlobalState, (globalState) => globalState.userFacilityIds),
+  getUserContactId: createSelector(getGlobalState, (globalState) => globalState.userContactId),
   getTrainingCardFormId: createSelector(getGlobalState, (globalState) => globalState.trainingCardFormId),
 
   // enketo

--- a/webapp/src/ts/services/calendar-interval.service.ts
+++ b/webapp/src/ts/services/calendar-interval.service.ts
@@ -8,11 +8,19 @@ export class CalendarIntervalService {
 
   constructor() { }
 
-  getCurrent(startDate) {
+  getCurrent(startDate:number) {
     return CalendarInterval.getCurrent(startDate);
   }
 
-  getPrevious(startDate: number, referenceDate?: Date) {
-    return CalendarInterval.getPrevious(startDate, referenceDate);
+  /**
+   * Returns the calendaristic interval that starts on the startDate day of month
+   * and contains date represented by timestamp.
+   * EG: getInterval(3, new Date('2023-08-21').valueOf()) will return
+   * the calendar interval of 2023-08-03 -> 2023-09-02
+   * @param startDate {number} interval start day - 1-31
+   * @param timestamp {number} date that should be included by the interval
+   */
+  getInterval(startDate:number, timestamp:number) {
+    return CalendarInterval.getInterval(startDate, timestamp);
   }
 }

--- a/webapp/src/ts/services/cht-datasource.service.ts
+++ b/webapp/src/ts/services/cht-datasource.service.ts
@@ -121,7 +121,10 @@ export class CHTDatasourceService {
         },
         getExtensionLib: (id) => {
           return this.extensionLibs[id];
-        }
+        },
+        analytics: {
+          getTargetDocs: () => ([]),
+        },
       }
     };
   }

--- a/webapp/src/ts/services/contact-summary.service.ts
+++ b/webapp/src/ts/services/contact-summary.service.ts
@@ -78,11 +78,11 @@ export class ContactSummaryService {
     return summary;
   }
 
-  get(contact, reports, lineage, targetDoc?) {
-    return this.ngZone.runOutsideAngular(() => this._get(contact, reports, lineage, targetDoc));
+  get(contact, reports, lineage, targetDocs) {
+    return this.ngZone.runOutsideAngular(() => this._get(contact, reports, lineage, targetDocs));
   }
 
-  private async _get(contact, reports, lineage, targetDoc?) {
+  private async _get(contact, reports, lineage, targetDocs) {
     if (!this.settings) {
       this.settings = await this.settingsService.get();
     }
@@ -98,9 +98,10 @@ export class ContactSummaryService {
     };
 
     const chtScriptApi = await this.chtDatasourceService.get();
+    chtScriptApi.v1.analytics.getTargetDocs = () => targetDocs;
 
     try {
-      const summary = generatorFunction(contact, reports || [], lineage || [], uhcStats, chtScriptApi, targetDoc);
+      const summary = generatorFunction(contact, reports || [], lineage || [], uhcStats, chtScriptApi, targetDocs[0]);
       return this.applyFilters(summary);
     } catch (error) {
       console.error('Configuration error in contact-summary function: ', error);

--- a/webapp/src/ts/services/contact-types.service.ts
+++ b/webapp/src/ts/services/contact-types.service.ts
@@ -80,6 +80,11 @@ export class ContactTypesService {
       .then(config => contactTypesUtils.getPersonTypes(config));
   }
 
+  async getPlaceChildTypes(type) {
+    const childTypes = await this.getChildren(type);
+    return childTypes.filter(type => !contactTypesUtils.isPersonType(type));
+  }
+
   /**
    * @returns {string} returns the contact type id of a given contact document
    */
@@ -92,9 +97,15 @@ export class ContactTypesService {
   }
 
   /**
-   *  @returns {boolean} returns whether the provided type is a person type
+   *  @returns {boolean} returns whether the provided contact has a person type
    */
-  isPersonType(type?) {
+  async isPerson(contact) {
+    let type;
+    if (typeof contact.type === 'object') {
+      type = contact.type;
+    } else {
+      type = await this.get(this.getTypeId(contact));
+    }
     return contactTypesUtils.isPersonType(type);
   }
 

--- a/webapp/src/ts/services/form.service.ts
+++ b/webapp/src/ts/services/form.service.ts
@@ -25,6 +25,7 @@ import { UserSettingsService } from '@mm-services/user-settings.service';
 import { ContactSaveService } from '@mm-services/contact-save.service';
 import { reduce as _reduce } from 'lodash-es';
 import { ContactTypesService } from '@mm-services/contact-types.service';
+import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 
 /**
  * Service for interacting with forms. This is the primary entry-point for CHT code to render forms and save the
@@ -55,7 +56,8 @@ export class FormService {
     private translateService: TranslateService,
     private ngZone: NgZone,
     private chtDatasourceService: CHTDatasourceService,
-    private enketoService: EnketoService
+    private enketoService: EnketoService,
+    private targetAggregatesService: TargetAggregatesService,
   ) {
     this.inited = this.init();
     this.globalActions = new GlobalActions(store);
@@ -66,6 +68,8 @@ export class FormService {
   private servicesActions: ServicesActions;
 
   private inited;
+  private userContactId;
+  private userFacilityIds;
 
   private init() {
     if (this.inited) {
@@ -131,6 +135,10 @@ export class FormService {
     return this.searchService.search('reports', { subjectIds: subjectIds }, { include_docs: true });
   }
 
+  private getTargetDocs(contact) {
+    return this.targetAggregatesService.getTargetDocs(contact, this.userFacilityIds, this.userContactId);
+  }
+
   private getContactSummary(doc, instanceData) {
     const contact = instanceData?.contact;
     if (!doc.hasContactSummary || !contact) {
@@ -140,8 +148,9 @@ export class FormService {
       .all([
         this.getContactReports(contact),
         this.getLineage(contact),
+        this.getTargetDocs(contact),
       ])
-      .then(([reports, lineage]) => this.contactSummaryService.get(contact, reports, lineage));
+      .then(([reports, lineage, targetDocs]) => this.contactSummaryService.get(contact, reports, lineage, targetDocs));
   }
 
   private canAccessForm(formContext: EnketoFormContext) {
@@ -178,6 +187,11 @@ export class FormService {
       const errorMessage = `Failed during the form "${formDoc.internalId}" rendering : `;
       throw new Error(errorMessage + error.message);
     }
+  }
+
+  setUserContext(userFacilityIds, userContactId) {
+    this.userFacilityIds = userFacilityIds;
+    this.userContactId = userContactId;
   }
 
   render(formContext: EnketoFormContext) {

--- a/webapp/src/ts/services/user-settings.service.ts
+++ b/webapp/src/ts/services/user-settings.service.ts
@@ -112,7 +112,7 @@ export class UserSettingsService {
 
 }
 
-interface UserSettings {
+export interface UserSettings {
   _id: string;
   contact_id: string;
   facility_id: string[];

--- a/webapp/tests/karma/ts/app.component.spec.ts
+++ b/webapp/tests/karma/ts/app.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
-import { Router, ActivationEnd } from '@angular/router';
+import { ActivationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -45,6 +45,8 @@ import { AnalyticsActions } from '@mm-actions/analytics';
 import { AnalyticsModulesService } from '@mm-services/analytics-modules.service';
 import { Selectors } from '@mm-selectors/index';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
+import { UserSettingsService } from '@mm-services/user-settings.service';
+import { FormService } from '@mm-services/form.service';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -83,6 +85,8 @@ describe('AppComponent', () => {
   let chtDatasourceService;
   let analyticsModulesService;
   let trainingCardsService;
+  let userSettingsService;
+  let formService;
   // End Services
 
   let globalActions;
@@ -155,6 +159,8 @@ describe('AppComponent', () => {
       setPrivacyPolicyAccepted: sinon.stub(GlobalActions.prototype, 'setPrivacyPolicyAccepted'),
       setShowPrivacyPolicy: sinon.stub(GlobalActions.prototype, 'setShowPrivacyPolicy'),
       setForms: sinon.stub(GlobalActions.prototype, 'setForms'),
+      setUserFacilityIds: sinon.stub(GlobalActions.prototype, 'setUserFacilityIds'),
+      setUserContactId: sinon.stub(GlobalActions.prototype, 'setUserContactId'),
     };
     analyticsActions = {
       setAnalyticsModules: sinon.stub(AnalyticsActions.prototype, 'setAnalyticsModules')
@@ -165,6 +171,8 @@ describe('AppComponent', () => {
     };
     telemetryService = { record: sinon.stub() };
     trainingCardsService = { initTrainingCards: sinon.stub() };
+    userSettingsService = { get: sinon.stub().resolves({ facility_id: ['facility'], contact_id: 'contact' }) };
+    formService = { setUserContext: sinon.stub() };
     consoleErrorStub = sinon.stub(console, 'error');
 
     const mockedSelectors = [
@@ -216,6 +224,8 @@ describe('AppComponent', () => {
           { provide: CHTDatasourceService, useValue: chtDatasourceService },
           { provide: AnalyticsModulesService, useValue: analyticsModulesService },
           { provide: TrainingCardsService, useValue: trainingCardsService },
+          { provide: UserSettingsService, useValue: userSettingsService },
+          { provide: FormService, useValue: formService },
           { provide: Router, useValue: router  },
         ]
       })
@@ -260,6 +270,9 @@ describe('AppComponent', () => {
     expect(recurringProcessManagerService.startUpdateRelativeDate.callCount).to.equal(1);
     expect(recurringProcessManagerService.startUpdateReadDocsCount.callCount).to.equal(0);
     expect(component.isSidebarFilterOpen).to.be.false;
+    expect(userSettingsService.get.calledOnce).to.equal(true);
+    expect(globalActions.setUserFacilityIds.calledOnceWith(['facility'])).to.equal(true);
+    expect(globalActions.setUserContactId.calledOnceWith('contact')).to.equal(true);
   });
 
   it('should display browser compatibility modal if using outdated chrome browser', async () => {

--- a/webapp/tests/karma/ts/modules/analytics/analytics-target-aggregates-detail.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/analytics/analytics-target-aggregates-detail.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angul
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Subject } from 'rxjs';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -218,10 +218,9 @@ describe('AnalyticsTargetAggregatesDetailComponent', () => {
       subtitle_translation_key: 'targets.this_month.subtitle',
       reportingPeriod: ReportingPeriod.CURRENT
     };
-    targetAggregatesService.isCurrentPeriod.resolves(true);
     translateService.instant = sinon.stub().returns('This month');
 
-    const result = (component as any).getReportingPeriodText(component.selected.reportingPeriod);
+    const result = (component as any).getReportingPeriodText(component.selected);
     expect(result).to.equal('This month');
   });
 
@@ -232,11 +231,9 @@ describe('AnalyticsTargetAggregatesDetailComponent', () => {
       reportingPeriod: ReportingPeriod.PREVIOUS,
       reportingMonth: 'April'
     };
-    targetAggregatesService.isPreviousPeriod.resolves(true);
     translateService.instant = sinon.stub().returns('This month');
 
-
-    const result = (component as any).getReportingPeriodText(component.selected.reportingPeriod);
+    const result = (component as any).getReportingPeriodText(component.selected);
     expect(result).to.equal('April');
   });
 });

--- a/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-content.component.spec.ts
@@ -1,5 +1,5 @@
-import { ComponentFixture, TestBed, fakeAsync, flush, waitForAsync } from '@angular/core/testing';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { of } from 'rxjs';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -183,7 +183,7 @@ describe('Contacts content component', () => {
   describe('load the user home place on mobile', () => {
     it(`should not load the user's home place when on mobile`, fakeAsync(() => {
       const selectContact = sinon.stub(ContactsActions.prototype, 'selectContact');
-      store.overrideSelector(Selectors.getUserFacilityId, 'homeplace');
+      store.overrideSelector(Selectors.getUserFacilityIds, 'homeplace');
       responsiveService.isMobile.returns(true);
       activatedRoute.params = of({});
       activatedRoute.snapshot.params = {};
@@ -197,7 +197,7 @@ describe('Contacts content component', () => {
 
   it(`should not load the user's home place when a param id is set`, fakeAsync(() => {
     const selectContact = sinon.stub(ContactsActions.prototype, 'selectContact');
-    store.overrideSelector(Selectors.getUserFacilityId, 'homeplace');
+    store.overrideSelector(Selectors.getUserFacilityIds, 'homeplace');
     activatedRoute.params = of({ id: 'contact-1234' });
     activatedRoute.snapshot.params = { id: 'contact-1234' };
 
@@ -211,7 +211,7 @@ describe('Contacts content component', () => {
 
   it(`should not load the user's home place when a search term exists`, fakeAsync(() => {
     const selectContact = sinon.stub(ContactsActions.prototype, 'selectContact');
-    store.overrideSelector(Selectors.getUserFacilityId, 'homeplace');
+    store.overrideSelector(Selectors.getUserFacilityIds, 'homeplace');
     store.overrideSelector(Selectors.getFilters, { search: 'text' });
     component.ngOnInit();
     flush();
@@ -222,7 +222,7 @@ describe('Contacts content component', () => {
 
   it(`should load the user's home place when a param id not set and no search term exists`, fakeAsync(() => {
     const selectContact = sinon.stub(ContactsActions.prototype, 'selectContact');
-    store.overrideSelector(Selectors.getUserFacilityId, ['homeplace']);
+    store.overrideSelector(Selectors.getUserFacilityIds, ['homeplace']);
     store.overrideSelector(Selectors.getFilters, undefined);
     activatedRoute.params = of({});
     activatedRoute.snapshot.params = {};

--- a/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts-report.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';

--- a/webapp/tests/karma/ts/modules/contacts/contacts.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/contacts/contacts.component.spec.ts
@@ -1,7 +1,7 @@
-import { TestBed, ComponentFixture, fakeAsync, flush, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { MatDialog } from '@angular/material/dialog';
-import { provideMockStore, MockStore } from '@ngrx/store/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -146,7 +146,7 @@ describe('TasksContentComponent', () => {
       selector: '#task-report',
       type: 'task',
       formDoc: form,
-      instanceData: 'nothing'
+      instanceData: 'nothing',
     });
 
     expect(get.callCount).to.eq(0);

--- a/webapp/tests/karma/ts/reducers/global.spec.ts
+++ b/webapp/tests/karma/ts/reducers/global.spec.ts
@@ -406,4 +406,23 @@ describe('Global Reducer', () => {
     state = globalReducer(state, Actions.setTrainingCardFormId('training:another_new_change'));
     expect(state).to.deep.equal({ trainingCardFormId: 'training:another_new_change' });
   });
+
+  it('should set userFacilityIds in state', () => {
+    state = globalReducer(state, Actions.setUserFacilityIds('facility_id'));
+    expect(state).to.deep.equal({ userFacilityIds: ['facility_id'] });
+
+    state = globalReducer(state, Actions.setUserFacilityIds('other'));
+    expect(state).to.deep.equal({ userFacilityIds: ['other'] });
+
+    state = globalReducer(state, Actions.setUserFacilityIds(['others']));
+    expect(state).to.deep.equal({ userFacilityIds: ['others'] });
+  });
+
+  it('should set userContactId in state', () => {
+    state = globalReducer(state, Actions.setUserContactId('contact_id'));
+    expect(state).to.deep.equal({ userContactId: 'contact_id' });
+
+    state = globalReducer(state, Actions.setUserContactId('other'));
+    expect(state).to.deep.equal({ userContactId: 'other' });
+  });
 });

--- a/webapp/tests/karma/ts/selectors/index.spec.ts
+++ b/webapp/tests/karma/ts/selectors/index.spec.ts
@@ -34,7 +34,8 @@ const state = {
     showPrivacyPolicy: 'show policy',
     unreadCount: 1230,
     translationsLoaded: 'have translations loaded',
-    userFacilityId: 'facility_uuid',
+    userFacilityIds: ['facility_uuid'],
+    userContactId: 'contact_uuid',
     enketoStatus: {
       edited: 'is edited',
       saving: 'is saving',
@@ -218,7 +219,11 @@ describe('Selectors', () => {
     });
 
     it('should getUserFacilityId', () => {
-      expect(Selectors.getUserFacilityId.projector(state.global)).to.equal(clonedState.global.userFacilityId);
+      expect(Selectors.getUserFacilityIds.projector(state.global)).to.deep.equal(clonedState.global.userFacilityIds);
+    });
+
+    it('should getUserContactId', () => {
+      expect(Selectors.getUserContactId.projector(state.global)).to.equal(clonedState.global.userContactId);
     });
 
     it('should getEnketoStatus', () => {
@@ -247,7 +252,7 @@ describe('Selectors', () => {
 
     // null checks
     it('should null check global state', () => {
-      expect(Selectors.getUserFacilityId.projector({})).to.equal(undefined);
+      expect(Selectors.getUserFacilityIds.projector({})).to.equal(undefined);
     });
 
     it('should null check enketo state', () => {

--- a/webapp/tests/karma/ts/services/cht-datasource.service.spec.ts
+++ b/webapp/tests/karma/ts/services/cht-datasource.service.spec.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
@@ -85,11 +85,18 @@ describe('CHTScriptApiService service', () => {
       const result = await service.get();
 
       expect(result).to.contain.keys([ 'v1' ]);
-      expect(result.v1).to.contain.keys([ 'hasPermissions', 'hasAnyPermission', 'getExtensionLib', 'person' ]);
+      expect(result.v1).to.contain.keys([
+        'hasPermissions',
+        'hasAnyPermission',
+        'getExtensionLib',
+        'person',
+        'analytics'
+      ]);
       expect(result.v1.hasPermissions).to.be.a('function');
       expect(result.v1.hasAnyPermission).to.be.a('function');
       expect(result.v1.getExtensionLib).to.be.a('function');
       expect(result.v1.person).to.be.a('object');
+      expect(result.v1.analytics).to.be.a('object');
     });
 
     it('should initialize extension libs', async () => {

--- a/webapp/tests/karma/ts/services/enketo.service.spec.ts
+++ b/webapp/tests/karma/ts/services/enketo.service.spec.ts
@@ -9,7 +9,7 @@ import { TranslateFromService } from '@mm-services/translate-from.service';
 import { EnketoPrepopulationDataService } from '@mm-services/enketo-prepopulation-data.service';
 import { AttachmentService } from '@mm-services/attachment.service';
 import { TranslateService } from '@mm-services/translate.service';
-import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
+import { EnketoFormContext, EnketoService } from '@mm-services/enketo.service';
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 import * as FileManager from '../../../../src/js/enketo/file-manager.js';
 

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { assert, expect } from 'chai';
 import { provideMockStore } from '@ngrx/store/testing';
 import * as _ from 'lodash-es';
+import { cloneDeep } from 'lodash-es';
 import { toBik_text } from 'bikram-sambat';
 import * as moment from 'moment';
 
@@ -29,11 +30,11 @@ import { FeedbackService } from '@mm-services/feedback.service';
 import * as medicXpathExtensions from '../../../../src/js/enketo/medic-xpath-extensions';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
 import { TrainingCardsService } from '@mm-services/training-cards.service';
-import { EnketoService, EnketoFormContext } from '@mm-services/enketo.service';
-import { cloneDeep } from 'lodash-es';
+import { EnketoFormContext, EnketoService } from '@mm-services/enketo.service';
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 import { EnketoTranslationService } from '@mm-services/enketo-translation.service';
 import * as FileManager from '../../../../src/js/enketo/file-manager.js';
+import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
 
 describe('Form service', () => {
   // return a mock form ready for putting in #dbContent
@@ -90,6 +91,7 @@ describe('Form service', () => {
   let consoleWarnMock;
   let feedbackService;
   let extractLineageService;
+  let targetAggregatesService;
 
   beforeEach(() => {
     enketoInit = sinon.stub();
@@ -156,6 +158,7 @@ describe('Form service', () => {
     consoleWarnMock = sinon.stub(console, 'warn');
     feedbackService = { submit: sinon.stub() };
     extractLineageService = { extract: ExtractLineageService.prototype.extract };
+    targetAggregatesService = { getTargetDocs: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
@@ -185,6 +188,7 @@ describe('Form service', () => {
         { provide: TrainingCardsService, useValue: trainingCardsService },
         { provide: FeedbackService, useValue: feedbackService },
         { provide: ExtractLineageService, useValue: extractLineageService },
+        { provide: TargetAggregatesService, useValue: targetAggregatesService },
       ],
     });
 
@@ -368,8 +372,10 @@ describe('Form service', () => {
       };
       ContactSummary.resolves({ context: { pregnant: true } });
       Search.resolves([{ _id: 'somereport' }]);
+      targetAggregatesService.getTargetDocs.resolves([{ _id: 't1' }, { _id: 't2' }]);
       LineageModelGenerator.contact.resolves({ lineage: [{ _id: 'someparent' }] });
       const formContext = new EnketoFormContext('div', 'report', mockEnketoDoc('myform'), instanceData);
+      service.setUserContext(['facility'], 'contact');
       return service.render(formContext).then(() => {
         expect(EnketoForm.callCount).to.equal(1);
         expect(EnketoForm.args[0][1].external.length).to.equal(1);
@@ -382,12 +388,17 @@ describe('Form service', () => {
         expect(Search.args[0][1].subjectIds).to.deep.equal(['fffff', '44509']);
         expect(LineageModelGenerator.contact.callCount).to.equal(1);
         expect(LineageModelGenerator.contact.args[0][0]).to.equal('fffff');
+        expect(targetAggregatesService.getTargetDocs.callCount).to.equal(1);
+        expect(targetAggregatesService.getTargetDocs.args[0]).to.deep.equal([
+          { _id: 'fffff', patient_id: '44509' }, ['facility'], 'contact'
+        ]);
         expect(ContactSummary.callCount).to.equal(1);
         expect(ContactSummary.args[0][0]._id).to.equal('fffff');
         expect(ContactSummary.args[0][1].length).to.equal(1);
         expect(ContactSummary.args[0][1][0]._id).to.equal('somereport');
         expect(ContactSummary.args[0][2].length).to.equal(1);
         expect(ContactSummary.args[0][2][0]._id).to.equal('someparent');
+        expect(ContactSummary.args[0][3]).to.deep.equal([{ _id: 't1' }, { _id: 't2' }]);
       });
     });
 

--- a/webapp/tests/karma/ts/services/target-aggregates.service.spec.ts
+++ b/webapp/tests/karma/ts/services/target-aggregates.service.spec.ts
@@ -1,12 +1,7 @@
 import { TestBed } from '@angular/core/testing';
-import {
-  TranslateFakeLoader,
-  TranslateLoader,
-  TranslateModule,
-  TranslateService
-} from '@ngx-translate/core';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import sinon from 'sinon';
-import { expect, assert } from 'chai';
+import { assert, expect } from 'chai';
 import * as moment from 'moment';
 
 import { TargetAggregatesService } from '@mm-services/target-aggregates.service';
@@ -44,8 +39,8 @@ describe('TargetAggregatesService', () => {
     settingsService = {get: sinon.stub()};
     contactTypesService = {
       getTypeId: sinon.stub(),
-      getChildren: sinon.stub(),
-      isPersonType: sinon.stub(),
+      getPlaceChildTypes: sinon.stub(),
+      isPerson: sinon.stub(),
     };
     getDataRecordsService = {get: sinon.stub()};
     searchService = {search: sinon.stub()};
@@ -61,6 +56,7 @@ describe('TargetAggregatesService', () => {
     translateFromService = {get: sinon.stub()};
     calendarIntervalService = {
       getCurrent: sinon.stub().returns({ end: 100 }),
+      getInterval: sinon.stub().returns({ end: 100 }),
       getPrevious: sinon.stub().returns({ end: 100 }),
     };
 
@@ -224,7 +220,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }, { id: 'type2' }, { id: 'type3' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }, { id: 'type2' }, { id: 'type3' }]);
       searchService.search.resolves([]);
       dbService.allDocs.resolves({ rows: [] });
 
@@ -239,8 +235,8 @@ describe('TargetAggregatesService', () => {
       expect(getDataRecordsService.get.args[1]).to.deep.equal([[]]);
       expect(contactTypesService.getTypeId.callCount).to.equal(1);
       expect(contactTypesService.getTypeId.args[0]).to.deep.equal([{ _id: 'home' }]);
-      expect(contactTypesService.getChildren.callCount).to.equal(1);
-      expect(contactTypesService.getChildren.args[0]).to.deep.equal(['home_type']);
+      expect(contactTypesService.getPlaceChildTypes.callCount).to.equal(1);
+      expect(contactTypesService.getPlaceChildTypes.args[0]).to.deep.equal(['home_type']);
       expect(searchService.search.callCount).to.equal(1);
       expect(searchService.search.args[0]).to.deep.equal([
         'contacts',
@@ -261,7 +257,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }, { id: 'type2' }, { id: 'type3' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }, { id: 'type2' }, { id: 'type3' }]);
       dbService.allDocs.resolves({ rows: [] });
 
       searchService.search.onCall(0).resolves(Array.from({ length: 100 }).map(() => ({ _id: 'place' })));
@@ -303,7 +299,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'home', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }, { id: 'type2' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }, { id: 'type2' }]);
 
       const places = Array.from({ length: 224 }).map((a, i) => ({ lineage: ['home'], contact: `contact${i}` }));
       const contacts = places.map(place => ({ _id: place.contact, name: randomString() }));
@@ -371,7 +367,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'home', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
 
       const randomBoolean = () => Math.random() < 0.5;
       const genPlace = (idx) => ({
@@ -443,8 +439,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }, { id: 'person' }, { id: 'person2' }, { id: 'type2' }]);
-      contactTypesService.isPersonType.callsFake(type => type.id.startsWith('person'));
+      contactTypesService.getPlaceChildTypes.resolves([ { id: 'type1' }, { id: 'type2' } ]);
       searchService.search.resolves([]);
       dbService.allDocs.resolves({ rows: [] });
 
@@ -453,13 +448,6 @@ describe('TargetAggregatesService', () => {
       expect(result.length).to.equal(1);
       expect(result[0].id).to.equal('target');
       expect(result[0].values.length).to.equal(0);
-      expect(contactTypesService.isPersonType.callCount).to.equal(4);
-      expect(contactTypesService.isPersonType.args).to.deep.equal([
-        [{ id: 'type1' }],
-        [{ id: 'person' }],
-        [{ id: 'person2' }],
-        [{ id: 'type2' }],
-      ]);
       expect(searchService.search.callCount).to.equal(1);
       expect(searchService.search.args[0]).to.deep.equal([
         'contacts',
@@ -478,9 +466,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'home', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'person' }, { id: 'person2' }]);
-      contactTypesService.isPersonType.callsFake(type => type.id.startsWith('person'));
-
+      contactTypesService.getPlaceChildTypes.resolves([]);
       dbService.allDocs.resolves({ rows: [] });
 
       const result = await service.getAggregates();
@@ -488,11 +474,6 @@ describe('TargetAggregatesService', () => {
       expect(result.length).to.equal(1);
       expect(result[0].id).to.equal('target');
       expect(result[0].values.length).to.equal(0);
-      expect(contactTypesService.isPersonType.callCount).to.equal(2);
-      expect(contactTypesService.isPersonType.args).to.deep.equal([
-        [{ id: 'person' }],
-        [{ id: 'person2' }],
-      ]);
       expect(searchService.search.callCount).to.equal(0);
       expect(getDataRecordsService.get.callCount).to.equal(1);
       expect(getDataRecordsService.get.args[0]).to.deep.equal([[ 'home' ]]);
@@ -507,7 +488,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([facilityId]).resolves([{ _id: facilityId, name: 'Test Facility' }]);
       contactTypesService.getTypeId.returns('district');
-      contactTypesService.getChildren.resolves([{ id: 'health_center' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'health_center' }]);
       searchService.search.resolves([]);
 
       dbService.allDocs.resolves({ rows: [] });
@@ -545,7 +526,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       searchService.search.resolves([]);
 
       dbService.allDocs.resolves({ rows: [] });
@@ -583,13 +564,17 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([facilityId]).resolves([{ _id: facilityId, name: 'Test Facility' }]);
       contactTypesService.getTypeId.returns('district');
-      contactTypesService.getChildren.resolves([{ id: 'health_center' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'health_center' }]);
       searchService.search.resolves([]);
 
       dbService.allDocs.resolves({ rows: [] });
 
       uhcSettingsService.getMonthStartDate.returns(1);
-      calendarIntervalService.getPrevious.returns({
+      calendarIntervalService.getCurrent.returns({
+        start: moment('2019-08-01').valueOf(),
+        end: moment('2019-08-31').valueOf(),
+      });
+      calendarIntervalService.getInterval.returns({
         start: moment('2019-07-01').valueOf(),
         end: moment('2019-07-31').valueOf(),
       });
@@ -608,8 +593,8 @@ describe('TargetAggregatesService', () => {
       }]);
       expect(uhcSettingsService.getMonthStartDate.callCount).to.equal(1);
       expect(uhcSettingsService.getMonthStartDate.args[0]).to.deep.equal([config]);
-      expect(calendarIntervalService.getPrevious.callCount).to.equal(1);
-      expect(calendarIntervalService.getPrevious.args[0]).to.deep.equal([1]);
+      expect(calendarIntervalService.getInterval.callCount).to.equal(1);
+      expect(calendarIntervalService.getInterval.args[0]).to.deep.equal([1, moment('2019-07-31').valueOf()]);
     });
 
     it('should exclude non-aggregable targets and hydrate aggregates', async () => {
@@ -626,7 +611,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       searchService.search.resolves([]);
       translateFromService.get.callsFake(e => e);
       dbService.allDocs.resolves({ rows: [] });
@@ -743,7 +728,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'facility-1', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       getDataRecordsService.get.withArgs(sinon.match.array).resolves(contacts);
       searchService.search.resolves([]);
       dbService.allDocs.resolves({ rows: targetDocs.map(doc => ({ doc })) });
@@ -881,7 +866,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'facility-1', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       getDataRecordsService.get.withArgs(sinon.match.array).resolves(contacts);
       searchService.search.resolves([]);
 
@@ -940,7 +925,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'facility-1', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       getDataRecordsService.get.withArgs(sinon.match.array).resolves(contacts);
       searchService.search.resolves([]);
 
@@ -1022,7 +1007,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'facility-1', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       getDataRecordsService.get.withArgs(sinon.match.array).resolves(contacts);
       searchService.search.resolves([]);
 
@@ -1098,7 +1083,7 @@ describe('TargetAggregatesService', () => {
       userSettingsService.getUserFacilities.resolves([{ _id: 'facility-1', name: 'Facility 1' }]);
       getDataRecordsService.get.withArgs([ 'home' ]).resolves([ { _id: 'home' } ]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       getDataRecordsService.get.withArgs(sinon.match.array).resolves(contacts);
       searchService.search.resolves([]);
 
@@ -1148,7 +1133,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs(['home']).resolves([{ _id: 'home' }]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       searchService.search.resolves([]);
 
       dbService.allDocs.resolves({ rows: [] });
@@ -1176,13 +1161,17 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs(['home']).resolves([{ _id: 'home' }]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       searchService.search.resolves([]);
 
       dbService.allDocs.resolves({ rows: [] });
 
       uhcSettingsService.getMonthStartDate.returns(1);
-      calendarIntervalService.getPrevious.returns({
+      calendarIntervalService.getCurrent.returns({
+        start: moment('2024-08-01').valueOf(),
+        end: moment('2024-08-31').valueOf(),
+      });
+      calendarIntervalService.getInterval.returns({
         start: moment('2024-07-01').valueOf(),
         end: moment('2024-07-31').valueOf(),
       });
@@ -1192,8 +1181,8 @@ describe('TargetAggregatesService', () => {
       expect(result).to.equal('July');
       expect(settingsService.get.callCount).to.equal(1);
       expect(uhcSettingsService.getMonthStartDate.callCount).to.equal(1);
-      expect(calendarIntervalService.getPrevious.callCount).to.equal(1);
-      expect(calendarIntervalService.getPrevious.args[0]).to.deep.equal([1]);
+      expect(calendarIntervalService.getInterval.callCount).to.equal(1);
+      expect(calendarIntervalService.getInterval.args[0]).to.deep.equal([1, moment('2024-07-31').valueOf()]);
     });
 
     it('should return "Last month" when getIntervalTag fails to get the correct month name', async () => {
@@ -1204,7 +1193,7 @@ describe('TargetAggregatesService', () => {
       getDataRecordsService.get.resolves([]);
       getDataRecordsService.get.withArgs(['home']).resolves([{ _id: 'home' }]);
       contactTypesService.getTypeId.returns('home_type');
-      contactTypesService.getChildren.resolves([{ id: 'type1' }]);
+      contactTypesService.getPlaceChildTypes.resolves([{ id: 'type1' }]);
       searchService.search.resolves([]);
       translateService.instant = sinon.stub().returns('Last month');
       settingsService.get.rejects({ some: 'err' });
@@ -1253,40 +1242,55 @@ describe('TargetAggregatesService', () => {
     });
   });
 
-  describe('getCurrentTargetDoc', () => {
+  describe('getTargetDocs', () => {
     it('should do nothing when no contact uuid', () => {
       return Promise
         .all([
-          service.getCurrentTargetDoc(),
-          service.getCurrentTargetDoc({}),
-          service.getCurrentTargetDoc(''),
+          service.getTargetDocs(undefined, undefined, undefined),
+          service.getTargetDocs({}, undefined, undefined),
+          service.getTargetDocs('', undefined, undefined),
         ])
         .then(results => {
-          expect(results).to.deep.equal([undefined, undefined, undefined]);
+          expect(results).to.deep.equal([[], [], []]);
         });
     });
 
     it('should throw when getting settings fails', () => {
       settingsService.get.rejects({ some: 'err' });
+      contactTypesService.isPerson.resolves(true);
 
       return service
-        .getCurrentTargetDoc('uuid')
+        .getTargetDocs({ _id: 'uuid' }, ['facility'], 'contact')
         .then(() => assert.isFalse('Should have thrown'))
         .catch(err => expect(err).to.deep.equal({ some: 'err' }));
     });
 
-    it('should fetch latest target doc ', async () => {
+    it('should fetch last 3 target docs for the contact', async () => {
       const config = { tasks: { targets: { items: [
         { id: 'target1', aggregate: true, type: 'count' },
         { id: 'target2', aggregate: false, type: 'percent' },
         { id: 'target3', type: 'count', goal: 22, translation_key: 'my target' },
       ] } } };
       settingsService.get.resolves(config);
+      contactTypesService.isPerson.resolves(true);
       uhcSettingsService.getMonthStartDate.returns(20);
       calendarIntervalService.getCurrent.returns({
         start: moment('2020-01-20').valueOf(),
         end: moment('2020-02-20').valueOf(),
       });
+      calendarIntervalService.getInterval
+        .onCall(0).returns({
+          start: moment('2020-01-20').valueOf(),
+          end: moment('2020-02-20').valueOf()
+        })
+        .onCall(1).returns({
+          start: moment('2019-12-20').valueOf(),
+          end: moment('2020-01-20').valueOf()
+        })
+        .onCall(2).returns({
+          start: moment('2019-11-20').valueOf(),
+          end: moment('2019-12-20').valueOf()
+        });
 
       const targetDoc = {
         _id: 'target~2020-02~uuid~username',
@@ -1300,68 +1304,239 @@ describe('TargetAggregatesService', () => {
         ]
       };
 
-      dbService.allDocs.resolves({ rows: [{ doc: targetDoc }] });
-
-      const result = await service.getCurrentTargetDoc('uuid');
-
-      expect(result).to.deep.equal({
-        _id: 'target~2020-02~uuid~username',
+      const targetDoc2 = {
+        _id: 'target~2020-01~uuid~username',
         owner: 'uuid',
         updated_date: 100,
-        reporting_period: '2020-02',
-        targets: [
-          { id: 'target1', value: { pass: 5, total: 5 }, aggregate: true, type: 'count' },
-          { id: 'target2', value: { pass: 12, total: 21 }, aggregate: false, type: 'percent' },
-          { id: 'target3', value: { pass: 8, total: 8 }, type: 'count', goal: 22, translation_key: 'my target' },
-        ]
-      });
+        reporting_period: '2020-01',
+        targets: targetDoc.targets,
+      };
 
-      expect(uhcSettingsService.getMonthStartDate.callCount).to.equal(1);
+      const targetDoc3 = {
+        _id: 'target~2019-12~uuid~username',
+        owner: 'uuid',
+        updated_date: 100,
+        reporting_period: '2020-01',
+        targets: targetDoc.targets,
+      };
+
+      dbService.allDocs.onCall(0).resolves({rows: [{ id: targetDoc._id, doc: targetDoc }]});
+      dbService.allDocs.onCall(1).resolves({rows: [{ id: targetDoc2._id, doc: targetDoc2 }]});
+      dbService.allDocs.onCall(2).resolves({rows: [{ id: targetDoc3._id, doc: targetDoc3 }]});
+
+      const result = await service.getTargetDocs({ _id: 'uuid' }, ['facility'], 'contact');
+
+      expect(result).to.deep.equal([targetDoc, targetDoc2, targetDoc3]);
+
+      expect(uhcSettingsService.getMonthStartDate.callCount).to.equal(3);
       expect(uhcSettingsService.getMonthStartDate.args[0]).to.deep.equal([config]);
-      expect(calendarIntervalService.getCurrent.callCount).to.equal(1);
+      expect(contactTypesService.isPerson.args[0]).to.deep.equal([{ _id: 'uuid' }]);
+      expect(calendarIntervalService.getCurrent.callCount).to.equal(3);
       expect(calendarIntervalService.getCurrent.args[0]).to.deep.equal([20]);
-
-      expect(dbService.allDocs.callCount).to.equal(1);
+      expect(calendarIntervalService.getInterval.callCount).to.equal(3);
+      expect(calendarIntervalService.getInterval.args[0]).to.deep.equal([20, moment('2020-02-20').valueOf()]);
+      expect(calendarIntervalService.getInterval.args[1]).to.deep.equal([20, moment('2020-01-20').valueOf()]);
+      expect(calendarIntervalService.getInterval.args[2]).to.deep.equal([20, moment('2019-12-20').valueOf()]);
+      expect(dbService.allDocs.callCount).to.equal(3);
       expect(dbService.allDocs.args[0]).to.deep.equal([{
         start_key: 'target~2020-02~uuid~',
         end_key: 'target~2020-02~uuid~\ufff0',
         include_docs: true,
       }]);
+      expect(dbService.allDocs.args[1]).to.deep.equal([{
+        start_key: 'target~2020-01~uuid~',
+        end_key: 'target~2020-01~uuid~\ufff0',
+        include_docs: true,
+      }]);
+      expect(dbService.allDocs.args[2]).to.deep.equal([{
+        start_key: 'target~2019-12~uuid~',
+        end_key: 'target~2019-12~uuid~\ufff0',
+        include_docs: true,
+      }]);
     });
 
-    it('should discard additional target docs', async () => {
+    it('should fetch user target docs when loading target docs for the facility', async () => {
       const config = { tasks: { targets: { items: [
         { id: 'target1', aggregate: true, type: 'count' },
       ] } } };
       settingsService.get.resolves(config);
-
-      const targetDocs = [
-        {
-          _id: 'target~2020-02~uuid~username1',
-          owner: 'uuid',
-          targets: [ { id: 'target1', value: { pass: 5, total: 5 } } ]
-        },
-        {
-          _id: 'target~2020-02~uuid~username2',
-          owner: 'uuid',
-          targets: [ { id: 'target1', value: { pass: 15, total: 15 } } ]
-        },
-        {
-          _id: 'target~2020-02~uuid~username3',
-          owner: 'uuid',
-          targets: [ { id: 'target1', value: { pass: 25, total: 25 } } ]
-        },
-      ];
-
-      dbService.allDocs.resolves({ rows: targetDocs.map(doc => ({ doc })) });
-
-      const result = await service.getCurrentTargetDoc('uuid');
-
-      expect(result).to.deep.equal({
-        _id: 'target~2020-02~uuid~username1',
-        owner: 'uuid',
-        targets: [ { id: 'target1', value: { pass: 5, total: 5 }, aggregate: true, type: 'count' }]
+      contactTypesService.isPerson.resolves(false);
+      uhcSettingsService.getMonthStartDate.returns(1);
+      calendarIntervalService.getCurrent.returns({
+        start: moment('2023-07-01').valueOf(),
+        end: moment('2023-08-01').valueOf(),
       });
+      calendarIntervalService.getInterval
+        .onCall(0).returns({
+          start: moment('2023-07-01').valueOf(),
+          end: moment('2023-08-01').valueOf()
+        })
+        .onCall(1).returns({
+          start: moment('2023-06-01').valueOf(),
+          end: moment('2023-07-01').valueOf()
+        })
+        .onCall(2).returns({
+          start: moment('2023-05-01').valueOf(),
+          end: moment('2023-06-01').valueOf()
+        });
+
+      const targetDoc = {
+        _id: 'target~2023-07~usercontact~username',
+        owner: 'uuid',
+        updated_date: 100,
+        reporting_period: '2023-07',
+        targets: [
+          { id: 'target1', value: { pass: 5, total: 5 } },
+          { id: 'target2', value: { pass: 12, total: 21 } },
+          { id: 'target3', value: { pass: 8, total: 8 } },
+        ]
+      };
+
+      const targetDoc2 = {
+        _id: 'target~2023-06~usercontact~username',
+        owner: 'usercontact',
+        updated_date: 100,
+        reporting_period: '2023-06',
+        targets: targetDoc.targets,
+      };
+
+      const targetDoc3 = {
+        _id: 'target~2023-105~usercontact~username',
+        owner: 'usercontact',
+        updated_date: 100,
+        reporting_period: '2023-05',
+        targets: targetDoc.targets,
+      };
+
+      dbService.allDocs.onCall(0).resolves({rows: [{ id: targetDoc._id, doc: targetDoc }]});
+      dbService.allDocs.onCall(1).resolves({rows: [{ id: targetDoc2._id, doc: targetDoc2 }]});
+      dbService.allDocs.onCall(2).resolves({rows: [{ id: targetDoc3._id, doc: targetDoc3 }]});
+
+      const result = await service.getTargetDocs({ _id: 'facility' }, ['facility'], 'usercontact');
+
+      expect(result).to.deep.equal([targetDoc, targetDoc2, targetDoc3]);
+      expect(uhcSettingsService.getMonthStartDate.callCount).to.equal(3);
+      expect(uhcSettingsService.getMonthStartDate.args[0]).to.deep.equal([config]);
+      expect(calendarIntervalService.getCurrent.callCount).to.equal(3);
+      expect(calendarIntervalService.getCurrent.args[0]).to.deep.equal([1]);
+      expect(calendarIntervalService.getInterval.callCount).to.equal(3);
+      expect(calendarIntervalService.getInterval.args[0]).to.deep.equal([1, moment('2023-08-01').valueOf()]);
+      expect(calendarIntervalService.getInterval.args[1]).to.deep.equal([1, moment('2023-07-01').valueOf()]);
+      expect(calendarIntervalService.getInterval.args[2]).to.deep.equal([1, moment('2023-06-01').valueOf()]);
+      expect(dbService.allDocs.callCount).to.equal(3);
+      expect(dbService.allDocs.args[0]).to.deep.equal([{
+        start_key: 'target~2023-08~usercontact~',
+        end_key: 'target~2023-08~usercontact~\ufff0',
+        include_docs: true,
+      }]);
+      expect(dbService.allDocs.args[1]).to.deep.equal([{
+        start_key: 'target~2023-07~usercontact~',
+        end_key: 'target~2023-07~usercontact~\ufff0',
+        include_docs: true,
+      }]);
+      expect(dbService.allDocs.args[2]).to.deep.equal([{
+        start_key: 'target~2023-06~usercontact~',
+        end_key: 'target~2023-06~usercontact~\ufff0',
+        include_docs: true,
+      }]);
+    });
+
+    it('should fetch user target docs when loading target docs for one of the facilities', async () => {
+      const config = { tasks: { targets: { items: [
+        { id: 'target1', aggregate: true, type: 'count' },
+      ] } } };
+      settingsService.get.resolves(config);
+      contactTypesService.isPerson.resolves(false);
+      uhcSettingsService.getMonthStartDate.returns(1);
+      calendarIntervalService.getCurrent.returns({
+        start: moment('2023-07-01').valueOf(),
+        end: moment('2023-08-01').valueOf(),
+      });
+      calendarIntervalService.getInterval
+        .onCall(0).returns({
+          start: moment('2023-07-01').valueOf(),
+          end: moment('2023-08-01').valueOf()
+        })
+        .onCall(1).returns({
+          start: moment('2023-06-01').valueOf(),
+          end: moment('2023-07-01').valueOf()
+        })
+        .onCall(2).returns({
+          start: moment('2023-05-01').valueOf(),
+          end: moment('2023-06-01').valueOf()
+        });
+
+      const targetDoc = {
+        _id: 'target~2023-07~usercontact~username',
+        owner: 'uuid',
+        updated_date: 100,
+        reporting_period: '2023-07',
+        targets: [
+          { id: 'target1', value: { pass: 5, total: 5 } },
+          { id: 'target2', value: { pass: 12, total: 21 } },
+          { id: 'target3', value: { pass: 8, total: 8 } },
+        ]
+      };
+
+      const targetDoc2 = {
+        _id: 'target~2023-06~usercontact~username',
+        owner: 'usercontact',
+        updated_date: 100,
+        reporting_period: '2023-06',
+        targets: targetDoc.targets,
+      };
+
+      const targetDoc3 = {
+        _id: 'target~2023-105~usercontact~username',
+        owner: 'usercontact',
+        updated_date: 100,
+        reporting_period: '2023-05',
+        targets: targetDoc.targets,
+      };
+
+      dbService.allDocs.onCall(0).resolves({rows: [{ id: targetDoc._id, doc: targetDoc }]});
+      dbService.allDocs.onCall(1).resolves({rows: [{ id: targetDoc2._id, doc: targetDoc2 }]});
+      dbService.allDocs.onCall(2).resolves({rows: [{ id: targetDoc3._id, doc: targetDoc3 }]});
+
+      const result = await service.getTargetDocs({ _id: 'facility2' }, ['facility1', 'facility2'], 'usercontact');
+
+      expect(result).to.deep.equal([targetDoc, targetDoc2, targetDoc3]);
+      expect(uhcSettingsService.getMonthStartDate.callCount).to.equal(3);
+      expect(uhcSettingsService.getMonthStartDate.args[0]).to.deep.equal([config]);
+      expect(calendarIntervalService.getCurrent.callCount).to.equal(3);
+      expect(calendarIntervalService.getCurrent.args[0]).to.deep.equal([1]);
+      expect(calendarIntervalService.getInterval.callCount).to.equal(3);
+      expect(calendarIntervalService.getInterval.args[0]).to.deep.equal([1, moment('2023-08-01').valueOf()]);
+      expect(calendarIntervalService.getInterval.args[1]).to.deep.equal([1, moment('2023-07-01').valueOf()]);
+      expect(calendarIntervalService.getInterval.args[2]).to.deep.equal([1, moment('2023-06-01').valueOf()]);
+      expect(dbService.allDocs.callCount).to.equal(3);
+      expect(dbService.allDocs.args[0]).to.deep.equal([{
+        start_key: 'target~2023-08~usercontact~',
+        end_key: 'target~2023-08~usercontact~\ufff0',
+        include_docs: true,
+      }]);
+      expect(dbService.allDocs.args[1]).to.deep.equal([{
+        start_key: 'target~2023-07~usercontact~',
+        end_key: 'target~2023-07~usercontact~\ufff0',
+        include_docs: true,
+      }]);
+      expect(dbService.allDocs.args[2]).to.deep.equal([{
+        start_key: 'target~2023-06~usercontact~',
+        end_key: 'target~2023-06~usercontact~\ufff0',
+        include_docs: true,
+      }]);
+    });
+
+    it('should not load target docs for contacts that are not persons', async () => {
+      const config = { tasks: { targets: { items: [
+        { id: 'target1', aggregate: true, type: 'count' },
+      ] } } };
+      settingsService.get.resolves(config);
+      contactTypesService.isPerson.resolves(false);
+
+      const result = await service.getTargetDocs({ _id: 'random' }, ['facility'], 'usercontact');
+      expect(result).to.deep.equal([]);
+      expect(contactTypesService.isPerson.args[0]).to.deep.equal([{ _id: 'random' }]);
     });
 
     it('should ignore targets that are not configured', async () => {
@@ -1370,25 +1545,26 @@ describe('TargetAggregatesService', () => {
         { id: 'target2', aggregate: false, type: 'percent' },
       ] } } };
       settingsService.get.resolves(config);
+      contactTypesService.isPerson.resolves(true);
 
-      const targetDocs = [
-        {
-          _id: 'target~2020-02~uuid~username1',
-          owner: 'uuid',
-          targets: [
-            { id: 'target1', value: { pass: 5, total: 5 } },
-            { id: 'target2', value: { pass: 10, total: 10 } },
-            { id: 'target3', value: { pass: 12, total: 12 } },
-            { id: 'target4', value: { pass: 18, total: 18 } },
-          ]
-        },
-      ];
+      const targetDoc = {
+        _id: 'target~2020-02~uuid~username1',
+        owner: 'uuid',
+        targets: [
+          { id: 'target1', value: { pass: 5, total: 5 } },
+          { id: 'target2', value: { pass: 10, total: 10 } },
+          { id: 'target3', value: { pass: 12, total: 12 } },
+          { id: 'target4', value: { pass: 18, total: 18 } },
+        ]
+      };
 
-      dbService.allDocs.resolves({ rows: targetDocs.map(doc => ({ doc })) });
+      dbService.allDocs.onCall(0).resolves({ rows: [{ id: targetDoc._id, doc: targetDoc }] });
+      dbService.allDocs.onCall(1).resolves({ rows: [] });
+      dbService.allDocs.onCall(2).resolves({ rows: [] });
 
-      const result = await service.getCurrentTargetDoc('uuid');
+      const result = await service.getTargetDocs({ _id: 'uuid' }, ['facility'], 'contact');
 
-      expect(result).to.deep.equal({
+      expect(result).to.deep.equal([{
         _id: 'target~2020-02~uuid~username1',
         owner: 'uuid',
         targets: [
@@ -1397,7 +1573,7 @@ describe('TargetAggregatesService', () => {
           { id: 'target3', value: { pass: 12, total: 12 } },
           { id: 'target4', value: { pass: 18, total: 18 } },
         ]
-      });
+      }]);
     });
   });
 


### PR DESCRIPTION

Adds new analytics property to CHTDatasourceAPI in webapp. This analytics property gets a targetDocs() list passed to contact-summary. This list has the latest 3 target docs for the contact. When generating the contact summary of one of the logged in user's facilities, pass the logged in user's target docs to contact-summary.

#9269

(cherry picked from commit bbe5dedd5ad345178b592c5a96d70e8314c172a0)

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.11.x-9394-targets/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.11.x-9394-targets/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.11.x-9394-targets/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

