### PR TITLE
fix(#8947): filter out valid outbound tasks with empty configs because they are not due

### DIFF
--- a/sentinel/src/schedule/outbound.js
+++ b/sentinel/src/schedule/outbound.js
@@ -168,7 +168,7 @@ const attachInfoDocs = tasks => {
   });
 };
 
-const batch = (configuredPushes, startKey) => {
+const batch = (dueConfiguredPushes, startKey) => {
   let nextKey;
   return queuedTasks(startKey)
     .then(({ validTasks = [], invalidTasks = [], lastDocId } = {}) => {
@@ -183,8 +183,9 @@ const batch = (configuredPushes, startKey) => {
     .then(validTasks => {
       const pushes = validTasks.reduce((acc, {task, doc, info}) => {
         const pushesForDoc =
-                getConfigurationsToPush(configuredPushes, task)
-                  .map(([key, config]) => ({task, doc, info, config, key}));
+                getConfigurationsToPush(dueConfiguredPushes, task)
+                  .map(([key, config]) => ({task, doc, info, config, key}))
+                  .filter(({config}) => config && Object.keys(config).length > 0); // Filter out tasks without configs
 
         return acc.concat(pushesForDoc);
       }, []);
@@ -200,7 +201,7 @@ const batch = (configuredPushes, startKey) => {
         Promise.resolve()
       );
     })
-    .then(() => nextKey && batch(configuredPushes, nextKey));
+    .then(() => nextKey && batch(dueConfiguredPushes, nextKey));
 };
 
 // Coordinates the attempted pushing of documents that need it

--- a/sentinel/tests/unit/schedule/outbound.spec.js
+++ b/sentinel/tests/unit/schedule/outbound.spec.js
@@ -854,6 +854,10 @@ describe('outbound schedule', () => {
         assert.equal(singlePush.args[0][2], doc1Info);
         assert.equal(singlePush.args[0][3], configs[VALID_CRON]);
         assert.equal(singlePush.args[0][4], VALID_CRON);
+        assert.equal(singlePush.args.find(arg => arg[0] === task2), undefined);
+        assert.equal(attachInfoDocs.args[0][0][0].task, task1);
+        assert.equal(attachInfoDocs.args[0][0][1].task, task2);
+        assert.equal(removeInvalidTasks.callCount, 0);
       });
     });
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This fixes a bug where outbound tasks that are not yet due are removed because of the cron setting.

closes #8947 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8947-outbound-push-cron-config-bug/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8947-outbound-push-cron-config-bug/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:8947-outbound-push-cron-config-bug/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

