### PR TITLE
fix(#9433): use existent facility when updating user

### DIFF
--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -2897,6 +2897,28 @@ describe('Users service', () => {
       });
     });
 
+    it('should update contact on user and user settings', () => {
+      const data = {
+        contact: 'maricica'
+      };
+
+      db.users.get.resolves({ facility_id: ['maine'], contact_id: 'june' });
+      db.medic.get.withArgs('org.couchdb.user:paul').resolves({ facility_id: ['maine'], contact_id: 'june' });
+      db.medic.get.withArgs('maricica').resolves({ _id: 'maricica', type: 'person', parent: { _id: 'maine' } });
+      sinon.stub(people, 'isAPerson').returns(true);
+
+      sinon.stub(roles, 'hasAllPermissions').returns(true);
+
+      db.medic.put.resolves({});
+      db.users.put.resolves({});
+      return service.updateUser('paul', data, true).then(() => {
+        chai.expect(db.medic.put.callCount).to.equal(1);
+        chai.expect(db.medic.put.args[0][0]).to.deep.include({ facility_id: ['maine'], contact_id: 'maricica' });
+        chai.expect(db.users.put.callCount).to.equal(1);
+        chai.expect(db.users.put.args[0][0]).to.deep.include({ facility_id: ['maine'], contact_id: 'maricica' });
+      });
+    });
+
     it('removes facility_id/contact on user and user settings for online user', () => {
       const data = {
         place: null,

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -369,6 +369,21 @@ describe('Users API', () => {
 
     });
 
+    it('should allow to only update the contact', async () => {
+      await utils.request({
+        path: `/api/v1/users/${username}`,
+        method: 'POST',
+        body: {
+          contact: newContactId,
+        },
+      });
+      const userSettingsDoc = await utils.getDoc(getUserId(username));
+      chai.expect(userSettingsDoc.contact_id).to.equal(newContactId);
+
+      const userDoc = await utils.usersDb.get(getUserId(username));
+      chai.expect(userDoc.contact_id).to.equal(newContactId);
+    });
+
   });
 
   describe('/api/v1/users-info', () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

#9433 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9433-fix-users-contact-update/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9433-fix-users-contact-update/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9433-fix-users-contact-update/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

