### PR TITLE
chore(#9327): remove shadow after clicking hamburger menu

### DIFF
--- a/webapp/src/css/material.less
+++ b/webapp/src/css/material.less
@@ -65,6 +65,10 @@ html, body {
   padding: 0 !important;
 }
 
+.app-menu-button .mat-mdc-button-persistent-ripple {
+  display: none;
+}
+
 /**
  * Medic's custom component style
  */


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

This PR closes https://github.com/medic/care-teams/issues/182

We still have the ripple-effect when clicking the menu-icon to open the Sidebar but importantly, when you close the Sidebar menu the shadow is not there. 

<details>
<summary>Video </summary>


https://github.com/user-attachments/assets/d899a776-34cf-480f-bc58-29befef77b16


</details>

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:182-hamburger-icon/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:182-hamburger-icon/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:182-hamburger-icon/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

