### PR TITLE
fix(#9446): change haproxy port in unit test

### DIFF
--- a/haproxy/tests/Makefile
+++ b/haproxy/tests/Makefile
@@ -7,7 +7,7 @@ test_scripts:
 
 .PHONY: test_with_docker_compose
 test_with_docker_compose:
-  ss -lptn 'sport = :5984'
+  sudo ss -lptn 'sport = :5984'
 	docker compose up --build --wait
 	bats with_mock.bats
 	docker compose down

--- a/haproxy/tests/Makefile
+++ b/haproxy/tests/Makefile
@@ -7,6 +7,7 @@ test_scripts:
 
 .PHONY: test_with_docker_compose
 test_with_docker_compose:
+	docker ps
 	sudo ss -lptn 'sport = :5984'
 	docker compose up --build --wait
 	bats with_mock.bats

--- a/haproxy/tests/Makefile
+++ b/haproxy/tests/Makefile
@@ -7,7 +7,7 @@ test_scripts:
 
 .PHONY: test_with_docker_compose
 test_with_docker_compose:
-  sudo ss -lptn 'sport = :5984'
+	sudo ss -lptn 'sport = :5984'
 	docker compose up --build --wait
 	bats with_mock.bats
 	docker compose down

--- a/haproxy/tests/Makefile
+++ b/haproxy/tests/Makefile
@@ -7,8 +7,6 @@ test_scripts:
 
 .PHONY: test_with_docker_compose
 test_with_docker_compose:
-	docker ps
-	sudo ss -lptn 'sport = :5984'
 	docker compose up --build --wait
 	bats with_mock.bats
 	docker compose down

--- a/haproxy/tests/Makefile
+++ b/haproxy/tests/Makefile
@@ -7,6 +7,7 @@ test_scripts:
 
 .PHONY: test_with_docker_compose
 test_with_docker_compose:
+  ss -lptn 'sport = :5984'
 	docker compose up --build --wait
 	bats with_mock.bats
 	docker compose down

--- a/haproxy/tests/compose.yml
+++ b/haproxy/tests/compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: ../
     ports:
-      - 127.0.0.1:5984:5984
+      - 127.0.0.1:15984:5984
     environment:
       COUCHDB_SERVERS: mock-couchdb1,mock-couchdb2,mock-couchdb3
       COUCHDB_USER: someuser

--- a/haproxy/tests/with_mock.bats
+++ b/haproxy/tests/with_mock.bats
@@ -8,23 +8,23 @@ setup() {
 [[ -n "${DEBUG_BATS:-}" ]] && set -x
 
 @test "should respond before timeout" {
-	run timeout 15 bash -c "until curl -fksm5 http://127.0.0.1:5984; do sleep 0.1; done"
+	run timeout 15 bash -c "until curl -fksm5 http://127.0.0.1:15984; do sleep 0.1; done"
 	assert_success
 }
 
 @test "should receive response from couchdb" {
-	run bash -c "curl -fksm5 http://127.0.0.1:5984/ | jq .couchdb"
+	run bash -c "curl -fksm5 http://127.0.0.1:15984/ | jq .couchdb"
 	assert_success
 	assert_output '"Welcome to mock-couchdb"'
 }
 
 @test "should receive 404 response if path doesn't exist" {
-	run curl -Iksm5 http://127.0.0.1:5984/doesnotexist
+	run curl -Iksm5 http://127.0.0.1:15984/doesnotexist
 	assert_line --partial --index 0 'HTTP/1.1 404 Not Found'
 }
 
 @test "should return json with on connection drop" {
-	run bash -c "curl -ksm5 http://127.0.0.1:5984/error/drop | jq .error"
+	run bash -c "curl -ksm5 http://127.0.0.1:15984/error/drop | jq .error"
 	assert_success
 	assert_output '"502 Bad Gateway"'
 }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Haproxy port in unit test was conflicting with existing CouchDB container (https://github.com/medic/cht-core/blob/master/.github/workflows/build.yml#L62)
I honestly don't know how this worked before. 

#9446

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9446-haporxy-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9446-haporxy-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9446-haporxy-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

