### PR TITLE
chore: docker helper 4x move curl TLS certs outside nginx container

### DIFF
--- a/scripts/add-local-ip-certs-to-docker-4.x.sh
+++ b/scripts/add-local-ip-certs-to-docker-4.x.sh
@@ -38,8 +38,8 @@
 
 update_nginx_local_ip_tls_cert(){
   nginxContainerId=$1
-  curl --fail --silent --show-error -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain
-  curl --fail --silent --show-error -o /tmp/local-ip-key https://local-ip.medicmobile.org/key
+  curl --retry 3 --fail --silent --show-error -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain
+  curl --retry 3 --fail --silent --show-error -o /tmp/local-ip-key https://local-ip.medicmobile.org/key
   docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem 2>/dev/null
   docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem 2>/dev/null
 }

--- a/scripts/add-local-ip-certs-to-docker-4.x.sh
+++ b/scripts/add-local-ip-certs-to-docker-4.x.sh
@@ -40,8 +40,8 @@ update_nginx_local_ip_tls_cert(){
   nginxContainerId=$1
   curl --retry 3 --fail --silent --show-error -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain
   curl --retry 3 --fail --silent --show-error -o /tmp/local-ip-key https://local-ip.medicmobile.org/key
-  docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem 2>/dev/null
-  docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem 2>/dev/null
+  docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem 1>/dev/null
+  docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem 1>/dev/null
 }
 
 container="${1:-cht-nginx}"
@@ -63,12 +63,12 @@ if [ "$status" = "true" ]; then
     update_nginx_local_ip_tls_cert "$container"
   elif [ "$action" = "expire" ]; then
     result="installed expired local-ip.medicmobile.org"
-    docker cp ./tls_certificates/local-ip-expired.crt "$container":/etc/nginx/private/cert.pem 2>/dev/null
-    docker cp ./tls_certificates/local-ip-expired.key "$container":/etc/nginx/private/key.pem 2>/dev/null
+    docker cp ./tls_certificates/local-ip-expired.crt "$container":/etc/nginx/private/cert.pem 1>/dev/null
+    docker cp ./tls_certificates/local-ip-expired.key "$container":/etc/nginx/private/key.pem 1>/dev/null
   elif [ "$action" = "self" ]; then
     result="installed self-signed"
-    docker cp ./tls_certificates/self-signed.crt "$container":/etc/nginx/private/cert.pem 2>/dev/null
-    docker cp ./tls_certificates/self-signed.key "$container":/etc/nginx/private/key.pem 2>/dev/null
+    docker cp ./tls_certificates/self-signed.crt "$container":/etc/nginx/private/cert.pem 1>/dev/null
+    docker cp ./tls_certificates/self-signed.key "$container":/etc/nginx/private/key.pem 1>/dev/null
   fi
 
   if [ "$result" != "" ]; then

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -271,10 +271,10 @@ get_system_and_docker_info(){
 update_nginx_local_ip_tls_cert(){
   nginxContainerId=$1
   rm -f /tmp/local-ip-fullchain /tmp/local-ip-key
-  curl --fail --silent --show-error -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain
-  curl --fail --silent --show-error -o /tmp/local-ip-key https://local-ip.medicmobile.org/key
-  docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem  2>/dev/null
-  docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem  2>/dev/null
+  curl  --retry 3 --fail --silent --show-error -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain
+  curl  --retry 3 --fail --silent --show-error -o /tmp/local-ip-key https://local-ip.medicmobile.org/key
+  docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem  1>/dev/null
+  docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem  1>/dev/null
   docker exec "$nginxContainerId" bash -c "nginx -s reload"  2>/dev/null
 }
 
@@ -283,7 +283,7 @@ validate_tls(){
   # by default curl validates TLS.  If we get back  60 then TLS isn't valid:
   # exitcode: https://everything.curl.dev/usingcurl/verbose/writeout.html
   # 60: https://everything.curl.dev/cmdline/exitcode.html
-  status=$(curl  --write-out "%{exitcode}"  -qs  "$url" -o /dev/null)
+  status=$(curl   --retry 3 --write-out "%{exitcode}"  -qs  "$url" -o /dev/null)
   if [ "$status" = "60" ]; then
     echo "false: status is $status"
   fi

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -501,7 +501,7 @@ done
 
 # output a new line with echo and then update certs every time we run to ensure they're current
 echo;update_nginx_local_ip_tls_cert "$nginxContainerId"
-if [ "$(validate_tls "$projectURL")" ];then
+if [ "$(validate_tls "$projectURL" 0)" ];then
   echo ""
   echo -e "${red}Failed to install local-ip TLS certificate. Check for errors above and try again${noColor}"
   get_system_and_docker_info

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -270,8 +270,8 @@ update_nginx_local_ip_tls_cert(){
   nginxContainerId=$1
   curl  -s -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain 2>/dev/null
   curl  -s -o /tmp/local-ip-key https://local-ip.medicmobile.org/key 2>/dev/null
-  docker cp /tmp/local-ip-fullchain ${nginxContainerId}:/etc/nginx/private/cert.pem  2>/dev/null
-  docker cp /tmp/local-ip-key ${nginxContainerId}:/etc/nginx/private/key.pem  2>/dev/null
+  docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem  2>/dev/null
+  docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem  2>/dev/null
   docker exec "$nginxContainerId" bash -c "nginx -s reload"  2>/dev/null
 }
 

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -90,7 +90,7 @@ show_help_intro() {
     echo "    ./cht-docker-compose.sh"
 }
 
-show_help_existing_stop_and_destroy() {
+show_help() {
     echo ""
     echo "Start existing project"
     echo "    ./cht-docker-compose.sh ENV-FILE.env"
@@ -248,6 +248,7 @@ get_global_running_container_count(){
 }
 
 get_system_and_docker_info(){
+  projectURL=$(get_local_ip_url "$(get_lan_ip)")
   info='Service Status Container Image'
   services="cht-upgrade-service haproxy healthcheck api sentinel nginx couchdb"
   IFS=' ' read -ra servicesArray <<<"$services"
@@ -261,24 +262,37 @@ get_system_and_docker_info(){
   echo "---DEBUG INFO---"
   echo "Load: $(get_load_avg)"
   echo "CHT Containers: $(get_running_container_count)"
-  echo "Global Containers $(get_global_running_container_count)"
+  echo "Global Containers: $(get_global_running_container_count)"
+  echo "URL: $projectURL"
   echo
   echo $"$info" | column -t
 }
 
 update_nginx_local_ip_tls_cert(){
   nginxContainerId=$1
-  curl  -s -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain 2>/dev/null
-  curl  -s -o /tmp/local-ip-key https://local-ip.medicmobile.org/key 2>/dev/null
+  rm -f /tmp/local-ip-fullchain /tmp/local-ip-key
+  curl --fail --silent --show-error -o /tmp/local-ip-fullchain https://local-ip.medicmobile.org/fullchain
+  curl --fail --silent --show-error -o /tmp/local-ip-key https://local-ip.medicmobile.org/key
   docker cp /tmp/local-ip-fullchain "${nginxContainerId}":/etc/nginx/private/cert.pem  2>/dev/null
   docker cp /tmp/local-ip-key "${nginxContainerId}":/etc/nginx/private/key.pem  2>/dev/null
   docker exec "$nginxContainerId" bash -c "nginx -s reload"  2>/dev/null
 }
 
+validate_tls(){
+  url=$1
+  # by default curl validates TLS.  If we get back  60 then TLS isn't valid:
+  # exitcode: https://everything.curl.dev/usingcurl/verbose/writeout.html
+  # 60: https://everything.curl.dev/cmdline/exitcode.html
+  status=$(curl  --write-out "%{exitcode}"  -qs  "$url" -o /dev/null)
+  if [ "$status" = "60" ]; then
+    echo "false: status is $status"
+  fi
+}
+
 if [ "$(docker_not_installed)" ];then
   echo ""
   echo -e "${red}\"docker\" or \"docker compose\" is not installed or could not be found. Please install and try again!${noColor}"
-  show_help_existing_stop_and_destroy
+  show_help
   exit 0
 fi
 
@@ -286,7 +300,7 @@ fi
 if [[ -n "${1-}" ]]; then
   if [[ "$1" == "--help" ]] || [[  "$1" == "-h" ]]; then
     show_help_intro
-    show_help_existing_stop_and_destroy
+    show_help
     exit 0
   elif [[ -f "$1" ]]; then
     projectFile=$1
@@ -295,7 +309,7 @@ if [[ -n "${1-}" ]]; then
   else
     echo ""
     echo -e "${red}File \"$1\" doesnt exist - be sure to include \".env\" at the end!${noColor}"
-    show_help_existing_stop_and_destroy
+    show_help
     exit 0
   fi
 fi
@@ -428,7 +442,7 @@ if [[ -z "$projectName" ]]; then
   else
     echo ""
     echo -e "${red}No projects found, please initialize a new one.${noColor}"
-    show_help_existing_stop_and_destroy
+    show_help
     exit 1
   fi
 fi
@@ -477,8 +491,14 @@ while [[ "$running" != "true" ]]; do
   running=$(is_nginx_running "$nginxContainerId")
 done
 
-# update certs every time we run to ensure they're current
-update_nginx_local_ip_tls_cert "$nginxContainerId"
+# output a new line with echo and then update certs every time we run to ensure they're current
+echo;update_nginx_local_ip_tls_cert "$nginxContainerId"
+if [ "$(validate_tls "$projectURL")" ];then
+  echo ""
+  echo -e "${red}Failed to install local-ip TLS certificate. Check for errors above and try again${noColor}"
+  get_system_and_docker_info
+  exit 0
+fi
 
 echo ""
 echo ""
@@ -493,7 +513,7 @@ echo "    Login: ${COUCHDB_USER}"
 echo "    Password: ${COUCHDB_PASSWORD}"
 echo ""
 echo " -------------------------------------------------------- "
-show_help_existing_stop_and_destroy
+show_help
 echo ""
 echo -e "${green} Have a great day!${noColor} "
 echo ""

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -286,7 +286,7 @@ validate_tls(){
   # exitcode: https://everything.curl.dev/usingcurl/verbose/writeout.html
   # 60: https://everything.curl.dev/cmdline/exitcode.html
   status=$(curl --retry 3 --write-out "%{exitcode}" -qs  "$url" -o /dev/null)
-  if [ "$status" != "60" ]; then
+  if [ "$status" != "0" ]; then
     if [ "$attempt" -gt $max_retries ]; then
       echo "false: status is $status"
     else

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -286,13 +286,13 @@ validate_tls(){
   # exitcode: https://everything.curl.dev/usingcurl/verbose/writeout.html
   # 60: https://everything.curl.dev/cmdline/exitcode.html
   status=$(curl --retry 3 --write-out "%{exitcode}" -qs  "$url" -o /dev/null)
-  if [ "$status" = "60" ]; then
-    if [ $attempt -gt $max_retries ]; then
+  if [ "$status" != "60" ]; then
+    if [ "$attempt" -gt $max_retries ]; then
       echo "false: status is $status"
     else
-      duration_seconds=$((1 * 2 ** $attempt))
+      duration_seconds=$((2 ** attempt))
       sleep $duration_seconds
-      validate_tls $url $(($attempt+1))
+      validate_tls "$url" $((attempt+1))
     fi
   fi
 }

--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -478,7 +478,7 @@ while [[ "$running" != "true" ]]; do
 done
 
 # update certs every time we run to ensure they're current
-update_nginx_local_ip_tls_cert $nginxContainerId
+update_nginx_local_ip_tls_cert "$nginxContainerId"
 
 echo ""
 echo ""


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

In the forums folks have [had issues](https://forum.communityhealthtoolkit.org/t/using-sudo-with-docker-helper-installing-tls-certs/3979/9?u=mrjones) getting TLS certs downloaded in docker helper.  This PR:
* updates [add cert script](https://github.com/medic/cht-core/blob/master/scripts/add-local-ip-certs-to-docker-4.x.sh) and [docker helper](https://github.com/medic/cht-core/blob/master/scripts/docker-helper-4.x/cht-docker-compose.sh) to move the `curl` calls to be on `localhost` instead of inside `nginx` container.
* be extra defensive about `curl` calls to output user facing errors in case of DNS or `404` errors
* add an explicit check for valid TLS after we install the cert
* unchanged: we re-install the cert every time clean
* updates docs URLs to not be redirects

## Testing
* test on a new install of CHT `4.10` in docker helper - ensure valid cert
* on the instance you just created, use the [add cert script](https://github.com/medic/cht-core/blob/master/scripts/add-local-ip-certs-to-docker-4.x.sh) to install a self signed cert and re-install  - ensure valid cert
* on an existing docker helper instance created not in this branch - re-run docker helper  - ensure valid cert


## Failure mode

This is is what it looks like when TLS installation fails.  This was achieved by [changing the local-ip cert](https://github.com/medic/cht-core/blob/57f8ed2b7672f334fbf125b015570de4d4b489a8/scripts/docker-helper-4.x/cht-docker-compose.sh#L274) to be a `404` URL

```bash
./cht-docker-compose.sh cleaaaaaaannnnn.env

homedir: /home/mrjones/.medic/cht-docker/cleaaaaaaannnnn-dir
WARN[0000] /home/mrjones/.medic/cht-docker/cleaaaaaaannnnn-dir/upgrade-service.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 1/0
 ✔ Container cleaaaaaaannnnn-dir-cht-upgrade-service-1  Running                                                                                                              0.0s 
Starting project "cleaaaaaaannnnn". First run takes a while. Will try for up to five minutes...
curl: (22) The requested URL returned error: 404

Failed to install local-ip TLS certificate. Check for errors above and try again

---DEBUG INFO---
Load: 1.16 1.09 1.37
CHT Containers: 7
Global Containers: 7
URL: https://192-168-68-26.local-ip.medicmobile.org:10451

Service              Status   Container                                  Image
cht-upgrade-service  running  cleaaaaaaannnnn-dir-cht-upgrade-service-1  public.ecr.aws/s5s3h4s7/cht-upgrade-service:latest
haproxy              running  cleaaaaaaannnnn-haproxy-1                  public.ecr.aws/medic/cht-haproxy:4.10.0
healthcheck          running  cleaaaaaaannnnn-healthcheck-1              public.ecr.aws/medic/cht-haproxy-healthcheck:4.10.0
api                  running  cleaaaaaaannnnn-api-1                      public.ecr.aws/medic/cht-api:4.10.0
sentinel             running  cleaaaaaaannnnn-sentinel-1                 public.ecr.aws/medic/cht-sentinel:4.10.0
nginx                running  cleaaaaaaannnnn-nginx-1                    public.ecr.aws/medic/cht-nginx:4.10.0
couchdb              running  cleaaaaaaannnnn-couchdb-1                  public.ecr.aws/medic/cht-couchdb:4.10.0
```

## Success mode

this is unchanged from before this PR and looks like:

```bash
./cht-docker-compose.sh cleaaaaaaannnnn.env

homedir: /home/mrjones/.medic/cht-docker/cleaaaaaaannnnn-dir
WARN[0000] /home/mrjones/.medic/cht-docker/cleaaaaaaannnnn-dir/upgrade-service.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Running 1/0
 ✔ Container cleaaaaaaannnnn-dir-cht-upgrade-service-1  Running                                                                                                              0.0s 
Starting project "cleaaaaaaannnnn". First run takes a while. Will try for up to five minutes...


 -------------------------------------------------------- 

  Success! "cleaaaaaaannnnn" is set up:

    https://192-168-68-26.local-ip.medicmobile.org:10451/ (CHT)
    https://192-168-68-26.local-ip.medicmobile.org:10451/_utils/ (Fauxton)

    Login: medic
    Password: password

 -------------------------------------------------------- 

Start existing project
    ./cht-docker-compose.sh ENV-FILE.env

Stop and keep project:
    ./cht-docker-compose.sh ENV-FILE.env stop

Stop and destroy all project data:
    ./cht-docker-compose.sh ENV-FILE.env destroy

https://docs.communityhealthtoolkit.org/hosting/4.x/app-developer/


 Have a great day! 
```

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:docker-helper-curl-tls-move/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:docker-helper-curl-tls-move/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:docker-helper-curl-tls-move/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

