### PR TITLE
fix(#9327): adjustments in old tab navigation

### DIFF
--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -59,7 +59,13 @@
 
     .page {
       top: @top-without-filter;
+      padding-left: 15px;
+      padding-top: 15px;
     }
+  }
+
+  &.error .page {
+    padding-left: 15px;
   }
 
   .header {

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -253,6 +253,7 @@
 
   .mm-badge-border {
     border: solid 1px @white;
+    margin: 0;
   }
 }
 
@@ -279,6 +280,10 @@
           .button-label {
             font-size: @font-XXXS;
           }
+        }
+
+        .mm-badge-border {
+          margin: 5px 0;
         }
       }
 

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -276,7 +276,7 @@
         width: 100%;
         padding: 0;
         a {
-          min-width: 40px;
+          min-width: 50px;
           .button-label {
             font-size: @font-XXXS;
           }
@@ -338,7 +338,7 @@
       .tabs {
         padding-left: 2px;
         a {
-          min-width: 40px;
+          min-width: 50px;
           .button-label {
             font-size: @font-XXXS;
           }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This fixes feedback from Michael
- Adjusts the positioning of the unread notification 
- Adjusts the tab's width 
- Adjusts padding on pages without list - old nav

Testing

<details> <summary>The unread notification </summary>

![Screenshot 2024-09-24 at 10 41 59 AM](https://github.com/user-attachments/assets/4cb92545-9baa-47b5-8eb8-efae2254e4a8)
![Screenshot 2024-09-24 at 10 41 50 AM](https://github.com/user-attachments/assets/a0c35179-f451-47b1-a204-b6836143645f)

</details> 

<details> <summary> The tab's width </summary>


https://github.com/user-attachments/assets/c16db214-e063-4c02-b804-f589e3bf6b1e



</details>

#9327

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9327-tab-nav-feedback/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9327-tab-nav-feedback/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9327-tab-nav-feedback/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

