### PR TITLE
fix(#9468): use latest helm-charts and troubleshooting for volumes

### DIFF
--- a/scripts/deploy/src/install.js
+++ b/scripts/deploy/src/install.js
@@ -7,7 +7,7 @@ import path from 'path';
 const MEDIC_REPO_NAME = 'medic';
 const MEDIC_REPO_URL = 'https://docs.communityhealthtoolkit.org/helm-charts';
 const CHT_CHART_NAME = `${MEDIC_REPO_NAME}/cht-chart-4x`;
-const DEFAULT_CHART_VERSION = '1.0.*';
+const DEFAULT_CHART_VERSION = '1.1.*';
 
 import { fileURLToPath } from 'url';
 import { obtainCertificateAndKey, createSecret } from './certificate.js';

--- a/scripts/deploy/troubleshooting/get-volume-binding
+++ b/scripts/deploy/troubleshooting/get-volume-binding
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <namespace> <deployment>"
+    exit 1
+fi
+
+NAMESPACE=$1
+DEPLOYMENT=$2
+
+get_pv_details() {
+    local pvc_name=$1
+    local pv_name=$(kubectl get pvc -n "$NAMESPACE" "$pvc_name" -o jsonpath='{.spec.volumeName}' 2>/dev/null)
+    if [ -n "$pv_name" ]; then
+        kubectl get pv "$pv_name" -o json 2>/dev/null | jq '{
+            pvName: .metadata.name,
+            pvSize: .spec.capacity.storage,
+            storageClass: .spec.storageClassName,
+            pvAccessModes: .spec.accessModes
+        }'
+    else
+        echo "{}"
+    fi
+}
+
+DEPLOYMENT_INFO=$(kubectl get deployment -n "$NAMESPACE" "$DEPLOYMENT" -o json 2>&1)
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to get deployment information"
+    echo "$DEPLOYMENT_INFO"
+    exit 1
+fi
+
+echo "$DEPLOYMENT_INFO" | jq --arg namespace "$NAMESPACE" '
+  .spec.template.spec.containers[].volumeMounts[] as $vm |
+  .spec.template.spec.volumes[] |
+  select(.name == $vm.name) |
+  select($vm.mountPath | endswith("local.d") | not) |
+  {
+    mountPath: $vm.mountPath,
+    name: $vm.name,
+    subPath: $vm.subPath,
+    volumeType: (
+      if .persistentVolumeClaim then "PVC"
+      elif .hostPath then "HostPath"
+      else "Other"
+      end
+    ),
+    claimName: (
+      if .persistentVolumeClaim then .persistentVolumeClaim.claimName
+      else null
+      end
+    ),
+    hostPath: (
+      if .hostPath then .hostPath.path
+      else null
+      end
+    )
+  }' | jq -c '.' | while read -r volume_info; do
+    claim_name=$(echo "$volume_info" | jq -r '.claimName // empty')
+    if [ -n "$claim_name" ]; then
+        pv_info=$(get_pv_details "$claim_name")
+        echo "$volume_info" | jq --argjson pv_info "$pv_info" '. + $pv_info'
+    else
+        echo "$volume_info"
+    fi
+done
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to process deployment information"
+    exit 1
+fi

--- a/scripts/deploy/troubleshooting/get-volume-binding
+++ b/scripts/deploy/troubleshooting/get-volume-binding
@@ -10,7 +10,8 @@ DEPLOYMENT=$2
 
 get_pv_details() {
     local pvc_name=$1
-    local pv_name=$(kubectl get pvc -n "$NAMESPACE" "$pvc_name" -o jsonpath='{.spec.volumeName}' 2>/dev/null)
+    local pv_name
+    pv_name=$(kubectl get pvc -n "$NAMESPACE" "$pvc_name" -o jsonpath='{.spec.volumeName}' 2>/dev/null)
     if [ -n "$pv_name" ]; then
         kubectl get pv "$pv_name" -o json 2>/dev/null | jq '{
             pvName: .metadata.name,
@@ -23,8 +24,7 @@ get_pv_details() {
     fi
 }
 
-DEPLOYMENT_INFO=$(kubectl get deployment -n "$NAMESPACE" "$DEPLOYMENT" -o json 2>&1)
-if [ $? -ne 0 ]; then
+if ! DEPLOYMENT_INFO=$(kubectl get deployment -n "$NAMESPACE" "$DEPLOYMENT" -o json 2>&1); then
     echo "Error: Failed to get deployment information"
     echo "$DEPLOYMENT_INFO"
     exit 1
@@ -63,9 +63,7 @@ echo "$DEPLOYMENT_INFO" | jq --arg namespace "$NAMESPACE" '
     else
         echo "$volume_info"
     fi
-done
-
-if [ $? -ne 0 ]; then
+done || {
     echo "Error: Failed to process deployment information"
     exit 1
-fi
+}


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

This needs to be merged after [this](https://github.com/medic/helm-charts/pull/24) PR gets merged that releases the newest helm-charts.

You use this troubleshooting script to get the pv, pvc information and the subPath you need to set for your pre-existing data.

Example output:

```
./troubleshooting/get-volume-binding example-namespace cht-couchdb
{
  "mountPath": "/opt/couchdb/data",
  "name": "couchdb-claim0",
  "subPath": "data",
  "volumeType": "PVC",
  "claimName": "couchdb-claim0",
  "hostPath": null,
  "pvName": "couchdb-pv-example-namespace",
  "pvSize": "100Gi",
  "storageClass": null,
  "pvAccessModes": [
    "ReadWriteOnce"
  ]
}
```

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cht-deploy-troubleshooting-and-helm-chart-update/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cht-deploy-troubleshooting-and-helm-chart-update/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:cht-deploy-troubleshooting-and-helm-chart-update/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

