### PR TITLE
fix(#9327): spacing in new nav and old nav

### DIFF
--- a/webapp/src/css/content-list.less
+++ b/webapp/src/css/content-list.less
@@ -47,7 +47,6 @@
   input[type="checkbox"] {
     display: none;
     float: left;
-    margin-left: -5px;
     margin-right: 5px;
   }
 
@@ -55,7 +54,7 @@
     display: flex;
     align-items: center;
     min-height: 70px;
-    padding: 10px 20px 10px 15px;
+    padding: 10px 20px 10px 8px;
     color: inherit;
 
     &:hover,
@@ -65,8 +64,7 @@
 
     .icon {
       align-self: start;
-      margin: 5px;
-      margin-left: -10px;
+      margin: 5px 7px 5px 0;
       img,
       svg {
         height: @icon-small;
@@ -257,7 +255,7 @@
     display: inline;
     width: 20px;
     height: 20px;
-    margin: 20px 10px;
+    margin: 20px 7px 20px 10px
   }
 
   .select-all {

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -1787,6 +1787,9 @@ mm-sidebar-menu .mat-sidenav-container {
 
   mm-search-bar {
     padding: 5px;
+    #sort-results-dropdown {
+      left: -215px !important; // Overriding another rule that already has !important
+    }
 
     .mm-search-bar-container {
       background: transparent;

--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -73,6 +73,21 @@ body {
       }
     }
 
+    &.testing .page {
+      padding-bottom: 15px;
+      input {
+        margin-bottom: 15px;
+      }
+    }
+
+    &.privacy-policy .page {
+      padding: 15px;
+    }
+
+    &.user .page {
+      padding-top: 15px;
+    }
+
     &.about,
     &.testing,
     &.error,
@@ -241,7 +256,7 @@ body {
     a {
       text-align: center;
       color: @filter-text-color;
-      width: 50px;
+      width: 42px;
       height: @font-extra-large;
     }
   }
@@ -270,7 +285,7 @@ body {
       display: inline-block;
       color: @filter-text-color;
       font-size: @font-XXL;
-      padding-left: 20px;
+      padding-left: 12px;
     }
 
     mm-search-bar {
@@ -630,9 +645,7 @@ mm-analytics-filters {
 .inbox-items {
   padding: 0;
   background-color: @form-background-color;
-  border: 1px solid @separator-color;
-  border-top: 0;
-  border-bottom: 0;
+  border-right: 1px solid @separator-color;
 
   .alert {
     margin: 10px;
@@ -1250,6 +1263,7 @@ mm-search-bar {
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;
       white-space: normal;
+      letter-spacing: normal;
     }
   }
 }
@@ -1287,9 +1301,11 @@ mm-sidebar-menu .mat-sidenav-container {
 
     .panel-header-title {
       font-size: @font-XXL;
+      font-weight: bold;
       line-height: @font-XXL;
       margin-left: 15px;
       color: @text-inverse-color;
+      letter-spacing: normal;
     }
 
     .panel-header-close {
@@ -1793,7 +1809,6 @@ mm-sidebar-menu .mat-sidenav-container {
           position: absolute;
           top: -6px;
           right: 1px;
-          border: 1px solid @chip-border-color;
         }
       }
     }
@@ -1830,7 +1845,7 @@ mm-sidebar-menu .mat-sidenav-container {
     .ellipsis-title {
       text-overflow: ellipsis;
       width: calc(@content-width - @tool-bar-title-right-margin);
-      padding-left: 4px;
+      padding-left: 0;
       font-size: @font-extra-large;
     }
   }

--- a/webapp/src/css/material.less
+++ b/webapp/src/css/material.less
@@ -7,9 +7,10 @@ html, body {
   }
 }
 
-.mat-mdc-button,
-.mat-mdc-unelevated-button {
+button.mat-mdc-button,
+button.mat-mdc-unelevated-button {
   font-size: @font-medium;
+  letter-spacing: normal;
 }
 
 .mat-mdc-button:not(:disabled).mat-primary {
@@ -87,6 +88,7 @@ mm-panel-header {
 
   .panel-header-title {
     font-size: @font-medium;
+    letter-spacing: normal;
     margin: 0;
   }
 

--- a/webapp/src/css/modal.less
+++ b/webapp/src/css/modal.less
@@ -5,6 +5,7 @@ mm-modal-layout {
     .panel-header-title {
       font-size: @font-XXL;
       font-weight: normal;
+      letter-spacing: normal;
     }
   }
 
@@ -13,6 +14,7 @@ mm-modal-layout {
     min-height: 50px;
     max-height: 75vh;
     padding: 0 24px;
+    letter-spacing: normal;
     textarea {
       margin: 0;
       width: 100%;

--- a/webapp/src/css/old-nav.less
+++ b/webapp/src/css/old-nav.less
@@ -3,6 +3,10 @@
     padding-left: 0;
   }
 
+  &.about .content .inner .page {
+    padding-top: 0;
+  }
+
   .app-menu-button {
     display: none;
   }
@@ -354,6 +358,7 @@
       .content {
         .page {
           top: calc(@top-navbar-height + 5px);
+          margin: 0;
         }
       }
     }

--- a/webapp/src/css/theme.less
+++ b/webapp/src/css/theme.less
@@ -89,6 +89,7 @@ a {
   padding: 10px;
   .icon {
     float: left;
+    margin-right: 4px;
     img,
     svg {
       width: @icon-small;


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- The filter's border colored was removed.
- Desktop - Aligned top bar title with the first element of the list icon/checkbox/text
- Mobile - Aligned top bar title with the secont element of the list icon/text
- Fixed letter spacing to mat components
- Fixed padding of about, user, privacy policy and testing pages
- Old nav - removes margin bottom of about, user, privacy policy and testing pages


Testing:

<details><summary> Old nav </summary>

https://github.com/user-attachments/assets/ff1560eb-5a84-4df7-8398-2531b95ef59b


https://github.com/user-attachments/assets/ebed931e-bece-4c2f-84f8-54bcc0334894

</details>

<details><summary> New nav  </summary>

https://github.com/user-attachments/assets/f858d60d-8d92-4dcb-9a72-664ae139a9a5

<img width="392" alt="Screenshot 2024-09-26 at 4 31 53 PM" src="https://github.com/user-attachments/assets/ed431602-2e6a-4ad2-82fa-98f8fadbf135">
<img width="380" alt="Screenshot 2024-09-26 at 4 30 59 PM" src="https://github.com/user-attachments/assets/e8f0ea66-b631-4486-8e21-f974d2313bf3">
<img width="384" alt="Screenshot 2024-09-26 at 4 30 11 PM" src="https://github.com/user-attachments/assets/0da39ef3-c69c-4741-a98f-1aadac51aebd">
<img width="380" alt="Screenshot 2024-09-26 at 4 29 00 PM" src="https://github.com/user-attachments/assets/5f40ade3-e11b-42bb-b7cd-a76a4cbcadf4">
<img width="377" alt="Screenshot 2024-09-26 at 4 28 10 PM" src="https://github.com/user-attachments/assets/cea92a85-c36e-48bb-bcf6-364f7065e85d">
<img width="378" alt="Screenshot 2024-09-26 at 4 27 33 PM" src="https://github.com/user-attachments/assets/8e7fd5f2-7421-4eff-9f5f-b07e0fe90252">
<img width="1219" alt="Screenshot 2024-09-26 at 4 35 21 PM" src="https://github.com/user-attachments/assets/7a925fe6-f29f-4814-8dcd-8f0612aa7dd0">
<img width="1214" alt="Screenshot 2024-09-26 at 4 34 55 PM" src="https://github.com/user-attachments/assets/f7b6a4a6-cb26-4373-82eb-c05a569e12ca">
<img width="1217" alt="Screenshot 2024-09-26 at 4 34 28 PM" src="https://github.com/user-attachments/assets/07151fe0-46c6-4bc2-8d08-a00b75f7cba0">
<img width="1215" alt="Screenshot 2024-09-26 at 4 34 06 PM" src="https://github.com/user-attachments/assets/339c8b28-03f8-4847-9d1e-4f1830c809be">
<img width="1216" alt="Screenshot 2024-09-26 at 4 33 41 PM" src="https://github.com/user-attachments/assets/f44520ec-9a87-412d-b321-e32645e89e6d">

</details>



#9327

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9327-spacing-aligments-feedback/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9327-spacing-aligments-feedback/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9327-spacing-aligments-feedback/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

