### PR TITLE
fix(#9292): add scroll to training cards content

### DIFF
--- a/webapp/src/css/modal.less
+++ b/webapp/src/css/modal.less
@@ -65,6 +65,15 @@ mm-modal-layout {
       background: none;
     }
 
+    .modal-body {
+      overflow: hidden;
+      margin-bottom: 11px;
+    }
+
+    .modal-footer {
+      padding: 0;
+    }
+
     .enketo {
       .or h2,
       .or h3,
@@ -79,14 +88,21 @@ mm-modal-layout {
         padding-left: 0;
         padding-right: 0;
       }
+
       .or-appearance-summary {
         .or-appearance-h1:not(.disabled) {
           padding-left: 5px;
           padding-right: 5px;
         }
+
         .or-appearance-li:not(.disabled):before {
           left: -10px;
         }
+      }
+
+      form {
+        max-height: 65vh;
+        overflow-y: auto;
       }
     }
 
@@ -109,9 +125,9 @@ mm-modal-layout {
 
 @media (max-width: @media-mobile) {
   mm-modal-layout {
-    .enketo {
-      #form-title {
-        display: inherit;
+    .enketo-modal .enketo {
+      form {
+        max-height: 60vh;
       }
 
       .form-footer {

--- a/webapp/src/ts/services/modal.service.ts
+++ b/webapp/src/ts/services/modal.service.ts
@@ -37,7 +37,7 @@ export class ModalService {
     return this.matDialog.open(component, {
       autoFocus: false,
       disableClose: true,
-      minWidth: isMobile ? '90vw' : '400px', // Give maximum space to date picker's calendar when in mobile.
+      minWidth: isMobile ? '90vw' : '340px', // Give maximum space to date picker's calendar when in mobile.
       width: '600px',
       maxWidth: '90vw',
       minHeight: '100px',


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Training cards feature is using Enketo; adding scroll to the the form body to make Enketo buttons always visible 

#9292

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:long-content-training-cards/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:long-content-training-cards/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:long-content-training-cards/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

