### PR TITLE
chore: update upgrade e2e

### DIFF
--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -6,6 +6,7 @@ const upgradePage = require('@page-objects/upgrade/upgrade.wdio.page');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
 const adminPage = require('@page-objects/default/admin/admin.wdio.page');
 const aboutPage = require('@page-objects/default/about/about.wdio.page');
+const oldNavigationPage = require('@page-objects/default/old-navigation/old-navigation.wdio.page');
 const constants = require('@constants');
 const version = require('../../../scripts/build/versions');
 const dataFactory = require('@factories/cht/generate');
@@ -60,7 +61,8 @@ describe('Performing an upgrade', () => {
       await commonPage.logout();
     }
 
-    await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD });
+    await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD, loadPage: false });
+    await oldNavigationPage.goToBase();
   });
 
   after(async () => {

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -57,7 +57,7 @@ describe('Performing an upgrade', () => {
     if (testFrontend) {
       // a variety of selectors that we use in e2e tests to interact with webapp
       // are not compatible with older versions of the app.
-      await loginPage.login(docs.user);
+      await loginPage.login({ username: docs.user.username, password: docs.user.password });
       await commonPage.logout();
     }
 

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -114,15 +114,15 @@ describe('Performing an upgrade', () => {
       state: 'finalized',
     });
 
-    if (!testFrontend) {
-      return;
-    }
-
     await adminPage.logout();
+  });
+
+  (testFrontend ? it : xit)('should display current branch in the about page', async () => {
     await loginPage.login({ username: docs.user.username, password: docs.user.password });
     await commonPage.sync(true);
     await browser.refresh();
     await commonPage.waitForPageLoaded();
+
     await commonPage.goToAboutPage();
     await (await aboutPage.aboutCard()).waitForDisplayed();
     const expected = TAG || `${utils.escapeBranchName(BRANCH)} (`;
@@ -131,12 +131,8 @@ describe('Performing an upgrade', () => {
   });
 
   it('should display upgrade page even without upgrade logs', async () => {
-    if (testFrontend) {
-      await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD, adminApp: true });
-    }
-
+    await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD, adminApp: true });
     await deleteUpgradeLogs();
-
     await upgradePage.goToUpgradePage();
 
     const currentVersion = await upgradePage.getCurrentVersion();

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -59,6 +59,8 @@ describe('Performing an upgrade', () => {
       // are not compatible with older versions of the app.
       await loginPage.login({ username: docs.user.username, password: docs.user.password });
       await commonPage.logout();
+      await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD });
+      return;
     }
 
     await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD, loadPage: false });
@@ -70,7 +72,7 @@ describe('Performing an upgrade', () => {
     await utils.revertDb([/^form:/], true);
   });
 
-  it('should have an upgrade_log after installing', async () => {
+  it('should have an upgrade_log after installing the app, without logs upgrade is aborted', async () => {
     const logs = await getUpgradeLogs();
     expect(logs.length).to.equal(1);
     expect(logs[0]).to.include({
@@ -79,11 +81,7 @@ describe('Performing an upgrade', () => {
     });
   });
 
-  it('should have valid semver after installing', async () => {
-    if (!testFrontend) {
-      return;
-    }
-
+  (testFrontend ? it : xit)('should have valid semver after installing', async () => {
     const deployInfo = await utils.request({ path: '/api/deploy-info' });
     expect(semver.valid(deployInfo.version)).to.be.ok;
   });

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -59,7 +59,7 @@ describe('Performing an upgrade', () => {
       // are not compatible with older versions of the app.
       await loginPage.login({ username: docs.user.username, password: docs.user.password });
       await commonPage.logout();
-      await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD });
+      await loginPage.login({ username: constants.USERNAME, password: constants.PASSWORD, adminApp: true });
       return;
     }
 
@@ -120,7 +120,7 @@ describe('Performing an upgrade', () => {
 
     await adminPage.logout();
     await loginPage.login({ username: docs.user.username, password: docs.user.password });
-
+    await commonPage.sync(true);
     await browser.refresh();
     await commonPage.waitForPageLoaded();
     await commonPage.goToAboutPage();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

CHT recently released the new nav; this PR updates the unit tests to run the upgrade from `latest` CHT version (with new nav) instead of old nav. 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:upgrade-tests-after-new-nav-release/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:upgrade-tests-after-new-nav-release/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:upgrade-tests-after-new-nav-release/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

