### PR TITLE
feat(#9488): show training cards once a day

### DIFF
--- a/tests/e2e/default/enketo/training-cards.wdio-spec.js
+++ b/tests/e2e/default/enketo/training-cards.wdio-spec.js
@@ -18,6 +18,12 @@ describe('Training Cards', () => {
 
   const formDocId = 'training:training-cards-text-only';
 
+  const setLastViewedDateInThePast = () => {
+    return browser.execute(function() {
+      this.localStorage.setItem('training-cards-last-viewed-date', new Date('2024-10-05 20:10:05').toISOString());
+    });
+  };
+
   before(async () => {
     const parent = placeFactory.place().build({ _id: 'dist1', type: 'district_hospital' });
     const user = userFactory.build({ roles: [ 'nurse', 'chw' ] });
@@ -52,9 +58,8 @@ describe('Training Cards', () => {
     expect(await reportsPage.leftPanelSelectors.allReports()).to.be.empty;
   });
 
-  it('should display training after it was canceled and the training doc was updated', async () => {
-    await commonPage.goToMessages();
-    await commonElements.waitForPageLoaded();
+  it('should not display training after it was canceled and the training doc was updated', async () => {
+    await setLastViewedDateInThePast();
     // Unfinished trainings should appear again after reload.
     await browser.refresh();
     await trainingCardsPage.waitForTrainingCards();
@@ -73,12 +78,7 @@ describe('Training Cards', () => {
     const updatedTrainingForm = await utils.getDoc(`form:${formDocId}`);
     expect(updatedTrainingForm.context.duration).to.equal(10);
 
-    await trainingCardsPage.waitForTrainingCards();
-    const context = 'training_cards_text_only';
-    const introCard = await trainingCardsPage.getCardContent(context, 'intro/intro_note_1:label"]');
-    expect(introCard).to.equal(
-      'There have been some changes to icons in your app. The next few screens will show you the difference.'
-    );
+    await trainingCardsPage.checkTrainingCardIsNotDisplayed();
   });
 
   it('should display training after privacy policy', async () => {
@@ -86,6 +86,7 @@ describe('Training Cards', () => {
     await utils.saveDocs([privacyPolicy]);
     await commonPage.goToReports();
     await commonElements.sync();
+    await setLastViewedDateInThePast();
     await browser.refresh();
 
     await trainingCardsPage.checkTrainingCardIsNotDisplayed();
@@ -97,6 +98,7 @@ describe('Training Cards', () => {
   it('should display training after reload and complete training', async () => {
     await commonPage.goToMessages();
     await commonElements.waitForPageLoaded();
+    await setLastViewedDateInThePast();
     // Unfinished trainings should appear again after reload.
     await browser.refresh();
     await trainingCardsPage.waitForTrainingCards();

--- a/tests/e2e/default/enketo/training-cards.wdio-spec.js
+++ b/tests/e2e/default/enketo/training-cards.wdio-spec.js
@@ -20,7 +20,7 @@ describe('Training Cards', () => {
 
   const setLastViewedDateInThePast = () => {
     return browser.execute(function() {
-      this.localStorage.setItem('training-cards-last-viewed-date', new Date('2024-10-05 20:10:05').toISOString());
+      this.localStorage.setItem('training-cards-last-viewed-date-user1', new Date('2024-10-05 20:10:05').toISOString());
     });
   };
 

--- a/webapp/src/ts/app.component.ts
+++ b/webapp/src/ts/app.component.ts
@@ -501,10 +501,7 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   private displayTrainingCards() {
-    if (this.showPrivacyPolicy && !this.privacyPolicyAccepted) {
-      return;
-    }
-    if (!this.trainingCardFormId) {
+    if (!this.trainingCardFormId || (this.showPrivacyPolicy && !this.privacyPolicyAccepted)) {
       return;
     }
 

--- a/webapp/src/ts/services/training-cards.service.ts
+++ b/webapp/src/ts/services/training-cards.service.ts
@@ -18,7 +18,7 @@ export const TRAINING_PREFIX: string = 'training:';
   providedIn: 'root'
 })
 export class TrainingCardsService {
-  private globalActions: GlobalActions;
+  private readonly globalActions: GlobalActions;
   private readonly STORAGE_KEY_LAST_VIEWED_DATE = 'training-cards-last-viewed-date';
 
   constructor(
@@ -111,7 +111,7 @@ export class TrainingCardsService {
 
     this.modalService
       .show(TrainingCardsComponent)
-      .afterOpened()
+      ?.afterOpened()
       .pipe(first())
       .subscribe(() => {
         window.localStorage.setItem(this.STORAGE_KEY_LAST_VIEWED_DATE, new Date().toISOString());
@@ -153,7 +153,7 @@ export class TrainingCardsService {
   }
 
   private hasBeenDisplayed() {
-    const dateString = window.localStorage.getItem(this.STORAGE_KEY_LAST_VIEWED_DATE) || '';
+    const dateString = window.localStorage.getItem(this.STORAGE_KEY_LAST_VIEWED_DATE) ?? '';
     const lastViewedDate = new Date(dateString);
 
     if (isNaN(lastViewedDate.getTime())) {

--- a/webapp/src/ts/services/training-cards.service.ts
+++ b/webapp/src/ts/services/training-cards.service.ts
@@ -114,7 +114,10 @@ export class TrainingCardsService {
       ?.afterOpened()
       .pipe(first())
       .subscribe(() => {
-        window.localStorage.setItem(this.STORAGE_KEY_LAST_VIEWED_DATE, new Date().toISOString());
+        const key = this.getLocalStorageKey();
+        if (key) {
+          window.localStorage.setItem(key, new Date().toISOString());
+        }
       });
   }
 
@@ -153,9 +156,13 @@ export class TrainingCardsService {
   }
 
   private hasBeenDisplayed() {
-    const dateString = window.localStorage.getItem(this.STORAGE_KEY_LAST_VIEWED_DATE) ?? '';
-    const lastViewedDate = new Date(dateString);
+    const key = this.getLocalStorageKey();
+    if (!key) {
+      return false;
+    }
 
+    const dateString = window.localStorage.getItem(key) ?? '';
+    const lastViewedDate = new Date(dateString);
     if (isNaN(lastViewedDate.getTime())) {
       return false;
     }
@@ -165,5 +172,14 @@ export class TrainingCardsService {
     today.setHours(0, 0, 0, 0);
 
     return lastViewedDate >= today;
+  }
+
+  private getLocalStorageKey() {
+    const username = this.sessionService.userCtx()?.name;
+    if (!username) {
+      return;
+    }
+
+    return `${this.STORAGE_KEY_LAST_VIEWED_DATE}-${username}`;
   }
 }

--- a/webapp/tests/karma/ts/services/training-cards.service.spec.ts
+++ b/webapp/tests/karma/ts/services/training-cards.service.spec.ts
@@ -777,7 +777,8 @@ describe('TrainingCardsService', () => {
 
     it('should display training when it has not been displayed today', async () => {
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
-      window.localStorage.setItem('training-cards-last-viewed-date', '2024-05-23 20:29:25');
+      sessionService.userCtx.returns({ name: 'ronald' });
+      window.localStorage.setItem('training-cards-last-viewed-date-ronald', '2024-05-23 20:29:25');
       clock = sinon.useFakeTimers(new Date('2025-05-25 20:29:25'));
 
       service.displayTrainingCards();
@@ -787,7 +788,7 @@ describe('TrainingCardsService', () => {
 
     it('should display training when last viewed date is empty', async () => {
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
-      window.localStorage.setItem('training-cards-last-viewed-date', '');
+      window.localStorage.setItem('training-cards-last-viewed-date-ronald', '');
       clock = sinon.useFakeTimers(new Date('2025-05-25 20:29:25'));
 
       service.displayTrainingCards();
@@ -795,14 +796,26 @@ describe('TrainingCardsService', () => {
       expect(modalService.show.calledOnce).to.be.true;
     });
 
-    it('should not display training when it has been displayed today', async () => {
+    it('should not display training when it has been displayed today for the same user', async () => {
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
-      window.localStorage.setItem('training-cards-last-viewed-date', '2024-05-23 20:29:25');
+      sessionService.userCtx.returns({ name: 'ronald' });
+      window.localStorage.setItem('training-cards-last-viewed-date-ronald', '2024-05-23 20:29:25');
       clock = sinon.useFakeTimers(new Date('2024-05-23 06:29:25'));
 
       service.displayTrainingCards();
 
       expect(modalService.show.notCalled).to.be.true;
+    });
+
+    it('should display training when it has not been displayed for a different user', async () => {
+      routeSnapshotService.get.returns({ data: { hideTraining: false } });
+      sessionService.userCtx.returns({ name: 'sarah' });
+      window.localStorage.setItem('training-cards-last-viewed-date-ronald', '2024-05-23 20:29:25');
+      clock = sinon.useFakeTimers(new Date('2024-05-23 06:29:25'));
+
+      service.displayTrainingCards();
+
+      expect(modalService.show.calledOnce).to.be.true;
     });
   });
 

--- a/webapp/tests/karma/ts/services/training-cards.service.spec.ts
+++ b/webapp/tests/karma/ts/services/training-cards.service.spec.ts
@@ -771,4 +771,39 @@ describe('TrainingCardsService', () => {
         .to.equal('Training Cards :: Cannot create document ID, user context does not have the "name" property.');
     }
   });
+
+  describe('Display training cards once', () => {
+    afterEach(() => window.localStorage.removeItem('training-cards-last-viewed-date'));
+
+    it('should display training when it has not been displayed today', async () => {
+      routeSnapshotService.get.returns({ data: { hideTraining: false } });
+      window.localStorage.setItem('training-cards-last-viewed-date', '2024-05-23 20:29:25');
+      clock = sinon.useFakeTimers(new Date('2025-05-25 20:29:25'));
+
+      service.displayTrainingCards();
+
+      expect(modalService.show.calledOnce).to.be.true;
+    });
+
+    it('should display training when last viewed date is empty', async () => {
+      routeSnapshotService.get.returns({ data: { hideTraining: false } });
+      window.localStorage.setItem('training-cards-last-viewed-date', '');
+      clock = sinon.useFakeTimers(new Date('2025-05-25 20:29:25'));
+
+      service.displayTrainingCards();
+
+      expect(modalService.show.calledOnce).to.be.true;
+    });
+
+    it('should not display training when it has been displayed today', async () => {
+      routeSnapshotService.get.returns({ data: { hideTraining: false } });
+      window.localStorage.setItem('training-cards-last-viewed-date', '2024-05-23 20:29:25');
+      clock = sinon.useFakeTimers(new Date('2024-05-23 06:29:25'));
+
+      service.displayTrainingCards();
+
+      expect(modalService.show.notCalled).to.be.true;
+    });
+  });
+
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Saves the last viewed date in the local storage, and if the date is before today, then displays the training cards

<details><summary>Test video: Desktop and mobile views</summary> 


https://github.com/user-attachments/assets/916b3a78-3fe1-4443-b64b-92e7c2a9a075



</details>

https://github.com/medic/cht-core/issues/9488

[PR CHT Docs](https://github.com/medic/cht-docs/pull/1612)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:training-cards-once-a-day/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:training-cards-once-a-day/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:training-cards-once-a-day/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

