### PR TITLE
fix(#9292): add back training cards form's title

### DIFF
--- a/webapp/src/css/modal.less
+++ b/webapp/src/css/modal.less
@@ -126,6 +126,12 @@ mm-modal-layout {
 @media (max-width: @media-mobile) {
   mm-modal-layout {
     .enketo-modal .enketo {
+      #form-title {
+        // Inheriting the display setting from desktop view. The form title is hidden by default for mobile devices,
+        // but in training cards, the title is optional.
+        display: inherit;
+      }
+
       form {
         max-height: 60vh;
       }

--- a/webapp/src/css/modal.less
+++ b/webapp/src/css/modal.less
@@ -125,25 +125,30 @@ mm-modal-layout {
 
 @media (max-width: @media-mobile) {
   mm-modal-layout {
-    .enketo-modal .enketo {
-      #form-title {
-        // Inheriting the display setting from desktop view. The form title is hidden by default for mobile devices,
-        // but in training cards, the title is optional.
+    .enketo-modal {
+      .enketo {
+        form {
+          max-height: 60vh;
+        }
+
+        .form-footer {
+          .btn.btn-link.cancel {
+            display: inline-block;
+          }
+
+          .previous-page {
+            float: none;
+          }
+        }
+      }
+
+      // The form title is hidden by default for mobile devices, but in training cards, the title is optional.
+      :not(.form-no-title) #form-title {
         display: inherit;
       }
 
-      form {
-        max-height: 60vh;
-      }
-
-      .form-footer {
-        .btn.btn-link.cancel {
-          display: inline-block;
-        }
-
-        .previous-page {
-          float: none;
-        }
+      .form-no-title  #form-title {
+        display: none;
       }
     }
   }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

When doing the work in #9292, the training form's title was removed. We are putting it back because it's optional. 

[When the form's properties is defined with an empty title](https://docs.communityhealthtoolkit.org/building/guides/training/training-cards/#step-3-configure-the-training-form), the training doesn't display any title:

```js
{
  "title": "", <----
  "context": {
    "start_date": "2023-07-13",
    "duration": 60,
    "user_roles": [ "nurse" ]
  }
}
```
Testing:

<img width="400" src="https://github.com/user-attachments/assets/9b752c3d-fb97-4aad-97a9-e888bfd6d343">

When it's not defined, it displays the form id:

```js
{
  "context": {
    "start_date": "2023-07-13",
    "duration": 60,
    "user_roles": [ "nurse" ]
  }
}
```
Testing:
<img width="400" src="https://github.com/user-attachments/assets/0e48c475-3ad9-4037-92eb-08e964d2b6b2">


Otherwise, the specified title:

```js
{
  "title": "Some training", <----
  "context": {
    "start_date": "2023-07-13",
    "duration": 60,
    "user_roles": [ "nurse" ]
  }
}
```

Testing:

<img width="400" alt="Screenshot 2024-10-09 at 2 28 18 PM" src="https://github.com/user-attachments/assets/02d87fd9-214a-47d6-866a-7f92b8872abf">

Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-training-cards-title/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-training-cards-title/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:fix-training-cards-title/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

