### PR TITLE
fix(#9552): handle rules-engine stale state after upgrade

### DIFF
--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -41,7 +41,7 @@ const self = {
     }
 
     const rulesConfigHash = hashRulesConfig(settings);
-    if (state?.rulesConfigHash !== rulesConfigHash || targetState.isStale(state?.targetState)) {
+    if (state.rulesConfigHash !== rulesConfigHash || targetState.isStale(state.targetState)) {
       state.stale = true;
     }
 

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -36,16 +36,16 @@ const self = {
     currentUserSettings = settings.user;
     setOnChangeState(stateChangeCallback);
 
+    if (!state) {
+      return true;
+    }
+
     const rulesConfigHash = hashRulesConfig(settings);
-    if (state && state.rulesConfigHash !== rulesConfigHash) {
+    if (state?.rulesConfigHash !== rulesConfigHash || targetState.isStale(state?.targetState)) {
       state.stale = true;
     }
 
-    if (state && targetState.isStale(state.targetState)) {
-      state.stale = true;
-    }
-
-    return !state || state.stale;
+    return state.stale;
   },
 
   /**

--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -41,6 +41,10 @@ const self = {
       state.stale = true;
     }
 
+    if (state && targetState.isStale(state.targetState)) {
+      state.stale = true;
+    }
+
     return !state || state.stale;
   },
 

--- a/shared-libs/rules-engine/src/target-state.js
+++ b/shared-libs/rules-engine/src/target-state.js
@@ -118,6 +118,8 @@ module.exports = {
     return state;
   },
 
+  isStale: (state) => !state || !state.targets || !state.aggregate,
+
   storeTargetEmissions: (state, contactIds, targetEmissions) => {
     let isUpdated = false;
     if (!Array.isArray(targetEmissions)) {

--- a/shared-libs/rules-engine/test/rules-state-store.spec.js
+++ b/shared-libs/rules-engine/test/rules-state-store.spec.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 const { RestorableRulesStateStore } = require('./mocks');
+const md5 = require('md5');
+
 const sinon = require('sinon');
 const moment = require('moment');
 
@@ -429,6 +431,37 @@ describe('rules-state-store', () => {
         id: 'target',
         value: { pass: 1, total: 1 },
       });
+    });
+  });
+
+  describe('load', () => {
+    it('should mark as stale when rules config hash has changed', () => {
+      const staleState = {};
+      const stale = rulesStateStore.load(staleState, { config: '123' });
+      expect(stale).to.equal(true);
+    });
+
+    it('should mark as stale when target-state is stale', () => {
+      const settings = { config: '123' };
+      const staleState = {
+        targetState: {},
+        rulesConfigHash: md5(JSON.stringify(settings))
+      };
+      const stale = rulesStateStore.load(staleState, settings);
+      expect(stale).to.equal(true);
+    });
+
+    it('should not mark as stale when not stale', () => {
+      const settings = { config: '123' };
+      const staleState = {
+        targetState: {
+          targets: {},
+          aggregate: {}
+        },
+        rulesConfigHash: md5(JSON.stringify(settings))
+      };
+      const stale = rulesStateStore.load(staleState, settings);
+      expect(stale).to.equal(undefined);
     });
   });
 });

--- a/shared-libs/rules-engine/test/target-state.spec.js
+++ b/shared-libs/rules-engine/test/target-state.spec.js
@@ -275,5 +275,19 @@ describe('target-state', () => {
       ]);
     });
   });
+
+  describe('isStale', () => {
+    it('should return true if state is invalid', () => {
+      expect(targetState.isStale()).to.equal(true);
+      expect(targetState.isStale({})).to.equal(true);
+      expect(targetState.isStale({ oldTarget: { emissions: [] } })).to.equal(true);
+      expect(targetState.isStale({ targets: {} })).to.equal(true);
+      expect(targetState.isStale({ aggregate: {} })).to.equal(true);
+    });
+    
+    it('should return false if state is valid', () => {
+      expect(targetState.isStale({ targets: {}, aggregate: {} })).to.equal(false);
+    });
+  });
 });
 

--- a/tests/e2e/default/targets/target-accuracy.wdio-spec.js
+++ b/tests/e2e/default/targets/target-accuracy.wdio-spec.js
@@ -1,10 +1,12 @@
 const path = require('path');
 const moment = require('moment');
 const chtConfUtils = require('@utils/cht-conf');
+const chtDbUtils = require('@utils/cht-db');
 const utils = require('@utils');
 const loginPage = require('@page-objects/default/login/login.wdio.page');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
 const contactsPage = require('@page-objects/default/contacts/contacts.wdio.page');
+const analyticsPage = require('@page-objects/default/analytics/analytics.wdio.page');
 const userFactory = require('@factories/cht/users/users');
 const placeFactory = require('@factories/cht/contacts/place');
 const personFactory = require('@factories/cht/contacts/person');
@@ -169,5 +171,24 @@ describe('Target accuracy', () => {
   it('should only create one target doc', async () => {
     const docs = await utils.db.allDocs({ startkey: 'target', endkey: 'target\ufff0' });
     expect(docs.rows.length).to.equal(1);
+  });
+
+  it('should handle old format of the rules-state-store', async () => {
+    const docId = '_local/rulesStateStore';
+    const localRulesStateStore = await chtDbUtils.getDoc(docId);
+    await chtDbUtils.updateDoc('_local/rulesStateStore', {
+      rulesStateStore: {
+        ...localRulesStateStore.rulesStateStore,
+        targetState: localRulesStateStore.rulesStateStore.targetState.targets
+      }
+    });
+
+    await commonPage.refresh();
+    await analyticsPage.goToTargets();
+    await commonPage.waitForPageLoaded();
+
+    const targets = await analyticsPage.getTargets();
+    console.log(targets);
+    expect(targets.length).to.equal(1);
   });
 });

--- a/tests/e2e/default/targets/target-accuracy.wdio-spec.js
+++ b/tests/e2e/default/targets/target-accuracy.wdio-spec.js
@@ -188,7 +188,11 @@ describe('Target accuracy', () => {
     await commonPage.waitForPageLoaded();
 
     const targets = await analyticsPage.getTargets();
-    console.log(targets);
     expect(targets.length).to.equal(1);
+    expect(targets[0]).to.deep.include({
+      title: 'targets.new_persons.title',
+      goal: '0',
+      count: '20',
+    });
   });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->
#9552 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-missing-aggregate/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-missing-aggregate/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-missing-aggregate/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

