### PR TITLE
chore(#9514): close sidebar on clicking same module in sidebar

### DIFF
--- a/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
+++ b/webapp/src/ts/components/sidebar-menu/sidebar-menu.component.html
@@ -8,6 +8,7 @@
         <a *ngFor="let module of moduleOptions"
           class="nav-item"
           [routerLink]="module.routerLink"
+          (click)="close()"
           [mmAuth]="module.hasPermissions">
           <mat-icon [fontIcon]="module.icon"></mat-icon>
           <span>{{ module.translationKey | translate }}</span>
@@ -54,7 +55,7 @@
             *ngIf="option.hasPermissions"
             [routerLink]="option.routerLink"
             [mmAuth]="option.hasPermissions"
-            (click)="option.click && option.click()">
+            (click)="option.click && option.click(); close()">
             <mat-icon [fontIcon]="option.icon"></mat-icon>
             <span>{{ option.translationKey | translate }}</span>
           </a>
@@ -62,7 +63,7 @@
           <a class="nav-item"
             *ngIf="!option.hasPermissions && option.canDisplay"
             [routerLink]="option.routerLink"
-            (click)="option.click && option.click()">
+            (click)="option.click && option.click(); close()">
             <mat-icon [fontIcon]="option.icon"></mat-icon>
             <span>{{ option.translationKey | translate }}</span>
           </a>


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR ensures when you click the links on the sidebar even if it the same module 

<details>
<summary>Desktop</summary>

https://github.com/user-attachments/assets/4ca64262-a14b-40ca-ba74-dc9b85b82af1

</details>

<details>
<summary>Mobile</summary>


https://github.com/user-attachments/assets/2746f446-da7b-4c31-a914-9f4571ee73a0



</details>

Closes #9514 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9514-close-sidebar/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9514-close-sidebar/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9514-close-sidebar/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

