### PR TITLE
fix(#9552): handle rules-engine stale state after upgrade  for 4.13.x

### DIFF
--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -36,12 +36,16 @@ const self = {
     currentUserSettings = settings.user;
     setOnChangeState(stateChangeCallback);
 
+    if (!state) {
+      return true;
+    }
+
     const rulesConfigHash = hashRulesConfig(settings);
-    if (state && state.rulesConfigHash !== rulesConfigHash) {
+    if (state.rulesConfigHash !== rulesConfigHash || targetState.isStale(state.targetState)) {
       state.stale = true;
     }
 
-    return !state || state.stale;
+    return state.stale;
   },
 
   /**

--- a/shared-libs/rules-engine/src/target-state.js
+++ b/shared-libs/rules-engine/src/target-state.js
@@ -118,6 +118,8 @@ module.exports = {
     return state;
   },
 
+  isStale: (state) => !state || !state.targets || !state.aggregate,
+
   storeTargetEmissions: (state, contactIds, targetEmissions) => {
     let isUpdated = false;
     if (!Array.isArray(targetEmissions)) {

--- a/shared-libs/rules-engine/test/rules-state-store.spec.js
+++ b/shared-libs/rules-engine/test/rules-state-store.spec.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 const { RestorableRulesStateStore } = require('./mocks');
+const md5 = require('md5');
+
 const sinon = require('sinon');
 const moment = require('moment');
 
@@ -429,6 +431,37 @@ describe('rules-state-store', () => {
         id: 'target',
         value: { pass: 1, total: 1 },
       });
+    });
+  });
+
+  describe('load', () => {
+    it('should mark as stale when rules config hash has changed', () => {
+      const staleState = {};
+      const stale = rulesStateStore.load(staleState, { config: '123' });
+      expect(stale).to.equal(true);
+    });
+
+    it('should mark as stale when target-state is stale', () => {
+      const settings = { config: '123' };
+      const staleState = {
+        targetState: {},
+        rulesConfigHash: md5(JSON.stringify(settings))
+      };
+      const stale = rulesStateStore.load(staleState, settings);
+      expect(stale).to.equal(true);
+    });
+
+    it('should not mark as stale when not stale', () => {
+      const settings = { config: '123' };
+      const staleState = {
+        targetState: {
+          targets: {},
+          aggregate: {}
+        },
+        rulesConfigHash: md5(JSON.stringify(settings))
+      };
+      const stale = rulesStateStore.load(staleState, settings);
+      expect(stale).to.equal(undefined);
     });
   });
 });

--- a/shared-libs/rules-engine/test/target-state.spec.js
+++ b/shared-libs/rules-engine/test/target-state.spec.js
@@ -275,5 +275,19 @@ describe('target-state', () => {
       ]);
     });
   });
+
+  describe('isStale', () => {
+    it('should return true if state is invalid', () => {
+      expect(targetState.isStale()).to.equal(true);
+      expect(targetState.isStale({})).to.equal(true);
+      expect(targetState.isStale({ oldTarget: { emissions: [] } })).to.equal(true);
+      expect(targetState.isStale({ targets: {} })).to.equal(true);
+      expect(targetState.isStale({ aggregate: {} })).to.equal(true);
+    });
+    
+    it('should return false if state is valid', () => {
+      expect(targetState.isStale({ targets: {}, aggregate: {} })).to.equal(false);
+    });
+  });
 });
 


### PR DESCRIPTION
#9552

(cherry picked from commit dc47c51e4660269c8daa3fd6e3ad08a4d37a7e8b)

<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-for-4.13.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-for-4.13.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-for-4.13.x/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

