### PR TITLE
fix(#9467): better handling of RapidPro error codes

### DIFF
--- a/tests/e2e/default/sms/rapidpro.wdio-spec.js
+++ b/tests/e2e/default/sms/rapidpro.wdio-spec.js
@@ -281,6 +281,12 @@ describe('RapidPro SMS Gateway', () => {
           group: 3,
           type: 'ANC Reminders LMP',
         },
+        {
+          messages: [{ to: 'phone6', message: 'message6', uuid: 'uuid6' }],
+          state: 'pending',
+          group: 3,
+          type: 'ANC Reminders LMP',
+        },
       ]
     });
 
@@ -304,7 +310,7 @@ describe('RapidPro SMS Gateway', () => {
       await setOutgoingKey();
 
       await utils.saveDoc(pregnancyReportWithTasks);
-      await browser.waitUntil(() => broadcastsEndpointRequests.length === 4, 1200);
+      await browser.waitUntil(() => broadcastsEndpointRequests.length === 5, 1200);
 
       const bodies = broadcastsEndpointRequests
         .map(item => item[0])
@@ -314,16 +320,17 @@ describe('RapidPro SMS Gateway', () => {
       verifyPhoneAndMessage(bodies[1], 3);
       verifyPhoneAndMessage(bodies[2], 4);
       verifyPhoneAndMessage(bodies[3], 5);
+      verifyPhoneAndMessage(bodies[4], 6);
 
       const headers = broadcastsEndpointRequests.map(item => item[1]);
-      expect(headers.length).to.equal(4);
+      expect(headers.length).to.equal(5);
       headers.forEach(header => expect(header.authorization).to.equal(`Token ${OUTGOING_KEY}`));
     });
 
     it('should set correct states from broadcast api', async () => {
       await setOutgoingKey();
 
-      const statuses = ['queued', '', 'queued', 'sent', 'failed'];
+      const statuses = ['queued', '', 'queued', 'sent', 'failed', undefined];
       broadcastsResult = (req, res) => {
         const idx = req.body.text.replace('message', '');
         res.json({
@@ -334,7 +341,7 @@ describe('RapidPro SMS Gateway', () => {
 
       const { rev } = await utils.saveDoc(pregnancyReportWithTasks);
       const revNumber = parseInt(rev);
-      await browser.waitUntil(() => broadcastsEndpointRequests.length === 4, 1200);
+      await browser.waitUntil(() => broadcastsEndpointRequests.length === 5, 1200);
       await utils.waitForDocRev([{ id: pregnancyReportWithTasks._id, rev: revNumber + 1 }]);
 
       const report = await utils.getDoc(pregnancyReportWithTasks._id);
@@ -343,6 +350,7 @@ describe('RapidPro SMS Gateway', () => {
       verifyGatewayRefAndState(report.scheduled_tasks[0], 'broadcast3', 'received-by-gateway');
       verifyGatewayRefAndState(report.scheduled_tasks[1], 'broadcast4', 'sent');
       verifyGatewayRefAndState(report.scheduled_tasks[2], 'broadcast5', 'failed');
+      verifyGatewayRefAndState(report.scheduled_tasks[3], 'broadcast6', 'received-by-gateway');
     });
 
     it('should update the states correctly from messages api', async () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- when api/v2/broadcast responds with 400, set the status as failed, so API doesn't retry sending the same message. This fixes incorrect phone number messages trying to be sent over and over. 
- when api/v2/broadcast responds with 200, but without a status update, set the state to queued to fix message duplication (https://forum.communityhealthtoolkit.org/t/duplication-of-messages-in-textit-rapidpro/4047/19).  

#9467

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9467-update-rapidpro/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9467-update-rapidpro/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9467-update-rapidpro/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

