### PR TITLE
fix(#9552): migrate stale target state for interval turnover

### DIFF
--- a/shared-libs/rules-engine/src/rules-state-store.js
+++ b/shared-libs/rules-engine/src/rules-state-store.js
@@ -42,6 +42,7 @@ const self = {
 
     const rulesConfigHash = hashRulesConfig(settings);
     if (state.rulesConfigHash !== rulesConfigHash || targetState.isStale(state.targetState)) {
+      state.targetState = targetState.migrateStaleState(state.targetState);
       state.stale = true;
     }
 

--- a/shared-libs/rules-engine/src/target-state.js
+++ b/shared-libs/rules-engine/src/target-state.js
@@ -102,6 +102,13 @@ const mergeEmissions = (state, contactIds, targetEmissions) => {
   return isUpdated;
 };
 
+const createState = (existentStaleState) => {
+  return {
+    targets: existentStaleState ? existentStaleState : {},
+    aggregate: {}
+  };
+};
+
 module.exports = {
   /**
    * Builds an empty target-state.
@@ -109,16 +116,14 @@ module.exports = {
    * @param {Object[]} targets An array of target definitions
    */
   createEmptyState: (targets=[]) => {
-    const state = {
-      targets: {},
-      aggregate: {}
-    };
+    const state = createState();
 
     targets.forEach(definition => state.targets[definition.id] = { ...definition, emissions: {} });
     return state;
   },
 
   isStale: (state) => !state || !state.targets || !state.aggregate,
+  migrateStaleState: (state) => module.exports.isStale(state) ? createState(state) : state,
 
   storeTargetEmissions: (state, contactIds, targetEmissions) => {
     let isUpdated = false;

--- a/shared-libs/rules-engine/test/rules-state-store.spec.js
+++ b/shared-libs/rules-engine/test/rules-state-store.spec.js
@@ -441,14 +441,17 @@ describe('rules-state-store', () => {
       expect(stale).to.equal(true);
     });
 
-    it('should mark as stale when target-state is stale', () => {
+    it('should mark as stale and migrate when target-state is stale', () => {
       const settings = { config: '123' };
+      const targets = { t1: { emissions: [] }, t2: { emissions: [] } };
+      Object.freeze(targets);
       const staleState = {
-        targetState: {},
+        targetState: targets,
         rulesConfigHash: md5(JSON.stringify(settings))
       };
       const stale = rulesStateStore.load(staleState, settings);
       expect(stale).to.equal(true);
+      expect(staleState.targetState).to.deep.equal({ targets, aggregate: { } });
     });
 
     it('should not mark as stale when not stale', () => {

--- a/shared-libs/rules-engine/test/target-state.spec.js
+++ b/shared-libs/rules-engine/test/target-state.spec.js
@@ -289,5 +289,24 @@ describe('target-state', () => {
       expect(targetState.isStale({ targets: {}, aggregate: {} })).to.equal(false);
     });
   });
+
+  describe('migrateStaleState', () => {
+    it('should migrate on stale state', () => {
+      expect(targetState.migrateStaleState({ })).to.deep.equal( { targets: {}, aggregate: {} });
+      const targets = { t1: { emissions: [] }, t2: { emissions: [] } };
+      Object.freeze(targets);
+      expect(targetState.migrateStaleState(targets)).to.deep.equal({ targets, aggregate: {}});
+    });
+
+    it('should not migrate on not stale state', () => {
+      const state = {
+        targets: { t1: { emissions: [] }, t2: { emissions: [] } },
+        aggregate: { targets: [], filterInterval: {} },
+      };
+      Object.freeze(state);
+      Object.freeze(state.targets);
+      expect(targetState.migrateStaleState(state)).to.equal(state);
+    });
+  });
 });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

#9552

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-interval-turnover/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-interval-turnover/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9552-interval-turnover/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

