### PR TITLE
chore(#9571): update CHT version to 4.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medic",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medic",
-      "version": "4.13.0",
+      "version": "4.14.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medic",
-  "version": "4.13.0",
+  "version": "4.14.0",
   "private": true,
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
# Description

Bump CHT version to 4.14.0
#9571

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9571-update-version/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9571-update-version/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9571-update-version/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

