### PR TITLE
feat(#9558): Task filter by household

### DIFF
--- a/webapp/src/css/inbox.less
+++ b/webapp/src/css/inbox.less
@@ -473,7 +473,7 @@ mm-analytics-filters {
   background-color: @background-color;
 }
 
-.reports .inbox-items, .contacts .inbox-items, .messages .inbox-items {
+.reports .inbox-items, .contacts .inbox-items, .messages .inbox-items, .tasks .inbox-items {
   overflow-y: hidden;
   overflow-x: hidden;
   height: 100%;
@@ -1110,6 +1110,49 @@ mm-search-bar {
     }
 
     &.disabled .search-bar-left-icon .fa {
+      color: @inactive-color;
+    }
+  }
+}
+
+mm-filter-slider-icon {
+  padding: 8px 0;
+  position: relative;
+  display: block;
+
+  .mm-filter-slider-container {
+    display: flex;
+    justify-content: flex-start;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0.8);
+
+    *, *:active, *:focus {
+      outline: none !important;
+      box-shadow: none;
+    }
+
+    .open-filter {
+      background-color: transparent;
+      margin: 0 3px;
+      font-size: @font-large;
+      position: relative;
+      border-radius: 0 px;
+
+      &:active {
+        box-shadow: none;
+      }
+
+      .filter-counter {
+        color: @chip-text-color;
+        font-size: @font-extra-extra-small;
+        background: @chip-background-color;
+        border-radius: 50%;
+        padding: 1px 5px;
+        vertical-align: middle;
+      }
+    }
+
+    &.disabled {
       color: @inactive-color;
     }
   }

--- a/webapp/src/ts/components/components.module.ts
+++ b/webapp/src/ts/components/components.module.ts
@@ -32,6 +32,7 @@ import { ReportImageComponent } from '@mm-components/report-image/report-image.c
 import { NavigationComponent } from '@mm-components/navigation/navigation.component';
 import { EnketoComponent } from '@mm-components/enketo/enketo.component';
 import { SearchBarComponent } from '@mm-components/search-bar/search-bar.component';
+import { FilterSliderIconComponent } from '@mm-components/filter-slider-icon/filter-slider-icon.component';
 import { MultiselectBarComponent } from '@mm-components/multiselect-bar/multiselect-bar.component';
 import {
   AnalyticsTargetsProgressComponent
@@ -61,6 +62,7 @@ import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
     FreetextFilterComponent,
     FastActionButtonComponent,
     SearchBarComponent,
+    FilterSliderIconComponent,
     MultiselectBarComponent,
     SortFilterComponent,
     SenderComponent,
@@ -104,6 +106,7 @@ import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
     FastActionButtonComponent,
     StatusFilterComponent,
     SearchBarComponent,
+    FilterSliderIconComponent,
     MultiselectBarComponent,
     FreetextFilterComponent,
     SortFilterComponent,

--- a/webapp/src/ts/components/filter-slider-icon/filter-slider-icon.component.html
+++ b/webapp/src/ts/components/filter-slider-icon/filter-slider-icon.component.html
@@ -1,0 +1,11 @@
+<section class="mm-filter-slider-container" [class.disabled]="disabled">
+  <button 
+    mat-flat-button 
+    class="open-filter" 
+    *ngIf="showFilter" 
+    (click)="toggleFilter.emit()">
+    <span class="fa fa-sliders"></span>
+    <span class="open-filter-label">{{ 'search_bar.filter.label' | translate }}</span>
+    <span class="filter-counter" *ngIf="activeFilters">{{ activeFilters.toString() | translate }}</span>
+  </button>
+</section>

--- a/webapp/src/ts/components/filter-slider-icon/filter-slider-icon.component.ts
+++ b/webapp/src/ts/components/filter-slider-icon/filter-slider-icon.component.ts
@@ -1,0 +1,84 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  AfterContentInit,
+  AfterViewInit,
+  Output,
+} from '@angular/core';
+import { Store } from '@ngrx/store';
+import { combineLatest, Subscription } from 'rxjs';
+
+import { Selectors } from '@mm-selectors/index';
+import { ResponsiveService } from '@mm-services/responsive.service';
+
+@Component({
+  selector: 'mm-filter-slider-icon',
+  templateUrl: './filter-slider-icon.component.html'
+})
+export class FilterSliderIconComponent implements AfterContentInit, AfterViewInit, OnDestroy {
+  @Input() disabled;
+  @Input() showFilter;
+  @Input() lastVisitedDateExtras;
+  @Output() toggleFilter: EventEmitter<any> = new EventEmitter();
+
+  private filters;
+  subscription: Subscription = new Subscription();
+  activeFilters: number = 0;
+  openSearch = false;
+
+  constructor(
+    private store: Store,
+    private responsiveService: ResponsiveService,
+  ) { }
+
+  ngAfterContentInit() {
+    this.subscribeToStore();
+  }
+
+  ngAfterViewInit() {
+  }
+
+  private subscribeToStore() {
+    const subscription = combineLatest(
+      this.store.select(Selectors.getSidebarFilter),
+      this.store.select(Selectors.getFilters),
+    ).subscribe(([sidebarFilter, filters]) => {
+      this.activeFilters = sidebarFilter?.filterCount?.total || 0;
+      this.filters = filters;
+
+      if (!this.openSearch && this.filters?.search) {
+        this.toggleMobileSearch();
+      }
+    });
+    this.subscription.add(subscription);
+  }
+
+  clear() {
+    if (this.disabled) {
+      return;
+    }
+    this.toggleMobileSearch(false);
+  }
+
+  toggleMobileSearch(forcedValue?) {
+    if (forcedValue === undefined && (this.disabled || !this.responsiveService.isMobile())) {
+      return;
+    }
+
+    this.openSearch = forcedValue !== undefined ? forcedValue : !this.openSearch;
+  }
+
+  showSearchIcon() {
+    return !this.openSearch && !this.filters?.search;
+  }
+
+  showClearIcon() {
+    return this.openSearch || !!this.filters?.search;
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/webapp/src/ts/modules/modules.module.ts
+++ b/webapp/src/ts/modules/modules.module.ts
@@ -42,6 +42,7 @@ import {
   AnalyticsTargetAggregatesDetailComponent
 } from '@mm-modules/analytics/analytics-target-aggregates-detail.component';
 import { TasksComponent } from '@mm-modules/tasks/tasks.component';
+import { TasksSidebarFilterComponent } from '@mm-modules/tasks/tasks-sidebar-filter.component';
 import { TasksContentComponent } from '@mm-modules/tasks/tasks-content.component';
 import { TasksGroupComponent } from '@mm-modules/tasks/tasks-group.component';
 import { TestingComponent } from '@mm-modules/testing/testing.component';
@@ -75,6 +76,7 @@ import { DirectivesModule } from '@mm-directives/directives.module';
     AnalyticsTargetAggregatesDetailComponent,
     AnalyticsTargetAggregatesSidebarFilterComponent,
     TasksComponent,
+    TasksSidebarFilterComponent,
     TasksContentComponent,
     TasksGroupComponent,
     TestingComponent,

--- a/webapp/src/ts/modules/tasks/tasks-content.component.html
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.html
@@ -1,55 +1,52 @@
-<div class="content-pane right-pane">
+<div class="empty-selection" *ngIf="loadingContent || loadingForm">
+  <div>
+    <div class="loader"></div>
+  </div>
+</div>
 
-  <div class="col-sm-8 item-content empty-selection" *ngIf="loadingContent || loadingForm">
+<div class="empty-selection" *ngIf="!selectedTask && !loadingContent">
+  <div>{{'No task selected' | translate}}</div>
+</div>
+
+<div class="empty-selection" *ngIf="!loadingContent && !loadingForm && contentError">
+  <div>{{ errorTranslationKey | translate}}</div>
+</div>
+
+<div id="tasks-content" class=".task-wrap" *ngIf="selectedTask && !form && !loadingContent && !loadingForm && !contentError">
+  <div class="body">
     <div>
-      <div class="loader"></div>
+      <ul>
+        <li>
+          <h2>{{selectedTask.title | translateFrom:selectedTask}}</h2>
+        </li>
+        <li>
+          <label>{{'task.date' | translate}}</label>
+          <p [innerHTML]="selectedTask.date | simpleDate"></p>
+        </li>
+        <li *ngIf="selectedTask.priority">
+          <label>{{'task.priority' |  translate}}</label>
+          <p [ngClass]="{'high-priority': selectedTask.priority === 'high', 'medium-priority': selectedTask.priority === 'medium'}">
+            <span class="priority">
+              <i class="fa fa-exclamation-triangle high-priority-icon"></i>
+              <i class="fa fa-info-circle medium-priority-icon"></i>
+            </span>
+            {{selectedTask.priorityLabel | translateFrom:selectedTask}}
+          </p>
+        </li>
+        <li *ngFor="let field of selectedTask.fields">
+          <label>{{field.label | translateFrom:selectedTask}}</label>
+          <p>{{field.value | translateFrom:selectedTask}}</p>
+        </li>
+        <li class="actions" *ngIf="selectedTask.actions.length">
+          <a class="btn btn-primary" *ngFor="let action of selectedTask.actions" (click)="performAction(action)">{{action.label | translateFrom:selectedTask}}</a>
+        </li>
+      </ul>
     </div>
   </div>
+</div>
 
-  <div class="col-sm-8 item-content empty-selection" *ngIf="!selectedTask && !loadingContent">
-    <div>{{'No task selected' | translate}}</div>
-  </div>
-
-  <div class="col-sm-8 item-content empty-selection" *ngIf="!loadingContent && !loadingForm && contentError">
-    <div>{{ errorTranslationKey | translate}}</div>
-  </div>
-
-  <div class="col-sm-8 item-content" *ngIf="selectedTask && !form && !loadingContent && !loadingForm && !contentError">
-    <div class="body">
-      <div>
-        <ul>
-          <li>
-            <h2>{{selectedTask.title | translateFrom:selectedTask}}</h2>
-          </li>
-          <li>
-            <label>{{'task.date' | translate}}</label>
-            <p [innerHTML]="selectedTask.date | simpleDate"></p>
-          </li>
-          <li *ngIf="selectedTask.priority">
-            <label>{{'task.priority' |  translate}}</label>
-            <p [ngClass]="{'high-priority': selectedTask.priority === 'high', 'medium-priority': selectedTask.priority === 'medium'}">
-              <span class="priority">
-                <i class="fa fa-exclamation-triangle high-priority-icon"></i>
-                <i class="fa fa-info-circle medium-priority-icon"></i>
-              </span>
-              {{selectedTask.priorityLabel | translateFrom:selectedTask}}
-            </p>
-          </li>
-          <li *ngFor="let field of selectedTask.fields">
-            <label>{{field.label | translateFrom:selectedTask}}</label>
-            <p>{{field.value | translateFrom:selectedTask}}</p>
-          </li>
-          <li class="actions" *ngIf="selectedTask.actions.length">
-            <a class="btn btn-primary" *ngFor="let action of selectedTask.actions" (click)="performAction(action)">{{action.label | translateFrom:selectedTask}}</a>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-sm-8 item-content" [hidden]="!selectedTask || !form || loadingForm || loadingContent || contentError">
-    <div class="body">
-      <mm-enketo formId="task-report" [status]="enketoStatus" (onSubmit)="save()" (onCancel)="navigationCancel()"></mm-enketo>
-    </div>
+<div [hidden]="!selectedTask || !form || loadingForm || loadingContent || contentError">
+  <div class="body">
+    <mm-enketo formId="task-report" [status]="enketoStatus" (onSubmit)="save()" (onCancel)="navigationCancel()"></mm-enketo>
   </div>
 </div>

--- a/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.html
+++ b/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.html
@@ -1,0 +1,49 @@
+<section class="sidebar-filter">
+  <div class="sidebar-backdrop" [ngClass]="{ hidden: !isOpen }" (click)="toggleSidebarFilter()"></div>
+
+  <div class="sidebar-main" [ngClass]="{ hidden: !isOpen }">
+    <div class="sidebar-header">
+      <p class="sidebar-title">{{ 'reports.sidebar.filter.title' | translate }}</p>
+      <a class="sidebar-reset" [class.disabled]="disabled" (click)="resetFilters()">{{ 'reports.sidebar.filter.reset' | translate }}</a>
+      <a class="sidebar-close fa fa-times" (click)="toggleSidebarFilter()"></a>
+    </div>
+
+    <div class="sidebar-body">
+      <accordion [closeOthers]="true" [isAnimated]="true">
+        <!-- 1. Place -->
+        <accordion-group id="place-filter-accordion">
+          <ng-container
+            accordion-heading
+            [ngTemplateOutlet]="headerTemplate"
+            [ngTemplateOutletContext]="{
+              numSelected: filterCount.placeFilter,
+              label: 'reports.sidebar.filter.place',
+              filters: [ 'placeFilter' ]
+            }">
+          </ng-container>
+          <mm-facility-filter
+            class="filter"
+            fieldId="placeFilter"
+            (search)="applyFilters()"
+            [disabled]="disabled"
+            [inline]="true">
+          </mm-facility-filter>
+        </accordion-group>
+      </accordion>
+    </div>
+
+    <div class="sidebar-footer">
+      <button type="button" class="btn btn-primary" (click)="toggleSidebarFilter()">{{ 'reports.sidebar.filter.submit' | translate }}</button>
+    </div>
+  </div>
+</section>
+
+<ng-template #headerTemplate let-numSelected="numSelected" let-label="label" let-filters="filters">
+  <button class="btn btn-link">
+    <p class="title">{{ label | translate }}</p>
+    <div class="chip" *ngIf="numSelected" [class.disabled]="disabled">
+      <span>{{ numSelected | translate }}</span>
+      <span class="fa fa-times" (click)="clearFilters(filters); $event.stopPropagation();"></span>
+    </div>
+  </button>
+</ng-template>

--- a/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-sidebar-filter.component.ts
@@ -1,0 +1,95 @@
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
+import { Store } from '@ngrx/store';
+
+import { GlobalActions } from '@mm-actions/global';
+import { FacilityFilterComponent } from '@mm-components/filters/facility-filter/facility-filter.component';
+import { TelemetryService } from '@mm-services/telemetry.service';
+
+type FilterComponent = FacilityFilterComponent;
+
+@Component({
+  selector: 'mm-tasks-sidebar-filter',
+  templateUrl: './tasks-sidebar-filter.component.html'
+})
+export class TasksSidebarFilterComponent implements AfterViewInit, OnDestroy {
+  @Output() search: EventEmitter<any> = new EventEmitter();
+  @Input() disabled;
+
+  @ViewChild(FacilityFilterComponent)
+  facilityFilter: FacilityFilterComponent;
+
+  private globalActions;
+  private filters: FilterComponent[] = [];
+  isResettingFilters = false;
+  isOpen = false;
+  filterCount:any = { };
+  dateFilterError = '';
+
+  constructor(
+    private store: Store,
+    private telemetryService: TelemetryService,
+  ) {
+    this.globalActions = new GlobalActions(store);
+  }
+
+  ngAfterViewInit() {
+    this.filters = [
+      this.facilityFilter,
+    ];
+  }
+
+  applyFilters() {
+    if (this.isResettingFilters || this.disabled) {
+      return;
+    }
+    this.search.emit();
+    this.countSelected();
+  }
+
+  clearFilters(fieldIds?) {
+    if (this.disabled) {
+      return;
+    }
+    const filters = fieldIds ? this.filters.filter(filter => fieldIds.includes(filter.fieldId)) : this.filters;
+    filters.forEach(filter => filter.clear());
+  }
+
+  countSelected() {
+    this.filterCount.total = 0;
+    this.filters.forEach(filter => {
+      const count = filter.countSelected() || 0;
+      this.filterCount.total += count;
+      this.filterCount[filter.fieldId] = count;
+    });
+    this.globalActions.setSidebarFilter({ filterCount: { ...this.filterCount }});
+  }
+
+  resetFilters() {
+    if (this.disabled) {
+      return;
+    }
+    this.isResettingFilters = true;
+    this.globalActions.clearFilters('search');
+    this.clearFilters();
+    this.isResettingFilters = false;
+    this.applyFilters();
+  }
+
+  toggleSidebarFilter() {
+    this.isOpen = !this.isOpen;
+    this.globalActions.setSidebarFilter({ isOpen: this.isOpen });
+  }
+
+  showDateFilterError(error) {
+    this.dateFilterError = error || '';
+  }
+
+  setDefaultFacilityFilter(filters) {
+    this.facilityFilter?.setDefault(filters?.facility);
+  }
+
+  ngOnDestroy() {
+    this.globalActions.clearSidebarFilter();
+    this.globalActions.clearFilters();
+  }
+}

--- a/webapp/src/ts/modules/tasks/tasks.component.html
+++ b/webapp/src/ts/modules/tasks/tasks.component.html
@@ -1,9 +1,24 @@
 <mm-tool-bar title="Tasks"></mm-tool-bar>
 
+<div class="filters tab-bar">
+  <div class="inner">
+    <mm-navigation></mm-navigation>
+    <mm-filter-slider-icon
+      *ngIf="useSidebarFilter && !selectMode"
+      (toggleFilter)="toggleFilter()"
+      [disabled]="selectMode && selectedTasks?.length"
+      [showFilter]="true">
+    </mm-filter-slider-icon>
+  </div>
+</div>
+
 <div class="inner">
   <div class="inbox page">
 
-    <div id="tasks-list" class="col-sm-4 inbox-items left-pane">
+    <div id="tasks-list" 
+      class="inbox-items left-pane"
+      [ngClass]="{ 'col-sm-3': isSidebarFilterOpen, 'col-sm-4': !isSidebarFilterOpen }">
+
       <ul *ngIf="!errorStack && hasTasks">
         <li *ngFor="let task of tasksList; trackBy: listTrackBy"
             [attr.data-record-id]="task._id"
@@ -41,6 +56,17 @@
       <div class="loader" *ngIf="loading && !tasksDisabled && !errorStack"></div>
     </div>
 
-    <router-outlet></router-outlet>
+    <div class="content-pane right-pane">
+      <div class="item-content" [ngClass]="{ 'col-sm-6': isSidebarFilterOpen, 'col-sm-8': !isSidebarFilterOpen }">
+        <router-outlet></router-outlet>
+      </div>
+    
+      <mm-tasks-sidebar-filter
+        class="col-sm-3 sidebar-filter-wrapper"
+        *ngIf="useSidebarFilter"
+        (search)="search()"
+        [disabled]="selectMode">
+      </mm-tasks-sidebar-filter>
+    </div>
   </div>
 </div>

--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit, AfterViewInit, ViewChild } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { combineLatest, Subscription } from 'rxjs';
 import { debounce as _debounce } from 'lodash-es';
@@ -13,11 +13,14 @@ import { GlobalActions } from '@mm-actions/global';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
 import { PerformanceService } from '@mm-services/performance.service';
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
+import { TasksSidebarFilterComponent } from '@mm-modules/tasks/tasks-sidebar-filter.component';
 
 @Component({
   templateUrl: './tasks.component.html',
 })
-export class TasksComponent implements OnInit, OnDestroy {
+export class TasksComponent implements OnInit, AfterViewInit, OnDestroy {
+  @ViewChild(TasksSidebarFilterComponent) tasksSidebarFilter: TasksSidebarFilterComponent;
+
   constructor(
     private store: Store,
     private changesService: ChangesService,
@@ -39,11 +42,17 @@ export class TasksComponent implements OnInit, OnDestroy {
 
   tasksList;
   selectedTask;
+  selectedTasks;
   errorStack;
   hasTasks;
   loading;
   tasksDisabled;
   userLineageLevel;
+  filters: any = {};
+  selectMode = false;  
+  selectModeAvailable = false;
+  useSidebarFilter = true;
+  isSidebarFilterOpen = false;  
 
   private tasksLoaded;
   private debouncedReload;
@@ -57,11 +66,15 @@ export class TasksComponent implements OnInit, OnDestroy {
     const taskList$ = combineLatest([
       this.store.select(Selectors.getTasksList),
       this.store.select(Selectors.getSelectedTask),
+      this.store.select(Selectors.getFilters),      
     ]).subscribe(([
       tasksList = [],
       selectedTask,
+      filters,      
     ]) => {
       this.selectedTask = selectedTask;
+      this.filters = filters;
+      
       // Make new reference because the one from store is read-only. Fixes: ExpressionChangedAfterItHasBeenCheckedError
       this.tasksList = tasksList.map(task => ({ ...task, selected: task._id === this.selectedTask?._id }));
     });
@@ -106,6 +119,10 @@ export class TasksComponent implements OnInit, OnDestroy {
     this.refreshTasks();
   }
 
+  async ngAfterViewInit() {
+    this.subscribeSidebarFilter();
+  }   
+
   ngOnDestroy() {
     this.subscription.unsubscribe();
     this.tasksActions.setTasksList([]);
@@ -118,6 +135,17 @@ export class TasksComponent implements OnInit, OnDestroy {
   refreshTaskList() {
     window.location.reload();
   }
+
+  private subscribeSidebarFilter() {
+    if (!this.useSidebarFilter) {
+      return;
+    }
+
+    const subscription = this.store
+      .select(Selectors.getSidebarFilter)
+      .subscribe(({ isOpen }) => this.isSidebarFilterOpen = !!isOpen);
+    this.subscription.add(subscription);
+  }  
 
   private hydrateEmissions(taskDocs) {
     return taskDocs.map(taskDoc => {
@@ -141,7 +169,7 @@ export class TasksComponent implements OnInit, OnDestroy {
       const taskDocs = isEnabled ? await this.rulesEngineService.fetchTaskDocsForAllContacts() : [];
       this.hasTasks = taskDocs.length > 0;
 
-      const hydratedTasks = await this.hydrateEmissions(taskDocs) || [];
+      let hydratedTasks = await this.hydrateEmissions(taskDocs) || [];
       const subjects = await this.getLineagesFromTaskDocs(hydratedTasks);
       if (subjects?.size) {
         const userLineageLevel = await this.userLineageLevel;
@@ -149,6 +177,19 @@ export class TasksComponent implements OnInit, OnDestroy {
           task.lineage = this.getTaskLineage(subjects, task, userLineageLevel);
         });
       }
+
+      if (subjects?.size) {
+        const userLineageLevel = await this.currentLevel;
+        hydratedTasks.forEach(task => {
+          task.lineageId = this.getTaskLineageById(subjects, task, userLineageLevel);
+        });
+      }
+
+      if(this.filters?.facilities) {
+        hydratedTasks = hydratedTasks.filter(task =>
+          task.lineageId.some(value => this.filters.facilities.selected.includes(value))
+        );        
+      }      
 
       this.tasksActions.setTasksList(hydratedTasks);
 
@@ -185,6 +226,18 @@ export class TasksComponent implements OnInit, OnDestroy {
     return task?._id;
   }
 
+  toggleFilter() {
+    this.tasksSidebarFilter?.toggleSidebarFilter();
+  }
+
+  resetFilter() {
+    this.tasksSidebarFilter?.resetFilters();
+  }
+
+  search() {
+    this.refreshTasks();
+  }  
+
   private getLineagesFromTaskDocs(taskDocs) {
     const ids = [ ...new Set(taskDocs.map(task => task.owner)) ];
     return this.lineageModelGeneratorService
@@ -198,4 +251,11 @@ export class TasksComponent implements OnInit, OnDestroy {
       ?.map(lineage => lineage?.name);
     return this.extractLineageService.removeUserFacility(lineage, userLineageLevel);
   }
+
+  private getTaskLineageById(subjects, task, userLineageLevel) {
+    const lineage = subjects
+      .get(task.owner)
+      ?.map(lineage => lineage?._id);
+      return this.extractLineageService.removeUserFacility(lineage, userLineageLevel);
+  }  
 }


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

We have down streamed the integration of a slide filter similar to the one in the reporting view in our local implementation. We have kept the user experience consistent with how the filter functions in the reporting view and have exposed the ability for the CHW to filter tasks by household. However, just to note that we have not implemented the freetext search bar, as this is currently out of scope, but this may be a useful inclusion in a future release.

1. Include a filter icon on the task view (filter icon has been extracted from the reporting view search bar)
2. Include slide filter, allowing filter by place

Issue Number #9558 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

