### PR TITLE
fix(#9604): fix integer validation in sms rules

### DIFF
--- a/shared-libs/validation/src/validator_functions.js
+++ b/shared-libs/validation/src/validator_functions.js
@@ -8,9 +8,9 @@ const re = {
 };
 
 const ValidatorFunctions = {
-  equals: (allValues, value, equalsTo) => value === equalsTo,
+  equals: (allValues, value, equalsTo) => value == equalsTo, // eslint-disable-line eqeqeq
 
-  iequals: (allValues, value, equalsTo) => value.toLowerCase() === equalsTo.toLowerCase(),
+  iequals: (allValues, value, equalsTo) => value.toLowerCase() == equalsTo.toLowerCase(), // eslint-disable-line eqeqeq
 
   sequals: (allValues, value, equalsTo) => value === equalsTo,
 
@@ -31,17 +31,7 @@ const ValidatorFunctions = {
     return ((numVal >= min) && (numVal <= max));
   },
 
-  in: (allValues, value) => {
-    const args = Array.prototype.slice.call(arguments);
-    args.shift();
-    args.shift();
-    for (const arg of args) {  
-      if (arg === value) {
-        return true;
-      }
-    }
-    return false;
-  },
+  in: (allValues, value, ...args) => args.some(arg => arg == value), // eslint-disable-line eqeqeq
 
   required: (allValues, value) => !!value,
 
@@ -67,9 +57,9 @@ const ValidatorFunctions = {
     return (new RegExp(regex, flags)).test(value);
   },
 
-  integer: (allValues, value) => parseInt(value, 10) === value,
+  integer: (allValues, value) => parseInt(value, 10) == value, // eslint-disable-line eqeqeq
 
-  equalsto: (allValues, value, equalsToKey) => value === allValues[equalsToKey],
+  equalsto: (allValues, value, equalsToKey) => value == allValues[equalsToKey], // eslint-disable-line eqeqeq
 
   exists: async (allValues, value, formName, fieldName) => {
     try {

--- a/shared-libs/validation/test/validations.js
+++ b/shared-libs/validation/test/validations.js
@@ -1157,4 +1157,27 @@ describe('validations', () => {
 
   });
 
+  it('should validate integers', () => {
+    const validations = [
+      {
+        property: 'lmp_year',
+        rule: '(integer && min(2078) && max(2090))',
+        translation_key: 'registration.lmp_date.year.incorrect'
+      },
+      {
+        property: 'lmp_month',
+        rule: '(integer && min(1) && max(12))',
+        translation_key: 'registration.lmp_date.month.incorrect'
+      }
+    ];
+    const doc = {
+      _id: 'same',
+      lmp_year: '2080',
+      lmp_month: '10'
+    };
+    return validation.validate(doc, validations).then(errors => {
+      assert.deepEqual(errors, []);
+    });
+  });
+
 });

--- a/shared-libs/validation/test/validator_functions.js
+++ b/shared-libs/validation/test/validator_functions.js
@@ -1,0 +1,127 @@
+const assert = require('chai').assert;
+const validatorFunctions = require('../src/validator_functions');
+
+describe('validator functions', () => {
+
+  describe('integer', () => {
+
+    const valid = ['0', '1', '2080', '-2', '   5'];
+
+    valid.forEach(value => {
+      it(`should return true for "${value}"`, () => {
+        assert.isTrue(validatorFunctions.integer(null, value));
+      });
+    });
+
+    const invalid = ['', 'a', '56b', '2.3', '-'];
+
+    invalid.forEach(value => {
+      it(`should return false for "${value}"`, () => {
+        assert.isFalse(validatorFunctions.integer(null, value));
+      });
+    });
+  });
+
+  describe('in', () => {
+
+    it('should return true for value in list', () => {
+      assert.isTrue(validatorFunctions.in(null, 'a', 'a', 'b', 'c'));
+    });
+
+    it('should return false for value not in list', () => {
+      assert.isFalse(validatorFunctions.in(null, 'd', 'a', 'b', 'c'));
+    });
+
+  });
+
+  describe('equals', () => {
+
+    it('should return true for equal values same type', () => {
+      assert.isTrue(validatorFunctions.equals(null, 'a', 'a'));
+    });
+
+    it('should return true for equal values different type', () => {
+      assert.isTrue(validatorFunctions.equals(null, '1', 1));
+    });
+
+    it('should return false for equal values difference case', () => {
+      assert.isFalse(validatorFunctions.equals(null, 'a', 'A'));
+    });
+
+    it('should return false for unequal values', () => {
+      assert.isFalse(validatorFunctions.equals(null, 'a', 'b'));
+    });
+
+  });
+
+  describe('iequals', () => {
+
+    it('should return true for equal values same type', () => {
+      assert.isTrue(validatorFunctions.iequals(null, 'a', 'a'));
+    });
+
+    it('should return false for equal values difference case', () => {
+      assert.isTrue(validatorFunctions.iequals(null, 'a', 'A'));
+    });
+
+    it('should return false for unequal values', () => {
+      assert.isFalse(validatorFunctions.iequals(null, 'a', 'b'));
+    });
+
+  });
+
+  describe('sequals', () => {
+
+    it('should return true for equal values same type', () => {
+      assert.isTrue(validatorFunctions.sequals(null, 'a', 'a'));
+    });
+
+    it('should return false for equal values different type', () => {
+      assert.isFalse(validatorFunctions.sequals(null, '1', 1));
+    });
+
+    it('should return false for equal values difference case', () => {
+      assert.isFalse(validatorFunctions.sequals(null, 'a', 'A'));
+    });
+
+    it('should return false for unequal values', () => {
+      assert.isFalse(validatorFunctions.sequals(null, 'a', 'b'));
+    });
+
+  });
+
+
+  describe('siequals', () => {
+
+    it('should return true for equal values same type', () => {
+      assert.isTrue(validatorFunctions.siequals(null, 'a', 'a'));
+    });
+
+    it('should return false for equal values difference case', () => {
+      assert.isTrue(validatorFunctions.siequals(null, 'a', 'A'));
+    });
+
+    it('should return false for unequal values', () => {
+      assert.isFalse(validatorFunctions.siequals(null, 'a', 'b'));
+    });
+
+  });
+
+  describe('equalsto', () => {
+
+    const allValues = {
+      name: 'gareth',
+      location: 'darmstadt'
+    };
+
+    it('should return true for equal values', () => {
+      assert.isTrue(validatorFunctions.equalsto(allValues, 'gareth', 'name'));
+    });
+
+    it('should return false for unequal values', () => {
+      assert.isFalse(validatorFunctions.equalsto(allValues, 'gareth', 'location'));
+    });
+
+  });
+
+});

--- a/shared-libs/validation/test/validator_functions.js
+++ b/shared-libs/validation/test/validator_functions.js
@@ -97,7 +97,7 @@ describe('validator functions', () => {
       assert.isTrue(validatorFunctions.siequals(null, 'a', 'a'));
     });
 
-    it('should return false for equal values difference case', () => {
+    it('should return true for equal values difference case', () => {
       assert.isTrue(validatorFunctions.siequals(null, 'a', 'A'));
     });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9604-fix-integer-validation/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9604-fix-integer-validation/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9604-fix-integer-validation/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

