### PR TITLE
fix(#9286): don't pass request timeout prop

### DIFF
--- a/api/src/services/setup/view-indexer.js
+++ b/api/src/services/setup/view-indexer.js
@@ -66,7 +66,6 @@ const indexView = async (dbName, ddocId, viewName) => {
         uri: `${environment.serverUrl}/${dbName}/${ddocId}/_view/${viewName}`,
         json: true,
         qs: { limit: 1 },
-        timeout: 2000,
       });
     } catch (requestError) {
       if (!continueIndexing) {

--- a/api/tests/mocha/services/setup/view-indexer.spec.js
+++ b/api/tests/mocha/services/setup/view-indexer.spec.js
@@ -6,7 +6,8 @@ const db = require('../../../../src/db');
 const env = require('@medic/environment');
 const request = require('@medic/couch-request');
 const databases = require('../../../../src/services/setup/databases');
-const upgradeLogService = require('../../../../src/services/setup/upgrade-log');
+const upgradeLogService = require('../../../../src/service' +
+                                  's/setup/upgrade-log');
 
 let viewIndexer;
 
@@ -60,38 +61,33 @@ describe('View indexer service', () => {
           uri: 'http://localhost/thedb/_design/:staged:one/_view/view1',
           json: true,
           qs: { limit: 1 },
-          timeout: 2000,
         }],
         [{
           uri: 'http://localhost/thedb/_design/:staged:one/_view/view2',
           json: true,
           qs: { limit: 1 },
-          timeout: 2000,
         }],
         [{
           uri: 'http://localhost/thedb/_design/:staged:one/_view/view3',
           json: true,
           qs: { limit: 1 },
-          timeout: 2000,
         }],
         [{
           uri: 'http://localhost/thedb/_design/:staged:three/_view/view4',
           json: true,
           qs: { limit: 1 },
-          timeout: 2000,
         }],
         [{
           uri: 'http://localhost/thedb-users-meta/_design/:staged:four/_view/view',
           json: true,
           qs: { limit: 1 },
-          timeout: 2000,
         }],
       ]);
     });
   });
 
   describe('indexView', () => {
-    it('should query the view with a timeout', async () => {
+    it('should query the view', async () => {
       sinon.stub(request, 'get').resolves();
       sinon.stub(env, 'serverUrl').value('http://localhost');
 
@@ -102,7 +98,6 @@ describe('View indexer service', () => {
         uri: 'http://localhost/medic/_design/:staged:medic/_view/contacts',
         json: true,
         qs: { limit: 1 },
-        timeout: 2000,
       }]);
     });
 
@@ -119,7 +114,6 @@ describe('View indexer service', () => {
         uri: 'http://localhost/other/_design/mydesign/_view/viewname',
         json: true,
         qs: { limit: 1 },
-        timeout: 2000,
       };
       expect(request.get.args).to.deep.equal(Array.from({ length: 21 }).map(() => [params]));
     });
@@ -137,7 +131,6 @@ describe('View indexer service', () => {
         uri: 'http://localhost/other/_design/mydesign/_view/viewname',
         json: true,
         qs: { limit: 1 },
-        timeout: 2000,
       };
       expect(request.get.args).to.deep.equal(Array.from({ length: 21 }).map(() => [params]));
     });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Removes view indexer request timeout param. This didn't end up terminating the request at haproxy level 

#9286
#9617
#8573

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9286-dont-timeout/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9286-dont-timeout/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9286-dont-timeout/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

