### PR TITLE
fix(#9618): don't crash api on startup if form is broken

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -82,7 +82,6 @@ process
     await migrations.run();
     logger.info('Database migrations completed successfully');
 
-    startupLog.start('forms');
     logger.info('Generating manifest');
     await manifest.generate();
     logger.info('Manifest generated successfully');
@@ -90,15 +89,20 @@ process
     logger.info('Generating service worker');
     await generateServiceWorker.run(true);
     logger.info('Service worker generated successfully');
-
-    logger.info('Updating xforms…');
-    await generateXform.updateAll();
-    logger.info('xforms updated successfully');
-
   } catch (err) {
     logger.error('Fatal error initialising API');
     logger.error('%o', err);
     process.exit(1);
+  }
+
+  try {
+    startupLog.start('forms');
+    logger.info('Updating xforms…');
+    await generateXform.updateAll();
+    logger.info('xforms updated successfully');
+  } catch (err) {
+    logger.error('Error initialising API');
+    logger.error('%o', err);
   }
 
   startupLog.complete();

--- a/tests/integration/api/server.spec.js
+++ b/tests/integration/api/server.spec.js
@@ -430,4 +430,28 @@ describe('server', () => {
     });
 
   });
+
+  describe('api startup', () => {
+    it('should start up with broken forms', async () => {
+      const waitForLogs = await utils.waitForApiLogs(/Failed to update xform/);
+
+      const formName = 'broken';
+      const formDoc = {
+        _id: `form:${formName}`,
+        title: formName,
+        type: 'form',
+        _attachments: {
+          xml: {
+            content_type: 'application/octet-stream',
+            data: btoa('this is totally not an xml'),
+          },
+        },
+      };
+      await utils.db.put(formDoc); // don't use utils.saveDoc because that actually waits for good forms
+      await waitForLogs.promise;
+
+      await utils.stopApi();
+      await utils.startApi();
+    }); 
+  });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

#9618

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9618-api-should-start-wiht-broken-forms/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9618-api-should-start-wiht-broken-forms/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9618-api-should-start-wiht-broken-forms/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

