### PR TITLE
chore(#9644): update cht-conf gh-action

### DIFF
--- a/.github/actions/deploy-conf/action.yml
+++ b/.github/actions/deploy-conf/action.yml
@@ -28,6 +28,6 @@ runs:
     shell: bash
     working-directory: ${{ inputs.directory }}
   - name: run cht
-    run: npx cht --url=https://${{ inputs.username }}:${{ inputs.password }}@${{ inputs.hostname }} compile-app-settings convert-app-forms convert-collect-forms convert-contact-forms upload-app-settings upload-app-forms upload-collect-forms upload-contact-forms upload-resources upload-custom-translations --force
+    run: npx cht --url=https://${{ inputs.username }}:${{ inputs.password }}@${{ inputs.hostname }} compile-app-settings convert-app-forms convert-collect-forms convert-contact-forms convert-training-forms upload-app-settings upload-app-forms upload-collect-forms upload-contact-forms upload-training-forms upload-resources upload-custom-translations --force
     shell: bash
     working-directory: ${{ inputs.directory }}


### PR DESCRIPTION
Fixes #9644 

Adds the commands needed for converting and uploading training forms via the cht-conf gh-action