### PR TITLE
chore(#9561): refactor services to fix cht-from error

### DIFF
--- a/tests/integration/cht-form/default/person-edit.wdio-spec.js
+++ b/tests/integration/cht-form/default/person-edit.wdio-spec.js
@@ -40,9 +40,6 @@ describe('cht-form web component - Edit Person Form', () => {
             created_by_place_uuid: ''
           }
         },
-        meta: {
-          instanceID: 'uuid:c558e232-0951-4ed8-8392-5ed8ac3c81b3'
-        }
       };
     });
 

--- a/webapp/src/ts/modules/messages/messages.component.ts
+++ b/webapp/src/ts/modules/messages/messages.component.ts
@@ -38,17 +38,17 @@ export class MessagesComponent implements OnInit, OnDestroy {
   userLineageLevel;
 
   constructor(
-    private router: Router,
-    private store: Store,
-    private changesService: ChangesService,
-    private fastActionButtonService:FastActionButtonService,
-    private messageContactService: MessageContactService,
-    private exportService: ExportService,
-    private modalService: ModalService,
-    private responsiveService: ResponsiveService,
-    private performanceService: PerformanceService,
-    private extractLineageService: ExtractLineageService,
-    private userContactService: UserContactService
+    private readonly router: Router,
+    private readonly store: Store,
+    private readonly changesService: ChangesService,
+    private readonly fastActionButtonService:FastActionButtonService,
+    private readonly messageContactService: MessageContactService,
+    private readonly exportService: ExportService,
+    private readonly modalService: ModalService,
+    private readonly responsiveService: ResponsiveService,
+    private readonly performanceService: PerformanceService,
+    private readonly extractLineageService: ExtractLineageService,
+    private readonly userContactService: UserContactService
   ) {
     this.globalActions = new GlobalActions(store);
     this.messagesActions = new MessagesActions(store);

--- a/webapp/src/ts/modules/messages/messages.component.ts
+++ b/webapp/src/ts/modules/messages/messages.component.ts
@@ -17,6 +17,7 @@ import { FastAction, FastActionButtonService } from '@mm-services/fast-action-bu
 import { PerformanceService } from '@mm-services/performance.service';
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 import { ButtonType } from '@mm-components/fast-action-button/fast-action-button.component';
+import { UserContactService } from '@mm-services/user-contact.service';
 
 @Component({
   templateUrl: './messages.component.html'
@@ -47,6 +48,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
     private responsiveService: ResponsiveService,
     private performanceService: PerformanceService,
     private extractLineageService: ExtractLineageService,
+    private userContactService: UserContactService
   ) {
     this.globalActions = new GlobalActions(store);
     this.messagesActions = new MessagesActions(store);
@@ -54,7 +56,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.trackPerformance = this.performanceService.track();
-    this.userLineageLevel = this.extractLineageService.getUserLineageToRemove();
+    this.userLineageLevel = this.userContactService.getUserLineageToRemove();
     this.subscribeToStore();
     this.updateConversations().then(() => this.displayFirstConversation(this.conversations));
     this.watchForChanges();

--- a/webapp/src/ts/modules/reports/reports.component.ts
+++ b/webapp/src/ts/modules/reports/reports.component.ts
@@ -107,7 +107,7 @@ export class ReportsComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   async ngAfterViewInit() {
-    this.userLineageLevel = this.extractLineageService.getUserLineageToRemove();
+    this.userLineageLevel = this.userContactService.getUserLineageToRemove();
     await this.checkPermissions();
     this.subscribeSidebarFilter();
     this.doInitialSearch();

--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -13,6 +13,7 @@ import { GlobalActions } from '@mm-actions/global';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
 import { PerformanceService } from '@mm-services/performance.service';
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
+import { UserContactService } from '@mm-services/user-contact.service';
 
 @Component({
   templateUrl: './tasks.component.html',
@@ -26,6 +27,7 @@ export class TasksComponent implements OnInit, OnDestroy {
     private performanceService: PerformanceService,
     private lineageModelGeneratorService: LineageModelGeneratorService,
     private extractLineageService: ExtractLineageService,
+    private userContactService: UserContactService
   ) {
     this.tasksActions = new TasksActions(store);
     this.globalActions = new GlobalActions(store);
@@ -102,7 +104,7 @@ export class TasksComponent implements OnInit, OnDestroy {
     this.hasTasks = false;
     this.loading = true;
     this.debouncedReload = _debounce(this.refreshTasks.bind(this), 1000, { maxWait: 10 * 1000 });
-    this.userLineageLevel = this.extractLineageService.getUserLineageToRemove();
+    this.userLineageLevel = this.userContactService.getUserLineageToRemove();
     this.refreshTasks();
   }
 

--- a/webapp/src/ts/modules/tasks/tasks.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks.component.ts
@@ -20,14 +20,14 @@ import { UserContactService } from '@mm-services/user-contact.service';
 })
 export class TasksComponent implements OnInit, OnDestroy {
   constructor(
-    private store: Store,
-    private changesService: ChangesService,
-    private contactTypesService: ContactTypesService,
-    private rulesEngineService: RulesEngineService,
-    private performanceService: PerformanceService,
-    private lineageModelGeneratorService: LineageModelGeneratorService,
-    private extractLineageService: ExtractLineageService,
-    private userContactService: UserContactService
+    private readonly store: Store,
+    private readonly changesService: ChangesService,
+    private readonly contactTypesService: ContactTypesService,
+    private readonly rulesEngineService: RulesEngineService,
+    private readonly performanceService: PerformanceService,
+    private readonly lineageModelGeneratorService: LineageModelGeneratorService,
+    private readonly extractLineageService: ExtractLineageService,
+    private readonly userContactService: UserContactService
   ) {
     this.tasksActions = new TasksActions(store);
     this.globalActions = new GlobalActions(store);

--- a/webapp/src/ts/services/extract-lineage.service.ts
+++ b/webapp/src/ts/services/extract-lineage.service.ts
@@ -1,19 +1,12 @@
 import { Injectable } from '@angular/core';
 
-import { UserSettingsService } from '@mm-services/user-settings.service';
-import { UserContactService } from '@mm-services/user-contact.service';
-import { AuthService } from '@mm-services/auth.service';
-
 @Injectable({
   providedIn: 'root'
 })
 export class ExtractLineageService {
 
-  constructor(
-    private userSettingsService: UserSettingsService,
-    private userContactService: UserContactService,
-    private authService: AuthService,
-  ) { }
+  constructor() {
+  }
 
   extract(contact) {
     if (!contact) {
@@ -30,20 +23,6 @@ export class ExtractLineageService {
     }
 
     return result;
-  }
-
-  async getUserLineageToRemove(): Promise<string | null> {
-    if (this.authService.online(true)) {
-      return null;
-    }
-
-    const { facility_id }:any = await this.userSettingsService.get();
-    if (!facility_id || (Array.isArray(facility_id) && facility_id.length > 1)) {
-      return null;
-    }
-
-    const user = await this.userContactService.get();
-    return user?.parent?.name as string;
   }
 
   removeUserFacility(lineage: string[], userLineageLevel: string): string[] | undefined {

--- a/webapp/src/ts/services/user-contact.service.ts
+++ b/webapp/src/ts/services/user-contact.service.ts
@@ -12,8 +12,8 @@ export class UserContactService {
   private readonly getPerson: ReturnType<typeof Person.v1.get>;
   private readonly getPersonWithLineage: ReturnType<typeof Person.v1.getWithLineage>;
   constructor(
-    private userSettingsService: UserSettingsService,
-    private authService: AuthService,
+    private readonly userSettingsService: UserSettingsService,
+    private readonly authService: AuthService,
     chtDatasourceService: CHTDatasourceService,
   ) {
     this.getPerson = chtDatasourceService.bind(Person.v1.get);

--- a/webapp/src/ts/services/user-contact.service.ts
+++ b/webapp/src/ts/services/user-contact.service.ts
@@ -3,6 +3,7 @@ import { Person, Qualifier } from '@medic/cht-datasource';
 
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
+import { AuthService } from '@mm-services/auth.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,6 +13,7 @@ export class UserContactService {
   private readonly getPersonWithLineage: ReturnType<typeof Person.v1.getWithLineage>;
   constructor(
     private userSettingsService: UserSettingsService,
+    private authService: AuthService,
     chtDatasourceService: CHTDatasourceService,
   ) {
     this.getPerson = chtDatasourceService.bind(Person.v1.get);
@@ -25,6 +27,20 @@ export class UserContactService {
     }
     const getPerson = hydrateLineage ? this.getPersonWithLineage : this.getPerson;
     return getPerson(Qualifier.byUuid(user.contact_id));
+  }
+
+  async getUserLineageToRemove(): Promise<string | null> {
+    if (this.authService.online(true)) {
+      return null;
+    }
+
+    const { facility_id }:any = await this.getUserSettings();
+    if (!facility_id || (Array.isArray(facility_id) && facility_id.length > 1)) {
+      return null;
+    }
+
+    const user = await this.get();
+    return user?.parent?.name as string;
   }
 
   private getUserSettings = async () => {

--- a/webapp/tests/karma/ts/modules/messages/messages.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/messages/messages.component.spec.ts
@@ -16,7 +16,6 @@ import { SettingsService } from '@mm-services/settings.service';
 import { ModalService } from '@mm-services/modal.service';
 import { NavigationComponent } from '@mm-components/navigation/navigation.component';
 import { NavigationService } from '@mm-services/navigation.service';
-import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 import { FastActionButtonService } from '@mm-services/fast-action-button.service';
 import { SendMessageComponent } from '@mm-modals/send-message/send-message.component';
 import { MessagesMoreMenuComponent } from '@mm-modules/messages/messages-more-menu.component';
@@ -26,6 +25,7 @@ import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
 import { PerformanceService } from '@mm-services/performance.service';
 import { ExportService } from '@mm-services/export.service';
 import { AuthService } from '@mm-services/auth.service';
+import { UserContactService } from '@mm-services/user-contact.service';
 
 describe('Messages Component', () => {
   let component: MessagesComponent;
@@ -37,7 +37,7 @@ describe('Messages Component', () => {
   let authService;
   let sessionService;
   let performanceService;
-  let extractLineageService;
+  let userContactService;
   let stopPerformanceTrackStub;
 
   beforeEach(waitForAsync(() => {
@@ -59,9 +59,8 @@ describe('Messages Component', () => {
       has: sinon.stub()
     };
     sessionService = { isAdmin: sinon.stub() };
-    extractLineageService = {
+    userContactService = {
       getUserLineageToRemove: sinon.stub(),
-      removeUserFacility: ExtractLineageService.prototype.removeUserFacility,
     };
     const mockedSelectors = [
       { selector: 'getSelectedConversation', value: {} },
@@ -96,7 +95,7 @@ describe('Messages Component', () => {
           { provide: AuthService, useValue: authService },
           { provide: FastActionButtonService, useValue: fastActionButtonService },
           { provide: PerformanceService, useValue: performanceService },
-          { provide: ExtractLineageService, useValue: extractLineageService },
+          { provide: UserContactService, useValue: userContactService },
           { provide: MatBottomSheet, useValue: { open: sinon.stub() } },
           { provide: MatDialog, useValue: { open: sinon.stub() } },
         ]
@@ -262,7 +261,7 @@ describe('Messages Component', () => {
     ];
 
     it('it should retrieve the hierarchy level of the connected user', fakeAsync(async () => {
-      extractLineageService.getUserLineageToRemove.resolves('CHW Bettys Area');
+      userContactService.getUserLineageToRemove.resolves('CHW Bettys Area');
 
       component.ngOnInit();
       tick();
@@ -274,7 +273,7 @@ describe('Messages Component', () => {
       sinon.resetHistory();
 
       messageContactService.getList.resolves(conversations);
-      extractLineageService.getUserLineageToRemove.resolves(undefined);
+      userContactService.getUserLineageToRemove.resolves(undefined);
       component.ngOnInit();
       tick();
       component.updateConversations({ merge: true });
@@ -307,7 +306,7 @@ describe('Messages Component', () => {
         },
       ];
 
-      extractLineageService.getUserLineageToRemove.resolves('CHW Bettys Area');
+      userContactService.getUserLineageToRemove.resolves('CHW Bettys Area');
       messageContactService.getList.resolves(conversations);
       component.ngOnInit();
       tick();

--- a/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
@@ -37,7 +37,6 @@ import { FastActionButtonService } from '@mm-services/fast-action-button.service
 import { FeedbackService } from '@mm-services/feedback.service';
 import { XmlFormsService } from '@mm-services/xml-forms.service';
 import { ReportsMoreMenuComponent } from '@mm-modules/reports/reports-more-menu.component';
-import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 
 describe('Reports Component', () => {
   let component: ReportsComponent;

--- a/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/reports/reports.component.spec.ts
@@ -56,7 +56,6 @@ describe('Reports Component', () => {
   let xmlFormsService;
   let feedbackService;
   let performanceService;
-  let extractLineageService;
   let stopPerformanceTrackStub;
   let store;
   let route;
@@ -108,6 +107,7 @@ describe('Reports Component', () => {
     modalService = { show: sinon.stub() };
     userContactService = {
       get: sinon.stub().resolves(userContactDoc),
+      getUserLineageToRemove: sinon.stub(),
     };
     fastActionButtonService = {
       getReportLeftSideActions: sinon.stub(),
@@ -115,10 +115,6 @@ describe('Reports Component', () => {
     };
     xmlFormsService = { subscribe: sinon.stub() };
     feedbackService = { submit: sinon.stub() };
-    extractLineageService = {
-      getUserLineageToRemove: sinon.stub(),
-      removeUserFacility: ExtractLineageService.prototype.removeUserFacility,
-    };
     route = { snapshot: { queryParams: { query: '' } } };
     router = {
       navigate: sinon.stub(),
@@ -169,7 +165,6 @@ describe('Reports Component', () => {
           { provide: FastActionButtonService, useValue: fastActionButtonService },
           { provide: FeedbackService, useValue: feedbackService },
           { provide: XmlFormsService, useValue: xmlFormsService },
-          { provide: ExtractLineageService, useValue: extractLineageService },
         ]
       })
       .compileComponents()
@@ -788,7 +783,7 @@ describe('Reports Component', () => {
 
     it('should not remove the lineage when user lineage level is undefined', fakeAsync(() => {
       sinon.resetHistory();
-      extractLineageService.getUserLineageToRemove.resolves(undefined);
+      userContactService.getUserLineageToRemove.resolves(undefined);
       const expectedReports = [
         {
           _id: '88b0dfff-4a82-4202-abea-d0cabe5aa9bd',
@@ -855,7 +850,7 @@ describe('Reports Component', () => {
     }));
 
     it('should remove lineage when user lineage level is defined', fakeAsync(() => {
-      extractLineageService.getUserLineageToRemove.resolves('CHW Bettys Area');
+      userContactService.getUserLineageToRemove.resolves('CHW Bettys Area');
       const expectedReports = [
         {
           _id: '88b0dfff-4a82-4202-abea-d0cabe5aa9bd',

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -18,7 +18,7 @@ import { ToolBarComponent } from '@mm-components/tool-bar/tool-bar.component';
 import { Selectors } from '@mm-selectors/index';
 import { NavigationService } from '@mm-services/navigation.service';
 import { LineageModelGeneratorService } from '@mm-services/lineage-model-generator.service';
-import { ExtractLineageService } from '@mm-services/extract-lineage.service';
+import { UserContactService } from '@mm-services/user-contact.service';
 
 describe('TasksComponent', () => {
   let getComponent;
@@ -27,7 +27,7 @@ describe('TasksComponent', () => {
   let performanceService;
   let stopPerformanceTrackStub;
   let contactTypesService;
-  let extractLineageService;
+  let userContactService;
   let clock;
   let store;
   let lineageModelGeneratorService;
@@ -48,9 +48,8 @@ describe('TasksComponent', () => {
       includes: sinon.stub(),
     };
     lineageModelGeneratorService = { reportSubjects: sinon.stub().resolves([]) };
-    extractLineageService = {
+    userContactService = {
       getUserLineageToRemove: sinon.stub(),
-      removeUserFacility: ExtractLineageService.prototype.removeUserFacility,
     };
 
     TestBed.configureTestingModule({
@@ -66,7 +65,7 @@ describe('TasksComponent', () => {
         { provide: PerformanceService, useValue: performanceService },
         { provide: ContactTypesService, useValue: contactTypesService },
         { provide: NavigationService, useValue: {} },
-        { provide: ExtractLineageService, useValue: extractLineageService },
+        { provide: UserContactService, useValue: userContactService },
         { provide: LineageModelGeneratorService, useValue: lineageModelGeneratorService },
       ],
       declarations: [
@@ -342,7 +341,7 @@ describe('TasksComponent', () => {
           owner: 'b',
         },
       ];
-      extractLineageService.getUserLineageToRemove.resolves(undefined);
+      userContactService.getUserLineageToRemove.resolves(undefined);
       rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
       lineageModelGeneratorService.reportSubjects.resolves(taskLineages);
 
@@ -374,7 +373,7 @@ describe('TasksComponent', () => {
           owner: 'b',
         },
       ];
-      extractLineageService.getUserLineageToRemove.resolves('CHW Bettys Area');
+      userContactService.getUserLineageToRemove.resolves('CHW Bettys Area');
       rulesEngineService.fetchTaskDocsForAllContacts.resolves(taskDocs);
       lineageModelGeneratorService.reportSubjects.resolves(taskLineages);
 

--- a/webapp/tests/karma/ts/services/extract-lineage.service.spec.ts
+++ b/webapp/tests/karma/ts/services/extract-lineage.service.spec.ts
@@ -3,28 +3,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
-import { UserSettingsService } from '@mm-services/user-settings.service';
-import { UserContactService } from '@mm-services/user-contact.service';
-import { AuthService } from '@mm-services/auth.service';
 
 describe('ExtractLineageService', () => {
   let service: ExtractLineageService;
-  let userSettingsService;
-  let userContactService;
-  let authService;
 
   beforeEach(() => {
-    userSettingsService = { get: sinon.stub() };
-    userContactService = { get: sinon.stub() };
-    authService = { online: sinon.stub() };
-
-    TestBed.configureTestingModule({
-      providers: [
-        { provide: UserContactService, useValue: userContactService },
-        { provide: UserSettingsService, useValue: userSettingsService },
-        { provide: AuthService, useValue: authService },
-      ]
-    });
     service = TestBed.inject(ExtractLineageService);
   });
 
@@ -78,52 +61,6 @@ describe('ExtractLineageService', () => {
       expect(service.extract(contact)).to.deep.equal(expected);
       // ensure the original contact is unchanged
       expect(contact.parent.age).to.equal(55);
-    });
-  });
-
-  describe('getUserLineageToRemove()', () => {
-    it('should return null when user is type online', async () => {
-      authService.online.returns(true);
-
-      const result = await service.getUserLineageToRemove();
-
-      expect(result).to.be.null;
-    });
-
-    it('should return null when user has more than one assigned facility', async () => {
-      authService.online.returns(false);
-      userSettingsService.get.resolves({ facility_id: [ 'id-1', 'id-2' ] });
-
-      const result = await service.getUserLineageToRemove();
-
-      expect(result).to.be.null;
-    });
-
-    it('should return null when parent is not defined', async () => {
-      authService.online.returns(false);
-      userSettingsService.get.resolves({ facility_id: [ 'id-1', 'id-2' ] });
-      userContactService.get.resolves({ parent: undefined });
-
-      const result = await service.getUserLineageToRemove();
-
-      expect(result).to.be.null;
-    });
-
-    it('should return facility name when user is type offline and has only one assigned facility', async () => {
-      authService.online.returns(false);
-      userSettingsService.get.resolves({ facility_id: 'id-1' });
-      userContactService.get.resolves({ parent: { name: 'Kisumu Area' } });
-
-      const resultWithString = await service.getUserLineageToRemove();
-
-      expect(resultWithString).to.equal('Kisumu Area');
-
-      userSettingsService.get.resolves({ facility_id: [ 'id-5' ] });
-      userContactService.get.resolves({ parent: { name: 'Kakamega Area' } });
-
-      const resultWithArray = await service.getUserLineageToRemove();
-
-      expect(resultWithArray).to.equal('Kakamega Area');
     });
   });
 

--- a/webapp/tests/karma/ts/services/user-contact.service.spec.ts
+++ b/webapp/tests/karma/ts/services/user-contact.service.spec.ts
@@ -6,9 +6,11 @@ import { Person, Qualifier } from '@medic/cht-datasource';
 import { UserContactService } from '@mm-services/user-contact.service';
 import { UserSettingsService } from '@mm-services/user-settings.service';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
+import { AuthService } from '@mm-services/auth.service';
 
 describe('UserContact service', () => {
   let service: UserContactService;
+  let authService;
   let getPerson;
   let getPersonWithLineage;
   let bind;
@@ -21,11 +23,13 @@ describe('UserContact service', () => {
     bind = sinon.stub();
     bind.withArgs(Person.v1.get).returns(getPerson);
     bind.withArgs(Person.v1.getWithLineage).returns(getPersonWithLineage);
+    authService = { online: sinon.stub() };
 
     TestBed.configureTestingModule({
       providers: [
         { provide: CHTDatasourceService, useValue: { bind } },
         { provide: UserSettingsService, useValue: { get: UserSettings } },
+        { provide: AuthService, useValue: authService },
       ],
     });
     service = TestBed.inject(UserContactService);
@@ -33,81 +37,146 @@ describe('UserContact service', () => {
 
   afterEach(() => {
     expect(bind.args).to.deep.equal([[Person.v1.get], [Person.v1.getWithLineage]]);
-    expect(UserSettings.callCount).to.equal(1);
     sinon.restore();
   });
 
-  it('returns error from user settings', async () => {
-    UserSettings.rejects(new Error('boom'));
+  describe('get', () => {
+    afterEach(() => {
+      expect(UserSettings.callCount).to.equal(1);
+      expect(authService.online.notCalled).to.be.true;
+    });
 
-    await expect(service.get()).to.be.rejectedWith('boom');
+    it('returns error from user settings', async () => {
+      UserSettings.rejects(new Error('boom'));
 
-    expect(getPerson.notCalled).to.be.true;
-    expect(getPersonWithLineage.notCalled).to.be.true;
+      await expect(service.get()).to.be.rejectedWith('boom');
+
+      expect(getPerson.notCalled).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
+
+    it('returns null when no configured contact', async () => {
+      UserSettings.resolves({});
+
+      const userContact = await service.get();
+
+      expect(userContact).to.be.null;
+      expect(getPerson.notCalled).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
+
+    it('returns null when user settings not in the database', async () => {
+      UserSettings.rejects({ code: 404, reason: 'missing' });
+
+      const userContact = await service.get();
+
+      expect(userContact).to.be.null;
+      expect(getPerson.notCalled).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
+
+    it('returns null when configured contact not in the database', async () => {
+      UserSettings.resolves({ contact_id: 'not-found' });
+      getPersonWithLineage.resolves(null);
+
+      const userContact = await service.get();
+
+      expect(userContact).to.be.null;
+      expect(getPerson.notCalled).to.be.true;
+      expect(getPersonWithLineage.calledOnceWithExactly(Qualifier.byUuid('not-found'))).to.be.true;
+    });
+
+    it('returns error from getting contact', async () => {
+      UserSettings.resolves({ contact_id: 'nobody' });
+      getPersonWithLineage.rejects(new Error('boom'));
+
+      await expect(service.get()).to.be.rejectedWith('boom');
+
+      expect(getPerson.notCalled).to.be.true;
+      expect(getPersonWithLineage.calledOnceWithExactly(Qualifier.byUuid('nobody'))).to.be.true;
+    });
+
+    it('returns contact with lineage', async () => {
+      const expected = { _id: 'somebody', name: 'Some Body' };
+      UserSettings.resolves({ contact_id: 'somebody' });
+      getPersonWithLineage.resolves(expected);
+
+      const actual = await service.get();
+
+      expect(actual).to.equal(expected);
+      expect(getPerson.notCalled).to.be.true;
+      expect(getPersonWithLineage.calledOnceWithExactly(Qualifier.byUuid(expected._id))).to.be.true;
+    });
+
+    it('returns contact without lineage', async () => {
+      const expected = { _id: 'somebody', name: 'Some Body' };
+      UserSettings.resolves({ contact_id: 'somebody' });
+      getPerson.resolves(expected);
+
+      const actual = await service.get({ hydrateLineage: false });
+
+      expect(actual).to.equal(expected);
+      expect(getPerson.calledOnceWithExactly(Qualifier.byUuid(expected._id))).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
   });
 
-  it('returns null when no configured contact', async () => {
-    UserSettings.resolves({});
+  describe('getUserLineageToRemove()', () => {
+    afterEach(() => {
+      expect(getPerson.notCalled).to.be.true;
+      expect(authService.online.calledWithExactly(true)).to.be.true;
+    });
 
-    const userContact = await service.get();
+    it('should return null when user is type online', async () => {
+      authService.online.returns(true);
 
-    expect(userContact).to.be.null;
-    expect(getPerson.notCalled).to.be.true;
-    expect(getPersonWithLineage.notCalled).to.be.true;
-  });
+      const result = await service.getUserLineageToRemove();
 
-  it('returns null when user settings not in the database', async () => {
-    UserSettings.rejects({ code: 404, reason: 'missing' });
+      expect(result).to.be.null;
+      expect(UserSettings.notCalled).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
 
-    const userContact = await service.get();
+    it('should return null when user has more than one assigned facility', async () => {
+      authService.online.returns(false);
+      UserSettings.resolves({ contact_id: 'somebody', facility_id: [ 'id-1', 'id-2' ] });
 
-    expect(userContact).to.be.null;
-    expect(getPerson.notCalled).to.be.true;
-    expect(getPersonWithLineage.notCalled).to.be.true;
-  });
+      const result = await service.getUserLineageToRemove();
 
-  it('returns null when configured contact not in the database', async () => {
-    UserSettings.resolves({ contact_id: 'not-found' });
-    getPersonWithLineage.resolves(null);
+      expect(result).to.be.null;
+      expect(UserSettings.calledOnceWithExactly()).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
 
-    const userContact = await service.get();
+    it('should return null when parent is not defined', async () => {
+      authService.online.returns(false);
+      UserSettings.resolves({ contact_id: 'somebody', facility_id: [ 'id-1', 'id-2' ] });
+      getPersonWithLineage.resolves({ parent: undefined });
 
-    expect(userContact).to.be.null;
-    expect(getPerson.notCalled).to.be.true;
-    expect(getPersonWithLineage.calledOnceWithExactly(Qualifier.byUuid('not-found'))).to.be.true;
-  });
+      const result = await service.getUserLineageToRemove();
 
-  it('returns error from getting contact', async () => {
-    UserSettings.resolves({ contact_id: 'nobody' });
-    getPersonWithLineage.rejects(new Error('boom'));
+      expect(result).to.be.null;
+      expect(UserSettings.calledOnceWithExactly()).to.be.true;
+      expect(getPersonWithLineage.notCalled).to.be.true;
+    });
 
-    await expect(service.get()).to.be.rejectedWith('boom');
+    it('should return facility name when user is type offline and has only one assigned facility', async () => {
+      authService.online.returns(false);
+      UserSettings.resolves({ contact_id: 'somebody', facility_id: 'id-1' });
+      getPersonWithLineage.resolves({ parent: { name: 'Kisumu Area' } });
 
-    expect(getPerson.notCalled).to.be.true;
-    expect(getPersonWithLineage.calledOnceWithExactly(Qualifier.byUuid('nobody'))).to.be.true;
-  });
+      const resultWithString = await service.getUserLineageToRemove();
 
-  it('returns contact with lineage', async () => {
-    const expected = { _id: 'somebody', name: 'Some Body' };
-    UserSettings.resolves({ contact_id: 'somebody' });
-    getPersonWithLineage.resolves(expected);
+      expect(resultWithString).to.equal('Kisumu Area');
 
-    const actual = await service.get();
+      UserSettings.resolves({ contact_id: 'somebody', facility_id: [ 'id-5' ] });
+      getPersonWithLineage.resolves({ parent: { name: 'Kakamega Area' } });
 
-    expect(actual).to.equal(expected);
-    expect(getPerson.notCalled).to.be.true;
-    expect(getPersonWithLineage.calledOnceWithExactly(Qualifier.byUuid(expected._id))).to.be.true;
-  });
+      const resultWithArray = await service.getUserLineageToRemove();
 
-  it('returns contact without lineage', async () => {
-    const expected = { _id: 'somebody', name: 'Some Body' };
-    UserSettings.resolves({ contact_id: 'somebody' });
-    getPerson.resolves(expected);
-
-    const actual = await service.get({ hydrateLineage: false });
-
-    expect(actual).to.equal(expected);
-    expect(getPerson.calledOnceWithExactly(Qualifier.byUuid(expected._id))).to.be.true;
-    expect(getPersonWithLineage.notCalled).to.be.true;
+      expect(resultWithArray).to.equal('Kakamega Area');
+      expect(UserSettings.callCount).to.equal(4);
+      expect(getPersonWithLineage.args).to.deep.equal([[Qualifier.byUuid('somebody')], [Qualifier.byUuid('somebody')]]);
+    });
   });
 });


### PR DESCRIPTION
# Description

Closes https://github.com/medic/cht-core/issues/9561

More details on source of the problem are in the issue, but TLDR is that a dependency on the `changes.service` leaked into cht-form. The `changes.service` tries to listen to the db for changes and prints an error if it cannot, before re-trying to listen again.  In cht-form, there is no db to listen to and the result is that when cht-form runs, the `changes.service` code just contantly spams error messages to the logs.  

My fix here is to update the service dependency tree to move some code out of the `extract-lineage.service` (which the `enketo.service` needs) and put it in the `user-contact.service`.  This essentially removes the dependency on the `changes.service` (and a number of other things not needed by `enketo.service`).   I think the `user-contact.service` is a reasonable place for this functionality anyway, but I am happy to hear other ideas for how to address this!

Additionally, I have added an after-hook to the cht-form integration tests to validate the browser console and check for any unexpected logs. Hopefully this will help catch issues like this in the future.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9561_fix_cht-form_logs/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9561_fix_cht-form_logs/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9561_fix_cht-form_logs/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

