### PR TITLE
fix(#9612): hide last submitted task from task list

### DIFF
--- a/tests/page-objects/default/tasks/tasks.wdio.page.js
+++ b/tests/page-objects/default/tasks/tasks.wdio.page.js
@@ -12,6 +12,7 @@ const getTaskById = (emissionId) => $(`${TASK_LIST_SELECTOR} li[data-record-id="
 const getTasks = () => $$(`${TASK_LIST_SELECTOR} li.content-row`);
 
 const getTaskInfo = async (taskElement) => {
+  await taskElement.scrollIntoView();
   const contactName = await (await taskElement.$('h4 span')).getText();
   const formTitle = await (await taskElement.$('.summary p')).getText();
   let lineage = '';

--- a/webapp/src/ts/reducers/tasks.ts
+++ b/webapp/src/ts/reducers/tasks.ts
@@ -47,6 +47,7 @@ const _tasksReducer = createReducer(
 
   on(Actions.setLastSubmittedTask, (state, { payload: { task } }) => ({
     ...state,
+    tasksList: state.tasksList.filter(t => task?._id !== t._id),
     taskGroup: {
       ...state.taskGroup,
       lastSubmittedTask: task

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -214,6 +214,7 @@ export class RulesEngineService implements OnDestroy {
 
   private dirtyContactCallback(change) {
     const subjectIds = [this.isReport(change.doc) ? RegistrationUtils.getSubjectId(change.doc) : change.id];
+    this.observable.next(subjectIds);
 
     if (this.debounceActive[this.CHANGE_WATCHER_KEY]?.active) {
       const oldSubjectIds = this.debounceActive[this.CHANGE_WATCHER_KEY].params;
@@ -238,7 +239,6 @@ export class RulesEngineService implements OnDestroy {
       this.telemetryService.record(this.getTelemetryTrackName('refresh', 'dirty-contacts'), contactIds.length);
 
       await this.rulesEngineCore.updateEmissionsFor(contactIds);
-      this.observable.next(contactIds);
       trackPerformance?.stop({ name: this.getTelemetryTrackName('refresh') });
     }, this.DEBOUNCE_CHANGE_MILLIS);
 

--- a/webapp/tests/karma/ts/reducers/tasks.spec.ts
+++ b/webapp/tests/karma/ts/reducers/tasks.spec.ts
@@ -277,6 +277,7 @@ describe('Tasks reducer', () => {
         tasksList: [
           { _id: 'task1', dueDate: 22, state: 'Ready' },
           { _id: 'task2', dueDate: 33, state: 'Ready' },
+          { _id: 'task_id2', due: '33', field: 2 }
         ],
         loaded: true,
         taskGroup: {

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -468,11 +468,15 @@ describe('RulesEngineService', () => {
 
       const change = changesService.subscribe.args[0][0];
       await change.callback(changeFeedFormat({ type: 'data_record', form: 'f', fields: { patient_id: 'p1' } }));
+      expect(callback.callCount).to.equal(1);
       await change.callback(changeFeedFormat({ _id: '2', type: 'person', patient_id: 'p2' }));
+      expect(callback.callCount).to.equal(2);
       tick(500);
       await change.callback(changeFeedFormat({ _id: '3', type: 'person', patient_id: 'p3' }));
+      expect(callback.callCount).to.equal(3);
       tick(900);
       await change.callback(changeFeedFormat({ type: 'data_record', form: 'f', fields: { patient_id: 'p3' }}));
+      expect(callback.callCount).to.equal(4);
 
       expect(rulesEngineCoreStubs.updateEmissionsFor.callCount).to.equal(0);
 
@@ -480,7 +484,7 @@ describe('RulesEngineService', () => {
 
       expect(rulesEngineCoreStubs.updateEmissionsFor.callCount).to.equal(1);
       expect(rulesEngineCoreStubs.updateEmissionsFor.args[0][0]).to.have.members([ 'p3', '3', '2', 'p1' ]);
-      expect(callback.callCount).to.equal(1);
+      expect(callback.callCount).to.equal(4);
       subscription.unsubscribe();
 
       expect(telemetryService.record.calledOnce).to.be.true;


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Due to a recent debounce in setting contacts as dirty, we ended up waiting for two debounce delays when reload tasks: one from rules engine and one from tasks component itself. We previously had only one debounce, so this issue was less visible, but still existed. 

As a fix: 
- I'm emitting the change notification early in rules engine, this way both debounces are in parallel
- I'm hiding the last submitted task from the task list immediately after submission. if the task was not completed by the action, it will show up again when the task list refreshes. 
- Optimizing an e2e test that took a long time due to getting info from "not rendered" angular elements. 

#9612

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

