### PR TITLE
perf(#9642): set `changes_doc_ids_optimization_threshold` a high value

### DIFF
--- a/couchdb/10-docker-default.ini
+++ b/couchdb/10-docker-default.ini
@@ -11,6 +11,7 @@ os_process_timeout = 60000
 max_dbs_open = 5000
 attachment_stream_buffer_size = 16384
 max_document_size = 4294967296 ; 4 GB
+changes_doc_ids_optimization_threshold = 40000
 
 [chttpd]
 port = 5984

--- a/couchdb/Dockerfile
+++ b/couchdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM couchdb:3.3.3 as base_couchdb_build
+FROM couchdb:3.4 as base_couchdb_build
 
 COPY --chown=couchdb:couchdb 10-docker-default.ini /opt/couchdb/etc/default.d/
 COPY --chown=couchdb:couchdb vm.args /opt/couchdb/etc/

--- a/couchdb/Dockerfile
+++ b/couchdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM couchdb:3.4 as base_couchdb_build
+FROM couchdb:3.4.2 as base_couchdb_build
 
 COPY --chown=couchdb:couchdb 10-docker-default.ini /opt/couchdb/etc/default.d/
 COPY --chown=couchdb:couchdb vm.args /opt/couchdb/etc/

--- a/sentinel/src/lib/purging.js
+++ b/sentinel/src/lib/purging.js
@@ -112,21 +112,19 @@ const getAlreadyPurgedDocs = (roleHashes, ids) => {
   }
 
   const purgeIds = ids.map(id => serverSidePurgeUtils.getPurgedId(id));
-  const changesOpts = {
+  const reqOpts = {
     doc_ids: purgeIds,
-    batch_size: purgeIds.length + 1,
-    seq_interval: purgeIds.length
+    include_docs: false,
   };
 
-  // requesting _changes instead of _all_docs because it's roughly twice faster
   return Promise
-    .all(roleHashes.map(hash => getPurgeDb(hash).changes(changesOpts)))
+    .all(roleHashes.map(hash => getPurgeDb(hash).allDocs(reqOpts)))
     .then(results => {
       results.forEach((result, idx) => {
         const hash = roleHashes[idx];
-        result.results.forEach(change => {
-          if (!change.deleted) {
-            purged[hash][serverSidePurgeUtils.extractId(change.id)] = change.changes[0].rev;
+        result.rows.forEach(row => {
+          if (!row.deleted && row.value?.rev) {
+            purged[hash][serverSidePurgeUtils.extractId(row.id)] = row.value?.rev;
           }
         });
       });

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -403,7 +403,7 @@ describe('routing', () => {
           if (idx === 0) {
             // online user request
             expect(result.limit).to.equal(1);
-            expect(result.fields).to.equal([]);
+            expect(result.fields).to.deep.equal([]);
           } else {
             // offline user requests
             expect(result.statusCode).to.equal(403);

--- a/tests/integration/api/routing.spec.js
+++ b/tests/integration/api/routing.spec.js
@@ -403,7 +403,7 @@ describe('routing', () => {
           if (idx === 0) {
             // online user request
             expect(result.limit).to.equal(1);
-            expect(result.fields).to.equal('all_fields');
+            expect(result.fields).to.equal([]);
           } else {
             // offline user requests
             expect(result.statusCode).to.equal(403);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

It appears that `changes_doc_ids_optimization_threshold` is still working and will provide us the same performance we had before. 

#9642

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9642-purging-without-changes-2/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9642-purging-without-changes-2/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9642-purging-without-changes-2/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

