### PR TITLE
chore(#9660): update e2e sync function

### DIFF
--- a/tests/e2e/default/admin/admin-access.wdio-spec.js
+++ b/tests/e2e/default/admin/admin-access.wdio-spec.js
@@ -10,8 +10,7 @@ describe('Acessing the admin app', () => {
   const parent = placeFactory.place().build({ _id: 'dist1', type: 'district_hospital' });
 
   afterEach(async () => {
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   it('should redirect to login when not logged in', async () => {

--- a/tests/e2e/default/admin/admin-access.wdio-spec.js
+++ b/tests/e2e/default/admin/admin-access.wdio-spec.js
@@ -10,7 +10,7 @@ describe('Acessing the admin app', () => {
   const parent = placeFactory.place().build({ _id: 'dist1', type: 'district_hospital' });
 
   afterEach(async () => {
-    await commonPage.reloadSession();
+    await common.reloadSession();
   });
 
   it('should redirect to login when not logged in', async () => {

--- a/tests/e2e/default/contacts/contact-details.wdio-spec.js
+++ b/tests/e2e/default/contacts/contact-details.wdio-spec.js
@@ -80,7 +80,6 @@ describe('Contact details page.', () => {
         { roles: settings.roles, permissions: settings.permissions },
         { revert: true, ignoreReload: true }
       );
-
     };
 
     before(async () => {
@@ -91,7 +90,6 @@ describe('Contact details page.', () => {
       await utils.createUsers([user]);
 
       await loginPage.login(user);
-      await commonElements.waitForPageLoaded();
     });
 
     after(async () => {
@@ -124,8 +122,7 @@ describe('Contact details page.', () => {
 
     it('should not show reports when permission is disabled', async () => {
       await updatePermissions(ROLE, [], ['can_view_reports']);
-      await commonElements.sync(true);
-      await browser.refresh();
+      await commonElements.sync({ expectReload: true, reload: true });
       await waitForContactLoaded(true);
 
       expect(await (await contactPage.reportsCardSelectors.rhsReportListElement()).isDisplayed()).to.equal(false);
@@ -135,8 +132,7 @@ describe('Contact details page.', () => {
 
     it('should not show tasks when permission is disabled', async () => {
       await updatePermissions(ROLE, ['can_view_reports'], ['can_view_tasks']);
-      await commonElements.sync(true);
-      await browser.refresh();
+      await commonElements.sync({ reload: true, expectReload: true });
       await waitForContactLoaded(false);
 
       expect(await (await contactPage.reportsCardSelectors.rhsReportListElement()).isDisplayed()).to.equal(true);
@@ -160,7 +156,7 @@ describe('Contact details page.', () => {
       const contactSummaryFile = path.join(__dirname, 'config/contact-summary-error-config.js');
 
       const { contactSummary } = await chtConfUtils.compileNoolsConfig({ contactSummary: contactSummaryFile });
-      await utils.updateSettings({ contact_summary: contactSummary }, true);
+      await utils.updateSettings({ contact_summary: contactSummary }, { ignoreReload: true });
 
       await utils.saveDocs([...places.values(), patient]);
     });

--- a/tests/e2e/default/contacts/muting-contact-using-form.wdio-spec.js
+++ b/tests/e2e/default/contacts/muting-contact-using-form.wdio-spec.js
@@ -68,7 +68,7 @@ describe('Mute/Unmute contacts using a specific form - ', () => {
 
   it('should show a popup when trying to submit a non-unmuting form against a muted contact', async () => {
     await utils.revertSettings(true);
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
     await commonPage.goToPeople(mutePerson._id);
 
     const modalDetails = await contactPage.openFormWithWarning('death_report');

--- a/tests/e2e/default/contacts/person-under-area.wdio-spec.js
+++ b/tests/e2e/default/contacts/person-under-area.wdio-spec.js
@@ -37,9 +37,7 @@ describe('Create Person Under Area, ', () => {
     await usersAdminPage.inputAddUserFields(username, 'Jack', 'chw', healthCenter2.name, person2.name, password);
     await usersAdminPage.saveUser();
 
-    await browser.reloadSession();
-    await browser.url('/');
-
+    await commonPage.reloadSession();
     await loginPage.login({ username, password });
 
     await commonPage.goToPeople();

--- a/tests/e2e/default/db/initial-replication.wdio-spec.js
+++ b/tests/e2e/default/db/initial-replication.wdio-spec.js
@@ -122,8 +122,7 @@ describe('initial-replication', () => {
   });
 
   afterEach(async () => {
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   it('should log user in', async () => {

--- a/tests/e2e/default/db/initial-replication.wdio-spec.js
+++ b/tests/e2e/default/db/initial-replication.wdio-spec.js
@@ -50,7 +50,7 @@ describe('initial-replication', () => {
     const localAllDocsPreSync = await chtDbUtils.getDocs();
     const docIdsPreSync = dataFactory.ids(localAllDocsPreSync);
 
-    await commonPage.sync(false, 7000);
+    await commonPage.sync();
 
     const localAllDocs = await chtDbUtils.getDocs();
     const localDocIds = dataFactory.ids(localAllDocs);

--- a/tests/e2e/default/db/ongoing-replication.wdio-spec.js
+++ b/tests/e2e/default/db/ongoing-replication.wdio-spec.js
@@ -42,7 +42,7 @@ describe('ongoing replication', function() {
     const isRevertingSettings = utils.revertSettings(true);
     if (isRevertingSettings) {
       await isRevertingSettings;
-      await commonPage.sync(true, 30000);
+      await commonPage.sync({ expectReload: true, timeout: 30000 });
     }
   });
 
@@ -72,7 +72,7 @@ describe('ongoing replication', function() {
     await saveData(additionalDenied);
 
     await browser.throttle('online');
-    await commonPage.sync(false, 30000);
+    await commonPage.sync({ expectReload: true, timeout: 30000 });
 
     const localDocsPostSync = await chtDbUtils.getDocs();
     const localDocIds = dataFactory.ids(localDocsPostSync);
@@ -132,7 +132,7 @@ describe('ongoing replication', function() {
     await utils.addTranslations('rnd', {});
     await waitForServiceWorker.promise;
 
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
     const [rnd] = await chtDbUtils.getDocs(['messages-rnd']);
     expect(rnd).to.include({
       type: 'translations',
@@ -144,7 +144,7 @@ describe('ongoing replication', function() {
     await utils.saveDoc(rnd);
     await waitForServiceWorker.promise;
 
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
     const [updatedRnd] = await chtDbUtils.getDocs(['messages-rnd']);
     expect(updatedRnd.updated).to.equal(rnd.updated);
   });
@@ -161,7 +161,7 @@ describe('ongoing replication', function() {
     await utils.deleteDocs(docIdsToDelete);
     await waitForServiceWorker.promise;
 
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
     const localDocsPostSync = await chtDbUtils.getDocs();
     const localDocIds = dataFactory.ids(localDocsPostSync);
 
@@ -171,7 +171,7 @@ describe('ongoing replication', function() {
   it('should download settings updates', async () => {
     await commonPage.sync();
     await utils.updateSettings({ test: true }, { ignoreReload: 'api' });
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
     const [settings] = await chtDbUtils.getDocs(['settings']);
     expect(settings.settings.test).to.equal(true);
   });

--- a/tests/e2e/default/enketo/extension-lib-form.wdio-spec.js
+++ b/tests/e2e/default/enketo/extension-lib-form.wdio-spec.js
@@ -13,8 +13,7 @@ describe('Extension lib xpath function', () => {
 
     const waitForServiceWorker = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);
     await waitForServiceWorker.promise;
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   it('calculate average', async () => {

--- a/tests/e2e/default/enketo/undo-death-report.wdio-spec.js
+++ b/tests/e2e/default/enketo/undo-death-report.wdio-spec.js
@@ -26,7 +26,7 @@ describe('Submit an undo death report', () => {
     await commonPage.goToPeople(person._id);
     await commonPage.openFastActionReport('death_report');
     await deathReportForm.submitDeathReport();
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
   });
 
   it('should submit an undo death report, ' +
@@ -43,7 +43,7 @@ describe('Submit an undo death report', () => {
     );
     await genericForm.submitForm();
     await commonPage.waitForPageLoaded();
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
 
     expect(await (await contactPage.deathCardSelectors.deathCard()).isDisplayed()).to.be.false;
 

--- a/tests/e2e/default/login/login-logout.wdio-spec.js
+++ b/tests/e2e/default/login/login-logout.wdio-spec.js
@@ -11,8 +11,7 @@ describe('Login page funcionality tests', () => {
   };
 
   afterEach(async () => {
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   describe('Locale', () => {

--- a/tests/e2e/default/more-options-menu/offline-user/all-permissions.wdio-spec.js
+++ b/tests/e2e/default/more-options-menu/offline-user/all-permissions.wdio-spec.js
@@ -128,7 +128,7 @@ describe('More Options Menu - Offline User', () => {
         'can_export_contacts', 'can_export_messages',
         'can_delete_reports', 'can_update_reports'];
       await utils.updatePermissions(offlineUser.roles, [], allPermissions, true);
-      await commonPage.sync(true);
+      await commonPage.sync({ expectReload: true });
     });
 
     after(async () => await utils.revertSettings(true));

--- a/tests/e2e/default/more-options-menu/offline-user/edit-permission-disabled.wdio-spec.js
+++ b/tests/e2e/default/more-options-menu/offline-user/edit-permission-disabled.wdio-spec.js
@@ -51,9 +51,8 @@ describe('More Options Menu - Offline User - Edit permissions disabled', () => {
     result = await utils.saveDoc(smsReport);
     smsReportId = result.id;
     await utils.createUsers([offlineUser]);
+    await utils.updatePermissions(offlineUser.roles, [], ['can_edit'], true);
     await loginPage.login(offlineUser);
-    await utils.updatePermissions(offlineUser.roles, [], ['can_edit']);
-    await commonPage.closeReloadModal();
   });
 
   after(async () => await utils.revertSettings(true));

--- a/tests/e2e/default/privacy-policy/privacy-policy.wdio-spec.js
+++ b/tests/e2e/default/privacy-policy/privacy-policy.wdio-spec.js
@@ -22,8 +22,7 @@ describe('Privacy policy', () => {
   users.forEach((user) => {
     describe(`for an ${user.isOffline ? 'offline':'online'} user`, () => {
       before(async () => {
-        await browser.reloadSession();
-        await browser.url('/');
+        await commonPage.reloadSession();
         await utils.saveDocs([parent, privacyPolicy]);
         await utils.createUsers([user]);
         await loginPage.login({ username: user.username, password: user.password, privacyPolicy: true });
@@ -51,16 +50,14 @@ describe('Privacy policy', () => {
       });
 
       it('should not show on subsequent login', async () => {
-        await browser.reloadSession();
-        await browser.url('/');
+        await commonPage.reloadSession();
         await loginPage.login({ username: user.username, password: user.password });
         await (await commonPage.tabsSelector.messagesTab()).waitForDisplayed();
         expect(await (await privacyPage.privacyWrapper()).isDisplayed()).to.not.be.true;
       });
 
       it('should show french policy on secondary login', async () => {
-        await browser.reloadSession();
-        await browser.url('/');
+        await commonPage.reloadSession();
         await loginPage.login({ username: user.username, password: user.password, locale: 'fr', privacyPolicy: true });
         await privacyPage.waitAndAcceptPolicy(await privacyPage.privacyWrapper(), frenchTexts);
         expect(await (await commonPage.tabsSelector.messagesTab()).isDisplayed()).to.be.true;
@@ -116,8 +113,7 @@ describe('Privacy policy', () => {
     before(async () => {
       await utils.saveDocs([parent, privacyPolicy]);
       await utils.createUsers([conflictUser]);
-      await browser.reloadSession();
-      await browser.url('/');
+      await commonPage.reloadSession();
       await loginPage.login({ username: conflictUser.username, password: conflictUser.password, privacyPolicy: true });
     });
 

--- a/tests/e2e/default/purge/purge.wdio-spec.js
+++ b/tests/e2e/default/purge/purge.wdio-spec.js
@@ -79,8 +79,7 @@ describe('purge', function() {
     await utils.deleteUsers([user]);
     await utils.revertDb([/^form:/], true);
 
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   it('purging runs on sync', async () => {

--- a/tests/e2e/default/purge/purge.wdio-spec.js
+++ b/tests/e2e/default/purge/purge.wdio-spec.js
@@ -79,7 +79,7 @@ describe('purge', function() {
     await utils.deleteUsers([user]);
     await utils.revertDb([/^form:/], true);
 
-    await commonPage.reloadSession();
+    await commonElements.reloadSession();
   });
 
   it('purging runs on sync', async () => {
@@ -103,7 +103,7 @@ describe('purge', function() {
     await updatePurgeSettings(filterHomeVisitReports, true);
     await runPurging();
 
-    await commonElements.sync(true);
+    await commonElements.sync({ expectReload: true });
 
     allReports = await getAllReports();
     // this only works because the client didn't have to "purge" these docs and the revs didn't have

--- a/tests/e2e/default/service-worker/service-worker.wdio-spec.js
+++ b/tests/e2e/default/service-worker/service-worker.wdio-spec.js
@@ -147,7 +147,7 @@ describe('Service worker cache', () => {
     await utils.saveDoc(branding);
     await waitForLogs.promise;
 
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true, serviceWorkerUpdate: true });
     await browser.throttle('offline'); // make sure we load the login page from cache
     await commonPage.logout();
     expect(await browser.getTitle()).to.equal('Not Medic');
@@ -161,7 +161,7 @@ describe('Service worker cache', () => {
     });
     await waitForLogs.promise;
 
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true, serviceWorkerUpdate: true });
     await browser.throttle('offline'); // make sure we load the login page from cache
     await commonPage.logout();
 
@@ -172,7 +172,7 @@ describe('Service worker cache', () => {
   it('adding new languages triggers login page refresh', async () => {
     const languageCode = 'ro';
     await utils.enableLanguage(languageCode);
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true, serviceWorkerUpdate: true });
 
     const waitForLogs = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);
     await utils.addTranslations(languageCode, {
@@ -183,7 +183,7 @@ describe('Service worker cache', () => {
     });
     await waitForLogs.promise;
 
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true, serviceWorkerUpdate: true });
     await commonPage.logout();
 
     await loginPage.changeLanguage(languageCode, 'Utilizator');
@@ -196,7 +196,7 @@ describe('Service worker cache', () => {
   });
 
   it('other translation updates do not trigger a login page refresh', async () => {
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true, serviceWorkerUpdate: true });
 
     const cacheDetails = await getCachedRequests(true);
 
@@ -207,7 +207,7 @@ describe('Service worker cache', () => {
       'some': 'thing',
     });
     await waitForLogs.promise;
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true, serviceWorkerUpdate: true });
 
     const updatedCacheDetails = await getCachedRequests(true);
 

--- a/tests/e2e/default/service-worker/service-worker.wdio-spec.js
+++ b/tests/e2e/default/service-worker/service-worker.wdio-spec.js
@@ -67,7 +67,6 @@ describe('Service worker cache', () => {
   const chw = userFactory.build({ place: district._id });
 
   const login = async () => {
-    await browser.throttle('online');
     await loginPage.login(chw);
     await commonPage.waitForPageLoaded();
   };
@@ -78,6 +77,7 @@ describe('Service worker cache', () => {
   };
 
   const loginIfNeeded = async () => {
+    await browser.throttle('online');
     if (!await isLoggedIn()) {
       await login();
     }
@@ -91,6 +91,10 @@ describe('Service worker cache', () => {
 
   beforeEach(async () => {
     await loginIfNeeded();
+  });
+
+  afterEach(async () => {
+    await utils.revertSettings(true);
   });
 
   after(async () => {
@@ -191,8 +195,6 @@ describe('Service worker cache', () => {
     expect(await (await loginPage.labelForUser()).getText()).to.equal('Utilizator');
     expect(await (await loginPage.loginButton()).getText()).to.equal('Autentificare');
     expect(await (await loginPage.labelForPassword()).getText()).to.equal('Parola');
-
-    await utils.revertSettings(true);
   });
 
   it('other translation updates do not trigger a login page refresh', async () => {

--- a/tests/e2e/default/targets/target-accuracy.wdio-spec.js
+++ b/tests/e2e/default/targets/target-accuracy.wdio-spec.js
@@ -66,7 +66,7 @@ describe('Target accuracy', () => {
     await commonPage.goToPeople(chwContact._id);
     await browser.takeScreenshot();
 
-    await commonPage.sync(false, 2000);
+    await commonPage.sync();
     const serverDoc = await utils.getDoc(targetDocId);
 
     expect(serverDoc._rev).to.match(/^1-/);
@@ -84,7 +84,7 @@ describe('Target accuracy', () => {
     await contactsPage.addPerson({ name: 'Jody' }, false);
     await commonPage.waitForPageLoaded();
 
-    await commonPage.sync(false, 2000);
+    await commonPage.sync();
     const serverDoc = await utils.getDoc(targetDocId);
 
     expect(serverDoc._rev).to.match(/^2-/);
@@ -102,7 +102,7 @@ describe('Target accuracy', () => {
     await contactsPage.editPersonName('Jody', 'Jody Ash');
     await commonPage.waitForPageLoaded();
 
-    await commonPage.sync(false, 2000);
+    await commonPage.sync();
     const serverDoc = await utils.getDoc(targetDocId);
     expect(serverDoc._rev).to.match(/^2-/);
   });
@@ -121,7 +121,7 @@ describe('Target accuracy', () => {
     await contactsPage.selectLHSRowByText('Jody Ash');
     await commonPage.waitForPageLoaded();
 
-    await commonPage.sync(false, 2000);
+    await commonPage.sync();
     const serverDoc = await utils.getDoc(targetDocId);
     expect(serverDoc._rev).to.match(/^2-/);
   });
@@ -134,7 +134,7 @@ describe('Target accuracy', () => {
     await commonPage.waitForPageLoaded();
 
     await browser.pause(1500); // wait for debounced calculation
-    await commonPage.sync(false, 2000);
+    await commonPage.sync();
 
     const serverDoc = await utils.getDoc(targetDocId);
     expect(serverDoc._rev).to.match(/^3-/);
@@ -153,7 +153,7 @@ describe('Target accuracy', () => {
     const contacts = Array.from({ length: 20 }).map(() => personFactory.build(parent));
     await utils.saveDocs(contacts);
 
-    await commonPage.sync(false, 2000);
+    await commonPage.sync();
     await browser.pause(1500); // wait for debounced calculation
 
     const serverDoc = await utils.getDoc(targetDocId);

--- a/tests/e2e/default/targets/target-aggregates.wdio-spec.js
+++ b/tests/e2e/default/targets/target-aggregates.wdio-spec.js
@@ -374,8 +374,7 @@ describe('Target aggregates', () => {
           targetAggregatesConfig.TARGETS_DEFAULT_CONFIG,
           userWithManyPlaces
         );
-        await commonPage.sync(true);
-        await browser.refresh();
+        await commonPage.sync({ reload: true, expectReload: true });
 
         await commonPage.goToAnalytics();
         await targetAggregatesPage.goToTargetAggregates(true);

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -69,13 +69,6 @@ describe('Tasks', () => {
     await utils.revertSettings(true);
   });
 
-  after(async () => {
-    await utils.deleteUsers([chw]);
-    await utils.revertDb([/^form:/], true);
-    await browser.deleteCookies();
-    await browser.refresh();
-  });
-
   it('should remove task from list when CHW completes a task successfully', async () => {
     await tasksPage.compileTasks('tasks-breadcrumbs-config.js', true);
     
@@ -104,7 +97,7 @@ describe('Tasks', () => {
     const taskElement = await tasksPage.getOpenTaskElement();
     await genericForm.submitForm();
     await taskElement.waitForDisplayed();
-    await commonPage.sync(true);
+    await commonPage.sync({ expectReload: true });
     task = await tasksPage.getTaskByContactAndForm('Megan Spice', 'person_create_follow_up');
     list = await tasksPage.getTasks();
     expect(list).to.have.length(3);

--- a/tests/e2e/default/training-materials/training-materials.wdio-spec.js
+++ b/tests/e2e/default/training-materials/training-materials.wdio-spec.js
@@ -61,7 +61,6 @@ describe('Training Materials Page', () => {
     await utils.saveDocs([ facility, firstTraining, expiredTraining, secondTraining ]);
     await utils.createUsers([ user ]);
     await loginPage.login(user);
-    await commonElements.waitForPageLoaded();
   });
 
   it('should quit training in modal, and be able to complete it later in the Training Material page,' +

--- a/tests/e2e/default/training-materials/training-materials.wdio-spec.js
+++ b/tests/e2e/default/training-materials/training-materials.wdio-spec.js
@@ -5,7 +5,6 @@ const commonPage = require('@page-objects/default/common/common.wdio.page');
 const trainingCardsPage = require('@page-objects/default/enketo/training-cards.wdio.page');
 const placeFactory = require('@factories/cht/contacts/place');
 const userFactory = require('@factories/cht/users/users');
-const commonElements = require('@page-objects/default/common/common.wdio.page');
 const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
 
 describe('Training Materials Page', () => {

--- a/tests/e2e/default/transitions/create-user-for-contacts.create-user.wdio-spec.js
+++ b/tests/e2e/default/transitions/create-user-for-contacts.create-user.wdio-spec.js
@@ -78,8 +78,7 @@ describe('Create user when adding contact', () => {
     NEW_USERS.length = 0;
     await utils.revertDb([/^form:/], true);
     await sentinelUtils.waitForSentinel();
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   it('Creates a new user while offline', async () => {

--- a/tests/e2e/default/transitions/create-user-for-contacts.replace-user.wdio-spec.js
+++ b/tests/e2e/default/transitions/create-user-for-contacts.replace-user.wdio-spec.js
@@ -169,8 +169,7 @@ describe('Create user for contacts', () => {
     NEW_USERS.length = 0;
     await utils.revertDb([/^form:/], true);
     await sentinelUtils.waitForSentinel();
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
   });
 
   describe('user replace', () => {
@@ -758,8 +757,7 @@ describe('Create user for contacts', () => {
         expect(districtFromRemote.contact._id).to.equal(replacementContactId);
 
         // Subsequent form reports are *not* re-parented to the new contact
-        await browser.reloadSession();
-        await browser.url('/');
+        await commonPage.reloadSession();
         await loginPage.login(ORIGINAL_USER);
         await commonPage.waitForPageLoaded();
         await browser.throttle('offline');

--- a/tests/e2e/default/translations/enabled-languages.wdio-spec.js
+++ b/tests/e2e/default/translations/enabled-languages.wdio-spec.js
@@ -17,8 +17,7 @@ describe('Enabling/disabling languages', () => {
 
   it('should disable a language and enable another', async () => {
     await utils.updateSettings(SETTINGS, { ignoreReload: true });
-    await browser.reloadSession();
-    await browser.url('/');
+    await commonPage.reloadSession();
 
     // assert English, Spanish, and French are available on the login page
     let locales = await loginPage.getAllLocales();

--- a/tests/e2e/default/translations/enabled-languages.wdio-spec.js
+++ b/tests/e2e/default/translations/enabled-languages.wdio-spec.js
@@ -1,6 +1,7 @@
 const utils = require('@utils');
 const loginPage = require('@page-objects/default/login/login.wdio.page');
 const adminPage = require('@page-objects/default/admin/admin.wdio.page');
+const commonPage = require('@page-objects/default/common/common.wdio.page');
 
 describe('Enabling/disabling languages', () => {
   const SETTINGS = {

--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -36,6 +36,10 @@ describe('Testing Incorrect locale', () => {
     await utils.saveDoc(place);
     await sentinelUtils.waitForSentinel();
   });
+
+  afterEach(async () => {
+    await utils.revertSettings(true);
+  });
   
   it('should work with incorrect locale', async () => {
     const waitForServiceWorker = await utils.waitForApiLogs(utils.SW_SUCCESSFUL_REGEX);

--- a/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
+++ b/tests/e2e/default/translations/incorrect-locale.wdio-spec.js
@@ -4,7 +4,6 @@ const userSettingsElements = require('@page-objects/default/users/user-settings.
 const contactElements = require('@page-objects/default/contacts/contacts.wdio.page');
 const loginPage = require('@page-objects/default/login/login.wdio.page');
 const placeFactory = require('@factories/cht/contacts/place');
-const sentinelUtils = require('@utils/sentinel');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
 
 describe('Testing Incorrect locale', () => {
@@ -31,14 +30,15 @@ describe('Testing Incorrect locale', () => {
     await utils.enableLanguage(LANGUAGE_CODE);
   };
 
-  before(async () => {
+  beforeEach(async () => {
     await loginPage.cookieLogin();
     await utils.saveDoc(place);
-    await sentinelUtils.waitForSentinel();
   });
 
   afterEach(async () => {
+    await utils.deleteDocs([ place._id, `messages-${LANGUAGE_CODE}` ]);
     await utils.revertSettings(true);
+    await commonElements.reloadSession();
   });
   
   it('should work with incorrect locale', async () => {
@@ -61,9 +61,5 @@ describe('Testing Incorrect locale', () => {
 
     const tasksFilter = await contactElements.getReportTaskFiltersText();
     expect(tasksFilter.sort()).to.deep.equal(['1 saptamana', '2 saptamani', 'View all'].sort());
-
-    await utils.revertSettings(true);
-    await utils.deleteDocs([ place._id, `messages-${LANGUAGE_CODE}` ]);
-    await browser.setCookies({ name: 'locale', value: 'en' });
   });
 });

--- a/tests/e2e/upgrade/upgrade.wdio-spec.js
+++ b/tests/e2e/upgrade/upgrade.wdio-spec.js
@@ -119,8 +119,7 @@ describe('Performing an upgrade', () => {
 
   (testFrontend ? it : xit)('should display current branch in the about page', async () => {
     await loginPage.login({ username: docs.user.username, password: docs.user.password });
-    await commonPage.sync(true);
-    await browser.refresh();
+    await commonPage.sync({ expectReload: true, reload: true });
     await commonPage.waitForPageLoaded();
 
     await commonPage.goToAboutPage();

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -3,7 +3,7 @@ const modalPage = require('@page-objects/default/common/modal.wdio.page');
 const constants = require('@constants');
 
 const ELEMENT_DISPLAY_PAUSE = 500; // 500ms
-const RELOAD_SYNC_TIMEOUT = 5000;
+const RELOAD_SYNC_TIMEOUT = 10000;
 
 const tabsSelector = {
   getAllButtonLabels: async () => await $$('.header .tabs .button-label'),
@@ -412,6 +412,8 @@ const sync = async ({
   await hideModalOverlay();
 
   await syncAndWaitForSuccess(expectReload, timeout);
+  // service worker updates require downloading all resources, and then it triggers the update modal.
+  // sometimes this action is not timely with a quick sync.
   serviceWorkerUpdate && await closeReloadModal(false, RELOAD_SYNC_TIMEOUT);
 
   if (reload) {

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -60,6 +60,7 @@ const isHamburgerMenuOpen = async () => {
 
 const openHamburgerMenu = async () => {
   if (!(await isHamburgerMenuOpen())) {
+    await closeReloadModal();
     await (await hamburgerMenuSelectors.hamburgerMenu()).waitForClickable();
     await (await hamburgerMenuSelectors.hamburgerMenu()).click();
   }

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -512,6 +512,11 @@ const createFormDoc = (path, formId) => {
   };
 };
 
+const reloadSession = async () => {
+  await browser.reloadSession();
+  await browser.url('/');
+};
+
 module.exports = {
   tabsSelector,
   fabSelectors,
@@ -573,4 +578,5 @@ module.exports = {
   loadNextInfiniteScrollPage,
   getErrorLog,
   createFormDoc,
+  reloadSession,
 };

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -381,7 +381,7 @@ const syncAndWaitForSuccess = async (expectReload, timeout = RELOAD_SYNC_TIMEOUT
     await browser.waitUntil(async () => {
       return (await (await hamburgerMenuSelectors.syncSuccess()).isDisplayedInViewport()) ||
              (await modalPage.isDisplayed());
-    });
+    }, { timeout });
     await openHamburgerMenu();
 
     if (!await (await hamburgerMenuSelectors.syncSuccess()).isDisplayedInViewport()) {

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -371,8 +371,6 @@ const syncAndWaitForSuccess = async (expectReload, timeout = RELOAD_SYNC_TIMEOUT
   if (retry < 0) {
     throw new Error('Failed to sync after 10 retries');
   }
-
-  expectReload && await closeReloadModal();
   try {
     await openHamburgerMenu();
     if (!await (await hamburgerMenuSelectors.syncInProgress()).isDisplayedInViewport()) {
@@ -384,20 +382,11 @@ const syncAndWaitForSuccess = async (expectReload, timeout = RELOAD_SYNC_TIMEOUT
       return (await (await hamburgerMenuSelectors.syncSuccess()).isDisplayedInViewport()) ||
              (await modalPage.isDisplayed());
     });
-    console.warn('promise done');
-
-    await closeReloadModal();
     await openHamburgerMenu();
 
     if (!await (await hamburgerMenuSelectors.syncSuccess()).isDisplayedInViewport()) {
       throw new Error('Failed to sync');
     }
-    // expectReload && await closeReloadModal(false, ELEMENT_DISPLAY_PAUSE);
-    // if (!await isHamburgerMenuOpen()) {
-    //   expectReload && await closeReloadModal(false, timeout);
-    //   await openHamburgerMenu();
-    // }
-    // await (await hamburgerMenuSelectors.syncSuccess()).waitForDisplayed({ timeout });
   } catch (err) {
     console.error(err);
     return await syncAndWaitForSuccess(expectReload, timeout, retry - 1);
@@ -423,8 +412,7 @@ const sync = async ({
   await hideModalOverlay();
 
   await syncAndWaitForSuccess(expectReload, timeout);
-  // await closeReloadModal(false, serviceWorkerUpdate ? timeout : ELEMENT_DISPLAY_PAUSE);
-  serviceWorkerUpdate && await closeReloadModal();
+  serviceWorkerUpdate && await closeReloadModal(false, RELOAD_SYNC_TIMEOUT);
 
   if (reload) {
     await browser.refresh();

--- a/tests/page-objects/default/common/modal.wdio.page.js
+++ b/tests/page-objects/default/common/modal.wdio.page.js
@@ -32,6 +32,10 @@ const cancel = async (timeout) => {
   await checkModalHasClosed();
 };
 
+const isDisplayed = async () => {
+  return await (await modal()).isDisplayedInViewport();
+};
+
 module.exports = {
   modal,
   body,
@@ -39,4 +43,5 @@ module.exports = {
   cancel,
   getModalDetails,
   checkModalHasClosed,
+  isDisplayed,
 };

--- a/tests/page-objects/default/common/modal.wdio.page.js
+++ b/tests/page-objects/default/common/modal.wdio.page.js
@@ -36,6 +36,7 @@ const isDisplayed = async () => {
   return await (await modal()).isDisplayedInViewport();
 };
 
+
 module.exports = {
   modal,
   body,

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1070,6 +1070,8 @@ const addTranslations = (languageCode, translations = {}) => {
           generic: {}
         };
       }
+
+      throw err;
     });
   };
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -559,14 +559,14 @@ const updateSettings = async (updates, options = {}) => {
   }
   const watcher = ignoreReload && Object.keys(updates).length && await waitForSettingsUpdateLogs(ignoreReload);
   await updateCustomSettings(updates);
-  if (!ignoreReload) {
+  if (!ignoreReload && !sync) {
     return await commonElements.closeReloadModal(true);
   }
   if (watcher) {
     await watcher.promise;
   }
   if (sync) {
-    await commonElements.sync(true);
+    await commonElements.sync({ expectReload: true });
   }
   if (refresh) {
     await browser.refresh();


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

When we sync, and an update comes, the update modal can appear _before_ we see the sync status update to successful, and it will close the sidebar menu when it shows up.
This made e2e sync function retry and spend time on unnecessary waits. 
Adds reloadSession common page function. 

#9660

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-e2e-sync/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-e2e-sync/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:update-e2e-sync/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

