### PR TITLE
feat: add couch configs to enable proxy authentication

### DIFF
--- a/couchdb/10-docker-default.ini
+++ b/couchdb/10-docker-default.ini
@@ -18,6 +18,15 @@ bind_address = 0.0.0.0
 server_options = [{recbuf, 262144}]
 socket_options = [{sndbuf, 262144}, {nodelay, true}]
 require_valid_user = true
+authentication_handlers = {chttpd_auth, cookie_authentication_handler}, {chttpd_auth, proxy_authentication_handler}, {chttpd_auth, default_authentication_handler}
+
+[chttpd_auth]
+require_valid_user = true
+secret = 5ec56423-0856-4b13-8ab7-9b476fea2c39 ; CHANGE ME  - proxy secret
+x_auth_roles = X-Auth-CouchDB-Roles ; http header name for passing the comma separated couch user roles
+x_auth_username = X-Auth-CouchDB-UserName ; http header name for passing the couch username
+proxy_use_secret = true
+x_auth_token = X-Auth-CouchDB-Token ; http header name for passing the proxy token
 
 [httpd]
 secure_rewrites = false


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

- Simple couchdb configuration update to enable [proxy authentication ](https://docs.couchdb.org/en/stable/api/server/authn.html#proxy-authentication)

## Building couchdb image with proxy auth enabled
1. Clone this fork, and pull from this branch
2. `npm ci`
3. `npm run build-dev`
4. Build images locally with the command  `npm run local-images`
5. `docker image ls` to get the new, timestamped, locally build couchdb image
6. Start your couchdb container using the new image. If you're running your couch using the [docker compose](https://docs.communityhealthtoolkit.org/contribute/code/core/dev-environment/#couchdb-setup-in-cht-4x) template, replace the image name with the local one in the `docker-compose.yml` file




## Restarting existing couchdb container with proxy auth enabled (thanks @mrjones-plip)
1. get to the couchdb shell with `docker exec -it cht-docker-couchdb-1 bash`
2. edit the config in `vi /opt/couchdb/etc/default.d/10-docker-default.ini`. You might have to install your favorite editor if it's not present in the container
3. Have your config changes take effect by restarting. do this by exiting the container shell and running `COUCHDB_USER=medic COUCHDB_PASSWORD=password docker compose -f docker-compose.yml -f couchdb-override.yml restart`

## Generating proxy auth token
Use the secret to generate a HMAC of the username... this will become our proxy token.
`echo -n "username" | openssl dgst -sha256 -hmac "the_secret"
`


<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design.
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

