### PR TITLE
fix(#9527): don't log error when privacy policy doc is malformed

### DIFF
--- a/api/src/errors.js
+++ b/api/src/errors.js
@@ -1,0 +1,19 @@
+class PublicError extends Error {
+  constructor(publicMessage, ...args) {
+    super(publicMessage, ...args);
+    this.publicMessage = publicMessage;
+  }
+}
+
+class NotFoundError extends Error {
+  constructor(message, ...args) {
+    super(message, ...args);
+    this.status = 404; // simulate PouchDb error
+    this.statusCode = 404; // simulate Request error
+  }
+}
+
+module.exports = {
+  PublicError,
+  NotFoundError,
+};

--- a/api/src/public-error.js
+++ b/api/src/public-error.js
@@ -1,8 +1,0 @@
-class PublicError extends Error {
-  constructor(publicMessage, ...args) {
-    super(publicMessage, ...args);
-    this.publicMessage = publicMessage;
-  }
-}
-
-module.exports = PublicError;

--- a/api/src/services/privacy-policy.js
+++ b/api/src/services/privacy-policy.js
@@ -2,6 +2,7 @@ const sanitizeHtml = require('sanitize-html');
 const db = require('../db');
 const logger = require('@medic/logger');
 const config = require('../config');
+const { NotFoundError } = require('../errors');
 
 const PRIVACY_POLICY_DOC_ID = 'privacy-policies';
 
@@ -22,9 +23,7 @@ const getDoc = (options=({})) => {
     .then(doc => {
       const policies = doc.privacy_policies;
       if (!policies || !Object.keys(policies).length) { // invalid doc
-        const err = new Error(`Invalid ${PRIVACY_POLICY_DOC_ID} doc: missing required "privacy_policies" property`);
-        err.status = 404;
-        throw err;
+        throw new NotFoundError(`Invalid ${PRIVACY_POLICY_DOC_ID} doc: missing required "privacy_policies" property`);
       }
       return doc;
     })

--- a/api/src/services/privacy-policy.js
+++ b/api/src/services/privacy-policy.js
@@ -22,7 +22,9 @@ const getDoc = (options=({})) => {
     .then(doc => {
       const policies = doc.privacy_policies;
       if (!policies || !Object.keys(policies).length) { // invalid doc
-        throw new Error(`Invalid ${PRIVACY_POLICY_DOC_ID} doc: missing required "privacy_policies" property`);
+        const err = new Error(`Invalid ${PRIVACY_POLICY_DOC_ID} doc: missing required "privacy_policies" property`);
+        err.status = 404;
+        throw err;
       }
       return doc;
     })

--- a/api/src/services/records.js
+++ b/api/src/services/records.js
@@ -3,7 +3,7 @@ const phoneNumber = require('@medic/phone-number');
 const config = require('../config');
 const smsparser = require('./report/smsparser');
 const validate = require('./report/validate');
-const PublicError = require('../public-error');
+const { PublicError } = require('../errors');
 const DATE_NUMBER_STRING = /(\d{13,})/;
 
 // matches invisible characters that can mess up our parsing


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

When privacy policies doc is malformed, treat it as a 404 instead of some custom error. 

#9527 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design.
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9527-fix-privacy-policy-error/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9527-fix-privacy-policy-error/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9527-fix-privacy-policy-error/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

