### PR TITLE
fix(#9715): update broken translation

### DIFF
--- a/api/resources/translations/messages-ar.properties
+++ b/api/resources/translations/messages-ar.properties
@@ -1237,7 +1237,7 @@ task.date = تاريخ الاستحقاق
 task.days.left = {DAYS, plural, one{1 day left} other{\# days left}}
 task.list.complete = لا مزيد من المهام
 task.overdue = موعد الاستحقاق اليوم
-task.overdue.days = {DAYS, plural,
+task.overdue.days = {DAYS, plural, =0{Due today} =1{Due yesterday} other{Due \# days ago}}
 task.priority = الأولوية
 task.state = حالة الرسالة
 task.type = نوع الرسالة


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

The error was due to a missing translation in the [Arabic translations file - row `1240`](https://github.com/medic/cht-core/issues/9683#issuecomment-2522716453).

Closes #9715 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design.
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9715-fix-arabic/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9715-fix-arabic/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9715-fix-arabic/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

