### PR TITLE
#9768 Uplifted sinon to 19+

### DIFF
--- a/admin/tests/unit/controllers/export-dhis.spec.js
+++ b/admin/tests/unit/controllers/export-dhis.spec.js
@@ -16,7 +16,8 @@ describe('dhis2 export controller', () => {
 
   beforeEach(() => {
     module('adminApp');
-    sinon.useFakeTimers(NOW);
+    sinon.useFakeTimers({ now: NOW });
+
     Settings = sinon.stub().resolves({ dhis_data_sets: dhisDataSets });
     Export = sinon.stub().resolves();
     query = sinon.stub().resolves({ rows: [

--- a/admin/tests/unit/controllers/forms-xml.spec.js
+++ b/admin/tests/unit/controllers/forms-xml.spec.js
@@ -230,7 +230,8 @@ describe('FormsXmlCtrl controller', () => {
     let clock;
 
     beforeEach(() => {
-      clock = sinon.useFakeTimers(NOW);
+      clock = sinon.useFakeTimers({ now: NOW });
+
     });
 
     afterEach(() => {

--- a/api/tests/mocha/services/export/dhis.spec.js
+++ b/api/tests/mocha/services/export/dhis.spec.js
@@ -17,7 +17,10 @@ describe('dhis export service', () => {
   let medic;
 
   beforeEach(async () => {
-    sinon.useFakeTimers(NOW.valueOf());
+    sinon.useFakeTimers({ 
+      now: NOW.valueOf(), 
+      toFake: ['Date'] 
+    });
     medic = await memdownMedic(path.resolve('.'));
     sinon.stub(db, 'medic').value(medic);
   });

--- a/config/default/test/extras/nools-extras.spec.js
+++ b/config/default/test/extras/nools-extras.spec.js
@@ -6,7 +6,8 @@ const extras = require('../../nools-extras');
 
 describe('Date related tests', () => {
   beforeEach(() => {
-    sinon.useFakeTimers(new Date());
+    sinon.useFakeTimers({ now: new Date() });
+
   });
   afterEach(() => {
     sinon.restore();

--- a/config/default/test/targets/births.spec.js
+++ b/config/default/test/targets/births.spec.js
@@ -26,7 +26,7 @@ describe('Births this month target tests', () => {
 
   it('birth this month should be counted', async () => {
     //await harness.setNow('2000-04-30');//DOB: 2000-04-24
-    clock = sinon.useFakeTimers(moment('2000-04-30').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-04-30').toDate()});
     const birthsThisMonth = await harness.getTargets({ type: 'births-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);
     expect(birthsThisMonth[0]).to.nested.include({ 'value.pass': 1, 'value.total': 1 });
@@ -34,7 +34,7 @@ describe('Births this month target tests', () => {
 
   it('birth last month should not be counted', async () => {
     //await harness.setNow('2000-04-30');//DOB: 2000-04-24
-    clock = sinon.useFakeTimers(moment('2000-05-01').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-05-01').toDate()});
     const birthsThisMonth = await harness.getTargets({ type: 'births-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);
     expect(birthsThisMonth[0]).to.nested.not.include({ 'value.pass': 1, 'value.total': 1 });

--- a/config/default/test/targets/deaths.spec.js
+++ b/config/default/test/targets/deaths.spec.js
@@ -25,7 +25,7 @@ describe('Death related targets tests', () => {
 
   it('death this month target test this month', async () => {
     //await harness.setNow('2000-04-30');//DOD: 2000-04-25
-    clock = sinon.useFakeTimers(moment('2000-04-30').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-04-30').toDate()});
     harness.subject = babyDeceasedAtAge1Day;
     const birthsThisMonth = await harness.getTargets({ type: 'deaths-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);
@@ -34,7 +34,7 @@ describe('Death related targets tests', () => {
 
   it('death this month target test next month', async () => {
     //await harness.setNow('2000-04-30');//DOD: 2000-04-25
-    clock = sinon.useFakeTimers(moment('2000-05-30').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-05-30').toDate()});
     harness.subject = babyDeceasedAtAge1Day;
     const birthsThisMonth = await harness.getTargets({ type: 'deaths-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);

--- a/config/demo/test/extras/nools-extras.spec.js
+++ b/config/demo/test/extras/nools-extras.spec.js
@@ -6,7 +6,7 @@ const extras = require('../../nools-extras');
 
 describe('Date related tests', () => {
   beforeEach(() => {
-    sinon.useFakeTimers(new Date());
+    sinon.useFakeTimers({now:new Date()});
   });
   afterEach(() => {
     sinon.restore();

--- a/config/demo/test/targets/births.spec.js
+++ b/config/demo/test/targets/births.spec.js
@@ -26,7 +26,7 @@ describe('Births this month target tests', () => {
 
   it('birth this month should be counted', async () => {
     //await harness.setNow('2000-04-30');//DOB: 2000-04-24
-    clock = sinon.useFakeTimers(moment('2000-04-30').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-04-30').toDate()});
     const birthsThisMonth = await harness.getTargets({ type: 'births-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);
     expect(birthsThisMonth[0]).to.nested.include({ 'value.pass': 1, 'value.total': 1 });
@@ -34,7 +34,7 @@ describe('Births this month target tests', () => {
 
   it('birth last month should not be counted', async () => {
     //await harness.setNow('2000-04-30');//DOB: 2000-04-24
-    clock = sinon.useFakeTimers(moment('2000-05-01').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-05-01').toDate()});
     const birthsThisMonth = await harness.getTargets({ type: 'births-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);
     expect(birthsThisMonth[0]).to.nested.not.include({ 'value.pass': 1, 'value.total': 1 });

--- a/config/demo/test/targets/deaths.spec.js
+++ b/config/demo/test/targets/deaths.spec.js
@@ -25,7 +25,7 @@ describe('Death related targets tests', () => {
 
   it('death this month target test this month', async () => {
     //await harness.setNow('2000-04-30');//DOD: 2000-04-25
-    clock = sinon.useFakeTimers(moment('2000-04-30').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-04-30').toDate()});
     harness.subject = babyDeceasedAtAge1Day;
     const birthsThisMonth = await harness.getTargets({ type: 'deaths-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);
@@ -34,7 +34,7 @@ describe('Death related targets tests', () => {
 
   it('death this month target test next month', async () => {
     //await harness.setNow('2000-04-30');//DOD: 2000-04-25
-    clock = sinon.useFakeTimers(moment('2000-05-30').toDate());
+    clock = sinon.useFakeTimers({now:moment('2000-05-30').toDate()});
     harness.subject = babyDeceasedAtAge1Day;
     const birthsThisMonth = await harness.getTargets({ type: 'deaths-this-month' });
     expect(birthsThisMonth).to.have.property('length', 1);

--- a/config/demo/test/tasks/delivery.spec.js
+++ b/config/demo/test/tasks/delivery.spec.js
@@ -53,7 +53,7 @@ describe('Delivery tasks tests', () => {
     for (const day of getTaskTestDays(70, MAX_DAYS_FOR_DELIVERY, deliveryTask, 7)) {
       await harness.setNow('1999-08-01');//LMP date
       await harness.flush(day);
-      clock = sinon.useFakeTimers(moment('1999-08-01').add(day, 'days').toDate());
+      clock = sinon.useFakeTimers({now:moment('1999-08-01').add(day, 'days').toDate()});
       const taskForDelivery = await harness.getTasks({ title: 'task.anc.delivery.title' });
 
       if (deliveryTaskDays.includes(day)) {
@@ -74,7 +74,7 @@ describe('Delivery tasks tests', () => {
     for (const day of getTaskTestDays(0, MAX_DAYS_FOR_DELIVERY, deliveryTask, 7)) {
       await harness.setNow('1999-08-01');//10 weeks after LMP date
       await harness.flush(day);
-      clock = sinon.useFakeTimers(moment('1999-08-01').add(day, 'days').toDate());
+      clock = sinon.useFakeTimers({now:moment('1999-08-01').add(day, 'days').toDate()});
       const taskForDelivery = await harness.getTasks({ title: 'task.anc.delivery.title' });
 
       if (deliveryTaskDays.includes(day) && cleared === false) {
@@ -102,7 +102,7 @@ describe('Delivery tasks tests', () => {
     for (const day of getTaskTestDays(70, MAX_DAYS_FOR_DELIVERY, deliveryTask, 7)) {
       await harness.setNow('1999-08-01');//10 weeks after LMP date
       await harness.flush(day);
-      clock = sinon.useFakeTimers(moment('1999-08-01').add(day, 'days').toDate());
+      clock = sinon.useFakeTimers({now:moment('1999-08-01').add(day, 'days').toDate()});
       const taskForDelivery = await harness.getTasks({ title: 'task.anc.delivery.title' });
       if (deliveryTaskDays.includes(day) && resolved === false) {
         expect(taskForDelivery.length).to.eq(1);//there is also a home-visit task

--- a/sentinel/tests/unit/lib/scheduling.spec.js
+++ b/sentinel/tests/unit/lib/scheduling.spec.js
@@ -50,13 +50,13 @@ describe('scheduling', () => {
     afterEach(() => clock.restore());
 
     it('should return the exact milliseconds for next schedule', () => {
-      clock = sinon.useFakeTimers(moment('2021-06-07T11:59:05').valueOf());       // 55 sec before 12 o'clock
+      clock = sinon.useFakeTimers({now:moment('2021-06-07T11:59:05').valueOf()});       // 55 sec before 12 o'clock
       const scheduleConfig = later.parse.cron('0 * * * *');                  // Run every hour at minute 0
       assert.equal(scheduling.nextScheduleMillis(scheduleConfig), 55 * 1000);
     });
 
     it('should return the exact milliseconds for next schedule with less than 1 sec', () => {
-      clock = sinon.useFakeTimers(moment('2021-06-07T11:59:59.910').valueOf());   // 90 millis before 12 o'clock
+      clock = sinon.useFakeTimers({now:moment('2021-06-07T11:59:59.910').valueOf()});   // 90 millis before 12 o'clock
       const scheduleConfig = later.parse.cron('0 12 * * *');                 // Run 12 o'clock
       assert.equal(scheduling.nextScheduleMillis(scheduleConfig), 90);
     });

--- a/sentinel/tests/unit/schedule/outbound.spec.js
+++ b/sentinel/tests/unit/schedule/outbound.spec.js
@@ -773,7 +773,7 @@ describe('outbound schedule', () => {
       configGet.returns(configs);
       batch.resolvesArg(0);
 
-      clock = sinon.useFakeTimers(new Date('2023-07-11T03:05:00+0000').getTime());
+      clock = sinon.useFakeTimers({now:new Date('2023-07-11T03:05:00+0000').getTime()});
 
       return outbound.execute().then((dueConfigs) => {
         assert.equal(configGet.callCount, 1);
@@ -845,7 +845,7 @@ describe('outbound schedule', () => {
 
       singlePush.resolves();
 
-      clock = sinon.useFakeTimers(new Date('2024-09-10T03:05:00+0000').getTime());
+      clock = sinon.useFakeTimers({now:new Date('2024-09-10T03:05:00+0000').getTime()});
 
       return outbound.execute().then(() => {
         assert.equal(singlePush.callCount, 1);

--- a/sentinel/tests/unit/schedule/purging.spec.js
+++ b/sentinel/tests/unit/schedule/purging.spec.js
@@ -12,7 +12,7 @@ let scheduler;
 describe('Purging Schedule', () => {
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(new Date());
+    clock = sinon.useFakeTimers({now:new Date()});
     scheduler = rewire('../../../src/schedule/purging');
   });
 

--- a/shared-libs/infodoc/test/infodoc.js
+++ b/shared-libs/infodoc/test/infodoc.js
@@ -415,7 +415,8 @@ describe('infodoc', () => {
     it('updateTransition should set transition data', () => {
       const now = new Date('2024-04-15');
       const then = new Date('2024-04-12');
-      clock = sinon.useFakeTimers(then.valueOf());
+      clock = sinon.useFakeTimers({ now: then.valueOf() });
+
       const change = { seq: 12, doc: { _rev: 2 }, info: {}};
       lib.updateTransition(change, 'update_clinics', true);
       assert.deepEqual(

--- a/shared-libs/rules-engine/test/integration.spec.js
+++ b/shared-libs/rules-engine/test/integration.spec.js
@@ -104,7 +104,7 @@ describe(`Rules Engine Integration Tests`, () => {
   let configHashSalt = 0;
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(TEST_START);
+    clock = sinon.useFakeTimers({now:TEST_START});
   });
 
   afterEach(() => {

--- a/shared-libs/rules-engine/test/pouchdb-provider.spec.js
+++ b/shared-libs/rules-engine/test/pouchdb-provider.spec.js
@@ -151,7 +151,7 @@ describe('pouchdb provider', () => {
     db = await memdownMedic('../..');
     await db.bulkDocs(fixtures);
 
-    clock = sinon.useFakeTimers(100000000);
+    clock = sinon.useFakeTimers({now:100000000});
     sinon.spy(db, 'put');
     sinon.spy(db, 'query');
   });

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -81,7 +81,7 @@ describe('provider-wireup integration tests', () => {
   let provider;
   let db;
   beforeEach(async () => {
-    clock = sinon.useFakeTimers(NOW);
+    clock = sinon.useFakeTimers({now:NOW});
     wireup = rewire('../src/provider-wireup');
     rulesStateStore = RestorableRulesStateStore();
     sinon.stub(rulesStateStore, 'currentUserContact').returns(currentUserContact);

--- a/shared-libs/rules-engine/test/rules-emitter.spec.js
+++ b/shared-libs/rules-engine/test/rules-emitter.spec.js
@@ -218,7 +218,7 @@ for (const rulesAreDeclarative of declarativeScenarios) {
 
       it('trigger task.anc.pregnancy_home_visit', async () => {
         const time = moment('2000-01-01');
-        clock = sinon.useFakeTimers(time.valueOf());
+        clock = sinon.useFakeTimers({now:time.valueOf()});
 
         const initialized = rulesEmitter.initialize(engineSettings({ rulesAreDeclarative }));
         expect(initialized).to.be.true;

--- a/shared-libs/rules-engine/test/task-states.spec.js
+++ b/shared-libs/rules-engine/test/task-states.spec.js
@@ -12,7 +12,7 @@ let clock;
 
 describe('task-states', () => {
   before(() => {
-    clock = sinon.useFakeTimers(NOW);
+    clock = sinon.useFakeTimers({now:NOW});
     TaskStates = rewire('../src/task-states');
     definedStates = Object.keys(TaskStates).filter(key => typeof TaskStates[key] === 'string');
   });

--- a/shared-libs/rules-engine/test/transform-task-emission-to-doc.spec.js
+++ b/shared-libs/rules-engine/test/transform-task-emission-to-doc.spec.js
@@ -13,7 +13,7 @@ let clock;
 
 describe('transform-task-emission-to-doc', () => {
   before(() => {
-    clock = sinon.useFakeTimers(NOW.valueOf());
+    clock = sinon.useFakeTimers({ now: NOW.valueOf(), toFake: ['Date']});
   });
   after(() => {
     sinon.restore();

--- a/shared-libs/rules-engine/test/update-temporal-state.spec.js
+++ b/shared-libs/rules-engine/test/update-temporal-state.spec.js
@@ -10,7 +10,7 @@ let clock;
 
 describe('update-temporal-states', () => {
   beforeEach(() => {
-    clock = sinon.useFakeTimers(NOW);
+    clock = sinon.useFakeTimers({now:NOW});
   });
 
   afterEach(() => {

--- a/shared-libs/transitions/test/unit/lib/muting_utils.js
+++ b/shared-libs/transitions/test/unit/lib/muting_utils.js
@@ -207,7 +207,7 @@ describe('mutingUtils', () => {
 
     it('should not update docs without changes when unmuting', () => {
       const timestamp = 5000;
-      clock = sinon.useFakeTimers(timestamp);
+      clock = sinon.useFakeTimers({now:timestamp});
       const contacts = [
         { _id: 'a' },
         { _id: 'b', muted: 100 },
@@ -1773,7 +1773,7 @@ describe('mutingUtils', () => {
     });
 
     it('should set muting history when available', () => {
-      clock = sinon.useFakeTimers(4567);
+      clock = sinon.useFakeTimers({now:4567});
       const mutedContact = {
         muted: 2000,
         muting_history: {
@@ -1874,7 +1874,7 @@ describe('mutingUtils', () => {
     describe('should update contact when muting context changes', () => {
       const timestamp = 4567;
       beforeEach(() => {
-        clock = sinon.useFakeTimers(timestamp);
+        clock = sinon.useFakeTimers({now:timestamp});
       });
 
       it('when muted on client, unmuted on server and muting', () => {
@@ -1992,7 +1992,7 @@ describe('mutingUtils', () => {
     describe('should not update contact when muting context does not change', () => {
       const timestamp = 4567;
       beforeEach(() => {
-        clock = sinon.useFakeTimers(timestamp);
+        clock = sinon.useFakeTimers({now:timestamp});
       });
 
       it('when unmuting an unmuted contact', () => {

--- a/shared-libs/transitions/test/unit/transitions/mark_for_outbound.js
+++ b/shared-libs/transitions/test/unit/transitions/mark_for_outbound.js
@@ -83,7 +83,7 @@ describe('mark for outbound', () => {
       outbound.send.rejects();
       db.sentinel.get.rejects({ status: 404 });
 
-      clock = sinon.useFakeTimers(new Date('2023-07-11T03:05:00+0000').getTime());
+      clock = sinon.useFakeTimers({now:new Date('2023-07-11T03:05:00+0000').getTime()});
 
       return markForOutbound
         .onMatch(change)

--- a/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
+++ b/webapp/tests/karma/ts/components/filters/date-filter.component.spec.ts
@@ -63,7 +63,7 @@ describe('Date Filter Component', () => {
   });
 
   it('ngAfterViewInit should initialize daterangepicker', () => {
-    clock = sinon.useFakeTimers(moment().valueOf());
+    clock = sinon.useFakeTimers({now:moment().valueOf()});
 
     component.ngAfterViewInit();
 
@@ -97,7 +97,7 @@ describe('Date Filter Component', () => {
   });
 
   it('should apply filter correctly', () => {
-    clock = sinon.useFakeTimers(moment().valueOf());
+    clock = sinon.useFakeTimers({now:moment().valueOf()});
     const setFilter = sinon.stub(GlobalActions.prototype, 'setFilter');
     const from = moment().subtract(2, 'days');
     const to = moment();

--- a/webapp/tests/karma/ts/modals/edit-message-group.component.spec.ts
+++ b/webapp/tests/karma/ts/modals/edit-message-group.component.spec.ts
@@ -106,7 +106,7 @@ describe('EditMessageGroupComponent', () => {
   describe('addTask', () => {
     it('should add task', () => {
       const NOW = 10000;
-      clock = sinon.useFakeTimers(NOW);
+      clock = sinon.useFakeTimers({now:NOW});
       component.report = { _id: 'report' };
       component.group = {
         number: 3,

--- a/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks.component.spec.ts
@@ -158,7 +158,7 @@ describe('TasksComponent', () => {
     const now = moment('2020-10-20');
     const futureDate = now.clone().add(3, 'days');
     const pastDate = now.clone().subtract(3, 'days');
-    clock = sinon.useFakeTimers(now.valueOf());
+    clock = sinon.useFakeTimers({ now: NOW.valueOf(), toFake: ['Date']});
     const taskDocs = [
       { _id: '1', emission: { _id: 'e1', dueDate: futureDate.format('YYYY-MM-DD') }, owner: 'a' },
       { _id: '2', emission: { _id: 'e2', dueDate: pastDate.format('YYYY-MM-DD') }, owner: 'b' },

--- a/webapp/tests/karma/ts/providers/parse.provider.spec.ts
+++ b/webapp/tests/karma/ts/providers/parse.provider.spec.ts
@@ -246,7 +246,7 @@ describe('Parse provider', () => {
         getInstance: sinon.stub().returns(new AgePipe(formatDateService, relativeDateService, sanitizer)),
       };
       const today = moment('2020-10-30');
-      clock = sinon.useFakeTimers(today.valueOf());
+      clock = sinon.useFakeTimers({now:today.valueOf()});
 
       provider = new ParseProvider(pipesService);
       let birthDate = moment('2019-01-01').valueOf();

--- a/webapp/tests/karma/ts/services/check-date.service.spec.ts
+++ b/webapp/tests/karma/ts/services/check-date.service.spec.ts
@@ -123,7 +123,7 @@ describe('CheckDateService', () => {
 
   describe('re-checking on every try until one response from the server is received', () => {
     it('should keep re-checking, record telemetry and never check again when clock is off', async () => {
-      clock = sinon.useFakeTimers(1606230000000);
+      clock = sinon.useFakeTimers({now:1606230000000});
 
       const check1 = service.check(true);
       const res1 = httpMock.expectOne(matchInfoEndpoint);
@@ -177,7 +177,7 @@ describe('CheckDateService', () => {
     });
 
     it('should keep re-checking, not record telemetry and never check again when clock is on', async () => {
-      clock = sinon.useFakeTimers(1606230000000);
+      clock = sinon.useFakeTimers({now:1606230000000});
 
       const check1 = service.check(true);
       const res1 = httpMock.expectOne(matchInfoEndpoint);

--- a/webapp/tests/karma/ts/services/contact-save.service.spec.ts
+++ b/webapp/tests/karma/ts/services/contact-save.service.spec.ts
@@ -200,7 +200,7 @@ describe('ContactSave service', () => {
       .returns({ _id: 'contact', parent: { _id: 'def' } })
       .withArgs(sinon.match({ _id: 'def' }))
       .returns({ _id: 'def' });
-    clock = sinon.useFakeTimers(5000);
+    clock = sinon.useFakeTimers({now:5000});
 
     return service
       .save(form, docId, type)

--- a/webapp/tests/karma/ts/services/form.service.spec.ts
+++ b/webapp/tests/karma/ts/services/form.service.spec.ts
@@ -1491,7 +1491,7 @@ describe('Form service', () => {
         .returns({ _id: 'contact', parent: { _id: 'def' } })
         .withArgs(sinon.match({ _id: 'def' }))
         .returns({ _id: 'def' });
-      clock = sinon.useFakeTimers(5000);
+      clock = sinon.useFakeTimers({now:5000});
 
       return service
         .saveContact(form, docId, type)
@@ -1540,7 +1540,7 @@ describe('Form service', () => {
         clonedDocs.push({ this: 'is a new doc' });
         return Promise.resolve(clonedDocs);
       });
-      clock = sinon.useFakeTimers(1000);
+      clock = sinon.useFakeTimers({now:1000});
 
       return service
         .saveContact(form, docId, type)

--- a/webapp/tests/karma/ts/services/migrations/target-checkpointer.migration.spec.ts
+++ b/webapp/tests/karma/ts/services/migrations/target-checkpointer.migration.spec.ts
@@ -118,7 +118,7 @@ describe('Target Checkpoint Migration', () => {
   describe('setHasRun', () => {
     it('should write flag local doc', async () => {
       const now = 123345;
-      clock = sinon.useFakeTimers(now);
+      clock = sinon.useFakeTimers({now:now});
       localDb.put = sinon.stub().resolves();
       await migration.setHasRun(dbService);
       expect(localDb.put.args).to.deep.equal([[{

--- a/webapp/tests/karma/ts/services/privacy-policies.service.spec.ts
+++ b/webapp/tests/karma/ts/services/privacy-policies.service.spec.ts
@@ -244,7 +244,7 @@ describe('PrivacyPoliciesService', () => {
     it('should create acceptance log when it does not exist', async () => {
       userSettingsService.get.resolves({ _id: 'user_id', known: true });
       userSettingsService.put.resolves();
-      clock = sinon.useFakeTimers(6000);
+      clock = sinon.useFakeTimers({now:6000});
 
       await service.accept({ language: 'en', digest: 'the_digest' });
 
@@ -273,7 +273,7 @@ describe('PrivacyPoliciesService', () => {
         }],
       });
       userSettingsService.put.resolves();
-      clock = sinon.useFakeTimers(9568);
+      clock = sinon.useFakeTimers({now:9568});
 
       await service.accept({ language: 'en', digest: 'dig' });
 
@@ -310,7 +310,7 @@ describe('PrivacyPoliciesService', () => {
         }],
       });
       userSettingsService.put.resolves();
-      clock = sinon.useFakeTimers(6987);
+      clock = sinon.useFakeTimers({now:6987});
 
       await service.accept({ language: 'en', digest: 'my_digest' });
 
@@ -347,7 +347,7 @@ describe('PrivacyPoliciesService', () => {
         }],
       });
       userSettingsService.put.rejects({ my: 'err' });
-      clock = sinon.useFakeTimers(6987);
+      clock = sinon.useFakeTimers({now:6987});
 
       return service
         .accept({ language: 'en', digest: 'my_digest' })

--- a/webapp/tests/karma/ts/services/relative-date.service.spec.ts
+++ b/webapp/tests/karma/ts/services/relative-date.service.spec.ts
@@ -22,7 +22,7 @@ describe('RelativeDate Service', () => {
     const relative = (timestamp, options) => options.withoutTime ?
       formatDateRelativeDay(timestamp, options) : formatDateRelativeTime(timestamp, options);
 
-    clock = sinon.useFakeTimers(5000);
+    clock = sinon.useFakeTimers({now:5000});
 
     TestBed.configureTestingModule({
       providers: [

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -795,7 +795,7 @@ describe('RulesEngineService', () => {
   it('should cancel all ensure freshness threads', async () => {
     fetchTargetsResult = sinon.stub().resolves([]);
     fetchTasksResult = sinon.stub().resolves([]);
-    clock = sinon.useFakeTimers(1000);
+    clock = sinon.useFakeTimers({now:1000});
     service = TestBed.inject(RulesEngineService);
 
     await service.isEnabled();
@@ -817,7 +817,7 @@ describe('RulesEngineService', () => {
   });
 
   it('should record correct telemetry data with emitted events', async () => {
-    clock = sinon.useFakeTimers(1000);
+    clock = sinon.useFakeTimers({now:1000});
     let fetchTargetResultPromise;
     const fetchTasksResultPromise: any[] = [];
     fetchTargetsResult = sinon.stub().callsFake(() => new Promise(resolve => fetchTargetResultPromise = resolve));
@@ -882,7 +882,7 @@ describe('RulesEngineService', () => {
 
   it('should record correct telemetry data for disabled actions', async () => {
     authService.has.withArgs('can_view_tasks').resolves(false);
-    clock = sinon.useFakeTimers(1000);
+    clock = sinon.useFakeTimers({now:1000});
     fetchTargetsResult = sinon.stub().resolves([]);
     fetchTasksResult = sinon.stub().resolves([]);
     service = TestBed.inject(RulesEngineService);
@@ -941,7 +941,7 @@ describe('RulesEngineService', () => {
         Failed: 22,
       };
 
-      clock = sinon.useFakeTimers(1000);
+      clock = sinon.useFakeTimers({now:1000});
       let fetchTasksBreakdownResult;
       rulesEngineCoreStubs.fetchTasksBreakdown.callsFake(() => new Promise(r => fetchTasksBreakdownResult = r));
       service = TestBed.inject(RulesEngineService);
@@ -968,7 +968,7 @@ describe('RulesEngineService', () => {
         Draft: 7,
       };
 
-      clock = sinon.useFakeTimers(1000);
+      clock = sinon.useFakeTimers({now:1000});
       let fetchTasksBreakdownResult;
       rulesEngineCoreStubs.fetchTasksBreakdown.callsFake(() => new Promise(r => fetchTasksBreakdownResult = r));
       service = TestBed.inject(RulesEngineService);

--- a/webapp/tests/karma/ts/services/search.service.spec.ts
+++ b/webapp/tests/karma/ts/services/search.service.spec.ts
@@ -155,7 +155,7 @@ describe('Search service', () => {
 
   describe('dateLastVisited', () => {
     beforeEach(() => {
-      clock = sinon.useFakeTimers(moment('2018-08-20 18:18:18').valueOf());
+      clock = sinon.useFakeTimers({now:moment('2018-08-20 18:18:18').valueOf()});
     });
 
     afterEach(() => {

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -129,7 +129,7 @@ describe('TelemetryService', () => {
     });
 
     service = TestBed.inject(TelemetryService);
-    clock = sinon.useFakeTimers(NOW);
+    clock = sinon.useFakeTimers({now:NOW});
   });
 
   afterEach(() => {

--- a/webapp/tests/karma/ts/services/training-cards.service.spec.ts
+++ b/webapp/tests/karma/ts/services/training-cards.service.spec.ts
@@ -65,7 +65,7 @@ describe('TrainingCardsService', () => {
   it('should show uncompleted training when none are completed', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [] });
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-789',
@@ -126,7 +126,7 @@ describe('TrainingCardsService', () => {
       { doc: { form: 'training:form-a' } },
       { doc: { form: 'training:form-b' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-456',
@@ -188,7 +188,7 @@ describe('TrainingCardsService', () => {
       { doc: { form: 'training:form-a' } },
       { doc: { form: 'training:form-b' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-789',
@@ -237,7 +237,7 @@ describe('TrainingCardsService', () => {
     localDb.allDocs.resolves({ rows: [
       { doc: { form: 'training:form-b' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-098',
@@ -293,7 +293,7 @@ describe('TrainingCardsService', () => {
   it('should not show training when privacy policy has not been accepted yet', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: []});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [{
       _id: 'form:training:abc-100',
       internalId: 'training:form-c',
@@ -317,7 +317,7 @@ describe('TrainingCardsService', () => {
       { doc: { form: 'training:form-b' } },
       { doc: { form: 'training:form-c' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-123',
@@ -368,7 +368,7 @@ describe('TrainingCardsService', () => {
     localDb.allDocs.resolves({ rows: [
       { doc: { form: 'training:form-a' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-123',
@@ -411,7 +411,7 @@ describe('TrainingCardsService', () => {
   it('should not show training forms when all trainings start in the future', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [] });
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-123',
@@ -454,7 +454,7 @@ describe('TrainingCardsService', () => {
   it('should not show training forms if their internalID does not have the right prefix', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [] });
-    clock = sinon.useFakeTimers(new Date('2022-06-03 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:cards-1',
@@ -503,7 +503,7 @@ describe('TrainingCardsService', () => {
   it('should not show the modal when no training forms', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [] });
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
 
     await service.displayTrainingCards([], true, true);
 
@@ -533,7 +533,7 @@ describe('TrainingCardsService', () => {
   it('should catch exception', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.rejects(new Error('some error'));
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [{
       _id: 'form:training:abc-123',
       internalId: 'training:form-a',
@@ -559,7 +559,7 @@ describe('TrainingCardsService', () => {
   it('should display training if route has hideTraining false', async () => {
     sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'a_user' });
     localDb.allDocs.resolves({ rows: [ { doc: { form: 'training:form-b' } } ] });
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [ {
       _id: 'form:training:abc-100',
       internalId: 'training:form-c',
@@ -582,7 +582,7 @@ describe('TrainingCardsService', () => {
     localDb.allDocs.resolves({ rows: [
       { doc: { form: 'training:form-b' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-098',
@@ -651,7 +651,7 @@ describe('TrainingCardsService', () => {
     localDb.allDocs.resolves({ rows: [
       { doc: { form: 'training:form-b' } },
     ]});
-    clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+    clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
     const xforms = [
       {
         _id: 'form:training:abc-098',
@@ -722,7 +722,7 @@ describe('TrainingCardsService', () => {
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
       sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'ronald' });
       window.localStorage.setItem('training-cards-last-viewed-date-ronald', '2024-05-23 20:29:25');
-      clock = sinon.useFakeTimers(new Date('2025-05-25 20:29:25'));
+      clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
       localDb.allDocs.resolves({ rows: [] });
       const xforms = [ {
         _id: 'form:training:abc-100',
@@ -739,7 +739,7 @@ describe('TrainingCardsService', () => {
       sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'ronald' });
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
       window.localStorage.setItem('training-cards-last-viewed-date-ronald', '');
-      clock = sinon.useFakeTimers(new Date('2025-05-25 20:29:25'));
+      clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
       localDb.allDocs.resolves({ rows: [] });
       const xforms = [ {
         _id: 'form:training:abc-100',
@@ -756,7 +756,7 @@ describe('TrainingCardsService', () => {
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
       sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'ronald' });
       window.localStorage.setItem('training-cards-last-viewed-date-ronald', '2024-05-23 20:29:25');
-      clock = sinon.useFakeTimers(new Date('2024-05-23 06:29:25'));
+      clock = sinon.useFakeTimers({now:new Date('2024-05-23 06:29:25')});
       localDb.allDocs.resolves({ rows: [] });
       const xforms = [ {
         _id: 'form:training:abc-100',
@@ -773,7 +773,7 @@ describe('TrainingCardsService', () => {
       routeSnapshotService.get.returns({ data: { hideTraining: false } });
       sessionService.userCtx.returns({ roles: [ 'chw' ], name: 'sarah' });
       window.localStorage.setItem('training-cards-last-viewed-date-ronald', '2024-05-23 20:29:25');
-      clock = sinon.useFakeTimers(new Date('2024-05-23 06:29:25'));
+      clock = sinon.useFakeTimers({now:new Date('2024-05-23 06:29:25')});
       localDb.allDocs.resolves({ rows: [ { doc: { form: 'training:form-b' } } ] });
       const xforms = [ {
         _id: 'form:training:abc-100',
@@ -794,7 +794,7 @@ describe('TrainingCardsService', () => {
         { doc: { form: 'training:form-a' } },
         { doc: { form: 'training:form-b' } },
       ]});
-      clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+      clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
       const xforms = [
         {
           _id: 'form:training:abc-789',
@@ -854,7 +854,7 @@ describe('TrainingCardsService', () => {
         { doc: { form: 'training:form-a' } },
         { doc: { form: 'training:form-b' } },
       ]});
-      clock = sinon.useFakeTimers(new Date('2022-05-23 20:29:25'));
+      clock = sinon.useFakeTimers({now:new Date('2022-05-23 20:29:25')});
       const xforms = [
         ...Array.from({ length: 30 }).map((item, index) => ({
           _id: 'form:training:abc-123' + index,

--- a/webapp/tests/karma/ts/services/uhc-stats.service.spec.ts
+++ b/webapp/tests/karma/ts/services/uhc-stats.service.spec.ts
@@ -19,7 +19,7 @@ describe('UHCStats Service', () => {
   let authService;
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(moment('2021-04-07 18:18:18').valueOf());
+    clock = sinon.useFakeTimers({now:moment('2021-04-07 18:18:18').valueOf()});
     localDb = { query: sinon.stub() };
     dbService = { get: sinon.stub().returns(localDb) };
     sessionService = { isAdmin: sinon.stub() };


### PR DESCRIPTION
Uplifted sinon to 19+ and modified the useFakeTimes function.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design.
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

