### PR TITLE
chore(#9796): ignore blocked dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,16 @@ updates:
       karma:
         patterns:
         - "karma*"
+    ignore:
+      - dependency-name: "@types/chai" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "@types/chai-as-promised" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "chai" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "chai-as-promised" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "chai-exclude" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "node-fetch" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "url-join" # ESM Modules https://github.com/medic/cht-core/issues/9770
+      - dependency-name: "pouchdb-*" # https://github.com/medic/cht-core/issues/9534
+
   - package-ecosystem: "npm"
     directory: "/admin"
     schedule:
@@ -47,3 +57,6 @@ updates:
         - "@ngrx/*"
         - "rxjs"
         - "zone.js"
+    ignore:
+      - dependency-name: "enketo-core" # https://github.com/medic/cht-core/issues/8755
+      - dependency-name: "jquery" # https://github.com/medic/cht-core/issues/8755


### PR DESCRIPTION
# Description

Closes https://github.com/medic/cht-core/issues/9796

Following the [dependabot config docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) to ignore the various dependencies that we cannot bump because they are associated with ongoing open issues.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:ignore-dependabot/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:ignore-dependabot/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:ignore-dependabot/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

