### PR TITLE
chore(#9796): ignore additional blocked dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
       - dependency-name: "node-fetch" # ESM Modules https://github.com/medic/cht-core/issues/9770
       - dependency-name: "url-join" # ESM Modules https://github.com/medic/cht-core/issues/9770
       - dependency-name: "pouchdb-*" # https://github.com/medic/cht-core/issues/9534
+      - dependency-name: "uuid" # https://github.com/medic/cht-core/issues/9769
 
   - package-ecosystem: "npm"
     directory: "/admin"
@@ -58,5 +59,9 @@ updates:
         - "rxjs"
         - "zone.js"
     ignore:
+      - dependency-name: "bootstrap" # https://github.com/medic/cht-core/issues/8176
+      - dependency-name: "bootstrap-daterangepicker" # https://github.com/medic/cht-core/issues/8176
       - dependency-name: "enketo-core" # https://github.com/medic/cht-core/issues/8755
       - dependency-name: "jquery" # https://github.com/medic/cht-core/issues/8755
+      - dependency-name: "select2" # https://github.com/medic/cht-core/issues/8755
+      - dependency-name: "signature_pad" # https://github.com/medic/cht-core/issues/8755

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,6 @@ updates:
       - dependency-name: "node-fetch" # ESM Modules https://github.com/medic/cht-core/issues/9770
       - dependency-name: "url-join" # ESM Modules https://github.com/medic/cht-core/issues/9770
       - dependency-name: "pouchdb-*" # https://github.com/medic/cht-core/issues/9534
-      - dependency-name: "uuid" # https://github.com/medic/cht-core/issues/9769
 
   - package-ecosystem: "npm"
     directory: "/admin"


### PR DESCRIPTION
# Description

Following up on https://github.com/medic/cht-core/pull/9797, here are more dependencies that are formally blocked from upgrading (associated with existing logged issues).  

My rational for which dependencies to ignore is based on dependencies that are known to be _hard blocked_. These are ones where we know an upgrade is going to require significant changes to a core platform (and this is documented on an existing issue).  I have not included dependencies like [uuid](https://github.com/medic/cht-core/issues/9769) or [sinon](https://github.com/medic/cht-core/issues/9768) in the ignore list since it is not clear if these upgrades are hard blocked (instead they may just require minor changes).


<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

