### PR TITLE
chore(#9842): bump bikram-sambat and bikram-sambat-bootstrap versions to 1.8.0

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -16,7 +16,7 @@
         "angular-sanitize": "^1.8.3",
         "angular-translate": "^2.19.1",
         "angular-ui-bootstrap": "^2.5.6",
-        "bikram-sambat-bootstrap": "^1.6.0",
+        "bikram-sambat-bootstrap": "^1.8.0",
         "bootstrap": "^3.4.1",
         "font-awesome": "^4.7.0",
         "jquery": "3.7.1",
@@ -344,20 +344,21 @@
       }
     },
     "node_modules/bikram-sambat": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.7.0.tgz",
-      "integrity": "sha512-wcFkKw+wruQhlTEy5km5t38mVYIeO1t9fjGGnfXoHfDxh0VLDouKjHVhlfvQbZIT5CNoWMymA2v4WEWMcL+Rvw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.0.tgz",
+      "integrity": "sha512-W31TkhvV5C1yiWEhF7XnVJOHPVK6ph1INVS8CNSWrlF5JPAnH6T4xU5S49LVrmZgR15LM9RH0LixtovXT1prKw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "eurodigit": "^3.1.3"
       }
     },
     "node_modules/bikram-sambat-bootstrap": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.6.0.tgz",
-      "integrity": "sha512-07jQZ77thYr4f9YXFEIiew4jz2NgvLbO6mjKWaTq/ml7ZjUIenq1Uu1oqApwiHl18i1D/sFoLoy0kqHQGa4LdQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.8.0.tgz",
+      "integrity": "sha512-izBy7VKVAHVAP67vE+kOk/v5UDGa2+MCRlmDqYStMkHLlMGNmGJtSfoAwvxwMvPlBwYlR3wn7135ApUTf9aBsQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "bikram-sambat": "^1.7.0",
+        "bikram-sambat": "^1.8.0",
         "eurodigit": "^3.1.1"
       }
     },
@@ -570,7 +571,8 @@
     "node_modules/eurodigit": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/eurodigit/-/eurodigit-3.1.3.tgz",
-      "integrity": "sha512-/bS2/yTT1/sa5tiT3sjxQ6dobYwGDkWRCeoWYUSUFcLYomEPWlgVfnCE3Iv4eJDJE9upHhtNycxD9XQbR+zicg=="
+      "integrity": "sha512-/bS2/yTT1/sa5tiT3sjxQ6dobYwGDkWRCeoWYUSUFcLYomEPWlgVfnCE3Iv4eJDJE9upHhtNycxD9XQbR+zicg==",
+      "license": "ISC"
     },
     "node_modules/font-awesome": {
       "version": "4.7.0",
@@ -1205,19 +1207,19 @@
       }
     },
     "bikram-sambat": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.7.0.tgz",
-      "integrity": "sha512-wcFkKw+wruQhlTEy5km5t38mVYIeO1t9fjGGnfXoHfDxh0VLDouKjHVhlfvQbZIT5CNoWMymA2v4WEWMcL+Rvw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.0.tgz",
+      "integrity": "sha512-W31TkhvV5C1yiWEhF7XnVJOHPVK6ph1INVS8CNSWrlF5JPAnH6T4xU5S49LVrmZgR15LM9RH0LixtovXT1prKw==",
       "requires": {
         "eurodigit": "^3.1.3"
       }
     },
     "bikram-sambat-bootstrap": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.6.0.tgz",
-      "integrity": "sha512-07jQZ77thYr4f9YXFEIiew4jz2NgvLbO6mjKWaTq/ml7ZjUIenq1Uu1oqApwiHl18i1D/sFoLoy0kqHQGa4LdQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.8.0.tgz",
+      "integrity": "sha512-izBy7VKVAHVAP67vE+kOk/v5UDGa2+MCRlmDqYStMkHLlMGNmGJtSfoAwvxwMvPlBwYlR3wn7135ApUTf9aBsQ==",
       "requires": {
-        "bikram-sambat": "^1.7.0",
+        "bikram-sambat": "^1.8.0",
         "eurodigit": "^3.1.1"
       }
     },

--- a/admin/package.json
+++ b/admin/package.json
@@ -11,7 +11,7 @@
     "angular-sanitize": "^1.8.3",
     "angular-translate": "^2.19.1",
     "angular-ui-bootstrap": "^2.5.6",
-    "bikram-sambat-bootstrap": "^1.6.0",
+    "bikram-sambat-bootstrap": "^1.8.0",
     "bootstrap": "^3.4.1",
     "font-awesome": "^4.7.0",
     "jquery": "3.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "async": "^3.2.6",
-        "bikram-sambat": "^1.7.0",
+        "bikram-sambat": "^1.8.0",
         "body-parser": "^1.20.3",
         "bowser": "^2.11.0",
         "buffer-shims": "^1.0.0",
@@ -13029,9 +13029,10 @@
       }
     },
     "node_modules/bikram-sambat": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.7.0.tgz",
-      "integrity": "sha512-wcFkKw+wruQhlTEy5km5t38mVYIeO1t9fjGGnfXoHfDxh0VLDouKjHVhlfvQbZIT5CNoWMymA2v4WEWMcL+Rvw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.0.tgz",
+      "integrity": "sha512-W31TkhvV5C1yiWEhF7XnVJOHPVK6ph1INVS8CNSWrlF5JPAnH6T4xU5S49LVrmZgR15LM9RH0LixtovXT1prKw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "eurodigit": "^3.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   },
   "dependencies": {
     "async": "^3.2.6",
-    "bikram-sambat": "^1.7.0",
+    "bikram-sambat": "^1.8.0",
     "body-parser": "^1.20.3",
     "bowser": "^2.11.0",
     "buffer-shims": "^1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -26,7 +26,7 @@
         "@ngrx/store": "^19.0.1",
         "@ngx-translate/core": "^16.0.4",
         "@webcomponents/webcomponentsjs": "^2.8.0",
-        "bikram-sambat-bootstrap": "^1.6.0",
+        "bikram-sambat-bootstrap": "^1.8.0",
         "bootstrap": "^3.4.1",
         "bootstrap-daterangepicker": "^2.1.30",
         "core-js": "^3.41.0",
@@ -6102,19 +6102,20 @@
       }
     },
     "node_modules/bikram-sambat": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.7.0.tgz",
-      "integrity": "sha512-wcFkKw+wruQhlTEy5km5t38mVYIeO1t9fjGGnfXoHfDxh0VLDouKjHVhlfvQbZIT5CNoWMymA2v4WEWMcL+Rvw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.0.tgz",
+      "integrity": "sha512-W31TkhvV5C1yiWEhF7XnVJOHPVK6ph1INVS8CNSWrlF5JPAnH6T4xU5S49LVrmZgR15LM9RH0LixtovXT1prKw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "eurodigit": "^3.1.3"
       }
     },
     "node_modules/bikram-sambat-bootstrap": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.6.0.tgz",
-      "integrity": "sha512-07jQZ77thYr4f9YXFEIiew4jz2NgvLbO6mjKWaTq/ml7ZjUIenq1Uu1oqApwiHl18i1D/sFoLoy0kqHQGa4LdQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.8.0.tgz",
+      "integrity": "sha512-izBy7VKVAHVAP67vE+kOk/v5UDGa2+MCRlmDqYStMkHLlMGNmGJtSfoAwvxwMvPlBwYlR3wn7135ApUTf9aBsQ==",
       "dependencies": {
-        "bikram-sambat": "^1.7.0",
+        "bikram-sambat": "^1.8.0",
         "eurodigit": "^3.1.1"
       }
     },
@@ -17434,19 +17435,19 @@
       "dev": true
     },
     "bikram-sambat": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.7.0.tgz",
-      "integrity": "sha512-wcFkKw+wruQhlTEy5km5t38mVYIeO1t9fjGGnfXoHfDxh0VLDouKjHVhlfvQbZIT5CNoWMymA2v4WEWMcL+Rvw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat/-/bikram-sambat-1.8.0.tgz",
+      "integrity": "sha512-W31TkhvV5C1yiWEhF7XnVJOHPVK6ph1INVS8CNSWrlF5JPAnH6T4xU5S49LVrmZgR15LM9RH0LixtovXT1prKw==",
       "requires": {
         "eurodigit": "^3.1.3"
       }
     },
     "bikram-sambat-bootstrap": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.6.0.tgz",
-      "integrity": "sha512-07jQZ77thYr4f9YXFEIiew4jz2NgvLbO6mjKWaTq/ml7ZjUIenq1Uu1oqApwiHl18i1D/sFoLoy0kqHQGa4LdQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/bikram-sambat-bootstrap/-/bikram-sambat-bootstrap-1.8.0.tgz",
+      "integrity": "sha512-izBy7VKVAHVAP67vE+kOk/v5UDGa2+MCRlmDqYStMkHLlMGNmGJtSfoAwvxwMvPlBwYlR3wn7135ApUTf9aBsQ==",
       "requires": {
-        "bikram-sambat": "^1.7.0",
+        "bikram-sambat": "^1.8.0",
         "eurodigit": "^3.1.1"
       }
     },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -40,7 +40,7 @@
     "@ngrx/store": "^19.0.1",
     "@ngx-translate/core": "^16.0.4",
     "@webcomponents/webcomponentsjs": "^2.8.0",
-    "bikram-sambat-bootstrap": "^1.6.0",
+    "bikram-sambat-bootstrap": "^1.8.0",
     "bootstrap": "^3.4.1",
     "bootstrap-daterangepicker": "^2.1.30",
     "core-js": "^3.41.0",


### PR DESCRIPTION
# Description

Bumps bikram-sambat and bikram-sambat-bootstrap versions to 1.8.0

#9842

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

