### PR TITLE
added editorconfig file based on the style guide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# JavaScript files
+[*.{js,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+quote_type = single
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# CouchDB document property names
+[*.{couch,couchdb}]
+indent_style = space
+indent_size = 2
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Add editorconfig configuration with respect to the style guide #611

Added a editorconfigfile based on the styleguide here https://docs.communityhealthtoolkit.org/contribute/code/style-guide/


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

