### PR TITLE
fix(#9888): update ddocs version logic to append timestamp locally

### DIFF
--- a/scripts/build/index.js
+++ b/scripts/build/index.js
@@ -191,7 +191,10 @@ const updateServiceWorker = async () => {
 };
 
 const setDdocsVersion = () => {
-  const version = versions.getVersion();
+  let version = versions.getVersion();
+  if (!process.env.TAG) {
+    version = `${version}-${new Date().getTime()}`;
+  }
   const databases = fs.readdirSync(ddocsBuildPath);
   databases.forEach(database => {
     const dbPath = path.resolve(ddocsBuildPath, database);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

This PR fixes the issue where local design document (ddoc) changes were not being deployed during development (#9888).  
The change modifies the `setDdocsVersion` function so that, for local builds (i.e. when the `TAG` environment variable is not set), the current timestamp is appended to the base version returned by `versions.getVersion()`. This ensures that a unique version string is generated each time `npm run build-ddocs` is executed, prompting the API server to detect changes and auto-deploy the updated design docs. For release builds (when `TAG` is set), the version remains as provided by `versions.getVersion()`.

<!-- ISSUE NUMBER -->

[https://github.com/medic/cht-core/issues/9888](url)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

