### PR TITLE
fix(#9905): mock auth service

### DIFF
--- a/webapp/tests/karma/ts/modules/messages/messages-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/messages/messages-content.component.spec.ts
@@ -22,6 +22,8 @@ import { ActivatedRoute } from '@angular/router';
 import { MessagesActions } from '@mm-actions/messages';
 import { SenderComponent } from '@mm-components/sender/sender.component';
 import { PerformanceService } from '@mm-services/performance.service';
+import { AuthDirective } from '@mm-directives/auth.directive';
+import { AuthService } from '@mm-services/auth.service';
 
 describe('MessagesContentComponent', () => {
   let component: MessagesContentComponent;
@@ -76,7 +78,8 @@ describe('MessagesContentComponent', () => {
           FormsModule,
           CommonModule,
           MessagesContentComponent,
-          SenderComponent
+          SenderComponent,
+          AuthDirective,
         ],
         providers: [
           provideMockStore({ selectors: mockedSelectors }),
@@ -90,6 +93,7 @@ describe('MessagesContentComponent', () => {
           { provide: ModalService, useValue: modalService },
           { provide: ActivatedRoute, useValue: activatedRoute },
           { provide: PerformanceService, useValue: performanceService },
+          { provide: AuthService, useValue: { has: sinon.stub() } },
         ]
       })
       .compileComponents()


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9905-fix-message-component-tests/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9905-fix-message-component-tests/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9905-fix-message-component-tests/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

