### PR TITLE
feat(#9903): auto-include current date in release notes

### DIFF
--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -280,7 +280,7 @@ const formatCommits = (commits) => {
 };
 
 const output = ({ warnings, types }, commits) => {
-  const currentDate = new Date().toISOString().split("T")[0];  // Format: YYYY-MM-DD
+  const currentDate = new Date().toISOString().split('T')[0];  // Format: YYYY-MM-DD
   console.log(`
 ---
 title: "${MILESTONE_NAME} release notes"

--- a/scripts/release-notes/index.js
+++ b/scripts/release-notes/index.js
@@ -280,12 +280,14 @@ const formatCommits = (commits) => {
 };
 
 const output = ({ warnings, types }, commits) => {
+  const currentDate = new Date().toISOString().split("T")[0];  // Format: YYYY-MM-DD
   console.log(`
 ---
 title: "${MILESTONE_NAME} release notes"
 linkTitle: "${MILESTONE_NAME}"
 weight:
 description: >
+  Released "${currentDate}"
 relevantLinks: >
 toc_hide: true
 ---


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Closes #9903 

This PR updates the release notes generation script to automatically include the current date when generating a new release page. The format and placement of the date follow the backdating pattern used in [cht-docs#1843](https://github.com/medic/cht-docs/issues/1843).

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Manually tested by generating release notes for 4.18.0. Output includes the correct local date format.
- [x] Backwards compatible: Script still works for all other releases without requiring additional inputs.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
