### PR TITLE
feat(#9838): refactor shared-libs/lineage to use cht-datasource for reading contacts

### DIFF
--- a/api/src/controllers/contacts-by-phone.js
+++ b/api/src/controllers/contacts-by-phone.js
@@ -1,6 +1,7 @@
 const db = require('../db');
 const config = require('../config');
-const lineage = require('@medic/lineage')(Promise, db.medic);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db.medic, datasource);
 const phoneNumber = require('@medic/phone-number');
 const serverUtils = require('../server-utils');
 

--- a/api/src/controllers/hydration.js
+++ b/api/src/controllers/hydration.js
@@ -1,5 +1,6 @@
 const db = require('../db');
-const lineage = require('@medic/lineage')(Promise, db.medic);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db.medic, datasource);
 const serverUtils = require('../server-utils');
 
 /**

--- a/api/src/manual-migrations/minify-contacts.js
+++ b/api/src/manual-migrations/minify-contacts.js
@@ -1,5 +1,6 @@
 const db = require('../db').medic;
-const lineage = require('@medic/lineage')(Promise, db);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db, datasource);
 
 module.exports = doc => {
   if ((doc.contact && doc.contact.type) || (doc.parent && doc.parent.type)) {

--- a/api/src/services/export/contact-mapper.js
+++ b/api/src/services/export/contact-mapper.js
@@ -1,6 +1,7 @@
 const db = require('../../db');
 const search = require('@medic/search')(Promise, db.medic);
-const lineage = require('@medic/lineage')(Promise, db.medic);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db.medic, datasource);
 
 module.exports = {
   getDocs: ids => lineage.fetchHydratedDocs(ids),

--- a/api/src/services/export/message-mapper.js
+++ b/api/src/services/export/message-mapper.js
@@ -4,7 +4,8 @@ const config = require('../../config');
 const dateFormat = require('./date-format');
 const messageUtils = require('@medic/message-utils');
 const registrationUtils = require('@medic/registration-utils');
-const lineage = require('@medic/lineage')(Promise, db.medic);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db.medic, datasource);
 
 const normalizeResponse = doc => {
   return {

--- a/api/src/services/export/report-mapper.js
+++ b/api/src/services/export/report-mapper.js
@@ -3,7 +3,8 @@ const objectPath = require('object-path');
 const db = require('../../db');
 const dateFormat = require('./date-format');
 const search = require('@medic/search')(Promise, db.medic);
-const lineage = require('@medic/lineage')(Promise, db.medic);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db.medic, datasource);
 
 // Flattens a given object into an object where the keys are dot-notation
 // paths to the flattened values:

--- a/package-lock.json
+++ b/package-lock.json
@@ -34491,6 +34491,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@medic/cht-datasource": "file:../cht-datasource",
         "@medic/contact-types-utils": "file:../contact-types-utils"
       }
     },

--- a/shared-libs/lineage/package.json
+++ b/shared-libs/lineage/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@medic/contact-types-utils": "file:../contact-types-utils"
+    "@medic/contact-types-utils": "file:../contact-types-utils",
+    "@medic/cht-datasource": "file:../cht-datasource"
   }
 }

--- a/shared-libs/lineage/src/index.js
+++ b/shared-libs/lineage/src/index.js
@@ -1,8 +1,8 @@
 /**
  * @module lineage
  */
-module.exports = (Promise, DB) => Object.assign(
+module.exports = (Promise, DB, datasource) => Object.assign(
   {},
-  require('./hydration')(Promise, DB),
+  require('./hydration')(Promise, DB, datasource),
   require('./minify')
 );

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 const async = require('async');
 const db = require('../db');
-const lineage = require('@medic/lineage')(Promise, db.medic);
+const datasource = require('@medic/cht-datasource');
+const lineage = require('@medic/lineage')(Promise, db.medic, datasource);
 const utils = require('../lib/utils');
 const logger = require('@medic/logger');
 const config = require('../config');


### PR DESCRIPTION
# Description

This PR refactors the shared-libs/lineage library and its consuming code to use cht-datasource for reading contacts instead of directly using PouchDB. The changes maintain backward compatibility while centralizing contact read operations through cht-datasource.

## Details
- Updated shared-libs/lineage to use cht-datasource:
  - Added cht-datasource as a dependency
  - Modified the library to accept datasource as a parameter
  - Refactored key functions to use cht-datasource with fallbacks to the original implementation
  - Key functions updated: fetchLineageById, fetchDoc, fetchDocs, contactUuidByShortcode, fetchHydratedDocs

- Updated consuming code to use the refactored lineage library:
  - shared-libs/transitions/src/transitions/index.js
  - api/src/controllers/hydration.js
  - api/src/controllers/contacts-by-phone.js
  - api/src/services/export/contact-mapper.js
  - api/src/services/export/report-mapper.js
  - api/src/services/export/message-mapper.js
  - api/src/manual-migrations/minify-contacts.js

# Issue

Closes #9838

# Code review checklist
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Tested: Unit tests pass, confirming that the refactored code maintains the same behavior
- [x] Backwards compatible: Works with existing data and includes fallback mechanisms to ensure robustness if cht-datasource operations fail

![Screenshot 2025-05-04 014035](https://github.com/user-attachments/assets/2480dfbe-e39d-4b2f-8cfa-bc1ebbcd6de7)

