### PR TITLE
feat(#9920): add visual tests for report filters

### DIFF
--- a/tests/e2e/visual/reports/report-filter.wdio-spec.js
+++ b/tests/e2e/visual/reports/report-filter.wdio-spec.js
@@ -1,0 +1,142 @@
+const utils = require('@utils');
+const commonElements = require('@page-objects/default/common/common.wdio.page');
+const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
+const loginPage = require('@page-objects/default/login/login.wdio.page');
+const reportFactory = require('@factories/cht/reports/generic-report');
+const personFactory = require('@factories/cht/contacts/person');
+const { resizeWindowForScreenshots, generateScreenshot } = require('@utils/screenshots');
+
+describe('Report Filter functionality test', () => {
+  const contact = personFactory.build();
+  const REPORTED_DATE = Date.now() - (13 * 60 * 60 * 1000);
+  const reports = [
+    reportFactory
+      .report()
+      .build({
+        fields: {
+          patient_name: 'Jadena'
+        },
+        form: 'Health Facility ANC reminder',
+        content_type: 'xml',
+        contact: {
+          _id: contact._id,
+        },
+        reported_date: REPORTED_DATE,
+        from: 'Unknown sender',
+      }),
+    reportFactory
+      .report()
+      .build({
+        fields: {
+          patient_name: 'Zoe'
+        },
+        form: 'Health Facility ANC reminder',
+        content_type: 'xml',
+        contact: {
+          _id: contact._id,
+        },
+        reported_date: REPORTED_DATE,
+        from: 'Unknown sender',
+      }),
+    reportFactory
+      .report()
+      .build({
+        fields: {
+          patient_name: 'Shaila'
+        },
+        form: 'Postnatal danger sign follow-up',
+        content_type: 'xml',
+        contact: {
+
+          _id: contact._id,
+        },
+        reported_date: REPORTED_DATE,
+        from: 'Unknown sender',
+      }),
+    reportFactory
+      .report()
+      .build({
+        fields: {
+          patient_name: 'Kelly'
+        },
+        form: 'Postnatal danger sign follow-up',
+        content_type: 'xml',
+        contact: {
+
+          _id: contact._id,
+        },
+        reported_date: REPORTED_DATE,
+        from: 'Unknown sender',
+      }),
+    reportFactory
+      .report()
+      .build({
+        fields: {
+          patient_name: 'Lena'
+        },
+        form: 'Health Facility ANC reminder',
+        content_type: 'xml',
+        contact: {
+
+          _id: contact._id,
+        },
+        reported_date: REPORTED_DATE,
+        from: 'Unknown sender',
+      }),
+    reportFactory
+      .report()
+      .build({
+        fields: {
+          patient_name: 'Lena'
+        },
+        form: 'Postnatal danger sign follow-up',
+        content_type: 'xml',
+        contact: {
+          _id: contact._id,
+        },
+        reported_date: REPORTED_DATE,
+        from: 'Unknown sender',
+      }),
+  ];
+
+  const docs = [contact, ...reports];
+  const savedUuids = [];
+  const reportUuids = [];
+
+  before(async () => {
+    const results = await utils.saveDocs(docs);
+    results.forEach(result => {
+      savedUuids.push(result.id);
+      // Store only report IDs separately
+      if (result.id !== contact._id) {
+        reportUuids.push(result.id);
+      }
+    });
+    await loginPage.cookieLogin();
+    await browser.pause(3000);
+  });
+
+  after(async () => {
+    await utils.revertDb([], true);
+  });
+
+  after(async () => {
+    await utils.revertDb([], true);
+  });
+
+  it('should test sidebar filter functionality and capture screenshots', async () => {
+    await resizeWindowForScreenshots();
+
+    await commonElements.goToReports();
+    await commonElements.waitForLoaders();
+    await browser.pause(1000);
+
+    await generateScreenshot('report', 'unfiltered-reports-list');
+
+    await reportsPage.openSidebarFilter();
+    await browser.pause(500);
+
+    await generateScreenshot('report', 'filter-sidebar');
+
+  });
+});

--- a/tests/e2e/visual/wdio.conf.js
+++ b/tests/e2e/visual/wdio.conf.js
@@ -32,11 +32,13 @@ exports.config = Object.assign(wdioBaseConfig.config, {
       'contacts/contact-user-management.wdio-spec.js',
       'contacts/contact-user-hierarchy-creation.wdio-spec.js',
       'reports/bulk-delete.wdio-spec.js',
+      'reports/report-filter.wdio-spec.js',
     ],
     mobileTests: [
       'contacts/contact-user-management.wdio-spec.js',
       'contacts/list-view-login-visual.wdio-spec.js',
       'reports/bulk-delete.wdio-spec.js',
+      'reports/report-filter.wdio-spec.js',
     ]
   },
   capabilities: process.argv.includes('--suite=mobileTests')


### PR DESCRIPTION
This pull request introduces a new end-to-end test for the report filter functionality in the visual testing suite. 

### New Test Case for Report Filter Functionality:

* [`tests/e2e/visual/reports/report-filter.wdio-spec.js`](diffhunk://#diff-a6371fb8705a9a8686ae2ac1fd33ad52bf2a0cf106a77b1f55e048c826be8c04R1-R142): Added a new test case to validate the sidebar filter functionality on the reports page. The test generates multiple reports using a factory, saves them to the database, applies a filter, and captures screenshots for both unfiltered and filtered states. It also includes setup and teardown logic for database operations.

### Configuration Updates:

* [`tests/e2e/visual/wdio.conf.js`](diffhunk://#diff-c040b550a2d7e82a1d012c32818b344d80cca3e1743b2e400040e8d47a1a2d46R35-R41): Updated the test suite configuration to include the newly added `report-filter.wdio-spec.js` file in both desktop and mobile test groups.

#9920

##Test Images
1. Mobile
![image](https://github.com/user-attachments/assets/6885f73c-5098-4ac9-af7b-ebfcd6d48b98)

2. Desktop

<img width="442" alt="image" src="https://github.com/user-attachments/assets/98b4c098-31ef-4563-ab56-e395b3e5e290" />


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

