### PR TITLE
fix(#9951): avoid circular call and clear deploy info cache when finalizing upgrade

### DIFF
--- a/api/src/services/setup/upgrade-steps.js
+++ b/api/src/services/setup/upgrade-steps.js
@@ -3,6 +3,7 @@ const viewIndexerProgress = require('./view-indexer-progress');
 const upgradeLogService = require('./upgrade-log');
 const viewIndexer = require('./view-indexer');
 const logger = require('@medic/logger');
+const environment = require('@medic/environment');
 const startupLog = require('./startup-log');
 
 /**
@@ -20,6 +21,7 @@ const finalize = async () => {
   await upgradeUtils.deleteStagedDdocs();
   await upgradeLogService.setFinalized();
   await upgradeUtils.cleanup();
+  await environment.getDeployInfo(true);
 };
 
 /**

--- a/api/tests/mocha/services/setup/upgrade-steps.spec.js
+++ b/api/tests/mocha/services/setup/upgrade-steps.spec.js
@@ -6,6 +6,7 @@ const upgradeLogService = require('../../../../src/services/setup/upgrade-log');
 const upgradeUtils = require('../../../../src/services/setup/utils');
 const viewIndexerProgress = require('../../../../src/services/setup/view-indexer-progress');
 const viewIndexer = require('../../../../src/services/setup/view-indexer');
+const environment = require('@medic/environment');
 
 let upgradeSteps;
 
@@ -28,6 +29,7 @@ describe('Upgrade steps', () => {
       sinon.stub(upgradeUtils, 'deleteStagedDdocs');
       sinon.stub(upgradeLogService, 'setFinalized');
       sinon.stub(upgradeUtils, 'cleanup');
+      sinon.stub(environment, 'getDeployInfo');
 
       await upgradeSteps.finalize();
 
@@ -37,6 +39,7 @@ describe('Upgrade steps', () => {
       expect(upgradeUtils.deleteStagedDdocs.callCount).to.equal(1);
       expect(upgradeLogService.setFinalized.callCount).to.equal(1);
       expect(upgradeUtils.cleanup.callCount).to.equal(1);
+      expect(environment.getDeployInfo.calledOnceWithExactly(true)).to.be.true;
     });
 
     it('should throw an error if unstage fails', async () => {

--- a/shared-libs/couch-request/src/couch-request.js
+++ b/shared-libs/couch-request/src/couch-request.js
@@ -26,6 +26,11 @@ const addServername = isTrue(process.env.ADD_SERVERNAME_TO_HTTP_AGENT);
 //  name of the host being connected to, and must be a host name, and not an IP address.".
 //
 
+const isInternalRequest = (options) => {
+  const url = new URL(options.uri);
+  return url.hostname === environment.host;
+};
+
 const getUserAgent = async () => {
   const chtVersion = await environment.getVersion();
   const platform = os.platform();
@@ -143,11 +148,6 @@ const setRequestOptions = async (options) => {
     options.headers[requestIdHeader] = requestId;
   }
 
-  // Set user-agent header if not already set
-  if (!options.headers['user-agent']) {
-    options.headers['user-agent'] = await getUserAgent();
-  }
-
   setRequestUri(options);
   setRequestAuth(options);
   setTimeout(options);
@@ -155,6 +155,11 @@ const setRequestOptions = async (options) => {
   setRequestContentType(options, sendJson);
   if (addServername) {
     options.servername = environment.host;
+  }
+
+  // only add user agent for external requests to avoid circular calls
+  if (!isInternalRequest(options) && !options.headers['user-agent']) {
+    options.headers['user-agent'] = await getUserAgent();
   }
 };
 

--- a/shared-libs/couch-request/test/couch-request.js
+++ b/shared-libs/couch-request/test/couch-request.js
@@ -740,7 +740,7 @@ describe('couch-request', () => {
     
     const requestOptions = global.fetch.args[0][1];
     expect(requestOptions.headers['user-agent']).to.equal('Community Health Toolkit/4.18.0 (test-platform,test-arch)');
-    expect(requestOptions.headers['authorization']).to.equal(undefined);
+    expect(requestOptions.headers.authorization).to.equal(undefined);
   });
 
   it('should not override user-agent header if already specified', async () => {

--- a/shared-libs/couch-request/test/couch-request.js
+++ b/shared-libs/couch-request/test/couch-request.js
@@ -107,7 +107,6 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           authorization: `Basic ${btoa('admin:password')}`,
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/test',
@@ -130,7 +129,6 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           authorization: `Basic ${btoa('admin:password')}`,
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/omg',
@@ -154,10 +152,31 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           authorization: `Basic ${btoa('admin:pass')}`,
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/doc/attachment',
+      }
+    ]);
+  });
+
+  it('should add user-agent header to external requests', async () => {
+    const opts = {
+      url: 'http://www.textit.com/api/v2/broadcasts.json',
+    };
+
+    await couchRequest.post(opts);
+
+    expect(global.fetch.args[0]).to.deep.equal([
+      'http://www.textit.com/api/v2/broadcasts.json',
+      {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
+        },
+        servername: 'test.com',
+        uri: 'http://www.textit.com/api/v2/broadcasts.json',
       }
     ]);
   });
@@ -183,7 +202,6 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           authorization: `Basic ${btoa('admin:pass')}`,
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic?number=2&string=yes&array=%5B%22one%22%2C%22two%22%5D&boolean=true',
@@ -207,7 +225,6 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           authorization: `Basic ${btoa('admin:123456')}`,
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/oops',
@@ -231,7 +248,6 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           authorization: `Basic ${btoa('admin:123456')}`,
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/omg',
@@ -249,7 +265,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/a',
@@ -314,7 +329,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/a',
@@ -336,7 +350,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         body: JSON.stringify({ foo: 'bar' }),
         servername: 'test.com',
@@ -359,7 +372,6 @@ describe('couch-request', () => {
         method: 'POST',
         headers: {
           'content-type': 'application/x-www-form-urlencoded',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         body: 'foo=bar&bar=baz',
         servername: 'test.com',
@@ -383,7 +395,6 @@ describe('couch-request', () => {
         headers: {
           'content-type': 'application/x-www-form-urlencoded',
           accept: 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         body: 'foo=bar&bar=baz',
         servername: 'test.com',
@@ -404,9 +415,7 @@ describe('couch-request', () => {
       'http://test.com:5984/b',
       {
         method: 'POST',
-        headers: {
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
-        },
+        headers: {},
         body: 'some random text',
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
@@ -428,7 +437,6 @@ describe('couch-request', () => {
         method: 'POST',
         headers: {
           'content-type': 'text/html',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         body: 'some random text',
         servername: 'test.com',
@@ -483,7 +491,6 @@ describe('couch-request', () => {
         headers: {
           'content-type': 'application/json',
           accept: 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
@@ -509,7 +516,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
@@ -534,7 +540,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         uri: 'http://test.com:5984/b',
       }
@@ -658,7 +663,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
@@ -681,7 +685,6 @@ describe('couch-request', () => {
         headers: {
           accept: 'application/json',
           'content-type': 'application/json',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
@@ -703,7 +706,6 @@ describe('couch-request', () => {
           accept: 'application/json',
           'content-type': 'application/json',
           'header-name': 'req_uuid',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
@@ -726,7 +728,6 @@ describe('couch-request', () => {
           'content-type': 'application/json',
           'header-name': 'req_uuid',
           'authorization': 'Basic 123',
-          'user-agent': 'Community Health Toolkit/4.18.0 (test-platform,test-arch)',
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
@@ -734,12 +735,12 @@ describe('couch-request', () => {
     ]]);
   });
 
-  it('should automatically add user-agent header to requests', async () => {
-    await couchRequest.get({ url: 'http://test.com:5984/test-user-agent' });
+  it('should automatically add user-agent header to external requests', async () => {
+    await couchRequest.get({ url: 'https://rapidpro.com/test-user-agent' });
     
     const requestOptions = global.fetch.args[0][1];
     expect(requestOptions.headers['user-agent']).to.equal('Community Health Toolkit/4.18.0 (test-platform,test-arch)');
-    
+    expect(requestOptions.headers['authorization']).to.equal(undefined);
   });
 
   it('should not override user-agent header if already specified', async () => {

--- a/shared-libs/environment/src/index.js
+++ b/shared-libs/environment/src/index.js
@@ -71,20 +71,15 @@ const getVersionFromDdoc = (ddoc) => {
     'unknown';
 };
 
-const getDeployInfo = async () => {
-  if (deployInfoCache) {
+const getDeployInfo = async (refresh = false) => {
+  if (deployInfoCache && !refresh) {
     return deployInfoCache;
   }
 
   try {
     // Lazy load couch-request only when needed
     const request = require('@medic/couch-request');
-    const ddoc = await request.get({
-      url: `${couchUrl}/_design/${module.exports.ddoc}`,
-      headers: {
-        'user-agent': 'Community Health Toolkit',
-      }
-    });
+    const ddoc = await request.get({ url: `${couchUrl}/_design/${module.exports.ddoc}` });
     deployInfoCache = {
       ...ddoc.build_info,
       ...ddoc.deploy_info,

--- a/shared-libs/environment/test/index.spec.js
+++ b/shared-libs/environment/test/index.spec.js
@@ -120,9 +120,6 @@ describe('environment', () => {
           [
             {
               url: 'http://admin:pass@localhost:5984/medicdb/_design/medic',
-              headers: {
-                'user-agent': 'Community Health Toolkit'
-              }
             }
           ]
         ]);        
@@ -142,6 +139,32 @@ describe('environment', () => {
 
         expect(result1).to.deep.equal(result2);
         expect(request.get.callCount).to.equal(1);
+      });
+
+      it('should clear cache when requested', async () => {
+        const ddoc = {
+          _id: '_design/medic',
+          build_info: { version: '4.1.0' }
+        };
+        sinon.stub(request, 'get').resolves(ddoc);
+        const env = rewire('../src/index');
+
+        const result1 = await env.getDeployInfo();
+        const result2 = await env.getDeployInfo();
+
+        expect(result1).to.deep.equal(result2);
+        expect(result1.version).to.equal(ddoc.build_info.version);
+        expect(request.get.callCount).to.equal(1);
+
+        ddoc.build_info.version = '4.2.0';
+        request.get.resolves(ddoc);
+
+        expect((await env.getDeployInfo()).version).to.equal('4.1.0');
+        expect(request.get.callCount).to.equal(1);
+        expect((await env.getDeployInfo(true)).version).to.equal('4.2.0');
+        expect(request.get.callCount).to.equal(2);
+        expect((await env.getDeployInfo()).version).to.equal('4.2.0');
+        expect(request.get.callCount).to.equal(2);
       });
 
       it('should throw error if request fails', async () => {

--- a/tests/e2e/default/sms/rapidpro.wdio-spec.js
+++ b/tests/e2e/default/sms/rapidpro.wdio-spec.js
@@ -395,6 +395,7 @@ describe('RapidPro SMS Gateway', () => {
         expect(expectedBroadcastIds.includes(query.broadcast)).to.be.true;
         requestedBroadcastIds.push(query.broadcast);
         expect(headers.authorization).to.equal(`Token ${OUTGOING_KEY}`);
+        expect(headers['user-agent']).to.include('Community Health Toolkit/');
       });
 
       // we don't have complete control over which docs are requested in the provided timespan


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

Fixes #9951 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9951-fix-circular-call/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9951-fix-circular-call/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9951-fix-circular-call/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

