### PR TITLE
feat(#9890): add mapping from OIDC to CHT user

### DIFF
--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -563,8 +563,8 @@ module.exports = {
     }
     const currentUrl =  new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
     try {
-      const { preferred_username, locale } = await sso.getIdToken(currentUrl);
-      const sessionCookie = await sso.getCookie(preferred_username);
+      const { username, locale } = await sso.getIdToken(currentUrl);
+      const sessionCookie = await sso.getCookie(username);
       req.body = { locale };
 
       const options = { headers: { Cookie: sessionCookie } };

--- a/api/src/controllers/login.js
+++ b/api/src/controllers/login.js
@@ -8,7 +8,9 @@ const privacyPolicy = require('../services/privacy-policy');
 const logger = require('@medic/logger');
 const db = require('../db');
 const dataContext = require('../services/data-context');
-const { tokenLogin, roles, users, validatePassword } = require('@medic/user-management')(config, db, dataContext);
+const {
+  tokenLogin, ssoLogin, roles, users, validatePassword
+} = require('@medic/user-management')(config, db, dataContext);
 const localeUtils = require('locale');
 const cookie = require('../services/cookie');
 const brandingService = require('../services/branding');
@@ -16,7 +18,6 @@ const translations = require('../translations');
 const template = require('../services/template');
 const rateLimitService = require('../services/rate-limit');
 const serverUtils = require('../server-utils');
-const appSettings = require('../services/settings');
 const sso = require('../services/sso-login');
 
 const PASSWORD_RESET_URL = '/medic/password-reset';
@@ -235,7 +236,7 @@ const setUserCtxCookie = (res, userCtx) => {
   cookie.setUserCtx(res, JSON.stringify(content));
 };
 
-const isOidcUser = (userDoc) => userDoc?.oidc === true && config.get('oidc_provider')?.client_id;
+const isOidcUser = (userDoc) => userDoc?.oidc_username && ssoLogin.isSsoLoginEnabled();
 
 const setCookies = async (req, res, sessionCookie) => {
   const options = { headers: { Cookie: sessionCookie } };
@@ -347,10 +348,9 @@ const loginByToken = async (req, res) => {
   }
 };
 
-const renderLogin = async (req) => {
-  const hasOidcProvider = await appSettings.hasOidcProvider();
-  return render('login', req, { hasOidcProvider });
-};
+const renderLogin = async (req) => render('login', req, {
+  hasOidcProvider: ssoLogin.isSsoLoginEnabled()
+});
 
 const renderPasswordReset = (req) => {
   return render('passwordReset', req);
@@ -537,7 +537,7 @@ module.exports = {
     } catch (err) {
       logger.error('Error updating password: %o', err);
       const status = err.status || 500;
-      res.status(status).json({ error: err.error || 'Error updating password' });
+      res.status(status).json({ error: err.error || err.message || 'Error updating password' });
     }
   },
   tokenGet: (req, res, next) => renderTokenLogin(req, res).catch(next),

--- a/api/src/services/settings.js
+++ b/api/src/services/settings.js
@@ -49,11 +49,6 @@ const getDeprecatedTransitions = () => {
     }));
 };
 
-const hasOidcProvider = async () => {
-  const settings = await module.exports.get();
-  return !!settings?.oidc_provider;
-};
-
 module.exports = {
   get: () => {
     return getDoc()
@@ -121,5 +116,4 @@ module.exports = {
   },
   getDeprecatedTransitions: getDeprecatedTransitions,
   SETTINGS_DOC_ID: SETTINGS_DOC_ID,
-  hasOidcProvider,
 };

--- a/api/tests/mocha/controllers/login.spec.js
+++ b/api/tests/mocha/controllers/login.spec.js
@@ -1168,7 +1168,7 @@ describe('login controller', () => {
     });
 
     it('gets id token and redirects to homepage with session cookie', async () => {
-      const idToken = { preferred_username: 'lil', locale: 'en' };
+      const idToken = { username: 'lil', locale: 'en' };
       sso.getIdToken.resolves(idToken);
       const sessionCookie = 'my-session-cookie';
       sso.getCookie.resolves(`AuthSession=${sessionCookie}`);
@@ -1182,7 +1182,7 @@ describe('login controller', () => {
       chai.expect(sso.getIdToken.calledOnceWithExactly(
         new URL(`http://xx.app.medicmobile.org/${environment.db}/login/oidc/get_token`)
       )).to.be.true;
-      chai.expect(sso.getCookie.calledOnceWithExactly(idToken.preferred_username)).to.be.true;
+      chai.expect(sso.getCookie.calledOnceWithExactly(idToken.username)).to.be.true;
       chai.expect(auth.getUserCtx.calledOnceWithExactly({
         headers: { Cookie: `AuthSession=${sessionCookie}` }
       })).to.be.true;
@@ -1197,7 +1197,7 @@ describe('login controller', () => {
     });
 
     it('redirects to login page with sso user error when failing to find valid CHT user', async () => {
-      const idToken = { preferred_username: 'lil', locale: 'en' };
+      const idToken = { username: 'lil', locale: 'en' };
       sso.getIdToken.resolves(idToken);
       const userNotFoundError = new Error('User not found');
       userNotFoundError.status = 401;
@@ -1210,7 +1210,7 @@ describe('login controller', () => {
       chai.expect(sso.getIdToken.calledOnceWithExactly(
         new URL(`http://xx.app.medicmobile.org/${environment.db}/login/oidc/get_token`)
       )).to.be.true;
-      chai.expect(sso.getCookie.calledOnceWithExactly(idToken.preferred_username)).to.be.true;
+      chai.expect(sso.getCookie.calledOnceWithExactly(idToken.username)).to.be.true;
       chai.expect(auth.getUserCtx.notCalled).to.be.true;
       chai.expect(users.getUserDoc.notCalled).to.be.true;
       chai.expect(res.cookie.notCalled).to.be.true;

--- a/ddocs/users-db/users/views/users_by_field/map.js
+++ b/ddocs/users-db/users/views/users_by_field/map.js
@@ -1,7 +1,13 @@
 function(doc) {
-  if (doc.contact_id) {
-    emit(['contact_id', doc.contact_id]);
-  }
+  [
+    'contact_id',
+    'oidc_username'
+  ].forEach(function(property) {
+    if (doc[property]) {
+      emit([property, doc[property]]);
+    }
+  });
+
   if (doc.facility_id) {
     var facilityIds = Array.isArray(doc.facility_id) ? doc.facility_id : [doc.facility_id];
     facilityIds.forEach(function(facilityId) {

--- a/shared-libs/user-management/src/index.js
+++ b/shared-libs/user-management/src/index.js
@@ -6,6 +6,7 @@ const bulkUploadLog = require('./bulk-upload-log');
 const roles = require('./roles');
 const tokenLogin = require('./token-login');
 const users = require('./users');
+const ssoLogin = require('./sso-login');
 
 module.exports = (sourceConfig, sourceDb, sourceDataContext) => {
   config.init(sourceConfig);
@@ -18,7 +19,8 @@ module.exports = (sourceConfig, sourceDb, sourceDataContext) => {
     roles,
     tokenLogin,
     users,
-    validatePassword: users.validatePassword
+    validatePassword: users.validatePassword,
+    isSsoLoginEnabled: ssoLogin.isSsoLoginEnabled
   };
 };
 

--- a/shared-libs/user-management/src/index.js
+++ b/shared-libs/user-management/src/index.js
@@ -18,9 +18,12 @@ module.exports = (sourceConfig, sourceDb, sourceDataContext) => {
     bulkUploadLog,
     roles,
     tokenLogin,
+    ssoLogin: {
+      isSsoLoginEnabled: ssoLogin.isSsoLoginEnabled,
+      getUserByOidcUsername: ssoLogin.getUserByOidcUsername,
+    },
     users,
     validatePassword: users.validatePassword,
-    isSsoLoginEnabled: ssoLogin.isSsoLoginEnabled
   };
 };
 

--- a/shared-libs/user-management/src/index.js
+++ b/shared-libs/user-management/src/index.js
@@ -6,8 +6,12 @@ const bulkUploadLog = require('./bulk-upload-log');
 const roles = require('./roles');
 const tokenLogin = require('./token-login');
 const users = require('./users');
-const ssoLogin = require('./sso-login');
+const { isSsoLoginEnabled, getUsersByOidcUsername } = require('./sso-login');
 
+const ssoLogin = {
+  isSsoLoginEnabled,
+  getUsersByOidcUsername,
+};
 module.exports = (sourceConfig, sourceDb, sourceDataContext) => {
   config.init(sourceConfig);
   db.init(sourceDb);
@@ -18,10 +22,7 @@ module.exports = (sourceConfig, sourceDb, sourceDataContext) => {
     bulkUploadLog,
     roles,
     tokenLogin,
-    ssoLogin: {
-      isSsoLoginEnabled: ssoLogin.isSsoLoginEnabled,
-      getUserByOidcUsername: ssoLogin.getUserByOidcUsername,
-    },
+    ssoLogin,
     users,
     validatePassword: users.validatePassword,
   };

--- a/shared-libs/user-management/src/roles.js
+++ b/shared-libs/user-management/src/roles.js
@@ -6,6 +6,11 @@ const config = require('./libs/config');
  * replicate or not, without requiring access to server settings.
  */
 const ONLINE_ROLE = 'mm-online';
+/**
+ * Indicates the user should authenticate via OIDC.
+ * Users with this role are not allowed to edit their profile/password.
+ */
+const OIDC_ROLE = 'mm-oidc';
 const DB_ADMIN_ROLE = '_admin';
 
 const hasRole = (userCtx, role) => {
@@ -47,7 +52,7 @@ module.exports = {
   },
   isDbAdmin,
   ONLINE_ROLE,
-
+  OIDC_ROLE,
   hasAllPermissions: (roles, permissions) => {
     if (module.exports.isDbAdmin({ roles })) {
       return true;

--- a/shared-libs/user-management/src/roles.js
+++ b/shared-libs/user-management/src/roles.js
@@ -6,11 +6,6 @@ const config = require('./libs/config');
  * replicate or not, without requiring access to server settings.
  */
 const ONLINE_ROLE = 'mm-online';
-/**
- * Indicates the user should authenticate via OIDC.
- * Users with this role are not allowed to edit their profile/password.
- */
-const OIDC_ROLE = 'mm-oidc';
 const DB_ADMIN_ROLE = '_admin';
 
 const hasRole = (userCtx, role) => {
@@ -52,7 +47,7 @@ module.exports = {
   },
   isDbAdmin,
   ONLINE_ROLE,
-  OIDC_ROLE,
+
   hasAllPermissions: (roles, permissions) => {
     if (module.exports.isDbAdmin({ roles })) {
       return true;

--- a/shared-libs/user-management/src/sso-login.js
+++ b/shared-libs/user-management/src/sso-login.js
@@ -1,5 +1,6 @@
 const config = require('./libs/config');
 const passwords = require('./libs/passwords');
+const { OIDC_ROLE } = require('./roles');
 
 const isSsoLoginEnabled = () => !!config.get('oidc_provider');
 
@@ -16,6 +17,12 @@ const validateSsoLogin = (data) => {
 
   data.password = passwords.generate();
   data.password_change_required = false;
+  if (!data.roles) {
+    data.roles = [];
+  }
+  if (!data.roles.includes(OIDC_ROLE)) {
+    data.roles.push(OIDC_ROLE);
+  }
 };
 
 const validateSsoLoginUpdate = (data, updatedUser) => {

--- a/shared-libs/user-management/src/token-login.js
+++ b/shared-libs/user-management/src/token-login.js
@@ -1,6 +1,7 @@
 const db = require('./libs/db');
 const config = require('./libs/config');
 const passwords = require('./libs/passwords');
+const ssoLogin = require('./sso-login');
 const taskUtils = require('@medic/task-utils');
 const phoneNumber = require('@medic/phone-number');
 const TOKEN_EXPIRE_TIME = 24 * 60 * 60 * 1000; // 24 hours
@@ -283,7 +284,7 @@ const getUserByToken = (token) => {
         throw expired;
       }
 
-      if (user.oidc && config.get().oidc_provider?.client_id) {
+      if (user.oidc_username && ssoLogin.isSsoLoginEnabled()) {
         const err = new Error('Token login not allowed for SSO users');
         err.status = 401;
         throw err;

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -456,7 +456,7 @@ const getSettingsUpdates = (username, data) => {
   });
 
   if (Object.keys(data).includes('oidc_username')) {
-    settings.oidc = !!data.oidc_username;
+    settings.oidc_login = !!data.oidc_username;
   }
 
   getCommonFieldsUpdates(settings, data);

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -895,7 +895,7 @@ const createMultiFacilityUser = async (data, appUrl) => {
   if (tokenLoginError) {
     throw error400(tokenLoginError.msg, tokenLoginError.key);
   }
-  const ssoLoginError = ssoLogin.validateSsoLogin(data);
+  const ssoLoginError = await ssoLogin.validateSsoLogin(data);
   if (ssoLoginError) {
     throw error400(ssoLoginError.msg);
   }
@@ -1023,7 +1023,7 @@ module.exports = {
       return Promise.reject(error400(tokenLoginError.msg, tokenLoginError.key));
     }
 
-    const ssoLoginError = ssoLogin.validateSsoLogin(data);
+    const ssoLoginError = await ssoLogin.validateSsoLogin(data);
     if (ssoLoginError) {
       return Promise.reject(error400(ssoLoginError.msg));
     }
@@ -1103,7 +1103,7 @@ module.exports = {
           throw new Error(tokenLoginError.msg);
         }
 
-        const ssoLoginError = ssoLogin.validateSsoLogin(user);
+        const ssoLoginError = await ssoLogin.validateSsoLogin(user);
         if (ssoLoginError) {
           throw error400(ssoLoginError.msg);
         }
@@ -1181,7 +1181,7 @@ module.exports = {
     if (tokenLoginError) {
       return Promise.reject(error400(tokenLoginError.msg, tokenLoginError.key));
     }
-    const ssoLoginError = ssoLogin.validateSsoLoginUpdate(data, user, userSettings);
+    const ssoLoginError = await ssoLogin.validateSsoLoginUpdate(data, user, userSettings);
     if (ssoLoginError) {
       return Promise.reject(error400(ssoLoginError.msg));
     }

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -51,7 +51,7 @@ const USER_EDITABLE_FIELDS = RESTRICTED_USER_EDITABLE_FIELDS.concat([
   'contact',
   'type',
   'roles',
-  'oidc',
+  'oidc_username',
 ]);
 
 const RESTRICTED_SETTINGS_EDITABLE_FIELDS = [
@@ -530,7 +530,7 @@ const missingFields = data => {
 
   if (tokenLogin.shouldEnableTokenLogin(data)) {
     required.push('phone');
-  } else if (!data.oidc) {
+  } else if (!data.oidc_username) {
     required.push('password');
   }
 
@@ -694,7 +694,7 @@ const validateUserContact = (data, user) => {
  * @param {string=} data.phone Valid phone number. Required if token_login is enabled for the user.
  * @param {Boolean=} data.token_login A boolean representing whether or not the Login by SMS should be enabled for this
  *   user.
- * @param {string=} data.oidc_provider Client ID for the OIDC Client. Can be set but not together 
+ * @param {string=} data.oidc_username unique OIDC identifier for user. Can be set but not together
  * with @param token_login|@param password
  * @param {string=} data.fullname Full name
  * @param {string=} data.email Email address
@@ -998,7 +998,7 @@ module.exports = {
    * @param {string=} data.phone Valid phone number. Required if token_login is enabled for the user.
    * @param {Boolean=} data.token_login A boolean representing whether or not the Login by SMS should be enabled for
    *   this user.
-   * @param {string=} data.oidc_provider Client ID for the OIDC Client. Can be set but not together 
+   * @param {string=} data.oidc_username unique OIDC identifier for user. Can be set but not together
    * with @param token_login|@param password
    * @param {string=} data.fullname Full name
    * @param {string=} data.email Email address
@@ -1053,7 +1053,7 @@ module.exports = {
    * @param {string=} users[].phone Valid phone number. Required if token_login is enabled for the user.
    * @param {Boolean=} users[].token_login A boolean representing whether or not the Login by SMS should be enabled for
    *   this user.
-   * @param {string=} users[].oidc_provider Client ID for the OIDC Client. Can be set but not together 
+   * @param {string=} users[].oidc_username unique OIDC identifier for user. Can be set but not together
    * with @param token_login|@param password
    * @param {string=} users[].fullname Full name
    * @param {string=} users[].email Email address

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -1181,7 +1181,7 @@ module.exports = {
     if (tokenLoginError) {
       return Promise.reject(error400(tokenLoginError.msg, tokenLoginError.key));
     }
-    const ssoLoginError = ssoLogin.validateSsoLoginUpdate(data, user);
+    const ssoLoginError = ssoLogin.validateSsoLoginUpdate(data, user, userSettings);
     if (ssoLoginError) {
       return Promise.reject(error400(ssoLoginError.msg));
     }

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -455,6 +455,10 @@ const getSettingsUpdates = (username, data) => {
     }
   });
 
+  if (Object.keys(data).includes('oidc_username')) {
+    settings.oidc = !!data.oidc_username;
+  }
+
   getCommonFieldsUpdates(settings, data);
 
   return settings;
@@ -1181,7 +1185,7 @@ module.exports = {
     if (tokenLoginError) {
       return Promise.reject(error400(tokenLoginError.msg, tokenLoginError.key));
     }
-    const ssoLoginError = await ssoLogin.validateSsoLoginUpdate(data, user, userSettings);
+    const ssoLoginError = await ssoLogin.validateSsoLoginUpdate(data, user);
     if (ssoLoginError) {
       return Promise.reject(error400(ssoLoginError.msg));
     }

--- a/shared-libs/user-management/test/unit/sso-login.spec.js
+++ b/shared-libs/user-management/test/unit/sso-login.spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const config = require('../../src/libs/config');
 const service = require('../../src/sso-login');
 const passwords = require('../../src/libs/passwords');
+const db = require('../../src/libs/db');
 
 describe('SSO Login service', () => {
   const GENERATED_PASSWORD = 'generatedPassword';
@@ -14,52 +15,75 @@ describe('SSO Login service', () => {
       get: sinon.stub()
     });
     generatePassword = sinon.stub(passwords, 'generate').returns(GENERATED_PASSWORD);
+    db.init({ users: { query: sinon.stub() } });
   });
   afterEach(() => {
     sinon.restore();
   });
 
   describe('validateSsoLogin', () => {
-    it('should return error message when oidc_username and password are present', () => {
+    it('should return error message when oidc_username and password are present', async () => {
       const data = { password: 'testPassword', oidc_username: 'test' };
-      const result = service.validateSsoLogin(data);
+      const result = await service.validateSsoLogin(data);
 
       expect(result).to.deep.equal({
         msg: 'Cannot set password or token_login with oidc_username.'
       });
       expect(config.get.notCalled).to.be.true;
       expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.notCalled).to.be.true;
     });
 
-    it('should return error message when oidc_username and token_login = true', () => {
+    it('should return error message when oidc_username and token_login = true', async () => {
       const data = { token_login: true, oidc_username: 'test' };
-      const result = service.validateSsoLogin(data);
+      const result = await service.validateSsoLogin(data);
       
       expect(result).to.deep.equal({
         msg: 'Cannot set password or token_login with oidc_username.'
       });
       expect(config.get.notCalled).to.be.true;
       expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.notCalled).to.be.true;
     });
 
-    it('should return error message when oidc_provider is not in app settings', () => {
+    it('should return error message when oidc_provider is not in app settings', async () => {
       const data = { oidc_username: 'test' };
       config.get.returns(undefined);
     
-      const result = service.validateSsoLogin(data);
+      const result = await service.validateSsoLogin(data);
 
       expect(result).to.deep.equal({
         msg: 'Cannot set oidc_username when OIDC Login is not enabled.'
       });
       expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
       expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.notCalled).to.be.true;
     });
 
-    it('should not return error message when oidc user is valid', () => {
+    it('should return error message when duplicate oidc user exists', async () => {
       const data = { oidc_username: 'test' };
       config.get.returns({ 'client_id': 'testClientId' });
+      db.users.query.resolves({ rows: [{ id: 'duplicate-user' }] });
 
-      const result = service.validateSsoLogin(data);
+      const result = await service.validateSsoLogin(data);
+
+      expect(result).to.deep.equal({
+        msg: 'The oidc_username [test] already exists for user [duplicate-user].'
+      });
+      expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
+      expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: false, limit: 2, key: ['oidc_username', 'test'] }
+      )).to.be.true;
+    });
+
+    it('should not return error message when oidc user is valid', async () => {
+      const data = { oidc_username: 'test' };
+      config.get.returns({ 'client_id': 'testClientId' });
+      db.users.query.resolves({ rows: [] });
+
+      const result = await service.validateSsoLogin(data);
 
       expect(result).to.equal(undefined);
       expect(data).to.deep.equal({
@@ -70,16 +94,21 @@ describe('SSO Login service', () => {
       });
       expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
       expect(generatePassword.calledOnceWithExactly()).to.be.true;
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: false, limit: 2, key: ['oidc_username', 'test'] }
+      )).to.be.true;
     });
 
-    it('should return undefined when oidc_username is not provided', () => {
+    it('should return undefined when oidc_username is not provided', async () => {
       const data = { password: 'testPassword' };
     
-      const result = service.validateSsoLogin(data);
+      const result = await service.validateSsoLogin(data);
 
       expect(result).to.equal(undefined);
       expect(config.get.notCalled).to.be.true;
       expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.notCalled).to.be.true;
     });
   });
 
@@ -88,17 +117,18 @@ describe('SSO Login service', () => {
       { password: 'testPassword', oidc_username: 'test', token_login: true },
       { token_login: true }
     ].forEach((data) => {
-      it('should return error message when token login modified to be invalid', () => {
+      it('should return error message when token login modified to be invalid', async () => {
         const user = { password: 'testPassword', oidc_username: 'test' };
         const userSettings = { type: 'user-settings' };
 
-        const result = service.validateSsoLoginUpdate(data, user, userSettings);
+        const result = await service.validateSsoLoginUpdate(data, user, userSettings);
 
         expect(result).to.deep.equal({
           msg: 'Cannot set token_login with oidc_username.'
         });
         expect(config.get.notCalled).to.be.true;
         expect(generatePassword.notCalled).to.be.true;
+        expect(db.users.query.notCalled).to.be.true;
         expect(user).to.deep.equal({ password: 'testPassword', oidc_username: 'test' });
         expect(userSettings).to.deep.equal({ type: 'user-settings' });
       });
@@ -108,38 +138,41 @@ describe('SSO Login service', () => {
       { oidc_username: 'test' },
       { password: 'testPassword' },
     ].forEach((data) => {
-      it('should return error message when password modified to be invalid', () => {
+      it('should return error message when password modified to be invalid', async () => {
         const user = { password: 'testPassword', oidc_username: 'test' };
         const userSettings = { type: 'user-settings' };
 
-        const result = service.validateSsoLoginUpdate(data, user, userSettings);
+        const result = await service.validateSsoLoginUpdate(data, user, userSettings);
 
         expect(result).to.deep.equal({
           msg: 'Cannot set password or token_login with oidc_username.'
         });
         expect(config.get.notCalled).to.be.true;
         expect(generatePassword.notCalled).to.be.true;
+        expect(db.users.query.notCalled).to.be.true;
         expect(user).to.deep.equal({ password: 'testPassword', oidc_username: 'test' });
         expect(userSettings).to.deep.equal({ type: 'user-settings' });
       });
     });
 
-    it('should not return when auth fields not modified on invalid user', () => {
+    it('should not return when auth fields not modified on invalid user', async () => {
       const user = { password: 'testPassword', oidc_username: 'test' };
       const userSettings = { type: 'user-settings' };
 
-      const result = service.validateSsoLoginUpdate({ contact: 'z' }, user, userSettings);
+      const result = await service.validateSsoLoginUpdate({ contact: 'z' }, user, userSettings);
 
       expect(result).to.equal(undefined);
       expect(config.get.notCalled).to.be.true;
       expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.notCalled).to.be.true;
       expect(user).to.deep.equal({ password: 'testPassword', oidc_username: 'test' });
       expect(userSettings).to.deep.equal({ type: 'user-settings' });
     });
 
-    it('should not return error message when oidc user is valid', () => {
+    it('should return error message when duplicate oidc user exists', async () => {
       const data = { oidc_username: 'test' };
       const user = {
+        _id: 'org.couchdb.user:test',
         oidc_username: 'test',
         roles: ['existing-role']
       };
@@ -148,8 +181,81 @@ describe('SSO Login service', () => {
         roles: ['existing-role']
       };
       config.get.returns({ 'oidc_provider': { 'client_id': 'testClientId' } });
+      db.users.query.resolves({ rows: [{ id: 'org.couchdb.user:test' }, { id: 'duplicate-user' }] });
 
-      const result = service.validateSsoLoginUpdate(data, user, userSettings);
+      const result = await service.validateSsoLoginUpdate(data, user, userSettings);
+
+      expect(result).to.deep.equal({
+        msg: 'The oidc_username [test] already exists for user [duplicate-user].'
+      });
+      expect(data).to.deep.equal({ oidc_username: 'test' });
+      expect(user).to.deep.equal({
+        _id: 'org.couchdb.user:test',
+        oidc_username: 'test',
+        roles: ['existing-role']
+      });
+      expect(userSettings).to.deep.equal({
+        type: 'user-settings',
+        roles: ['existing-role']
+      });
+      expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
+      expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: false, limit: 2, key: ['oidc_username', 'test'] }
+      )).to.be.true;
+    });
+
+    it('should not return error message when oidc user is valid', async () => {
+      const data = { oidc_username: 'test' };
+      const user = {
+        _id: 'org.couchdb.user:test',
+        oidc_username: 'test',
+        roles: ['existing-role']
+      };
+      const userSettings = {
+        type: 'user-settings',
+        roles: ['existing-role']
+      };
+      config.get.returns({ 'oidc_provider': { 'client_id': 'testClientId' } });
+      db.users.query.resolves({ rows: [{ id: 'org.couchdb.user:test' }] });
+
+      const result = await service.validateSsoLoginUpdate(data, user, userSettings);
+
+      expect(result).to.equal(undefined);
+      expect(data).to.deep.equal({ oidc_username: 'test' });
+      expect(user).to.deep.equal({
+        _id: 'org.couchdb.user:test',
+        oidc_username: 'test',
+        password_change_required: false,
+        password: GENERATED_PASSWORD,
+        roles: ['existing-role', 'mm-oidc']
+      });
+      expect(userSettings).to.deep.equal({
+        type: 'user-settings',
+        roles: ['existing-role', 'mm-oidc']
+      });
+      expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
+      expect(generatePassword.calledOnceWithExactly()).to.be.true;
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: false, limit: 2, key: ['oidc_username', 'test'] }
+      )).to.be.true;
+    });
+
+    it('should not add oidc role when it already exists', async () => {
+      const data = { oidc_username: 'test' };
+      const user = {
+        oidc_username: 'test',
+        roles: ['existing-role', 'mm-oidc']
+      };
+      const userSettings = {
+        type: 'user-settings',
+      };
+      config.get.returns({ 'oidc_provider': { 'client_id': 'testClientId' } });
+      db.users.query.resolves({ rows: [] });
+
+      const result = await service.validateSsoLoginUpdate(data, user, userSettings);
 
       expect(result).to.equal(undefined);
       expect(data).to.deep.equal({ oidc_username: 'test' });
@@ -165,38 +271,13 @@ describe('SSO Login service', () => {
       });
       expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
       expect(generatePassword.calledOnceWithExactly()).to.be.true;
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: false, limit: 2, key: ['oidc_username', 'test'] }
+      )).to.be.true;
     });
 
-    it('should not add oidc role when it already exists', () => {
-      const data = { oidc_username: 'test' };
-      const user = {
-        oidc_username: 'test',
-        roles: ['existing-role', 'mm-oidc']
-      };
-      const userSettings = {
-        type: 'user-settings',
-      };
-      config.get.returns({ 'oidc_provider': { 'client_id': 'testClientId' } });
-
-      const result = service.validateSsoLoginUpdate(data, user, userSettings);
-
-      expect(result).to.equal(undefined);
-      expect(data).to.deep.equal({ oidc_username: 'test' });
-      expect(user).to.deep.equal({
-        oidc_username: 'test',
-        password_change_required: false,
-        password: GENERATED_PASSWORD,
-        roles: ['existing-role', 'mm-oidc']
-      });
-      expect(userSettings).to.deep.equal({
-        type: 'user-settings',
-        roles: ['existing-role', 'mm-oidc']
-      });
-      expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
-      expect(generatePassword.calledOnceWithExactly()).to.be.true;
-    });
-
-    it('should remove oidc role when a user is updated to not be oidc', () => {
+    it('should remove oidc role when a user is updated to not be oidc', async () => {
       const data = { oidc_username: null };
       const user = {
         oidc_username: null,
@@ -207,7 +288,7 @@ describe('SSO Login service', () => {
         roles: ['existing-role', 'mm-oidc']
       };
 
-      const result = service.validateSsoLoginUpdate(data, user, userSettings);
+      const result = await service.validateSsoLoginUpdate(data, user, userSettings);
 
       expect(result).to.equal(undefined);
       expect(data).to.deep.equal({ oidc_username: null });
@@ -221,6 +302,7 @@ describe('SSO Login service', () => {
       });
       expect(config.get.notCalled).to.be.true;
       expect(generatePassword.notCalled).to.be.true;
+      expect(db.users.query.notCalled).to.be.true;
     });
   });
 
@@ -237,6 +319,48 @@ describe('SSO Login service', () => {
       const result = service.isSsoLoginEnabled();
       expect(result).to.be.false;
       expect(config.get.calledOnceWithExactly('oidc_provider')).to.be.true;
+    });
+  });
+
+  describe('getUserByOidcUsername', () => {
+    it('should return user document when oidc_username exists', async () => {
+      const oidcUsername = 'test';
+      const userDoc = { _id: 'userId', oidc_username: oidcUsername };
+      db.users.query.resolves({ rows: [{ doc: userDoc }] });
+
+      const result = await service.getUserByOidcUsername(oidcUsername);
+
+      expect(result).to.deep.equal(userDoc);
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: true, limit: 1, key: ['oidc_username', oidcUsername] }
+      )).to.be.true;
+    });
+
+    it('should throw error when user with oidc_username does not exist', async () => {
+      const oidcUsername = 'test';
+      db.users.query.resolves({ rows: [] });
+
+      await expect(service.getUserByOidcUsername(oidcUsername))
+        .to.be.rejectedWith(`User with oidc_username [${oidcUsername}] not found.`);
+
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: true, limit: 1, key: ['oidc_username', oidcUsername] }
+      )).to.be.true;
+    });
+
+    it('should throw error when multiple users with oidc_username exist', async () => {
+      const oidcUsername = 'test';
+      db.users.query.resolves({ rows: [{}, {}] });
+
+      await expect(service.getUserByOidcUsername(oidcUsername))
+        .to.be.rejectedWith(`Multiple users with oidc_username [${oidcUsername}] found.`);
+
+      expect(db.users.query.calledOnceWithExactly(
+        'users/users_by_field',
+        { include_docs: true, limit: 1, key: ['oidc_username', oidcUsername] }
+      )).to.be.true;
     });
   });
 });

--- a/shared-libs/user-management/test/unit/token-login.spec.js
+++ b/shared-libs/user-management/test/unit/token-login.spec.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 
 const config = require('../../src/libs/config');
 const db = require('../../src/libs/db');
+const ssoLogin = require('../../src/sso-login');
 const service = require('../../src/token-login');
 
 const oneDayInMS = 24 * 60 * 60 * 1000;
@@ -274,11 +275,11 @@ describe('TokenLogin service', () => {
     });
 
     it('should throw when user is oidc', () => {
-      config.get.returns({ oidc_provider: { client_id: 'testProvider' } });
+      sinon.stub(ssoLogin, 'isSsoLoginEnabled').returns(true);
       const future = new Date().getTime() + 1000;
       db.medic.get.resolves({ user: 'org.couchdb.user:user' });
       db.users.get.resolves({
-        oidc: true,
+        oidc_username: 'true',
         token_login: {
           active: true,
           token: 'the_token',
@@ -295,6 +296,7 @@ describe('TokenLogin service', () => {
           chai.expect(db.medic.get.args[0]).to.deep.equal([`token:login:the_token`]);
           chai.expect(db.users.get.callCount).to.equal(1);
           chai.expect(db.users.get.args[0]).to.deep.equal(['org.couchdb.user:user']);
+          chai.expect(ssoLogin.isSsoLoginEnabled.calledOnceWithExactly()).to.be.true;
         });
     });
 

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -4237,7 +4237,7 @@ describe('Users service', () => {
 
       it('returns error if oidc validation fails', async () => {
         const message = 'OIDC Login is not enabled';
-        validateSsoLogin.returns({ msg: message });
+        validateSsoLogin.resolves({ msg: message });
 
         await chai.expect(service.createMultiFacilityUser(ssoUserData))
           .to.be.eventually.rejectedWith(Error)
@@ -4254,6 +4254,7 @@ describe('Users service', () => {
       it('succeeds if oidc validation passes', async () => {
         validateSsoLogin.callsFake(user => {
           user.password = GENERATED_PASSWORD;
+          return Promise.resolve();
         });
         sinon.stub(places, 'placesExist').resolves();
 
@@ -4295,7 +4296,7 @@ describe('Users service', () => {
 
       it('returns error if oidc validation fails', async () => {
         const message = 'OIDC Login is not enabled';
-        validateSsoLogin.returns({ msg: message });
+        validateSsoLogin.resolves({ msg: message });
 
         await chai.expect(service.createUser(ssoUserData))
           .to.be.eventually.rejectedWith(Error)
@@ -4312,6 +4313,7 @@ describe('Users service', () => {
       it('succeeds if oidc validation passes', async () => {
         validateSsoLogin.callsFake(user => {
           user.password = GENERATED_PASSWORD;
+          return Promise.resolve();
         });
         getPlace.resolves(userContact.parent);
         sinon.stub(places, 'getPlace').resolves(userContact.parent);
@@ -4369,7 +4371,7 @@ describe('Users service', () => {
 
       it('returns error if oidc validation fails', async () => {
         const error = 'OIDC Login is not enabled';
-        validateSsoLogin.returns({ msg: error });
+        validateSsoLogin.resolves({ msg: error });
 
         const response = await service.createUsers([ssoUserData]);
 
@@ -4386,11 +4388,12 @@ describe('Users service', () => {
       it('returns error if oidc validation fails for some users', async () => {
         const error0 = 'OIDC Login is not enabled';
         const error1 = 'a different error';
-        validateSsoLogin.onFirstCall().returns({ msg: error0 });
+        validateSsoLogin.onFirstCall().resolves({ msg: error0 });
         validateSsoLogin.onSecondCall().callsFake(user => {
           user.password = GENERATED_PASSWORD;
+          return Promise.resolve();
         });
-        validateSsoLogin.onThirdCall().returns({ msg: error1 });
+        validateSsoLogin.onThirdCall().resolves({ msg: error1 });
         getPlace.resolves(userContact.parent);
         sinon.stub(places, 'getPlace').resolves(userContact.parent);
         sinon.stub(people, 'getOrCreatePerson').resolves(userContact);
@@ -4442,6 +4445,7 @@ describe('Users service', () => {
       it('succeeds if oidc validation passes', async () => {
         validateSsoLogin.callsFake(user => {
           user.password = GENERATED_PASSWORD;
+          return Promise.resolve();
         });
         getPlace.resolves(userContact.parent);
         sinon.stub(places, 'getPlace').resolves(userContact.parent);
@@ -4554,7 +4558,7 @@ describe('Users service', () => {
 
       it('returns error if oidc validation fails', async () => {
         const message = 'OIDC Login is not enabled';
-        validateSsoLoginUpdate.returns({ msg: message });
+        validateSsoLoginUpdate.resolves({ msg: message });
         const existingUserData = {
           facility_id: [ssoUserData.place],
           contact_id: ssoUserData.contact,
@@ -4597,6 +4601,7 @@ describe('Users service', () => {
       it('succeeds when oidc validation passes and called with full access', async () => {
         validateSsoLoginUpdate.callsFake((_, user) => {
           user.password = GENERATED_PASSWORD;
+          return Promise.resolve();
         });
         const existingUserData = {
           facility_id: [ssoUserData.place],

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -4269,7 +4269,7 @@ describe('Users service', () => {
         };
         chai.expect(db.medic.put.calledOnceWithExactly({
           ...expectedUser,
-          oidc: true,
+          oidc_login: true,
           type: 'user-settings',
         })).to.be.true;
         chai.expect(db.users.put.calledOnceWithExactly({
@@ -4332,7 +4332,7 @@ describe('Users service', () => {
         chai.expect(db.medic.put.calledOnceWithExactly({
           ...expectedUser,
           type: 'user-settings',
-          oidc: true,
+          oidc_login: true,
         })).to.be.true;
         chai.expect(db.users.put.calledOnceWithExactly({
           ...expectedUser,
@@ -4421,7 +4421,7 @@ describe('Users service', () => {
         chai.expect(db.medic.put.calledOnceWithExactly({
           ...expectedUser1,
           type: 'user-settings',
-          oidc: true,
+          oidc_login: true,
         })).to.be.true;
         chai.expect(db.users.put.calledOnceWithExactly({
           ...expectedUser1,
@@ -4495,9 +4495,9 @@ describe('Users service', () => {
         ]);
 
         chai.expect(db.medic.put.args).to.deep.equal([
-          [{ ...expectedUser, type: 'user-settings', oidc: true, }],
-          [{ ...expectedUser1, type: 'user-settings', oidc: true, }],
-          [{ ...expectedUser2, type: 'user-settings', oidc: true, }],
+          [{ ...expectedUser, type: 'user-settings', oidc_login: true, }],
+          [{ ...expectedUser1, type: 'user-settings', oidc_login: true, }],
+          [{ ...expectedUser2, type: 'user-settings', oidc_login: true, }],
         ]);
         chai.expect(db.users.put.args).to.deep.equal([
           [{
@@ -4647,7 +4647,7 @@ describe('Users service', () => {
         )).to.be.true;
         chai.expect(db.medic.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
         chai.expect(db.users.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
-        chai.expect(db.medic.put.calledOnceWithExactly({ ...existingUserSettings, oidc: true })).to.be.true;
+        chai.expect(db.medic.put.calledOnceWithExactly({ ...existingUserSettings, oidc_login: true })).to.be.true;
         chai.expect(db.users.put.calledOnceWithExactly(updatedUser)).to.be.true;
       });
 
@@ -4663,7 +4663,7 @@ describe('Users service', () => {
         const existingUserSettings = {
           ...existingUserData,
           type: 'user-settings',
-          oidc: true,
+          oidc_login: true,
         };
         db.medic.get.resolves({ ...existingUserSettings });
         const existingUser = {
@@ -4694,7 +4694,7 @@ describe('Users service', () => {
         )).to.be.true;
         chai.expect(db.medic.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
         chai.expect(db.users.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
-        chai.expect(db.medic.put.calledOnceWithExactly({ ...existingUserSettings, oidc: false })).to.be.true;
+        chai.expect(db.medic.put.calledOnceWithExactly({ ...existingUserSettings, oidc_login: false })).to.be.true;
         chai.expect(db.users.put.calledOnceWithExactly(updatedUser)).to.be.true;
       });
 

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -4218,7 +4218,7 @@ describe('Users service', () => {
         username: 'x',
         contact: userContact._id,
         roles: ['test-role'],
-        oidc: true,
+        oidc_username: 'test',
       };
       validateSsoLogin = sinon
         .stub(ssoLogin, 'validateSsoLogin');
@@ -4275,7 +4275,7 @@ describe('Users service', () => {
           type: 'user',
           password: GENERATED_PASSWORD,
           password_change_required: false,
-          oidc: true,
+          oidc_username: 'test',
         })).to.be.true;
         chai.expect(validateSsoLogin.calledOnceWithExactly(ssoUserData)).to.be.true;
         chai.expect(service.__get__('validateNewUsername').calledOnceWithExactly(ssoUserData.username)).to.be.true;
@@ -4335,7 +4335,7 @@ describe('Users service', () => {
           type: 'user',
           password: GENERATED_PASSWORD,
           password_change_required: false,
-          oidc: true,
+          oidc_username: 'test',
         })).to.be.true;
         chai.expect(validateSsoLogin.calledOnceWithExactly(ssoUserData)).to.be.true;
         chai.expect(getPlace.calledOnceWithExactly(Qualifier.byUuid(expectedUser.facility_id[0]))).to.be.true;
@@ -4419,7 +4419,7 @@ describe('Users service', () => {
           type: 'user',
           password: GENERATED_PASSWORD,
           password_change_required: false,
-          oidc: true,
+          oidc_username: 'test',
         })).to.be.true;
         chai.expect(db.medicLogs.get.args).to.deep.equal([[undefined], [undefined], [undefined], [undefined]]);
         chai.expect(validateSsoLogin.args).to.deep.equal([
@@ -4495,21 +4495,21 @@ describe('Users service', () => {
             type: 'user',
             password: GENERATED_PASSWORD,
             password_change_required: false,
-            oidc: true,
+            oidc_username: 'test',
           }],
           [{
             ...expectedUser1,
             type: 'user',
             password: GENERATED_PASSWORD,
             password_change_required: false,
-            oidc: true,
+            oidc_username: 'test',
           }],
           [{
             ...expectedUser2,
             type: 'user',
             password: GENERATED_PASSWORD,
             password_change_required: false,
-            oidc: true,
+            oidc_username: 'test',
           }],
         ]);
         chai.expect(db.medicLogs.get.args).to.deep.equal([[undefined], [undefined], [undefined], [undefined]]);
@@ -4573,7 +4573,7 @@ describe('Users service', () => {
           password: 'existingPassword',
         };
         db.users.get.resolves({ ...existingUser });
-        const updates = { oidc: true };
+        const updates = { oidc_username: 'test' };
 
         await chai.expect(service.updateUser(ssoUserData.username, { ...updates }, true))
           .to.be.eventually.rejectedWith(Error)
@@ -4617,7 +4617,7 @@ describe('Users service', () => {
         db.users.get.resolves({ ...existingUser });
         db.users.put.resolves({ id: existingUserData._id });
         db.medic.put.resolves({ id: existingUserData._id });
-        const updates = { oidc: true };
+        const updates = { oidc_username: 'test' };
 
         const response = await service.updateUser(ssoUserData.username, { ...updates }, true);
 
@@ -4641,13 +4641,13 @@ describe('Users service', () => {
       });
 
       it('returns error when changing oidc without full access', async () => {
-        const updates = { oidc: true };
+        const updates = { oidc_username: 'test' };
 
         await chai.expect(service.updateUser(ssoUserData.username, { ...updates }, false))
           .to.be.eventually.rejectedWith(Error)
           .and.to.deep.include({
             status: 401,
-            message: 'You do not have permission to modify: oidc',
+            message: 'You do not have permission to modify: oidc_username',
           });
 
         chai.expect(validateSsoLoginUpdate.notCalled).to.be.true;

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -4585,7 +4585,8 @@ describe('Users service', () => {
         };
         chai.expect(validateSsoLoginUpdate.calledOnceWithExactly(
           { ...updates, contact_id: undefined, facility_id: undefined },
-          updatedUser
+          updatedUser,
+          existingUserSettings
         )).to.be.true;
         chai.expect(db.medic.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
         chai.expect(db.users.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
@@ -4632,7 +4633,8 @@ describe('Users service', () => {
         };
         chai.expect(validateSsoLoginUpdate.calledOnceWithExactly(
           { ...updates, contact_id: undefined, facility_id: undefined },
-          updatedUser
+          updatedUser,
+          existingUserSettings
         )).to.be.true;
         chai.expect(db.medic.get.calledOnceWithExactly(existingUserData._id)).to.be.true;
         chai.expect(db.users.get.calledOnceWithExactly(existingUserData._id)).to.be.true;

--- a/tests/integration/api/controllers/login.spec.js
+++ b/tests/integration/api/controllers/login.spec.js
@@ -173,7 +173,7 @@ describe('login', () => {
       await utils.request({ path: '/api/v2/users', method: 'POST', body: user });
       // Manually update user to be OIDC so we also know the password
       const userDoc = await getUser(user);
-      await utils.usersDb.put({ ...userDoc, oidc: true });
+      await utils.usersDb.put({ ...userDoc, oidc_username: 'true' });
 
       const response = await loginWithData({ user: user.username, password });
 
@@ -295,7 +295,7 @@ describe('login', () => {
         .then(userDoc => {
           // grab the token and mark as SSO user
           const token = userDoc.token_login.token;
-          userDoc.oidc = true;
+          userDoc.oidc_username = 'true';
           return utils.usersDb
             .put(userDoc)
             .then(() => token);
@@ -427,7 +427,7 @@ describe('login', () => {
         await utils.createUsers([{
           ...user,
           password: undefined,
-          oidc: true,
+          oidc_username: 'true',
         }]);
         const response = await oidcLogin(code);
 
@@ -441,7 +441,7 @@ describe('login', () => {
       await utils.createUsers([{
         ...user,
         password: undefined,
-        oidc: true,
+        oidc_username: mockIdProvider.EMAIL,
       }]);
       const response = await oidcLogin();
       chai.expect(response).to.include({ status: 302 });

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -2237,7 +2237,7 @@ describe('Users API', () => {
         expect(userSettingsDoc).excluding(skippedUserFields).to.deep.equal({
           ...expectedUserData,
           type: 'user-settings',
-          oidc: true,
+          oidc_login: true,
         });
       });
 
@@ -2271,7 +2271,7 @@ describe('Users API', () => {
           expect(userSettingsDoc).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
             type: 'user-settings',
-            oidc: true,
+            oidc_login: true,
           });
         });
       });
@@ -2322,7 +2322,7 @@ describe('Users API', () => {
           expect(userSettingsDoc).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
             type: 'user-settings',
-            ...(originalUserData.oidc_username ? { oidc: true } : {})
+            ...(originalUserData.oidc_username ? { oidc_login: true } : {})
           });
 
           const updatedResult = await utils.request({
@@ -2342,7 +2342,7 @@ describe('Users API', () => {
           expect(updatedUserSettings).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
             type: 'user-settings',
-            oidc: !!updatedUserData.oidc_username
+            oidc_login: !!updatedUserData.oidc_username
           });
         });
       });

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -2230,15 +2230,14 @@ describe('Users API', () => {
         };
         expect(userDoc).excluding(skippedUserFields).to.deep.equal({
           ...expectedUserData,
-          roles: [...expectedUserData.roles, 'mm-oidc'],
           type: 'user',
           oidc_username: body.oidc_username,
           password_change_required: false,
         });
         expect(userSettingsDoc).excluding(skippedUserFields).to.deep.equal({
           ...expectedUserData,
-          roles: [...expectedUserData.roles, 'mm-oidc'],
           type: 'user-settings',
+          oidc: true,
         });
       });
 
@@ -2265,15 +2264,14 @@ describe('Users API', () => {
           };
           expect(userDoc).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
-            roles: [...expectedUserData.roles, 'mm-oidc'],
             type: 'user',
             oidc_username: body.oidc_username,
             password_change_required: false,
           });
           expect(userSettingsDoc).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
-            roles: [...expectedUserData.roles, 'mm-oidc'],
             type: 'user-settings',
+            oidc: true,
           });
         });
       });
@@ -2282,17 +2280,17 @@ describe('Users API', () => {
         [
           'user to be an OIDC user',
           { password, password_change_required: false, roles: ['chw'] },
-          { oidc_username: uuid(), roles: ['chw', 'mm-oidc'] }
+          { oidc_username: uuid(), roles: ['chw'] }
         ],
         [
           'OIDC user to be a normal user',
-          { oidc_username: uuid(), roles: ['chw', 'mm-oidc'] },
+          { oidc_username: uuid(), roles: ['chw'] },
           { oidc_username: null, password, password_change_required: false, roles: ['chw'] }
         ],
         [
           'OIDC user to have a different oidc_username',
-          { oidc_username: uuid(), roles: ['chw', 'mm-oidc'] },
-          { oidc_username: uuid(), roles: ['chw', 'mm-oidc'] }
+          { oidc_username: uuid(), roles: ['chw'] },
+          { oidc_username: uuid(), roles: ['chw'] }
         ]
       ].forEach(([test, originalUserData, updatedUserData]) => {
         it(`should update an existing ${test}`, async () => {
@@ -2324,6 +2322,7 @@ describe('Users API', () => {
           expect(userSettingsDoc).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
             type: 'user-settings',
+            ...(originalUserData.oidc_username ? { oidc: true } : {})
           });
 
           const updatedResult = await utils.request({
@@ -2342,8 +2341,8 @@ describe('Users API', () => {
           });
           expect(updatedUserSettings).excluding(skippedUserFields).to.deep.equal({
             ...expectedUserData,
-            roles: updatedUserData.roles,
             type: 'user-settings',
+            oidc: !!updatedUserData.oidc_username
           });
         });
       });

--- a/tests/utils/mock-oidc-provider.js
+++ b/tests/utils/mock-oidc-provider.js
@@ -7,13 +7,14 @@ const { generateKeyPairSync } = require('crypto');
 const { hostURL } = require('@utils');
 const { BASE_URL, DB_NAME } = require('@constants');
 
+const SECRET = 'secret';
+const EMAIL = 'test@email.com';
 const appTokenUrl = `${BASE_URL}/${DB_NAME}/login/oidc`;
-
 const authenticatedRedirectUrl = `${appTokenUrl}?code=dummy`;
 
 const getOidcBaseUrl = () => hostURL(server.address().port);
 
-const getJWT_KEYS = (secret = 'secret') => generateKeyPairSync(
+const getJWT_KEYS = () => generateKeyPairSync(
   'rsa',
   {
     modulusLength: 4096,
@@ -25,12 +26,12 @@ const getJWT_KEYS = (secret = 'secret') => generateKeyPairSync(
       type: 'pkcs8',
       format: 'pem',
       cipher: 'aes-256-cbc',
-      passphrase: secret
+      passphrase: SECRET
     }
   }
 );
 
-const generateIdToken =  (issuer, secret = 'secret') => {
+const generateIdToken =  (issuer) => {
   const payload = {
     issuer,
     algorithm: 'RS256',
@@ -42,9 +43,10 @@ const generateIdToken =  (issuer, secret = 'secret') => {
       preferred_username: 'testuser',
       sub: '12345',
       name: 'John Doe',
-      aud: 'cht'
+      aud: 'cht',
+      email: EMAIL,
     },
-    { key: privateKey.replace(/\\n/gm, '\n'), passphrase: secret },
+    { key: privateKey.replace(/\\n/gm, '\n'), passphrase: SECRET },
     payload
   );
 };
@@ -139,6 +141,7 @@ const stopOidcServer = () => {
 };
 
 module.exports = {
+  EMAIL,
   getOidcBaseUrl,
   getDiscoveryUrl: () => `${getOidcBaseUrl()}.well-known/openid-configuration`,
   appTokenUrl,

--- a/webapp/src/ts/modules/configuration-user/configuration-user.component.ts
+++ b/webapp/src/ts/modules/configuration-user/configuration-user.component.ts
@@ -24,11 +24,14 @@ export class ConfigurationUserComponent implements OnInit {
     private userSettingsService: UserSettingsService,
   ) { }
 
-  async ngOnInit() {
+  ngOnInit() {
     this.loading = true;
-    const user:any = await this.userSettingsService.get();
-    this.canUpdatePassword = !user.token_login && !this.sessionService.isAdmin();
-    this.loading = false;
+    this.userSettingsService
+      .get()
+      .then(user => {
+        this.canUpdatePassword = !user.token_login && !user.oidc_login && !this.sessionService.isAdmin();
+        this.loading = false;
+      });
   }
 
   updatePassword() {

--- a/webapp/src/ts/services/user-settings.service.ts
+++ b/webapp/src/ts/services/user-settings.service.ts
@@ -117,6 +117,8 @@ export interface UserSettings {
   contact_id: string;
   facility_id: string[];
   name: string;
+  oidc_login?: boolean;
   roles: string[];
+  token_login?: Record<string, unknown>;
   type: string;
 }

--- a/webapp/tests/karma/karma-unit.base.conf.js
+++ b/webapp/tests/karma/karma-unit.base.conf.js
@@ -46,7 +46,7 @@ module.exports = {
         statements: 87,
         lines: 87,
         branches: 79,
-        functions: 86,
+        functions: 85,
       },
     },
   }

--- a/webapp/tests/karma/ts/modules/configuration-user/configuration-user.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/configuration-user/configuration-user.component.spec.ts
@@ -34,9 +34,7 @@ describe('Configuration User Component', () => {
           { provide: UserSettingsService, useValue: userSettingsService },
         ]
       })
-      .compileComponents()
-      .then(() => {
-      });
+      .compileComponents();
   });
 
   const createComponent = () => {

--- a/webapp/tests/karma/ts/modules/configuration-user/configuration-user.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/configuration-user/configuration-user.component.spec.ts
@@ -1,0 +1,91 @@
+import { fakeAsync, flush, TestBed } from '@angular/core/testing';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { SessionService } from '@mm-services/session.service';
+import { ModalService } from '@mm-services/modal.service';
+import { UserSettingsService } from '@mm-services/user-settings.service';
+import { ConfigurationUserComponent } from '@mm-modules/configuration-user/configuration-user.component';
+import { provideMockStore } from '@ngrx/store/testing';
+import { TranslateFakeLoader, TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { NavigationService } from '@mm-services/navigation.service';
+import { EditUserSettingsComponent } from '@mm-modals/edit-user/edit-user-settings.component';
+import { UpdatePasswordComponent } from '@mm-modals/edit-user/update-password.component';
+
+describe('Configuration User Component', () => {
+  let modalService;
+  let sessionService;
+  let userSettingsService;
+
+  beforeEach(async () => {
+    modalService = { show: sinon.stub() };
+    sessionService = { isAdmin: sinon.stub() };
+    userSettingsService = { get: sinon.stub() };
+
+    await TestBed
+      .configureTestingModule({
+        imports: [
+          TranslateModule.forRoot({ loader: { provide: TranslateLoader, useClass: TranslateFakeLoader } }),
+        ],
+        providers: [
+          provideMockStore({ selectors: [] }),
+          { provide: ModalService, useValue: modalService },
+          { provide: NavigationService, useValue: {} },
+          { provide: SessionService, useValue: sessionService },
+          { provide: UserSettingsService, useValue: userSettingsService },
+        ]
+      })
+      .compileComponents()
+      .then(() => {
+      });
+  });
+
+  const createComponent = () => {
+    const fixture = TestBed.createComponent(ConfigurationUserComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    return component;
+  };
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('ngOnInit', () => {
+    [
+      ['user can update password', { token_login: false, oidc_login: false }, false, true],
+      ['token login is enabled', { token_login: true, oidc_login: false }, false, false],
+      ['oidc login is enabled', { token_login: false, oidc_login: true }, false, false],
+      ['the user is an admin', { token_login: false, oidc_login: false }, true, false],
+    ].forEach(([test, user, isAdmin, expectedCanUpdatePass]) => {
+      it(`correctly initializes the component when ${test}`, fakeAsync(() => {
+        userSettingsService.get.resolves(user);
+        sessionService.isAdmin.returns(isAdmin);
+        const component = createComponent();
+        expect(component.loading).to.be.true;
+
+        flush();
+
+        expect(component.loading).to.be.false;
+        expect(component.canUpdatePassword).to.equal(expectedCanUpdatePass);
+      }));
+    });
+  });
+
+  it('editSettings shows edit user settings component', () => {
+    userSettingsService.get.resolves({});
+
+    const component = createComponent();
+    component.editSettings();
+
+    expect(modalService.show.calledOnceWithExactly(EditUserSettingsComponent)).to.be.true;
+  });
+
+  it('updatePassword shows update password component', () => {
+    userSettingsService.get.resolves({});
+
+    const component = createComponent();
+    component.updatePassword();
+
+    expect(modalService.show.calledOnceWithExactly(UpdatePasswordComponent)).to.be.true;
+  });
+});

--- a/webapp/tests/karma/ts/services/update-password.service.spec.ts
+++ b/webapp/tests/karma/ts/services/update-password.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { expect } from 'chai';
+import { UpdatePasswordService } from '@mm-services/update-password.service';
+import { provideHttpClient } from '@angular/common/http';
+
+describe('Update password service', () => {
+  let service: UpdatePasswordService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+    service = TestBed.inject(UpdatePasswordService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('updates settings', async () => {
+    const username = 'username';
+    const currentPassword = 'currentPassword';
+    const newPassword = 'newPassword';
+    const successResponse = { success: true };
+    const authB64 = window.btoa(`${username}:${currentPassword}`);
+
+    const update = service.update(username, currentPassword, newPassword);
+    const res = httpMock.expectOne('/api/v1/users/username');
+    res.flush(successResponse);
+    const result = await update;
+
+    expect(result).to.equal(successResponse);
+    expect(res.request.body).to.deep.equal({ password: 'newPassword' });
+    expect(res.request.headers.get('Content-Type')).to.equal('application/json');
+    expect(res.request.headers.get('Accept')).to.equal('application/json');
+    expect(res.request.headers.get('Authorization')).to.equal(`Basic ${authB64}`);
+  });
+});


### PR DESCRIPTION
# Description

Closes #9963
Closes #9836
Closes #9938

Updates OIDC user configuration.  Instead of a boolean `oidc` field on the `_users` doc, there is now a string `oidc_username` field on the `_users` doc and a boolean `oidc_login` field on the `user-settings` doc.  This follows the pattern from token login where the auth-sensitive information is stored on the `_users` doc, while non-sensitive info is kept on the `user-settings` doc to allow the offline user UI logic to handle special cases for OIDC users.

Specifically, when a user had `oidc_login: true` in their user settings doc, they will not see the option in the app to update their password.


# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [X] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

