### PR TITLE
fix(#9968): docker helper couchdb upgrade fix

### DIFF
--- a/scripts/docker-helper-4.x/cht-docker-compose.sh
+++ b/scripts/docker-helper-4.x/cht-docker-compose.sh
@@ -73,7 +73,7 @@ create_compose_files() {
   curl -s -o "$homeDir/upgrade-service.yml" \
     https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml
   curl -s -o "$homeDir/compose/cht-core.yml" "${stagingUrlBase}"/docker-compose/cht-core.yml
-  curl -s -o "$homeDir/compose/couchdb.yml" "${stagingUrlBase}"/docker-compose/cht-couchdb.yml
+  curl -s -o "$homeDir/compose/cht-couchdb.yml" "${stagingUrlBase}"/docker-compose/cht-couchdb.yml
 
   echo -e "${green} done${noColor} "
 }
@@ -193,7 +193,7 @@ service_has_image_downloaded(){
   if [ "$service" == "cht-upgrade-service" ]; then
     compose_path="${homeDir}/upgrade-service.yml"
   elif [ "$service" == "couchdb" ]; then
-    compose_path="${homeDir}/compose/couchdb.yml"
+    compose_path="${homeDir}/compose/cht-couchdb.yml"
   else
     compose_path="${homeDir}/compose/cht-core.yml"
   fi


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

This PR renames the docker compose file for couchdb in docker helper to be  `cht-couchdb.yml` .  

Shout out to @sugat009 and @dianabarsan for making this an easy PR to throw together!

closes #9968

## Testing

1. ensure new instance created in this branch's docker helper starts up correct
2. ensure new instance created in this branch's docker helper can be upgraded to new version and the couchdb image version gets upgraded too
3. note that instances created from `master` right now will need to be upgraded by renaming the compose file. for example, if have a project called `test1` then you would call: `mv ~/.medic/cht-docker/test1-dir/compose/couchdb.yml  ~/.medic/cht-docker/test1-dir/compose/cht-couchdb.yml`

   Test that renaming a couch file from `master` works on this branch per above



# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9968-fix-helper-coudhb-upgrades/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9968-fix-helper-coudhb-upgrades/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9968-fix-helper-coudhb-upgrades/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

