### PR TITLE
feat(#9974): support opening contact edit form from task

### DIFF
--- a/tests/e2e/default/tasks/config/tasks-contact-config.js
+++ b/tests/e2e/default/tasks/config/tasks-contact-config.js
@@ -1,0 +1,44 @@
+
+module.exports = [
+  {
+    name: 'add_household_members_task',
+    title: 'Add Household Members',
+    appliesTo: 'contacts',
+    appliesToType: ['clinic'],
+    resolvedIf: () => false,
+    events: [{
+      id: 'add_household_members_task_event_id',
+      days: 0,
+      start: 0,
+      end: 1,
+    }],
+    actions: [
+      {
+        type: 'contact',
+        modifyContent: (content, { contact }) => {
+          content.type = 'person';
+          content.parent_id = contact._id;
+        },
+      }
+    ],
+  },
+  {
+    name: 'edit_contact_task',
+    title: 'Edit Person',
+    appliesTo: 'contacts',
+    appliesToType: ['person'],
+    resolvedIf: () => false,
+    events: [{
+      id: 'edit_contact_event_id',
+      days: 0,
+      start: 0,
+      end: 1,
+    }],
+    actions: [{
+      type: 'contact',
+      modifyContent: (content, { contact }) => {
+        content.edit_id = contact._id;
+      },
+    }],
+  }
+];

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -11,6 +11,7 @@ const chtConfUtils = require('@utils/cht-conf');
 const sentinelUtils = require('@utils/sentinel');
 const commonPage = require('@page-objects/default/common/common.wdio.page');
 const chtDbUtils = require('@utils/cht-db');
+const modalPage = require('@page-objects/default/common/modal.wdio.page');
 
 describe('Tasks', () => {
 
@@ -149,5 +150,34 @@ describe('Tasks', () => {
     expect(feedbackDocs.length).to.equal(1);
     expect(feedbackDocs[0].info.message).to.include('Cannot read properties of undefined (reading \'name\')');
     await chtDbUtils.clearFeedbackDocs();
+  });
+
+  describe('contact tasks', () => {
+    beforeEach(async () => {
+      await tasksPage.compileTasks('tasks-contact-config.js', true);
+      await commonPage.goToTasks();
+    });
+
+    it('should launch an add contact form when type is provided in content', async () => {
+      expect(await tasksPage.getTasks()).to.have.length(4);
+      const task = await tasksPage.getTaskByContactAndForm(clinic.name, 'Add Household Members');
+      await task.click();
+
+      expect(await browser.getUrl()).to.include(`/contacts/${clinic._id}/add/person`);
+      expect(await genericForm.getFormTitle()).to.equal('New person');
+      await genericForm.cancelForm();
+      await modalPage.submit();
+    });
+
+    it('should launch an edit contact form when edit_id is provided in content', async () => {
+      expect(await tasksPage.getTasks()).to.have.length(4);
+      const task = await tasksPage.getTaskByContactAndForm(chwContact.name, 'Edit Person');
+      await task.click();
+
+      expect(await genericForm.getFormTitle()).to.equal('Edit person');
+      expect(await browser.getUrl()).to.include(`/contacts/${chwContact._id}/edit`);
+      await genericForm.cancelForm();
+      await modalPage.submit();
+    });
   });
 });

--- a/webapp/src/ts/modules/tasks/tasks-content.component.html
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.html
@@ -40,7 +40,9 @@
             <p>{{field.value | translateFrom:selectedTask}}</p>
           </li>
           <li class="actions" *ngIf="selectedTask.actions.length">
-            <a class="btn btn-primary" *ngFor="let action of selectedTask.actions" (click)="performAction(action)">{{action.label | translateFrom:selectedTask}}</a>
+            <ng-container *ngFor="let action of selectedTask.actions">
+              <a *ngIf="action.content?.status !== 'done'" class="btn btn-primary" (click)="performAction(action)">{{action.label | translateFrom:selectedTask}}</a>
+            </ng-container>
           </li>
         </ul>
       </div>

--- a/webapp/src/ts/modules/tasks/tasks-content.component.html
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.html
@@ -40,9 +40,7 @@
             <p>{{field.value | translateFrom:selectedTask}}</p>
           </li>
           <li class="actions" *ngIf="selectedTask.actions.length">
-            <ng-container *ngFor="let action of selectedTask.actions">
-              <a *ngIf="action.content?.status !== 'done'" class="btn btn-primary" (click)="performAction(action)">{{action.label | translateFrom:selectedTask}}</a>
-            </ng-container>
+            <a class="btn btn-primary" *ngFor="let action of selectedTask.actions" (click)="performAction(action)">{{action.label | translateFrom:selectedTask}}</a>
           </li>
         </ul>
       </div>

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -304,8 +304,8 @@ export class TasksContentComponent implements OnInit, OnDestroy {
     }
 
     if (action.type === 'contact') {
-      if (action.content?._id){
-        this.router.navigate(['/contacts', action.content._id, 'edit']);
+      if (action.content?.id){
+        this.router.navigate(['/contacts', action.content.id, 'edit']);
       } else if (action.content?.parent_id) {
         this.router.navigate(['/contacts', action.content.parent_id, 'add', action.content.type || '']);
       } else {

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -304,7 +304,7 @@ export class TasksContentComponent implements OnInit, OnDestroy {
     }
 
     if (action.type === 'contact') {
-      if (action.content?.parent_id) {
+      if (action.content?.parent_id && action.content?.type) {
         this.router.navigate(['/contacts', action.content.parent_id, 'add', action.content.type || '']);
       } else if (action.content?.type) {
         this.router.navigate(['/contacts', 'add', action.content.type]);

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -304,12 +304,14 @@ export class TasksContentComponent implements OnInit, OnDestroy {
     }
 
     if (action.type === 'contact') {
-      if (action.content?.id){
-        this.router.navigate(['/contacts', action.content.id, 'edit']);
-      } else if (action.content?.parent_id) {
+      if (action.content?.parent_id) {
         this.router.navigate(['/contacts', action.content.parent_id, 'add', action.content.type || '']);
+      } else if (action.content?.type) {
+        this.router.navigate(['/contacts', 'add', action.content.type]);
+      } else if (action.content?.edit_id) {
+        this.router.navigate(['/contacts', action.content.edit_id, 'edit']);
       } else {
-        this.router.navigate(['/contacts', 'add', action.content?.type || '']);
+        this.router.navigate(['/contacts', action.content?.contact?._id ?? '']);
       }
     }
   }

--- a/webapp/src/ts/modules/tasks/tasks-content.component.ts
+++ b/webapp/src/ts/modules/tasks/tasks-content.component.ts
@@ -304,7 +304,9 @@ export class TasksContentComponent implements OnInit, OnDestroy {
     }
 
     if (action.type === 'contact') {
-      if (action.content?.parent_id) {
+      if (action.content?._id){
+        this.router.navigate(['/contacts', action.content._id, 'edit']);
+      } else if (action.content?.parent_id) {
         this.router.navigate(['/contacts', action.content.parent_id, 'add', action.content.type || '']);
       } else {
         this.router.navigate(['/contacts', 'add', action.content?.type || '']);

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -486,11 +486,11 @@ describe('TasksContentComponent', () => {
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(0);
     });
 
-    it('should work with action of type "contact" and content with "_id"', async () => {
+    it('should work with action of type "contact" and content with "id"', async () => {
       await compileComponent([]);
       sinon.resetHistory();
 
-      const action = { type: 'contact', content: { _id: '123' } };
+      const action = { type: 'contact', content: { id: '123' } };
       await component.performAction(action);
 
       expect(xmlFormsService.get.callCount).to.equal(0);

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -472,6 +472,27 @@ describe('TasksContentComponent', () => {
       expect(router.navigate.args[0]).to.deep.equal([['/contacts', 'add', 'c_type']]);
     });
 
+    it('should work with action of type "contact" with parent without type', async () => {
+      await compileComponent([]);
+      sinon.resetHistory();
+
+      const action = { 
+        type: 'contact', 
+        content: { 
+          parent_id: 'district_hospital_uuid',
+          contact: { 
+            _id: 'my_contact' 
+          } 
+        } 
+      };
+      await component.performAction(action);
+
+      expect(xmlFormsService.get.callCount).to.equal(0);
+      expect(formService.render.callCount).to.equal(0);
+      expect(router.navigate.callCount).to.equal(1);
+      expect(router.navigate.args[0]).to.deep.equal([['/contacts', 'my_contact']]);
+    });
+
     it('should work with action of type "contact" and content with "edit_id"', async () => {
       await compileComponent([]);
       sinon.resetHistory();

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -489,13 +489,13 @@ describe('TasksContentComponent', () => {
       await compileComponent([]);
       sinon.resetHistory();
 
-      const action = { type: 'contact' };
+      const action = { type: 'contact', content: { contact: { _id: 'my_contact' } } };
       await component.performAction(action);
 
       expect(xmlFormsService.get.callCount).to.equal(0);
       expect(formService.render.callCount).to.equal(0);
       expect(router.navigate.callCount).to.equal(1);
-      expect(router.navigate.args[0]).to.deep.equal([['/contacts', '']]);
+      expect(router.navigate.args[0]).to.deep.equal([['/contacts', 'my_contact']]);
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(0);
     });
 

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -472,6 +472,19 @@ describe('TasksContentComponent', () => {
       expect(router.navigate.args[0]).to.deep.equal([['/contacts', 'add', 'c_type']]);
     });
 
+    it('should work with action of type "contact" and content with "edit_id"', async () => {
+      await compileComponent([]);
+      sinon.resetHistory();
+
+      const action = { type: 'contact', content: { edit_id: '123' } };
+      await component.performAction(action);
+
+      expect(xmlFormsService.get.callCount).to.equal(0);
+      expect(formService.render.callCount).to.equal(0);
+      expect(router.navigate.callCount).to.equal(1);
+      expect(router.navigate.args[0]).to.deep.equal([['/contacts', '123', 'edit']]);
+    });
+
     it('should work with action of type "contact" without parent or type', async () => {
       await compileComponent([]);
       sinon.resetHistory();
@@ -482,21 +495,8 @@ describe('TasksContentComponent', () => {
       expect(xmlFormsService.get.callCount).to.equal(0);
       expect(formService.render.callCount).to.equal(0);
       expect(router.navigate.callCount).to.equal(1);
-      expect(router.navigate.args[0]).to.deep.equal([['/contacts', 'add', '']]);
+      expect(router.navigate.args[0]).to.deep.equal([['/contacts', '']]);
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(0);
-    });
-
-    it('should work with action of type "contact" and content with "id"', async () => {
-      await compileComponent([]);
-      sinon.resetHistory();
-
-      const action = { type: 'contact', content: { id: '123' } };
-      await component.performAction(action);
-
-      expect(xmlFormsService.get.callCount).to.equal(0);
-      expect(formService.render.callCount).to.equal(0);
-      expect(router.navigate.callCount).to.equal(1);
-      expect(router.navigate.args[0]).to.deep.equal([['/contacts', '123', 'edit']]);
     });
 
     it('should render form when action type is report', async () => {

--- a/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
+++ b/webapp/tests/karma/ts/modules/tasks/tasks-content.component.spec.ts
@@ -486,6 +486,19 @@ describe('TasksContentComponent', () => {
       expect(tasksForContactService.getLeafPlaceAncestor.callCount).to.equal(0);
     });
 
+    it('should work with action of type "contact" and content with "_id"', async () => {
+      await compileComponent([]);
+      sinon.resetHistory();
+
+      const action = { type: 'contact', content: { _id: '123' } };
+      await component.performAction(action);
+
+      expect(xmlFormsService.get.callCount).to.equal(0);
+      expect(formService.render.callCount).to.equal(0);
+      expect(router.navigate.callCount).to.equal(1);
+      expect(router.navigate.args[0]).to.deep.equal([['/contacts', '123', 'edit']]);
+    });
+
     it('should render form when action type is report', async () => {
       const form = { _id: 'myform', title: 'My Form' };
       const action = { type: 'report', form: 'myform', content: { contact: { _id: 'my_contact' } } };


### PR DESCRIPTION
# Description

Allow editing of a contact via the linked task entry. The CHT already allows creating a new contact based on type through a task; this builds on that functionality.

Closes https://github.com/medic/cht-core/issues/9974

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

