### PR TITLE
feat(#9957): dynamic sorting of tasks by priority and due date

### DIFF
--- a/config/default/tasks.js
+++ b/config/default/tasks.js
@@ -133,8 +133,7 @@ module.exports = [
       },
     ],
     //every two weeks from reported date until 42nd week, show before due date: 6 days, show after due date: 7 days
-    events: [...Array(21).keys()].map((i) =>
-      generateEventForHomeVisit((i + 1) * 2, 6, 7)
+    events: [...Array(21).keys()].map(i => generateEventForHomeVisit((i + 1) * 2, 6, 7)
     ),
   },
 

--- a/config/default/tasks.js
+++ b/config/default/tasks.js
@@ -48,8 +48,14 @@ function checkTaskResolvedForHomeVisit(contact, report, event, dueDate) {
   return isFormArraySubmittedInWindow(contact.reports, ['pregnancy_home_visit'], startTime, endTime);
 }
 
-module.exports = [
+function getPriorityCategory(score) {
+  if (score < 6){ return 'Low priority';}
+  else if (score >= 6 && score <= 8){ return 'Medium priority';}
+  else if (score > 8){ return 'High priority';}
+  return '';
+}
 
+module.exports = [
   //ANC Home Visit: 12, 20, 26, 30, 34, 36, 38, 40 weeks (Known LMP)
   {
     name: 'anc.pregnancy_home_visit.known_lmp',
@@ -95,9 +101,18 @@ module.exports = [
       //We only want to show until 42 weeks + 7 days
       return !recentLMP && addDays(report.reported_date, MAX_DAYS_IN_PREGNANCY + 7) >= today;
     },
-
     resolvedIf: checkTaskResolvedForHomeVisit,
-
+    priority: function(contact, report) {
+      console.warn('CONTACT', contact);
+      console.warn('REPORT', report);
+      const taskTypeScore = 8;
+      const individualScore = 2;
+      const score = taskTypeScore + individualScore;
+      return {
+        level: score,
+        label: getPriorityCategory(score),
+      };
+    },
     actions: [
       {
         type: 'report',
@@ -128,6 +143,14 @@ module.exports = [
       const endTime = addDays(dueDate, event.end + 1).getTime();
       return isFormArraySubmittedInWindow(contact.reports, ['pregnancy_facility_visit_reminder'], startTime, endTime);
 
+    },
+    priority: function(contact, report) {
+      console.warn('CONTACT', contact);
+      console.warn('REPORT', report);
+      return {
+        level: 'medium',
+        label: '',
+      };
     },
     actions: [{
       type: 'report',
@@ -164,6 +187,15 @@ module.exports = [
       const startTime = Math.max(addDays(dueDate, -event.start).getTime(), report.reported_date + 1);
       const endTime = addDays(dueDate, event.end + 1).getTime();
       return isFormArraySubmittedInWindow(contact.reports, ['pregnancy_danger_sign_follow_up'], startTime, endTime);
+    },
+    priority: function (contact, report) {
+      console.warn('CONTACT', contact);
+      console.warn('REPORT', report);
+      const score = 10;
+      return {
+        level: score,
+        label: getPriorityCategory(score),
+      };
     },
     actions: [
       {
@@ -238,6 +270,15 @@ module.exports = [
       const endTime = addDays(dueDate, event.end + 1).getTime();
       return isFormArraySubmittedInWindow(contact.reports, ['pnc_danger_sign_follow_up_mother'], startTime, endTime);
     },
+    priority: function(contact, report) {
+      console.warn('CONTACT', contact);
+      console.warn('REPORT', report);
+      const score = 3;
+      return {
+        level: score,
+        label: getPriorityCategory(score),
+      };
+    },
     actions: [
       {
         type: 'report',
@@ -280,6 +321,15 @@ module.exports = [
       const endTime = addDays(dueDate, event.end).getTime();
       return isFormArraySubmittedInWindow(contact.reports, ['pnc_danger_sign_follow_up_baby'], startTime, endTime);
     },
+    priority: function(contact, report, event, dueDate) {
+      console.warn(contact);
+      console.warn(event);
+      console.warn(dueDate);
+      return {
+        level: 10,
+        label: 'High',
+      };
+    },
     actions: [
       {
         type: 'report',
@@ -318,6 +368,15 @@ module.exports = [
       const endTime = addDays(dueDate, event.end + 1).getTime();
       return isFormArraySubmittedInWindow(contact.reports, ['pnc_danger_sign_follow_up_baby'], startTime, endTime);
     },
+    priority: function(contact, report, event, dueDate) {
+      console.warn(contact);
+      console.warn(event);
+      console.warn(dueDate);
+      return {
+        level: 10,
+        label: 'High',
+      };
+    },
     actions: [
       {
         type: 'report',
@@ -339,4 +398,3 @@ module.exports = [
     ]
   }
 ];
-

--- a/webapp/src/ts/reducers/tasks.ts
+++ b/webapp/src/ts/reducers/tasks.ts
@@ -23,17 +23,27 @@ const initialState = {
  */
 
 const orderByDueDateAndPriority = (t1, t2) => {
-  const getDueDate = (dueDate) => {
+  const getDueDate = dueDate => {
     if (typeof dueDate === 'number') {
       return dueDate;
     }
-    if (dueDate && moment(dueDate).isValid()) {
-      return moment(dueDate).valueOf();
+    // Handle string values
+    if (typeof dueDate === 'string') {
+      // Try parsing as number first
+      const numericDate = Number(dueDate);
+      if (!isNaN(numericDate)) {
+        return numericDate;
+      }
+
+      // If not a number, try parsing as date
+      if (moment(dueDate).isValid()) {
+        return moment(dueDate).valueOf();
+      }
     }
     return NaN;
   };
 
-  const getPriorityValue = (priority) => {
+  const getPriorityValue = priority => {
     if (typeof priority === 'number' && priority >= 0) {
       return priority;
     }
@@ -85,7 +95,7 @@ const orderByDueDateAndPriority = (t1, t2) => {
 
 const _tasksReducer = createReducer(
   initialState,
-  on(GlobalActions.clearSelected, (state) => ({ ...state, selected: null })),
+  on(GlobalActions.clearSelected, state => ({ ...state, selected: null })),
 
   on(Actions.setTasksList, (state, { payload: { tasks } }) => {
     return {
@@ -106,7 +116,7 @@ const _tasksReducer = createReducer(
 
   on(Actions.setLastSubmittedTask, (state, { payload: { task } }) => ({
     ...state,
-    tasksList: state.tasksList.filter((t) => task?._id !== t._id),
+    tasksList: state.tasksList.filter(t => task?._id !== t._id),
     taskGroup: {
       ...state.taskGroup,
       lastSubmittedTask: task,
@@ -141,7 +151,7 @@ const _tasksReducer = createReducer(
     },
   })),
 
-  on(Actions.clearTaskGroup, (state) => ({
+  on(Actions.clearTaskGroup, state => ({
     ...state,
     taskGroup: { ...initialState.taskGroup },
   }))

--- a/webapp/src/ts/reducers/tasks.ts
+++ b/webapp/src/ts/reducers/tasks.ts
@@ -14,20 +14,60 @@ const initialState = {
   },
 };
 
-const orderByDueDate = (t1, t2) => {
-  const lhs = t1?.dueDate;
-  const rhs = t2?.dueDate;
-  if (!lhs && !rhs) {
-    return 0;
-  }
-  if (!lhs) {
-    return 1;
-  }
-  if (!rhs) {
-    return -1;
+/**
+ * Task prioritization algorithm that combines:
+ * 1. Overdue status (most urgent)
+ * 2. Due today status (high urgency)
+ * 3. Priority (importance)
+ * 4. Due date (soonest first)
+ * 5. Tasks without due dates (lowest priority)
+ * 
+ * Sorting rules (in order):
+ * 1. Overdue tasks appear first (most urgent), sorted by priority (higher first)
+ * 2. Tasks due today appear next, sorted by priority (higher first)
+ * 3. Then sort other dates too by date and priority (high to low)
+ * 4. For equal priority, sort by due date (earlier first)
+ * 5. Tasks without due dates appear last
+ */
+const orderByDueDateAndPriority = (t1, t2) => {
+  const getPriorityScore = (t) => {
+    if (t?.priority === 'high') {
+      return 10;
+    } else if (t?.priority === 'medium') {
+      return 6;
+    } else if (typeof t?.priority === 'string') {
+      return 0;
+    } else {
+      return t?.priority ?? 0;
+    }
+  };
+
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  
+  const getDateScore = (t) => {
+    if (!t?.dueDate) return Infinity;
+    const date = new Date(t.dueDate).getTime();
+    return Math.floor((date - startOfToday) / (1000 * 60 * 60 * 24));
+  };
+
+  const p1 = getPriorityScore(t1);
+  const p2 = getPriorityScore(t2);
+  const days1 = getDateScore(t1);
+  const days2 = getDateScore(t2);
+
+  // Compare by due date (earlier first)
+  if (days1 !== days2) {
+    return days1 - days2;
   }
 
-  return lhs < rhs ? -1 : 1;
+  // Compare by priority (higher first)
+  if (p1 !== p2) {
+    return p2 - p1;
+  }
+
+  // Otherwise maintain original order
+  return 0;
 };
 
 const _tasksReducer = createReducer(
@@ -37,7 +77,7 @@ const _tasksReducer = createReducer(
   on(Actions.setTasksList, (state, { payload: { tasks } }) => {
     return {
       ...state,
-      tasksList: [...tasks].sort(orderByDueDate),
+      tasksList: [...tasks].sort(orderByDueDateAndPriority),
     };
   }),
 

--- a/webapp/src/ts/reducers/tasks.ts
+++ b/webapp/src/ts/reducers/tasks.ts
@@ -1,7 +1,8 @@
 import { createReducer, on } from '@ngrx/store';
 
-import { Actions } from '@mm-actions/tasks';
 import { Actions as GlobalActions } from '@mm-actions/global';
+import { Actions } from '@mm-actions/tasks';
+import moment from 'moment';
 
 const initialState = {
   tasksList: [] as any[],
@@ -15,59 +16,71 @@ const initialState = {
 };
 
 /**
- * Task prioritization algorithm that combines:
- * 1. Overdue status (most urgent)
- * 2. Due today status (high urgency)
- * 3. Priority (importance)
- * 4. Due date (soonest first)
- * 5. Tasks without due dates (lowest priority)
- * 
  * Sorting rules (in order):
- * 1. Overdue tasks appear first (most urgent), sorted by priority (higher first)
- * 2. Tasks due today appear next, sorted by priority (higher first)
- * 3. Then sort other dates too by date and priority (high to low)
- * 4. For equal priority, sort by due date (earlier first)
- * 5. Tasks without due dates appear last
+ * 1. Valid priorities sort first (higher value = higher priority)
+ * 2. Equal priorities sort by due date (earlier = higher priority)
+ * 3. Invalid/missing values sort last while maintaining original order
  */
+
 const orderByDueDateAndPriority = (t1, t2) => {
-  const getPriorityScore = (t) => {
-    if (t?.priority === 'high') {
-      return 10;
-    } else if (t?.priority === 'medium') {
-      return 6;
-    } else if (typeof t?.priority === 'string') {
-      return 0;
-    } else {
-      return t?.priority ?? 0;
+  const getDueDate = (dueDate) => {
+    if (typeof dueDate === 'number') {
+      return dueDate;
     }
+    if (moment(dueDate).isValid()) {
+      return moment(dueDate).valueOf();
+    }
+    return NaN;
   };
 
-  const now = new Date();
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-  
-  const getDateScore = (t) => {
-    if (!t?.dueDate) return Infinity;
-    const date = new Date(t.dueDate).getTime();
-    return Math.floor((date - startOfToday) / (1000 * 60 * 60 * 24));
+  const getPriorityValue = (priority) => {
+    if (typeof priority === 'number' && priority >= 0) {
+      return priority;
+    }
+    return NaN;
   };
 
-  const p1 = getPriorityScore(t1);
-  const p2 = getPriorityScore(t2);
-  const days1 = getDateScore(t1);
-  const days2 = getDateScore(t2);
+  const lhsDate = getDueDate(t1?.dueDate);
+  const rhsDate = getDueDate(t2?.dueDate);
+  const lhsPriority = getPriorityValue(t1?.priority);
+  const rhsPriority = getPriorityValue(t2?.priority);
 
-  // Compare by due date (earlier first)
-  if (days1 !== days2) {
-    return days1 - days2;
+  const compareDates = () => {
+    // Both dates invalid, maintain original order
+    if (isNaN(lhsDate) && isNaN(rhsDate)) {
+      return 0;
+    }
+    // Move tasks without dates to end
+    if (isNaN(lhsDate)) {
+      return 1;
+    }
+    if (isNaN(rhsDate)) {
+      return -1;
+    }
+    // Sort by date ascending
+    return lhsDate - rhsDate;
+  };
+
+  // Priority comparison cascade
+  if (isNaN(lhsPriority) && isNaN(rhsPriority)) {
+    return compareDates(); // Both priorities invalid, sort by date
   }
 
-  // Compare by priority (higher first)
-  if (p1 !== p2) {
-    return p2 - p1;
+  // Move tasks without valid priorities to end
+  if (isNaN(lhsPriority)) {
+    return 1;
+  }
+  if (isNaN(rhsPriority)) {
+    return -1;
   }
 
-  // Otherwise maintain original order
-  return 0;
+  // Both priorities are valid, sort in descending order
+  if (lhsPriority !== rhsPriority) {
+    return rhsPriority - lhsPriority;
+  }
+
+  // Same priority, sort by date
+  return compareDates();
 };
 
 const _tasksReducer = createReducer(
@@ -81,16 +94,22 @@ const _tasksReducer = createReducer(
     };
   }),
 
-  on(Actions.setTasksLoaded, (state, { payload: { loaded }}) => ({ ...state, loaded })),
+  on(Actions.setTasksLoaded, (state, { payload: { loaded } }) => ({
+    ...state,
+    loaded,
+  })),
 
-  on(Actions.setSelectedTask, (state, { payload: { selected } }) => ({ ...state, selected })),
+  on(Actions.setSelectedTask, (state, { payload: { selected } }) => ({
+    ...state,
+    selected,
+  })),
 
   on(Actions.setLastSubmittedTask, (state, { payload: { task } }) => ({
     ...state,
-    tasksList: state.tasksList.filter(t => task?._id !== t._id),
+    tasksList: state.tasksList.filter((t) => task?._id !== t._id),
     taskGroup: {
       ...state.taskGroup,
-      lastSubmittedTask: task
+      lastSubmittedTask: task,
     },
   })),
 
@@ -114,9 +133,11 @@ const _tasksReducer = createReducer(
   on(Actions.setTaskGroup, (state, { payload: { taskGroup } }) => ({
     ...state,
     taskGroup: {
-      lastSubmittedTask: taskGroup.lastSubmittedTask || state.taskGroup.lastSubmittedTask,
+      lastSubmittedTask:
+        taskGroup.lastSubmittedTask || state.taskGroup.lastSubmittedTask,
       contact: taskGroup.contact || state.taskGroup.contact,
-      loadingContact: taskGroup.loadingContact || state.taskGroup.loadingContact,
+      loadingContact:
+        taskGroup.loadingContact || state.taskGroup.loadingContact,
     },
   })),
 

--- a/webapp/src/ts/reducers/tasks.ts
+++ b/webapp/src/ts/reducers/tasks.ts
@@ -27,7 +27,7 @@ const orderByDueDateAndPriority = (t1, t2) => {
     if (typeof dueDate === 'number') {
       return dueDate;
     }
-    if (moment(dueDate).isValid()) {
+    if (dueDate && moment(dueDate).isValid()) {
       return moment(dueDate).valueOf();
     }
     return NaN;

--- a/webapp/src/ts/services/format-date.service.ts
+++ b/webapp/src/ts/services/format-date.service.ts
@@ -107,12 +107,16 @@ export class FormatDateService {
     const today = moment().startOf('day');
     const diff = date.diff(today, 'days');
 
-    if (diff <= 0) {
+    if (diff < 0) {
       if (this.config.taskDaysOverdue) {
         return this.translateService.instant('task.overdue.days', { DAYS: Math.abs(diff) });
       }
 
       return this.translateService.instant('task.overdue');
+    }
+
+    if (diff === 0) {
+      return this.translateService.instant('Due today');
     }
 
     if (diff <= this.config.taskDayLimit) {

--- a/webapp/src/ts/services/format-date.service.ts
+++ b/webapp/src/ts/services/format-date.service.ts
@@ -1,22 +1,26 @@
-import * as moment from 'moment';
 import { Injectable } from '@angular/core';
+import {
+  toBik as toBikramSambat,
+  toBik_text as toBikramSambatText,
+  toDev as toDevanagariDate,
+} from 'bikram-sambat';
+import * as moment from 'moment';
 import { RelativeTimeKey } from 'moment';
-import { toBik_text as toBikramSambatText, toBik as toBikramSambat, toDev as toDevanagariDate } from 'bikram-sambat';
 
+import { FormatNumberService } from '@mm-services/format-number.service';
+import { LanguageService } from '@mm-services/language.service';
 import { SettingsService } from '@mm-services/settings.service';
 import { TranslateService } from '@mm-services/translate.service';
-import { LanguageService } from '@mm-services/language.service';
-import { FormatNumberService } from '@mm-services/format-number.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class FormatDateService {
   constructor(
-    private translateService:TranslateService,
-    private settingsService:SettingsService,
-    private languageService:LanguageService,
-    private formatNumberService:FormatNumberService,
+    private translateService: TranslateService,
+    private settingsService: SettingsService,
+    private languageService: LanguageService,
+    private formatNumberService: FormatNumberService
   ) {
     this.initConfig();
   }
@@ -34,8 +38,8 @@ export class FormatDateService {
       ageBreaks: [
         { unit: 'years', key: { singular: 'y', plural: 'yy' }, min: 1 },
         { unit: 'months', key: { singular: 'M', plural: 'MM' }, min: 1 },
-        { unit: 'days', key: { singular: 'd', plural: 'dd' }, min: 0 }
-      ]
+        { unit: 'days', key: { singular: 'd', plural: 'dd' }, min: 0 },
+      ],
     };
   }
 
@@ -43,7 +47,7 @@ export class FormatDateService {
     this.initConfig();
     return this.settingsService
       .get()
-      .then((res:any) => {
+      .then((res: any) => {
         this.config.date = res.date_format;
         this.config.datetime = res.reported_date_format;
         if (typeof res.task_day_limit !== 'undefined') {
@@ -65,7 +69,11 @@ export class FormatDateService {
 
     if (key === 'dayMonth') {
       const bikDate = toBikramSambat(momentDate);
-      const devanagariDate = toDevanagariDate(bikDate.year, bikDate.month, bikDate.day);
+      const devanagariDate = toDevanagariDate(
+        bikDate.year,
+        bikDate.month,
+        bikDate.day
+      );
       return `${devanagariDate.day} ${devanagariDate.month}`;
     }
 
@@ -107,16 +115,14 @@ export class FormatDateService {
     const today = moment().startOf('day');
     const diff = date.diff(today, 'days');
 
-    if (diff < 0) {
+    if (diff <= 0) {
       if (this.config.taskDaysOverdue) {
-        return this.translateService.instant('task.overdue.days', { DAYS: Math.abs(diff) });
+        return this.translateService.instant('task.overdue.days', {
+          DAYS: Math.abs(diff),
+        });
       }
 
       return this.translateService.instant('task.overdue');
-    }
-
-    if (diff === 0) {
-      return this.translateService.instant('Due today');
     }
 
     if (diff <= this.config.taskDayLimit) {
@@ -144,7 +150,14 @@ export class FormatDateService {
     // postformatting is not applied to relativeTime.
     // https://github.com/moment/moment/issues/5935
     const localizedQuantity = this.formatNumberService.localize(quantity);
-    const output = moment.localeData().relativeTime(localizedQuantity, true, <RelativeTimeKey>key, diff.quantity > 0);
+    const output = moment
+      .localeData()
+      .relativeTime(
+        localizedQuantity,
+        true,
+        <RelativeTimeKey>key,
+        diff.quantity > 0
+      );
     if (options.suffix) {
       return moment.localeData().pastFuture(diff.quantity, output);
     }
@@ -163,7 +176,7 @@ export class FormatDateService {
     return this.format(date, 'dayMonth');
   }
 
-  relative(date, options:any = {}) {
+  relative(date, options: any = {}) {
     if (options.task) {
       return this.getTaskDueDate(date);
     }
@@ -173,7 +186,7 @@ export class FormatDateService {
     return moment(date).fromNow(false);
   }
 
-  age(date, options:any = {}) {
+  age(date, options: any = {}) {
     return this.relativeDate(date, options);
   }
 

--- a/webapp/tests/karma/ts/reducers/tasks.spec.ts
+++ b/webapp/tests/karma/ts/reducers/tasks.spec.ts
@@ -221,7 +221,7 @@ describe('Tasks reducer', () => {
     it('should sort provided tasks by due date', () => {
       const tasks = [
         { _id: 'task1', dueDate: false, state: 'Ready', field: 1 },
-        { _id: 'task2', dueDate: null, state: 'Ready', field: 2 },
+        { _id: 'task2', dueDate: undefined, state: 'Ready', field: 2 },
         { _id: 'task3', dueDate: 0, state: 'Ready', field: 3 },
         { _id: 'task4', dueDate: 500, state: 'Ready', field: 4 },
         { _id: 'task5', dueDate: 500, state: 'Ready', field: 5 },
@@ -249,7 +249,7 @@ describe('Tasks reducer', () => {
           { _id: 'task5', dueDate: 500, state: 'Ready', field: 5 },
           { _id: 'task8', dueDate: 899, state: 'Ready', field: 8 },
           { _id: 'task1', dueDate: false, state: 'Ready', field: 1 },
-          { _id: 'task2', dueDate: null, state: 'Ready', field: 2 },
+          { _id: 'task2', dueDate: undefined, state: 'Ready', field: 2 },
         ],
       });
     });
@@ -327,9 +327,16 @@ describe('Tasks reducer', () => {
           field: 10,
         },
         {
-          _id: 'task11',
+          _id: 'task14',
           dueDate: '2025-05-17',
           priority: 2,
+          state: 'Ready',
+          field: 14,
+        },
+        {
+          _id: 'task11',
+          dueDate: undefined,
+          priority: undefined,
           state: 'Ready',
           field: 11,
         },
@@ -388,11 +395,11 @@ describe('Tasks reducer', () => {
             field: 8,
           },
           {
-            _id: 'task11',
+            _id: 'task14',
             dueDate: '2025-05-17',
             priority: 2,
             state: 'Ready',
-            field: 11,
+            field: 14,
           },
           {
             _id: 'task4',
@@ -449,6 +456,13 @@ describe('Tasks reducer', () => {
             priority: 'high',
             state: 'Ready',
             field: 6,
+          },
+          {
+            _id: 'task11',
+            dueDate: undefined,
+            priority: undefined,
+            state: 'Ready',
+            field: 11,
           },
         ],
       });

--- a/webapp/tests/karma/ts/reducers/tasks.spec.ts
+++ b/webapp/tests/karma/ts/reducers/tasks.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import { Actions } from '@mm-actions/tasks';
 import { Actions as GlobalActions } from '@mm-actions/global';
+import { Actions } from '@mm-actions/tasks';
 import { tasksReducer } from '@mm-reducers/tasks';
 
 describe('Tasks reducer', () => {
@@ -221,7 +221,7 @@ describe('Tasks reducer', () => {
     it('should sort provided tasks by due date', () => {
       const tasks = [
         { _id: 'task1', dueDate: false, state: 'Ready', field: 1 },
-        { _id: 'task2', dueDate: undefined, state: 'Ready', field: 2 },
+        { _id: 'task2', dueDate: null, state: 'Ready', field: 2 },
         { _id: 'task3', dueDate: 0, state: 'Ready', field: 3 },
         { _id: 'task4', dueDate: 500, state: 'Ready', field: 4 },
         { _id: 'task5', dueDate: 500, state: 'Ready', field: 5 },
@@ -242,15 +242,215 @@ describe('Tasks reducer', () => {
         },
         tasksList: [
           { _id: 'task9', dueDate: -100, state: 'Ready', field: 9 },
+          { _id: 'task3', dueDate: 0, state: 'Ready', field: 3 },
           { _id: 'task7', dueDate: 125, state: 'Ready', field: 7 },
           { _id: 'task6', dueDate: 250, state: 'Ready', field: 6 },
           { _id: 'task4', dueDate: 500, state: 'Ready', field: 4 },
           { _id: 'task5', dueDate: 500, state: 'Ready', field: 5 },
           { _id: 'task8', dueDate: 899, state: 'Ready', field: 8 },
           { _id: 'task1', dueDate: false, state: 'Ready', field: 1 },
-          { _id: 'task2', dueDate: undefined, state: 'Ready', field: 2 },
-          { _id: 'task3', dueDate: 0, state: 'Ready', field: 3 },
-        ]
+          { _id: 'task2', dueDate: null, state: 'Ready', field: 2 },
+        ],
+      });
+    });
+
+    it('should sort provided tasks by priority and due date', () => {
+      const tasks = [
+        {
+          _id: 'task1',
+          dueDate: '2025-05-30',
+          priority: 'invalid',
+          state: 'Ready',
+          field: 1,
+        },
+        {
+          _id: 'task2',
+          dueDate: '2025-05-30',
+          priority: 3,
+          state: 'Ready',
+          field: 2,
+        },
+        {
+          _id: 'task3',
+          dueDate: '2025-05-27',
+          priority: 1,
+          state: 'Ready',
+          field: 3,
+        },
+        {
+          _id: 'task4',
+          dueDate: '2025-05-27',
+          priority: 2,
+          state: 'Ready',
+          field: 4,
+        },
+        {
+          _id: 'task5',
+          dueDate: '2025-05-31',
+          priority: undefined,
+          state: 'Ready',
+          field: 5,
+        },
+        {
+          _id: 'task6',
+          dueDate: '2025-05-31',
+          priority: 'high',
+          state: 'Ready',
+          field: 6,
+        },
+        {
+          _id: 'task7',
+          dueDate: '2025-05-07',
+          priority: 1,
+          state: 'Ready',
+          field: 7,
+        },
+        {
+          _id: 'task8',
+          dueDate: '2025-05-07',
+          priority: 2,
+          state: 'Ready',
+          field: 8,
+        },
+        {
+          _id: 'task9',
+          dueDate: null,
+          priority: 3,
+          state: 'Ready',
+          field: 9,
+        },
+        {
+          _id: 'task10',
+          dueDate: false,
+          priority: 2,
+          state: 'Ready',
+          field: 10,
+        },
+        {
+          _id: 'task11',
+          dueDate: '2025-05-17',
+          priority: 2,
+          state: 'Ready',
+          field: 11,
+        },
+        {
+          _id: 'task12',
+          dueDate: '2025-05-17',
+          priority: 5,
+          state: 'Ready',
+          field: 12,
+        },
+        {
+          _id: 'task13',
+          dueDate: '2025-05-17',
+          priority: -1,
+          state: 'Ready',
+          field: 13,
+        },
+      ];
+
+      state = tasksReducer(state, Actions.setTasksList(tasks));
+      expect(state).to.deep.equal({
+        selected: null,
+        loaded: false,
+        taskGroup: {
+          lastSubmittedTask: null,
+          contact: null,
+          loadingContact: null,
+        },
+        tasksList: [
+          {
+            _id: 'task12',
+            dueDate: '2025-05-17',
+            priority: 5,
+            state: 'Ready',
+            field: 12,
+          },
+          {
+            _id: 'task2',
+            dueDate: '2025-05-30',
+            priority: 3,
+            state: 'Ready',
+            field: 2,
+          },
+          {
+            _id: 'task9',
+            dueDate: null,
+            priority: 3,
+            state: 'Ready',
+            field: 9,
+          },
+          {
+            _id: 'task8',
+            dueDate: '2025-05-07',
+            priority: 2,
+            state: 'Ready',
+            field: 8,
+          },
+          {
+            _id: 'task11',
+            dueDate: '2025-05-17',
+            priority: 2,
+            state: 'Ready',
+            field: 11,
+          },
+          {
+            _id: 'task4',
+            dueDate: '2025-05-27',
+            priority: 2,
+            state: 'Ready',
+            field: 4,
+          },
+          {
+            _id: 'task10',
+            dueDate: false,
+            priority: 2,
+            state: 'Ready',
+            field: 10,
+          },
+          {
+            _id: 'task7',
+            dueDate: '2025-05-07',
+            priority: 1,
+            state: 'Ready',
+            field: 7,
+          },
+          {
+            _id: 'task3',
+            dueDate: '2025-05-27',
+            priority: 1,
+            state: 'Ready',
+            field: 3,
+          },
+          {
+            _id: 'task13',
+            dueDate: '2025-05-17',
+            priority: -1,
+            state: 'Ready',
+            field: 13,
+          },
+          {
+            _id: 'task1',
+            dueDate: '2025-05-30',
+            priority: 'invalid',
+            state: 'Ready',
+            field: 1,
+          },
+          {
+            _id: 'task5',
+            dueDate: '2025-05-31',
+            priority: undefined,
+            state: 'Ready',
+            field: 5,
+          },
+          {
+            _id: 'task6',
+            dueDate: '2025-05-31',
+            priority: 'high',
+            state: 'Ready',
+            field: 6,
+          },
+        ],
       });
     });
   });
@@ -277,7 +477,7 @@ describe('Tasks reducer', () => {
         tasksList: [
           { _id: 'task1', dueDate: 22, state: 'Ready' },
           { _id: 'task2', dueDate: 33, state: 'Ready' },
-          { _id: 'task_id2', due: '33', field: 2 }
+          { _id: 'task_id2', due: '33', field: 2 },
         ],
         loaded: true,
         taskGroup: {


### PR DESCRIPTION
Closes https://github.com/medic/cht-core/issues/9957

**Is your feature request related to a problem? Please describe.**
  Currently tasks are sorted only by due date. The update takes into account both a priority score and due date.

**Describe the solution you'd like**
  Implemented a refined sorting algorithm that (Sort by priority and then due date within the same priority):
  - Primarily sorts tasks by priority (higher numbers first)
  - For tasks with equal priority, sorts by due date (earlier dates first)
  - Handles invalid values consistently:
      - Tasks with invalid priorities move to end
      - Within same priority, invalid dates move to end
      - Maintains original order when both priority and date are invalid

**Describe alternatives you've considered**
****Alternative Solution 1****
Similar to the proposed solution, but with the priority property of a task not be a number, but an array, with one number representing the priority of the task when it is not due, one number for when it’s due and one number for when it’s overdue. Then web-app will just select the right number when sorting tasks, and not recompute priority based on due date.

****Alternative Solution 2****
Options for frontend sorting: 
- Sort by due date and then priority within the same due date.
- Sorting by Due date first for tasks above the due date, then by priority for tasks that are not due. 
- Sort by priority for tasks that are above due date, then by due date for tasks that are not due.

**Additional context**
- The solution maintains backwards compatibility with existing task structures
- Includes comprehensive test cases covering edge cases like:
  - Invalid date formats (null, false, undefined).
  - Invalid priority values (strings, negative numbers).
  - Duplicate priorities and dates.
  - Missing fields.