### PR TITLE
chore: update GH action config to not require translations for publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,7 +374,7 @@ jobs:
       if: ${{ failure() }}
 
   publish:
-    needs: [tests, config-tests, test-cht-form, translations]
+    needs: [tests, config-tests, test-cht-form]
     name: Publish branch build
     runs-on: ubuntu-22.04
     timeout-minutes: 60


### PR DESCRIPTION
# Description

When doing development that requires new translation strings we need to provide _values_ for the translation keys for each of the required languages or else the `translations` job will fail in CI.  However, early in the development process we may not know all the needed translation strings (or how they will eventually be used/displayed). Finalizing the UX often comes towards the end of development. That is the point where our [translation process](https://docs.communityhealthtoolkit.org/community/contributing/translations/#adding-new-keys) indicates we should reach out on the forum to ask for help translating the strings.  

I think it is useful to have the `translations` job continue to fail until values are actually provided for the required languages, but I would also like the CI run to still publish the Docker images for the branch even if `translations` fails. This will allow for easier manual testing (e.g. using the docker-helper to spin up instances from the branch images) without having to hack anything (like updating the workflow config or including placeholder translation values).

The CI is still in a "Failing" state when the `translations` job fails even if `publish` runs and passes successfully.  So, you still cannot merge a PR where the `translations` job fails.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

