### PR TITLE
feat(#9971): add caching for Chrome 90 installer to optimize build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,6 +312,7 @@ jobs:
         mkdir -p allure-results/history
         cp -r build-history-data/cht-core/allure/${{ env.JOB_NAME }}/allure-report/history allure-results | true
     - name: Cache Chrome 90 Installer
+      if: ${{ matrix.chrome-version == '90' }}
       id: cache-chrome
       uses: actions/cache@v4
       with:
@@ -320,20 +321,16 @@ jobs:
         restore-keys: |
           chrome90-${{ runner.os }}-
           chrome90-
-      if: ${{ matrix.chrome-version == '90' }}
-    - name: Install Chrome 90
+    - name: Download Chrome 90
       if: ${{ matrix.chrome-version == '90' && steps.cache-chrome.outputs.cache-hit != 'true' }}
       run: |
         mkdir -p /tmp/chrome90
         wget -O "/tmp/chrome90/google-chrome-stable_current_amd64.deb" https://www.slimjet.com/chrome/download-chrome.php?file=files/90.0.4430.72/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i "/tmp/chrome90/google-chrome-stable_current_amd64.deb"
-    - name: Install Chrome 90 from Cache
-      if: ${{ matrix.chrome-version == '90' && steps.cache-chrome.outputs.cache-hit == 'true' }}
+    - name: Install Chrome 90
+      if: ${{ matrix.chrome-version == '90' }}
       run: |
         sudo dpkg -i "/tmp/chrome90/google-chrome-stable_current_amd64.deb"
-    - name: Install chromedriver for Chrome 90
-      if: ${{ matrix.chrome-version == '90' }}
-      run: npm install chromedriver@^90.0.1
+        npm install chromedriver@^90.0.1
     - name: Run tests ${{ matrix.cmd }}-${{ matrix.suite }} on Chrome ${{ matrix.chrome-version }}
       run: npm run ${{ matrix.cmd }} -- --suite=${{ matrix.suite }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,6 +317,9 @@ jobs:
       with:
         path: /tmp/chrome90
         key: chrome90-${{ runner.os }}-90.0.4430.72
+        restore-keys: |
+          chrome90-${{ runner.os }}-
+          chrome90-
     - name: Install Chrome 90
       if: steps.cache-chrome.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,12 +311,24 @@ jobs:
       run: |
         mkdir -p allure-results/history
         cp -r build-history-data/cht-core/allure/${{ env.JOB_NAME }}/allure-report/history allure-results | true
+    - name: Cache Chrome 90 Installer
+      id: cache-chrome
+      uses: actions/cache@v4
+      with:
+        path: /tmp/chrome90
+        key: chrome90-${{ runner.os }}-90.0.4430.72
     - name: Install Chrome 90
-      if: ${{matrix.chrome-version=='90'}}
+      if: steps.cache-chrome.outputs.cache-hit != 'true'
       run: |
-        wget -O "google-chrome-stable_current_amd64.deb" https://www.slimjet.com/chrome/download-chrome.php?file=files/90.0.4430.72/google-chrome-stable_current_amd64.deb
-        sudo dpkg -i "google-chrome-stable_current_amd64.deb"
-        npm install chromedriver@^90.0.1
+        mkdir -p /tmp/chrome90
+        wget -O "/tmp/chrome90/google-chrome-stable_current_amd64.deb" https://www.slimjet.com/chrome/download-chrome.php?file=files/90.0.4430.72/google-chrome-stable_current_amd64.deb
+        sudo dpkg -i "/tmp/chrome90/google-chrome-stable_current_amd64.deb"
+    - name: Install Chrome 90 from Cache
+      if: steps.cache-chrome.outputs.cache-hit == 'true'
+      run: |
+        sudo dpkg -i "/tmp/chrome90/google-chrome-stable_current_amd64.deb"
+    - name: Install chromedriver for Chrome 90
+      run: npm install chromedriver@^90.0.1
     - name: Run tests ${{ matrix.cmd }}-${{ matrix.suite }} on Chrome ${{ matrix.chrome-version }}
       run: npm run ${{ matrix.cmd }} -- --suite=${{ matrix.suite }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,17 +320,19 @@ jobs:
         restore-keys: |
           chrome90-${{ runner.os }}-
           chrome90-
+      if: ${{ matrix.chrome-version == '90' }}
     - name: Install Chrome 90
-      if: steps.cache-chrome.outputs.cache-hit != 'true'
+      if: ${{ matrix.chrome-version == '90' && steps.cache-chrome.outputs.cache-hit != 'true' }}
       run: |
         mkdir -p /tmp/chrome90
         wget -O "/tmp/chrome90/google-chrome-stable_current_amd64.deb" https://www.slimjet.com/chrome/download-chrome.php?file=files/90.0.4430.72/google-chrome-stable_current_amd64.deb
         sudo dpkg -i "/tmp/chrome90/google-chrome-stable_current_amd64.deb"
     - name: Install Chrome 90 from Cache
-      if: steps.cache-chrome.outputs.cache-hit == 'true'
+      if: ${{ matrix.chrome-version == '90' && steps.cache-chrome.outputs.cache-hit == 'true' }}
       run: |
         sudo dpkg -i "/tmp/chrome90/google-chrome-stable_current_amd64.deb"
     - name: Install chromedriver for Chrome 90
+      if: ${{ matrix.chrome-version == '90' }}
       run: npm install chromedriver@^90.0.1
     - name: Run tests ${{ matrix.cmd }}-${{ matrix.suite }} on Chrome ${{ matrix.chrome-version }}
       run: npm run ${{ matrix.cmd }} -- --suite=${{ matrix.suite }}


### PR DESCRIPTION
This pull request introduces caching for the Chrome 90 installer in the GitHub Actions workflow to optimize build times. The key changes include adding a cache step, modifying the Chrome installation logic to leverage the cache, and separating the chromedriver installation.


Closes #9971 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

