### PR TITLE
fix: resolve deprecated userName faker usage

### DIFF
--- a/tests/e2e/default/telemetry/telemetry.wdio-spec.js
+++ b/tests/e2e/default/telemetry/telemetry.wdio-spec.js
@@ -36,7 +36,7 @@ describe('Telemetry', () => {
     phone: '+9779841299392',
   });
   const user = userFactory.build({
-    username: Faker.internet.userName().toLowerCase().replace(/[^0-9a-zA-Z_]/g, ''),
+    username: Faker.internet.username().toLowerCase().replace(/[^0-9a-zA-Z_]/g, ''),
     password: 'Secret_1',
     place: healthCenter._id,
     contact: contact._id,


### PR DESCRIPTION
# Description
This small PR resolves the `faker` deprecation warings which you can find in the [CI logs](https://github.com/medic/cht-core/actions/runs/15336080315/job/43153950799#step:16:363):
```python
[@faker-js/faker]: faker.internet.userName() is deprecated since v9.1.0 and will be removed in v10.0.0. Please use faker.internet.username() instead.
```

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

