### PR TITLE
feat(#9983): app_url is required when token login is enabled.

### DIFF
--- a/shared-libs/user-management/src/token-login.js
+++ b/shared-libs/user-management/src/token-login.js
@@ -48,7 +48,6 @@ const generateToken = () => {
  * - if the user already had token-login enabled, the previous sms document's tasks are cleared
  * - updates the user document to contain information about the active `token-login` context for the user
  * - updates the user-settings document to contain some information to be displayed in the admin page
- * @param {String} appUrl - the base URL of the application
  * @param {Object} response - the response of previous actions
  * @returns {Promise<{Object}>} - updated response to be sent to the client
  */
@@ -117,7 +116,6 @@ const disableTokenLogin = (response) => {
  * Enables or disables token-login for a user
  * When enabling, if `token-login` configuration is missing or invalid, no changes are made.
  * @param {Object} data - the request body
- * @param {String} appUrl - the base URL of the application
  * @param {Object} response - the response of previous actions
  * @returns {Promise<{Object}>} - updated response to be sent to the client
  */

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -699,7 +699,7 @@ const validateUserContact = (data, user) => {
  * @param {string} appUrl request protocol://hostname
  */
 /* eslint-enable max-len */
-const createUserEntities = async (data, appUrl) => {
+const createUserEntities = async (data) => {
   // Preserve the place's primary contact, if data.place already exists in the DB.
   // => if we're creating the place alongside the user, set the contact as the place's primary contact
   const preservePrimaryContact = !(_.isObject(data.place) && !data.place._rev);
@@ -713,7 +713,7 @@ const createUserEntities = async (data, appUrl) => {
   hydratePayload(data);
   await createUser(data, response);
   await createUserSettings(data, response);
-  await tokenLogin.manageTokenLogin(data, appUrl, response);
+  await tokenLogin.manageTokenLogin(data, response);
   return response;
 };
 
@@ -876,7 +876,7 @@ const getUserSettings = async({ name }) => {
   return hydrateUserSettings(medicUser);
 };
 
-const createMultiFacilityUser = async (data, appUrl) => {
+const createMultiFacilityUser = async (data) => {
   const missing = missingFields(data);
   if (missing.length > 0) {
     return Promise.reject(error400(
@@ -903,7 +903,7 @@ const createMultiFacilityUser = async (data, appUrl) => {
 
   await createUser(data, response);
   await createUserSettings(data, response);
-  await tokenLogin.manageTokenLogin(data, appUrl, response);
+  await tokenLogin.manageTokenLogin(data, response);
   return response;
 };
 
@@ -1145,7 +1145,7 @@ module.exports = {
    *                                     security-related things?
    * @param      {String}    appUrl      request protocol://hostname
    */
-  updateUser: async (username, data, fullAccess, appUrl) => {
+  updateUser: async (username, data, fullAccess) => {
     await validateUpdateAttempt(data, fullAccess);
     hydratePayload(data);
 
@@ -1167,7 +1167,7 @@ module.exports = {
       'user-settings': await saveUserSettingsUpdates(userSettings),
     };
 
-    return tokenLogin.manageTokenLogin(data, appUrl, response);
+    return tokenLogin.manageTokenLogin(data, response);
   },
 
   /**

--- a/shared-libs/user-management/test/unit/token-login.spec.js
+++ b/shared-libs/user-management/test/unit/token-login.spec.js
@@ -480,14 +480,14 @@ describe('TokenLogin service', () => {
 
   describe('manageTokenLogin', () => {
     it('should do nothing when undefined', () => {
-      return service.manageTokenLogin({}, '', { user: { id: 'user' } }).then(actual => {
+      return service.manageTokenLogin({}, { user: { id: 'user' } }).then(actual => {
         chai.expect(actual).to.deep.equal({ user: { id: 'user' } });
       });
     });
 
     it('should do nothing when no config', () => {
       config.get.withArgs('token_login').returns();
-      return service.manageTokenLogin({ token_login: true }, '', { user: { id: 'user' } }).then(actual => {
+      return service.manageTokenLogin({ token_login: true }, { user: { id: 'user' } }).then(actual => {
         chai.expect(actual).to.deep.equal({ user: { id: 'user' } });
       });
     });
@@ -498,7 +498,7 @@ describe('TokenLogin service', () => {
         db.medic.get.withArgs('userID').resolves({ _id: 'userID' });
         db.users.get.withArgs('userID').resolves({ _id: 'userID' });
 
-        return service.manageTokenLogin({ token_login: false }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: false }, response).then(actual => {
           chai.expect(actual).to.deep.equal({ user: { id: 'userID' }, 'user-settings': { id: 'userID' } });
         });
       });
@@ -536,7 +536,7 @@ describe('TokenLogin service', () => {
         db.medic.put.resolves();
         db.users.put.resolves();
 
-        return service.manageTokenLogin({ token_login: false }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: false }, response).then(actual => {
           chai.expect(db.medic.put.callCount).to.equal(2);
           chai.expect(db.medic.put.args[0]).to.deep.equal([{
             _id: 'token:login:aaa',
@@ -608,7 +608,7 @@ describe('TokenLogin service', () => {
         db.medic.put.resolves();
         db.users.put.resolves();
 
-        return service.manageTokenLogin({ token_login: false }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: false }, response).then(actual => {
           chai.expect(db.medic.put.callCount).to.equal(1);
           chai.expect(db.medic.put.args[0]).to.deep.equal([{
             _id: 'userID',
@@ -651,7 +651,7 @@ describe('TokenLogin service', () => {
         db.medic.put.resolves();
         db.users.put.resolves();
 
-        return service.manageTokenLogin({ token_login: false }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: false }, response).then(actual => {
           chai.expect(db.medic.put.callCount).to.equal(1);
           chai.expect(db.medic.put.args[0]).to.deep.equal([{
             _id: 'userID',
@@ -676,6 +676,7 @@ describe('TokenLogin service', () => {
       beforeEach(() => {
         addMessage = sinon.stub();
         config.getTransitionsLib.returns({ messages: { addMessage } });
+        config.get.withArgs('app_url').returns('http://host');
       });
 
       it('should generate password, token, create sms and update user docs', () => {
@@ -703,7 +704,7 @@ describe('TokenLogin service', () => {
 
         clock.tick(2000);
 
-        return service.manageTokenLogin({ token_login: true }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: true }, response).then(actual => {
           chai.expect(db.users.put.callCount).to.equal(1);
           chai.expect(db.users.put.args[0][0]).to.deep.include({
             _id: 'userID',
@@ -811,7 +812,7 @@ describe('TokenLogin service', () => {
 
         clock.tick(2000);
 
-        return service.manageTokenLogin({ token_login: true }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: true }, response).then(actual => {
           chai.expect(db.users.put.callCount).to.equal(1);
           chai.expect(db.users.put.args[0][0]).to.deep.include({
             _id: 'my_user',
@@ -953,7 +954,7 @@ describe('TokenLogin service', () => {
 
         clock.tick(5000);
 
-        return service.manageTokenLogin({ token_login: true }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: true }, response).then(actual => {
           chai.expect(db.users.put.callCount).to.equal(1);
           chai.expect(db.users.put.args[0][0].token_login).to.deep.include({
             active: true,
@@ -1050,7 +1051,7 @@ describe('TokenLogin service', () => {
 
         clock.tick(2000);
 
-        return service.manageTokenLogin({ token_login: true }, '', response).then(actual => {
+        return service.manageTokenLogin({ token_login: true }, response).then(actual => {
           chai.expect(db.users.put.callCount).to.equal(1);
           chai.expect(db.users.put.args[0][0]).to.deep.include({
             _id: 'userID',
@@ -1110,7 +1111,7 @@ describe('TokenLogin service', () => {
         clock.tick(2000);
 
         return service
-          .manageTokenLogin({ token_login: true }, '', response)
+          .manageTokenLogin({ token_login: true }, response)
           .then(() => chai.assert.fail('Should have thrown'))
           .catch(err => {
             chai.expect(err.message).to.equal('Failed to generate unique token');

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -1682,7 +1682,7 @@ describe('Users service', () => {
       const tokenLoginConfig = { message: 'sms', enabled: true };
       config.get
         .withArgs('token_login').returns(tokenLoginConfig)
-        .withArgs('app_url').returns('');
+        .withArgs('app_url').returns('http://realhost');
 
       sinon.stub(roles, 'isOffline').returns(false);
       sinon.stub(roles, 'hasAllPermissions').returns(false);
@@ -3507,7 +3507,7 @@ describe('Users service', () => {
       const tokenLoginConfig = { message: 'sms', enabled: true };
       config.get
         .withArgs('token_login').returns(tokenLoginConfig)
-        .withArgs('app_url').returns('');
+        .withArgs('app_url').returns('http://realhost');
 
       sinon.stub(roles, 'isOffline').returns(false);
       sinon.stub(roles, 'hasAllPermissions').returns(false);


### PR DESCRIPTION
# Description

This pull request refactors the `token-login` functionality in the `user-management` module to remove the `appUrl` parameter from various methods, instead retrieve it directly from the configuration and making it a required field when enabling token login. It also updates related test cases to align with the refactored implementation.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

