### PR TITLE
test(#9998): fix flaky tasks test

### DIFF
--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -87,6 +87,7 @@ describe('Tasks', () => {
 
   it('should add a task when CHW completes a task successfully, and that task creates another task', async () => {
     await tasksPage.compileTasks('tasks-breadcrumbs-config.js', true);
+    await browser.pause(500);
 
     await commonPage.goToTasks();
     let list = await tasksPage.getTasks();
@@ -134,10 +135,9 @@ describe('Tasks', () => {
 
   it('Should show error message for bad config', async () => {
     await tasksPage.compileTasks('tasks-error-config.js', true);
+
     await commonPage.goToTasks();
-
     const { errorMessage, url, username, errorStack } = await commonPage.getErrorLog();
-
     expect(username).to.equal(chw.username);
     expect(url).to.equal('localhost');
     expect(errorMessage).to.equal('Error fetching tasks');

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -86,7 +86,7 @@ describe('Tasks', () => {
   });
 
   it('should add a task when CHW completes a task successfully, and that task creates another task', async () => {
-    await tasksPage.compileTasks('tasks-breadcrumbs-config.js', false);
+    await tasksPage.compileTasks('tasks-breadcrumbs-config.js', true);
 
     await commonPage.goToTasks();
     let list = await tasksPage.getTasks();

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -48,6 +48,16 @@ describe('Tasks', () => {
     reported_date: new Date().getTime(),
   });
 
+  const DOCS_TO_KEEP = [
+    ...Array.from(places.values()).map(doc => doc._id),
+    chwContact._id,
+    patient._id,
+    patient2._id,
+    'fixture:user:user1',
+    'org.couchdb.user:user1',
+    [/^form:/],
+  ];
+
   before(async () => {
     await utils.saveDocs([
       ...places.values(), healthCenter2, chwContact, patient, patient2,
@@ -66,7 +76,8 @@ describe('Tasks', () => {
 
   afterEach(async () => {
     await commonPage.logout();
-    await utils.revertSettings(true);
+    await utils.revertDb(DOCS_TO_KEEP, true);
+    await utils.revertSettings(false);
   });
 
   it('should remove task from list when CHW completes a task successfully', async () => {
@@ -90,7 +101,7 @@ describe('Tasks', () => {
 
     await commonPage.goToTasks();
     let list = await tasksPage.getTasks();
-    expect(list).to.have.length(2);
+    expect(list).to.have.length(3);
     let task = await tasksPage.getTaskByContactAndForm('Megan Spice', 'person_create');
     await task.click();
     await tasksPage.waitForTaskContentLoaded('Home Visit');
@@ -100,7 +111,7 @@ describe('Tasks', () => {
     await commonPage.sync({ expectReload: true });
     task = await tasksPage.getTaskByContactAndForm('Megan Spice', 'person_create_follow_up');
     list = await tasksPage.getTasks();
-    expect(list).to.have.length(3);
+    expect(list).to.have.length(4);
   });
 
   it('should load multiple pages of tasks on infinite scrolling', async () => {

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -48,16 +48,6 @@ describe('Tasks', () => {
     reported_date: new Date().getTime(),
   });
 
-  const DOCS_TO_KEEP = [
-    ...Array.from(places.values()).map(doc => doc._id),
-    chwContact._id,
-    patient._id,
-    patient2._id,
-    'fixture:user:user1',
-    'org.couchdb.user:user1',
-    [/^form:/],
-  ];
-
   before(async () => {
     await utils.saveDocs([
       ...places.values(), healthCenter2, chwContact, patient, patient2,
@@ -76,8 +66,7 @@ describe('Tasks', () => {
 
   afterEach(async () => {
     await commonPage.logout();
-    await utils.revertDb(DOCS_TO_KEEP, true);
-    await utils.revertSettings(false);
+    await utils.revertSettings(true);
   });
 
   it('should remove task from list when CHW completes a task successfully', async () => {
@@ -101,7 +90,7 @@ describe('Tasks', () => {
 
     await commonPage.goToTasks();
     let list = await tasksPage.getTasks();
-    expect(list).to.have.length(3);
+    expect(list).to.have.length(2);
     let task = await tasksPage.getTaskByContactAndForm('Megan Spice', 'person_create');
     await task.click();
     await tasksPage.waitForTaskContentLoaded('Home Visit');
@@ -111,7 +100,7 @@ describe('Tasks', () => {
     await commonPage.sync({ expectReload: true });
     task = await tasksPage.getTaskByContactAndForm('Megan Spice', 'person_create_follow_up');
     list = await tasksPage.getTasks();
-    expect(list).to.have.length(4);
+    expect(list).to.have.length(3);
   });
 
   it('should load multiple pages of tasks on infinite scrolling', async () => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #9998 

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9998-flaky-tasks-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9998-flaky-tasks-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:9998-flaky-tasks-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

