### PR TITLE
feat(#9869): add storageFree and storageTotal to user-devices API

### DIFF
--- a/api/src/services/export/user-devices.js
+++ b/api/src/services/export/user-devices.js
@@ -19,6 +19,7 @@ module.exports = async () => {
     const date = doc.value.date;
     const browser = doc.value.device.userAgent && getBrowser(doc.value.device.userAgent);
     const { apk, android, cht, settings } = doc.value.device.versions;
+    const storage = (doc.value.device && doc.value.device.storage) || {};
     return {
       user,
       deviceId,
@@ -31,6 +32,8 @@ module.exports = async () => {
       android,
       cht,
       settings,
+      storageFree: storage.free,
+      storageTotal: storage.total,
     };
   });
 };

--- a/api/tests/mocha/services/export-data.spec.js
+++ b/api/tests/mocha/services/export-data.spec.js
@@ -331,6 +331,10 @@ describe('Export Data Service', () => {
             device: {
               userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36', // eslint-disable-line max-len
               versions: { cht: 'unknown', settings: '4-83c8561a13479b245b295e97401f2f55' },
+              storage: {
+                free: 26544680960,
+                total: 56544680960
+              }
             },
           },
         },
@@ -347,6 +351,10 @@ describe('Export Data Service', () => {
                 cht: 'unknown',
                 settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
               },
+                storage: {
+                  free: 16713310208,
+                  total: 26544680960
+            }
             },
           },
         },
@@ -381,7 +389,9 @@ describe('Export Data Service', () => {
           apk: undefined,
           android: undefined,
           cht: 'unknown',
-          settings: '4-83c8561a13479b245b295e97401f2f55'
+          settings: '4-83c8561a13479b245b295e97401f2f55',
+          storageFree: 26544680960,
+          storageTotal: 56544680960
         },
         {
           user: 'chw1',
@@ -394,7 +404,9 @@ describe('Export Data Service', () => {
           apk: 'v1.0.4-4',
           android: '10',
           cht: 'unknown',
-          settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba'
+          settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
+          storageFree: 16713310208,
+          storageTotal: 26544680960
         },
         {
           android: undefined,
@@ -407,7 +419,9 @@ describe('Export Data Service', () => {
           date: '2022-11-29',
           deviceId: 'b1c172d8-82b0-42fd-8401-313796b8c802',
           settings: undefined,
-          user: 'min-data'
+          user: 'min-data',
+          storageFree: undefined,
+          storageTotal: undefined
         }
       ]);
     });
@@ -439,6 +453,10 @@ describe('Export Data Service', () => {
               cht: 'unknown',
               settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
             },
+            storage: {
+              free: 100,
+              total: 200
+            }
           },
         },
       },
@@ -458,7 +476,9 @@ describe('Export Data Service', () => {
         apk: undefined,
         android: undefined,
         cht: 'unknown',
-        settings: '4-83c8561a13479b245b295e97401f2f55'
+        settings: '4-83c8561a13479b245b295e97401f2f55',
+        storageFree: undefined,
+        storageTotal: undefined
       },
       {
         user: 'chw1',
@@ -471,7 +491,9 @@ describe('Export Data Service', () => {
         apk: 'v1.0.4-4',
         android: '10',
         cht: 'unknown',
-        settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba'
+        settings: '5-5ad24c388d1d4c4a7fcb6b05cff875ba',
+        storageFree: 100,
+        storageTotal: 200
       }
     ]);
     logger.error.callCount.should.equal(1);

--- a/ddocs/users-meta-db/users-meta/views/device_by_user/map.js
+++ b/ddocs/users-meta-db/users-meta/views/device_by_user/map.js
@@ -27,6 +27,16 @@ function(doc) {
           cht: doc.metadata.versions && doc.metadata.versions.app,
           settings: doc.metadata.versions && doc.metadata.versions.settings,
         },
+        storage: {
+          free: doc.device &&
+            doc.device.deviceInfo &&
+            doc.device.deviceInfo.storage &&
+            doc.device.deviceInfo.storage.free,
+          total: doc.device &&
+            doc.device.deviceInfo &&
+            doc.device.deviceInfo.storage &&
+            doc.device.deviceInfo.storage.total
+        }
       },
     });
   }

--- a/tests/integration/api/controllers/export-data.spec.js
+++ b/tests/integration/api/controllers/export-data.spec.js
@@ -403,7 +403,9 @@ describe('Export Data V2.0', () => {
       apk,
       android,
       cht,
-      settings
+      settings,
+      storageFree,
+      storageTotal
     }) => {
       const [year, month, day] = date.split('-');
       const getUserAgent = () => {
@@ -415,33 +417,43 @@ describe('Export Data V2.0', () => {
           : `AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${browser.version} Safari/537.36`;
         return `Mozilla/5.0 (X11; Linux x86_64) ${platform}`;
       };
-      return {
-        _id: `telemetry-${date}-${user}-${deviceId}`,
-        type: 'telemetry',
-        metadata: {
-          year,
-          month,
-          day,
-          user,
-          deviceId,
-          versions: {
-            app: cht,
-            settings
-          }
-        },
-        device: {
-          userAgent: getUserAgent(),
-          deviceInfo: {
-            app: {
-              version: apk
-            },
-            software: {
-              androidVersion: android
-            }
-          }
-        }
-      };
+
+       const deviceInfo = {
+      app: {
+        version: apk
+      },
+      software: {
+        androidVersion: android
+      }
     };
+
+    if (typeof storageFree !== 'undefined' || typeof storageTotal !== 'undefined') {
+      deviceInfo.storage = {
+        free: storageFree,
+        total: storageTotal
+      };
+    }
+
+    return {
+      _id: `telemetry-${date}-${user}-${deviceId}`,
+      type: 'telemetry',
+      metadata: {
+        year,
+        month,
+        day,
+        user,
+        deviceId,
+        versions: {
+          app: cht,
+          settings
+        }
+      },
+      device: {
+        userAgent: getUserAgent(),
+        deviceInfo: deviceInfo
+      }
+    };
+  };
 
     const otherDocs = [
       {
@@ -523,13 +535,24 @@ describe('Export Data V2.0', () => {
           apk: 'v1.0.1',
           android: '5.1',
           cht: `4.6.0`,
-          settings: uuid()
+          settings: uuid(),
+          storageFree: 16713310208,
+          storageTotal: 26544680960
         },
         {
           user: 'min_data',
           deviceId: uuid(),
           date: '2011-11-11',
-          browser: {}
+          browser: {
+            name: undefined,
+          version: undefined
+          },
+          apk: undefined,
+          android: undefined,
+          cht: undefined,
+          settings: undefined,
+          storageFree: undefined,
+          storageTotal: undefined
         }
       ];
       await saveUsersMetaDocs([...otherDocs, ...expectedData.map(createTelemetryDoc)]);
@@ -548,6 +571,7 @@ describe('Export Data V2.0', () => {
           name: 'Firefox',
           version: '47.0',
         },
+        storageFree: 1000, storageTotal: 2000
       };
       const userData1 = {
         user: 'chw1',
@@ -557,6 +581,7 @@ describe('Export Data V2.0', () => {
           name: 'Firefox',
           version: '48.0',
         },
+        storageFree: 3000, storageTotal: 4000
       };
       const userDataLatest = {
         user: 'chw1',
@@ -566,6 +591,7 @@ describe('Export Data V2.0', () => {
           name: 'Chrome',
           version: '121.0.6167.184',
         },
+        storageFree: 5000, storageTotal: 6000
       };
       const userDataDifferentDevice = {
         user: 'chw1',
@@ -575,6 +601,7 @@ describe('Export Data V2.0', () => {
           name: 'Firefox',
           version: '122.0.1',
         },
+        storageFree: 7000, storageTotal: 8000
       };
       await saveUsersMetaDocs([userData0, userData1, userDataLatest, userDataDifferentDevice].map(createTelemetryDoc));
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:
<type>(#<issue number>): <subject>
Quick example:
feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.
https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Closes #9869

## Summary

This pull request enhances the `/api/v2/export/user-devices` endpoint by adding `storageFree` and `storageTotal` fields for each user device. This addresses the need for administrators to easily monitor device disk space, which can help in diagnosing performance issues related to low storage on Community Health Worker (CHW) devices.

Previously, obtaining this information was a hard process involving manual checks of telemetry documents in CouchDB or setting up complex data synchronization pipelines.

## Implementation Details

The following changes were made to implement this feature:

1. **CouchDB View Updated** (`ddocs/users-meta-db/users-meta/views/device_by_user/map.js`):
   * The map function was modified to extract `doc.device.deviceInfo.storage.free` and `doc.device.deviceInfo.storage.total` from telemetry documents.
   * These values are now emitted as part of the device information.

2. **API Service Modified** (`api/src/services/export/user-devices.js`):
   * The service now retrieves the `storage.free` and `storage.total` values from the data emitted by the CouchDB view.
   * These are included in the final JSON response as `storageFree` and `storageTotal` respectively.

3. **Tests Updated:**
   * **Unit Tests** (`api/tests/mocha/services/export-data.spec.js`): Updated to include mock data and assertions for the new `storageFree` and `storageTotal` fields in the `user-devices` export.
   * **Integration Tests** (`tests/integration/api/controllers/export-data.spec.js`):
      * The `createTelemetryDoc` helper was updated to allow inclusion of storage information.
      * Tests that interact with the `/api/v2/export/user-devices` endpoint were updated to verify the presence and correctness of the new storage fields in the API response.

## How to Test

Please follow the detailed testing steps outlined in issue #9869. Key verification points include:

1. Setting up a development environment and creating a test user with telemetry data containing storage information (as per the sample JSON in the issue).
2. Making a `curl` call to `http://medic:password@localhost:5988/api/v2/export/user-devices`.
3. Verifying that the output for the test user's device now includes the `storageFree` and `storageTotal` fields with the correct values from the telemetry document.

## Affected Files

* `api/src/services/export/user-devices.js`
* `api/tests/mocha/services/export-data.spec.js`
* `ddocs/users-meta-db/users-meta/views/device_by_user/map.js`
* `tests/integration/api/controllers/export-data.spec.js`

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [[style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [[cht-docs](https://github.com/medic/cht-docs/)](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License
The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.