### PR TITLE
feat(#9835): add `ReportQualifier` functions and update `hasField`

### DIFF
--- a/shared-libs/cht-datasource/src/libs/core.ts
+++ b/shared-libs/cht-datasource/src/libs/core.ts
@@ -87,16 +87,19 @@ export const isRecord = (value: unknown): value is Record<string, unknown> => {
 /** @internal */
 export const hasField = <T extends Record<string, unknown>>(
   value: T,
-  field: { name: keyof T, type: string }
+  field: { name: keyof T, type: string, ensure_truthy_value?: boolean},
 ): value is T & Record<typeof field.name, string> => {
   const valueField = value[field.name];
+  if (field.ensure_truthy_value) {
+    return typeof valueField === field.type && !!valueField;
+  }
   return typeof valueField === field.type;
 };
 
 /** @internal */
 export const hasFields = (
   value: Record<string, unknown>,
-  fields: NonEmptyArray<{ name: string, type: string }>
+  fields: NonEmptyArray<{ name: string, type: string, ensure_truthy_value?: boolean}>,
 ): boolean => fields.every(field => hasField(value, field));
 
 /** @internal */

--- a/shared-libs/cht-datasource/src/libs/core.ts
+++ b/shared-libs/cht-datasource/src/libs/core.ts
@@ -84,22 +84,28 @@ export const isRecord = (value: unknown): value is Record<string, unknown> => {
   return value !== null && typeof value === 'object';
 };
 
+interface FieldDescriptor<T> {
+  name: keyof T;
+  type: string;
+  ensureTruthyValue?: boolean
+}
+
 /** @internal */
 export const hasField = <T extends Record<string, unknown>>(
   value: T,
-  field: { name: keyof T, type: string, ensure_truthy_value?: boolean},
-): value is T & Record<typeof field.name, string> => {
-  const valueField = value[field.name];
-  if (field.ensure_truthy_value) {
-    return typeof valueField === field.type && !!valueField;
+  {name, type, ensureTruthyValue = false}: FieldDescriptor<T>
+): value is T & Record<typeof name, string> => {
+  const valueField = value[name];
+  if (ensureTruthyValue) {
+    return typeof valueField === type && !!valueField;
   }
-  return typeof valueField === field.type;
+  return typeof valueField === type;
 };
 
 /** @internal */
-export const hasFields = (
-  value: Record<string, unknown>,
-  fields: NonEmptyArray<{ name: string, type: string, ensure_truthy_value?: boolean}>,
+export const hasFields = <T extends Record<string, unknown>>(
+  value: T,
+  fields: NonEmptyArray<FieldDescriptor<T>>,
 ): boolean => fields.every(field => hasField(value, field));
 
 /** @internal */

--- a/shared-libs/cht-datasource/src/qualifier.ts
+++ b/shared-libs/cht-datasource/src/qualifier.ts
@@ -186,8 +186,8 @@ export const byContactQualifier = (data: unknown): ContactQualifier => {
  * @returns `true` if the given type is a {@link ContactQualifier}, otherwise `false`.
  */
 export const isContactQualifier = (qualifier: unknown): qualifier is ContactQualifier => {
-  if (isRecord(qualifier) && hasFields(qualifier, [{name: 'type', type: 'string', ensure_truthy_value: true}, 
-    {name: 'name', type: 'string', ensure_truthy_value: true}])){
+  if (isRecord(qualifier) && hasFields(qualifier, [{name: 'type', type: 'string', ensureTruthyValue: true}, 
+    {name: 'name', type: 'string', ensureTruthyValue: true}])){
     if ('reported_date' in qualifier && !isValidReportedDate(qualifier.reported_date)){
       return false;
     }
@@ -242,8 +242,8 @@ export const byReportQualifier = (data: unknown): ReportQualifier => {
  */
 export const isReportQualifier = (qualifier: unknown): qualifier is ReportQualifier => {
   if (isRecord(qualifier) && 
-      hasFields(qualifier, [{name: 'type', type: 'string', ensure_truthy_value: true}, 
-        {name: 'form', type: 'string', ensure_truthy_value: true}])
+      hasFields(qualifier, [{name: 'type', type: 'string', ensureTruthyValue: true}, 
+        {name: 'form', type: 'string', ensureTruthyValue: true}])
   ){
     if ('reported_date' in qualifier && !isValidReportedDate(qualifier.reported_date)){
       return false;

--- a/shared-libs/cht-datasource/src/qualifier.ts
+++ b/shared-libs/cht-datasource/src/qualifier.ts
@@ -175,7 +175,7 @@ export const byContactQualifier = (data: unknown): ContactQualifier => {
     );
   }
   if (!isContactQualifier(qualifier)){
-    throw new InvalidArgumentError(`Missing required fields [${JSON.stringify(data)}].`);
+    throw new InvalidArgumentError(`Missing or empty required fields [${JSON.stringify(data)}].`);
   }
   return qualifier;
 };
@@ -186,7 +186,8 @@ export const byContactQualifier = (data: unknown): ContactQualifier => {
  * @returns `true` if the given type is a {@link ContactQualifier}, otherwise `false`.
  */
 export const isContactQualifier = (qualifier: unknown): qualifier is ContactQualifier => {
-  if (isRecord(qualifier) && hasFields(qualifier, [{name: 'type', type: 'string'}, {name: 'name', type: 'string'}])){
+  if (isRecord(qualifier) && hasFields(qualifier, [{name: 'type', type: 'string', ensure_truthy_value: true}, 
+    {name: 'name', type: 'string', ensure_truthy_value: true}])){
     if ('reported_date' in qualifier && !isValidReportedDate(qualifier.reported_date)){
       return false;
     }
@@ -241,15 +242,9 @@ export const byReportQualifier = (data: unknown): ReportQualifier => {
  */
 export const isReportQualifier = (qualifier: unknown): qualifier is ReportQualifier => {
   if (isRecord(qualifier) && 
-      hasFields(qualifier, [{name: 'type', type: 'string'}, {name: 'form', type: 'string'}])
+      hasFields(qualifier, [{name: 'type', type: 'string', ensure_truthy_value: true}, 
+        {name: 'form', type: 'string', ensure_truthy_value: true}])
   ){
-    if (
-      typeof qualifier.type !== 'string' || qualifier.type.trim() === '' ||
-      typeof qualifier.form !== 'string' || qualifier.form.trim() === ''
-    ) {
-      return false;
-    }
-
     if ('reported_date' in qualifier && !isValidReportedDate(qualifier.reported_date)){
       return false;
     }

--- a/shared-libs/cht-datasource/src/qualifier.ts
+++ b/shared-libs/cht-datasource/src/qualifier.ts
@@ -195,6 +195,70 @@ export const isContactQualifier = (qualifier: unknown): qualifier is ContactQual
   return false;
 };
 
+/** 
+ * A qualifier for a report
+ */
+type ReportQualifier = Readonly<{
+  type: string,
+  form: string,
+  reported_date?: string | number,
+  _id?: string,
+  _rev?: string
+}>;
+
+/**
+ * Builds a qualifier for creation and update of a report with
+ * the given fields.
+ * @param data object containing the fields for a report
+ * @returns the report qualifier
+ * @throws Error if data is not an object
+ * @throws Error if type is not provided or is empty
+ * @throws Error if form is not provided or is empty
+ * @throws Error if reported_date is not in a valid format.
+ * Valid formats are 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or <unix epoch>.
+ */
+export const byReportQualifier = (data: unknown): ReportQualifier => {
+  if (!isRecord(data)) {
+    throw new InvalidArgumentError('Invalid "data": expected an object.');
+  }
+  const qualifier = {...data};
+  if ('reported_date' in qualifier && !isValidReportedDate(qualifier.reported_date)) {
+    throw new InvalidArgumentError(
+      // eslint-disable-next-line max-len
+      `Invalid reported_date. Expected format to be 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or a Unix epoch.`
+    );
+  }
+  if (!isReportQualifier(qualifier)) {
+    throw new InvalidArgumentError(`Missing or empty required fields [${JSON.stringify(data)}].`);
+  }
+  return qualifier;
+};
+
+/**
+ * Returns `true` if the given qualifier is a {@link ReportQualifier} otherwise `false`.
+ * @param qualifier the qualifier to check
+ * @returns `true` if the given type is a {@link ReportQualifier}, otherwise `false`.
+ */
+export const isReportQualifier = (qualifier: unknown): qualifier is ReportQualifier => {
+  if (isRecord(qualifier) && 
+      hasFields(qualifier, [{name: 'type', type: 'string'}, {name: 'form', type: 'string'}])
+  ){
+    if (
+      typeof qualifier.type !== 'string' || qualifier.type.trim() === '' ||
+      typeof qualifier.form !== 'string' || qualifier.form.trim() === ''
+    ) {
+      return false;
+    }
+
+    if ('reported_date' in qualifier && !isValidReportedDate(qualifier.reported_date)){
+      return false;
+    }
+    return true;
+  }
+  return false;
+};
+
+
 /** @internal */
 const isValidReportedDate = (value: unknown): boolean => {
   if (typeof value === 'number') {

--- a/shared-libs/cht-datasource/test/qualifier.spec.ts
+++ b/shared-libs/cht-datasource/test/qualifier.spec.ts
@@ -149,8 +149,8 @@ describe('qualifier', () => {
         {
           type: 'person', reported_date: '2025-06-03T12:45:30Z'
         }
-      ].forEach((quantifier) => expect(() => byContactQualifier(quantifier))
-        .to.throw(`Missing or empty required fields [${JSON.stringify(quantifier)}].`));
+      ].forEach((qualifier) => expect(() => byContactQualifier(qualifier))
+        .to.throw(`Missing or empty required fields [${JSON.stringify(qualifier)}].`));
       
     });
   });
@@ -167,7 +167,7 @@ describe('qualifier', () => {
         {
           type: 'person', reported_date: '2025-06-03T12:45:30Z'
         }
-      ].forEach((quantifier) => expect(isContactQualifier(quantifier)).to.be.false);
+      ].forEach((qualifier) => expect(isContactQualifier(qualifier)).to.be.false);
     });
   
     it('returns false for invalid reported_date format', () => {
@@ -178,7 +178,7 @@ describe('qualifier', () => {
         {
           name: 'A', type: 'person', reported_date: '2025'
         }
-      ].forEach((quantifier) => expect(isContactQualifier(quantifier)).to.be.false);
+      ].forEach((qualifier) => expect(isContactQualifier(qualifier)).to.be.false);
     });
   
     it('returns true for valid contact qualifiers', () => {
@@ -193,7 +193,7 @@ describe('qualifier', () => {
           name: 'B', type: 'person', reported_date: '2025-06-03T12:45:30.222Z', id: 'id-1',
           _rev: 'revision-3'
         }
-      ].forEach((quantifier) => expect(isContactQualifier(quantifier)).to.be.true);
+      ].forEach((qualifier) => expect(isContactQualifier(qualifier)).to.be.true);
     });
   });
 

--- a/shared-libs/cht-datasource/test/qualifier.spec.ts
+++ b/shared-libs/cht-datasource/test/qualifier.spec.ts
@@ -138,25 +138,31 @@ describe('qualifier', () => {
       })).to.throw(`Invalid reported_date. Expected format to be 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or a Unix epoch.`);
     });
   
-    it('throws error for missing required fields.', () => {
+    it('throws error for missing or empty required fields.', () => {
       [
         {
           name: 'A'
         },
         {
+          name: '', type: 'person'
+        },
+        {
           type: 'person', reported_date: '2025-06-03T12:45:30Z'
         }
       ].forEach((quantifier) => expect(() => byContactQualifier(quantifier))
-        .to.throw(`Missing required fields [${JSON.stringify(quantifier)}].`));
+        .to.throw(`Missing or empty required fields [${JSON.stringify(quantifier)}].`));
       
     });
   });
   
   describe('isContactQualifier', () => {
-    it('returns false for missing required fields.', () => {
+    it('returns false for missing or empty required fields.', () => {
       [
         {
           name: 'A'
+        },
+        {
+          name: 'A', type: ''
         },
         {
           type: 'person', reported_date: '2025-06-03T12:45:30Z'


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description
Commit 1 adds the `ReportQualifier` based on the description in #9835.
An additional error is included in cases where the `data` is not a valid `object`.

Commit 2 tweaks `hasField` and `hasFields` to perform an optional
truthy check on values, which is utilized to detect empty strings 
in `isContactQualifier` and `isReportQualifier` to return `false`
for such field values.
<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

