### PR TITLE
feat(#10019): refactor shared-libs/lineage library to use cht-datasource

### DIFF
--- a/shared-libs/lineage/src/hydration.js
+++ b/shared-libs/lineage/src/hydration.js
@@ -46,7 +46,7 @@ const getContactIds = (contacts) => {
   return _.uniq(ids);
 };
 
-module.exports = function(Promise, DB) {
+module.exports = function(Promise, DB, dataContext) {
   const fillParentsInDocs = function(doc, lineage) {
     if (!doc || !lineage.length) {
       return doc;

--- a/shared-libs/lineage/src/index.js
+++ b/shared-libs/lineage/src/index.js
@@ -1,8 +1,8 @@
 /**
  * @module lineage
  */
-module.exports = (Promise, DB) => Object.assign(
+module.exports = (Promise, DB, dataContext) => Object.assign(
   {},
-  require('./hydration')(Promise, DB),
+  require('./hydration')(Promise, DB, dataContext),
   require('./minify')
 );

--- a/shared-libs/lineage/test/hydration.spec.js
+++ b/shared-libs/lineage/test/hydration.spec.js
@@ -10,11 +10,10 @@ describe('Lineage', function() {
   let DB;
 
   beforeEach(function() {
-    allDocs = sinon.stub();
     get = sinon.stub();
-    query = sinon.stub();
-    DB = { allDocs, get, query };
-    lineage = lineageFactory(Promise, DB);
+    getWithLineage = sinon.stub();
+    dataContext = { Contact: { v1: { get, getWithLineage } } };
+    lineage = lineageFactory(Promise, {}, dataContext);
   });
 
   afterEach(function() {
@@ -22,43 +21,40 @@ describe('Lineage', function() {
   });
 
   describe('fetchLineageById', function() {
-    it('queries db with correct parameters', function() {
-      query.resolves({ rows: [] });
+    it('calls getWithLineage with correct parameters', function() {
+      getWithLineage.resolves([]);
       const id = 'banana';
 
       return lineage.fetchLineageById(id).then(() => {
-        chai.expect(query.callCount).to.equal(1);
-        chai.expect(query.getCall(0).args[0]).to.equal('medic-client/docs_by_id_lineage');
-        chai.expect(query.getCall(0).args[1].startkey).to.deep.equal([ id ]);
-        chai.expect(query.getCall(0).args[1].endkey).to.deep.equal([ id, {} ]);
-        chai.expect(query.getCall(0).args[1].include_docs).to.deep.equal(true);
+        chai.expect(getWithLineage.callCount).to.equal(1);
+        chai.expect(getWithLineage.getCall(0).args[0]).to.equal(id);
       });
     });
   });
 
   describe('fetchContacts', function() {
     it('fetches contacts with correct parameters', function() {
-      allDocs.resolves({ rows: [] });
+      get.resolves({ _id: 'def' });
       const fakeLineage = [
         { _id: 'abc', contact: { _id: 'def' }, parent: { _id: 'ghi' } },
         { _id: 'ghi' }
       ];
 
       return lineage.fetchContacts(fakeLineage).then(() => {
-        chai.expect(allDocs.callCount).to.equal(1);
-        chai.expect(allDocs.getCall(0).args[0]).to.deep.equal({ keys: ['def'], include_docs: true });
+        chai.expect(get.callCount).to.equal(1);
+        chai.expect(get.getCall(0).args[0]).to.deep.equal('def');
       });
     });
 
     it('does not fetch contacts that it has already got via lineage', function() {
-      allDocs.resolves({ rows: [] });
+      get.resolves();
       const fakeLineage = [
         { _id: 'abc', contact: { _id: 'def' }, parent: { _id: 'def' } },
         { _id: 'def' }
       ];
 
       return lineage.fetchContacts(fakeLineage).then(() => {
-        chai.expect(allDocs.callCount).to.equal(0);
+        chai.expect(get.callCount).to.equal(0);
       });
     });
   });

--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -86,7 +86,8 @@ describe('Tasks', () => {
   });
 
   it('should add a task when CHW completes a task successfully, and that task creates another task', async () => {
-    await tasksPage.compileTasks('tasks-breadcrumbs-config.js', false);
+    await tasksPage.compileTasks('tasks-breadcrumbs-config.js', true);
+    await browser.pause(500);
 
     await commonPage.goToTasks();
     let list = await tasksPage.getTasks();
@@ -134,10 +135,9 @@ describe('Tasks', () => {
 
   it('Should show error message for bad config', async () => {
     await tasksPage.compileTasks('tasks-error-config.js', true);
+
     await commonPage.goToTasks();
-
     const { errorMessage, url, username, errorStack } = await commonPage.getErrorLog();
-
     expect(username).to.equal(chw.username);
     expect(url).to.equal('localhost');
     expect(errorMessage).to.equal('Error fetching tasks');


### PR DESCRIPTION
# Description

This pull request refactors the `lineage` module to replace direct database queries with calls to a new `dataContext` object, improving modularity and testability. It also updates the associated unit tests to mock the `dataContext` methods.

fixes #10019 

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

