### PR TITLE
chore(#10013): use ubuntu-latest for ci workers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
   build:
     name: Compile the app
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
   config-tests:
     needs: build
     name: ${{ matrix.cmd }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     
     strategy:
@@ -109,7 +109,7 @@ jobs:
 
   test-cht-form:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
   tests-k3d:
     needs: build
     name: ${{ matrix.cmd }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     strategy:
@@ -201,7 +201,7 @@ jobs:
   translations:
     needs: build
     name: Lint translations
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
@@ -216,7 +216,7 @@ jobs:
   tests:
     needs: build
     name: ${{ matrix.cmd }}-${{ matrix.suite || '' }}${{ matrix.chrome-version == '90' && '-minimum-browser' || '' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     
     env:
@@ -390,7 +390,7 @@ jobs:
   publish:
     needs: [tests, config-tests, test-cht-form]
     name: Publish branch build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     
     if: ${{ github.event_name != 'pull_request' }}
@@ -441,7 +441,7 @@ jobs:
   publish-generated-docs:
     needs: [publish]
     name: Publish generated docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ github.event_name != 'pull_request' }}
     steps:
@@ -467,7 +467,7 @@ jobs:
   upgrade:
     needs: [publish]
     name: Upgrade from ${{ matrix.version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,8 @@ jobs:
   config-tests:
     needs: build
     name: ${{ matrix.cmd }}
-    runs-on: ubuntu-latest
+    # these tests fail on newer os. https://github.com/medic/cht-conf-test-harness/issues/279
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     
     strategy:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   cleanup:
     name: Deleting old published artefacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint_pr_title:
     name: Lint PR title
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scalability.yml
+++ b/.github/workflows/scalability.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Set up Medic on EC2 and Execute Jmeter on another EC2
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Unbuntu 24-04 comes with docker compose 2.36.0: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

closes #10013 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:ubuntu-latest/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:ubuntu-latest/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:ubuntu-latest/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

