### PR TITLE
fix(#10050): update tasks e2e test for stability

### DIFF
--- a/tests/e2e/default/tasks/tasks.wdio-spec.js
+++ b/tests/e2e/default/tasks/tasks.wdio-spec.js
@@ -58,16 +58,7 @@ describe('Tasks', () => {
 
     const formsPath = path.join(__dirname, 'forms');
     await chtConfUtils.compileAndUploadAppForms(formsPath);
-  });
-
-  beforeEach(async () => {
     await loginPage.login(chw);
-    await commonPage.waitForPageLoaded();
-  });
-
-  afterEach(async () => {
-    await commonPage.logout();
-    await utils.revertSettings(true);
   });
 
   it('should remove task from list when CHW completes a task successfully', async () => {
@@ -88,7 +79,6 @@ describe('Tasks', () => {
 
   it('should add a task when CHW completes a task successfully, and that task creates another task', async () => {
     await tasksPage.compileTasks('tasks-breadcrumbs-config.js', true);
-    await browser.pause(500);
 
     await commonPage.goToTasks();
     let list = await tasksPage.getTasks();

--- a/tests/page-objects/default/common/common.wdio.page.js
+++ b/tests/page-objects/default/common/common.wdio.page.js
@@ -432,7 +432,7 @@ const syncAndWaitForSuccess = async (expectReload, timeout = RELOAD_SYNC_TIMEOUT
     }
     await openHamburgerMenu();
 
-    if (!await hamburgerMenuSelectors.syncSuccess().isDisplayed({ withinViewport: true })) {
+    if (!await hamburgerMenuSelectors.syncSuccess().isDisplayed()) {
       throw new Error('Failed to sync');
     }
   } catch (err) {

--- a/tests/page-objects/default/tasks/tasks.wdio.page.js
+++ b/tests/page-objects/default/tasks/tasks.wdio.page.js
@@ -96,7 +96,7 @@ const compileTasks = async (tasksFileName, sync) => {
   await chtConfUtils.initializeConfigDir();
   const tasksFilePath = path.join(__dirname, `../../../e2e/default/tasks/config/${tasksFileName}`);
   const settings = await chtConfUtils.compileNoolsConfig({ tasks: tasksFilePath });
-  await utils.updateSettings(settings, { ignoreReload: 'api', sync });
+  await utils.updateSettings(settings, { ignoreReload: 'api', sync, refresh: sync, revert: true });
 };
 
 const isTaskElementDisplayed = async (type, text) => {


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

closes #10050 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10050-fix-flaky-test/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10050-fix-flaky-test/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10050-fix-flaky-test/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

