### PR TITLE
feat(#10036): add API support for `createPerson`

### DIFF
--- a/api/src/controllers/person.js
+++ b/api/src/controllers/person.js
@@ -10,6 +10,7 @@ const getPerson = ({ with_lineage }) => ctx.bind(
     : Person.v1.get
 );
 const getPageByType = () => ctx.bind(Person.v1.getPage);
+const createPerson = () => ctx.bind(Person.v1.createPerson);
 
 const checkUserPermissions = async (req) => {
   const userCtx = await auth.getUserCtx(req);
@@ -38,5 +39,13 @@ module.exports = {
 
       return res.json(docs);
     }),
+    
+    createPerson: serverUtils.doOrError(async (req, res) => {
+      await checkUserPermissions(req);
+
+      const personQualifier = Qualifier.byPersonQualifier(req.body);
+      const personDoc = await createPerson()(personQualifier);
+      return res.json(personDoc);
+    })
   },
 };

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -498,7 +498,7 @@ app.postJson('/api/v1/people', function(req, res) {
 
 app.get('/api/v1/person', person.v1.getAll);
 app.get('/api/v1/person/:uuid', person.v1.get);
-app.post('/api/v1/person', person.v1.createPerson);
+app.postJson('/api/v1/person', person.v1.createPerson);
 
 app.get('/api/v1/contact/uuid', contact.v1.getUuids);
 app.get('/api/v1/contact/:uuid', contact.v1.get);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -498,6 +498,7 @@ app.postJson('/api/v1/people', function(req, res) {
 
 app.get('/api/v1/person', person.v1.getAll);
 app.get('/api/v1/person/:uuid', person.v1.get);
+app.post('/api/v1/person', person.v1.createPerson);
 
 app.get('/api/v1/contact/uuid', contact.v1.getUuids);
 app.get('/api/v1/contact/:uuid', contact.v1.get);

--- a/shared-libs/cht-datasource/src/index.ts
+++ b/shared-libs/cht-datasource/src/index.ts
@@ -274,6 +274,14 @@ export const getDatasource = (ctx: DataContext) => {
          * @throws InvalidArgumentError if no type is provided or if the type is not for a person
          */
         getByType: (personType: string) => ctx.bind(Person.v1.getAll)(Qualifier.byContactType(personType)),
+        
+        /**
+         * Creates a person.
+         * @param qualifer the object defining the person properties.
+         * @returns a person.
+         * @throws InvalidArgumentError if the type of qualifer is not valid for creating a person.
+         */
+        createPerson: (qualifier: unknown) => ctx.bind(Person.v1.createPerson)(Qualifier.byPersonQualifier(qualifier))
       },
       report: {
         /**

--- a/shared-libs/cht-datasource/src/index.ts
+++ b/shared-libs/cht-datasource/src/index.ts
@@ -278,7 +278,7 @@ export const getDatasource = (ctx: DataContext) => {
         /**
          * Creates a person.
          * @param qualifer the object defining the person properties.
-         * @returns a person.
+         * @returns the created person.
          * @throws InvalidArgumentError if the type of qualifer is not valid for creating a person.
          */
         createPerson: (qualifier: unknown) => ctx.bind(Person.v1.createPerson)(Qualifier.byPersonQualifier(qualifier))

--- a/shared-libs/cht-datasource/src/libs/parameter-validators.ts
+++ b/shared-libs/cht-datasource/src/libs/parameter-validators.ts
@@ -2,9 +2,11 @@ import { InvalidArgumentError } from './error';
 import {
   ContactTypeQualifier,
   FreetextQualifier,
+  PersonQualifier,
   UuidQualifier,
   isContactTypeQualifier,
   isFreetextQualifier,
+  isPersonQualifier,
   isUuidQualifier,
 } from '../qualifier';
 import { Nullable } from './core';
@@ -15,6 +17,15 @@ export const assertTypeQualifier: (qualifier: unknown) => asserts qualifier is C
 ) => {
   if (!isContactTypeQualifier(qualifier)) {
     throw new InvalidArgumentError(`Invalid contact type [${JSON.stringify(qualifier)}].`);
+  }
+};
+
+/** @internal */
+export const assertPersonQualifier: (qualifier: unknown) => asserts qualifier is PersonQualifier = (
+  qualifier: unknown
+) => {
+  if (!isPersonQualifier(qualifier)) {
+    throw new InvalidArgumentError(`Invalid person type [${JSON.stringify(qualifier)}].`);
   }
 };
 

--- a/shared-libs/cht-datasource/src/person.ts
+++ b/shared-libs/cht-datasource/src/person.ts
@@ -43,6 +43,19 @@ export namespace v1 {
       };
     };
 
+  const createPersonDoc =
+  <T>(
+      localFn: (c: LocalDataContext) => (qualifier: PersonQualifier) => Promise<T>,
+      remoteFn: (c: RemoteDataContext) => (qualifier: PersonQualifier) => Promise<T>
+    ) => (context: DataContext) => {
+      assertDataContext(context);
+      const fn = adapt(context, localFn, remoteFn);
+      return async (qualifier: PersonQualifier): Promise<T> => {
+        assertPersonQualifier(qualifier);
+        return fn(qualifier);
+      };
+    };
+
   /**
    * Returns a person for the given qualifier.
    * @param context the current data context
@@ -124,22 +137,5 @@ export namespace v1 {
    * @returns a function for creating a person.
    * @throws Error if a data context is not provided
    */
-  export const createPerson = (context:DataContext): typeof curriedFn => {
-    assertDataContext(context);
-    
-    const fn =  Local.Person.v1.createPerson(context as LocalDataContext);
-
-    /**
-     * Returns the created person.
-     * @param qualifier the qualifier to create the person
-     * @returns returns the created person.
-     * @throws Error if qualifier if of invalid type
-     */
-    const curriedFn =  async (qualifier: PersonQualifier): Promise<Person> => {
-      assertPersonQualifier(qualifier);
-      return await fn(qualifier);
-    };
-
-    return curriedFn;
-  };
+  export const createPerson = createPersonDoc(Local.Person.v1.createPerson, Remote.Person.v1.createPerson);
 }

--- a/shared-libs/cht-datasource/src/person.ts
+++ b/shared-libs/cht-datasource/src/person.ts
@@ -9,7 +9,7 @@ import { RemoteDataContext } from './remote/libs/data-context';
 import { getPagedGenerator, NormalizedParent, Nullable, Page } from './libs/core';
 import { DEFAULT_DOCS_PAGE_LIMIT } from './libs/constants';
 import { assertCursor, assertLimit, assertTypeQualifier, assertUuidQualifier } from './libs/parameter-validators';
-import { InvalidArgumentError } from '../dist';
+import { InvalidArgumentError } from './libs/error';
 
 /** */
 export namespace v1 {

--- a/shared-libs/cht-datasource/src/person.ts
+++ b/shared-libs/cht-datasource/src/person.ts
@@ -138,7 +138,7 @@ export namespace v1 {
      * @returns returns the created person.
      * @throws Error if qualifier if of invalid type
      */
-    const curriedFn =  async(qualifer: PersonQualifier):Promise<Person> => {
+    const curriedFn =  async (qualifier: PersonQualifier): Promise<Person> => {
       return await fn(qualifer);
     };
 

--- a/shared-libs/cht-datasource/src/person.ts
+++ b/shared-libs/cht-datasource/src/person.ts
@@ -4,12 +4,12 @@ import * as Contact from './contact';
 import * as Remote from './remote';
 import * as Local from './local';
 import * as Place from './place';
-import { isLocalDataContext, LocalDataContext } from './local/libs/data-context';
+import { LocalDataContext } from './local/libs/data-context';
 import { RemoteDataContext } from './remote/libs/data-context';
 import { getPagedGenerator, NormalizedParent, Nullable, Page } from './libs/core';
 import { DEFAULT_DOCS_PAGE_LIMIT } from './libs/constants';
-import { assertCursor, assertLimit, assertTypeQualifier, assertUuidQualifier } from './libs/parameter-validators';
-import { InvalidArgumentError } from './libs/error';
+import { assertCursor, assertLimit, assertPersonQualifier, 
+  assertTypeQualifier, assertUuidQualifier } from './libs/parameter-validators';
 
 /** */
 export namespace v1 {
@@ -127,7 +127,7 @@ export namespace v1 {
   export const createPerson = (context:DataContext): typeof curriedFn => {
     assertDataContext(context);
     
-    const fn =  Local.Person.v1.createPerson(context);
+    const fn =  Local.Person.v1.createPerson(context as LocalDataContext);
 
     /**
      * Returns the created person.
@@ -136,7 +136,8 @@ export namespace v1 {
      * @throws Error if qualifier if of invalid type
      */
     const curriedFn =  async (qualifier: PersonQualifier): Promise<Person> => {
-      return await fn(qualifer);
+      assertPersonQualifier(qualifier);
+      return await fn(qualifier);
     };
 
     return curriedFn;

--- a/shared-libs/cht-datasource/src/person.ts
+++ b/shared-libs/cht-datasource/src/person.ts
@@ -127,9 +127,6 @@ export namespace v1 {
   export const createPerson = (context:DataContext): typeof curriedFn => {
     assertDataContext(context);
     
-    if (!isLocalDataContext(context)) {
-      throw new InvalidArgumentError('Require LocalDataContext');
-    }
     const fn =  Local.Person.v1.createPerson(context);
 
     /**

--- a/shared-libs/cht-datasource/src/qualifier.ts
+++ b/shared-libs/cht-datasource/src/qualifier.ts
@@ -176,8 +176,8 @@ export const byContactQualifierNonAssertive = (data: unknown) : Record<string, u
   insertReportedDateIfMissing(qualifier);
   if (!isValidReportedDate(qualifier.reported_date)){
     throw new InvalidArgumentError(
-      // eslint-disable-next-line max-len
-      `Invalid reported_date. Expected format to be 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or a Unix epoch.`
+      'Invalid reported_date. Expected format to be ' +
+        '\'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.'
     );
   }
   if (!checkContactQualifierFields(qualifier)){
@@ -242,8 +242,8 @@ export const byReportQualifier = (data: unknown): ReportQualifier => {
   insertReportedDateIfMissing(qualifier);
   if (!isValidReportedDate(qualifier.reported_date)) {
     throw new InvalidArgumentError(
-      // eslint-disable-next-line max-len
-      `Invalid reported_date. Expected format to be 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or a Unix epoch.`
+      'Invalid reported_date. Expected format to be ' +
+        '\'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.'
     );
   }
   if (!isReportQualifier(qualifier)) {
@@ -319,8 +319,10 @@ export const byPersonQualifier = (data: unknown): PersonQualifier => {
 
   // cannot use checkFieldLineageAndThrowError as parent is required in `person`
   if (!isNormalizedParent(qualifier.parent)) {
-    // eslint-disable-next-line max-len
-    throw new InvalidArgumentError(`Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(qualifier)}].`);
+    throw new InvalidArgumentError(`Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(
+      qualifier
+    )
+    }].`);
   }
 
   if (hasBloatedLineage(qualifier)) {
@@ -430,12 +432,16 @@ const checkFieldLineageAndThrowError = (data: Record<string, unknown>, field?:st
   }
   
   if (!isNormalizedParent(normalized_parent)) {
-    // eslint-disable-next-line max-len
-    throw new InvalidArgumentError(`Missing required fields (parent, _id) in the ${field??'parent'} hierarchy [${JSON.stringify(data)}].`);
+    throw new InvalidArgumentError(
+      `Missing required fields (parent, _id) in the ${
+        field ?? 'parent'
+      } hierarchy [${JSON.stringify(data)}].`
+    );
   }
   if (hasBloatedLineage(hierarchyRoot)) {
-    // eslint-disable-next-line max-len
-    throw new InvalidArgumentError(`Additional fields found in the ${field??'parent'} lineage [${JSON.stringify(data)}].`);
+    throw new InvalidArgumentError(
+      `Additional fields found in the ${field ?? 'parent'} lineage [${JSON.stringify(data)}].`
+    );
   }
 };
 
@@ -455,11 +461,9 @@ const hasInvalidContactLineageForField = (data: Record<string, unknown>, field?:
   }
   
   if (!isNormalizedParent(normalized_parent)) {
-    // eslint-disable-next-line max-len
     return true;
   }
   if (hasBloatedLineage(hierarchyRoot)) {
-    // eslint-disable-next-line max-len
     return true;
   }
 };

--- a/shared-libs/cht-datasource/src/qualifier.ts
+++ b/shared-libs/cht-datasource/src/qualifier.ts
@@ -181,7 +181,7 @@ export const byContactQualifierNonAssertive = (data: unknown) : Record<string, u
     );
   }
   if (!checkContactQualifierFields(qualifier)){
-    throw new InvalidArgumentError(`Missing or empty required fields [${JSON.stringify(data)}].`);
+    throw new InvalidArgumentError(`Missing or empty required fields (name, type) for [${JSON.stringify(data)}].`);
   }
   return qualifier;
 };
@@ -247,7 +247,7 @@ export const byReportQualifier = (data: unknown): ReportQualifier => {
     );
   }
   if (!isReportQualifier(qualifier)) {
-    throw new InvalidArgumentError(`Missing or empty required fields [${JSON.stringify(data)}].`);
+    throw new InvalidArgumentError(`Missing or empty required fields (type, form) in [${JSON.stringify(data)}].`);
   }
   return qualifier;
 };
@@ -314,12 +314,13 @@ export const byPersonQualifier = (data: unknown): PersonQualifier => {
   const qualifier = byContactQualifierNonAssertive(data);
   
   if (!hasField(qualifier, { name: 'parent', type: 'object' })) {
-    throw new InvalidArgumentError(`Missing or empty required fields [${JSON.stringify(qualifier)}].`);
+    throw new InvalidArgumentError(`Missing or empty required field (parent) [${JSON.stringify(qualifier)}].`);
   }
 
   // cannot use checkFieldLineageAndThrowError as parent is required in `person`
   if (!isNormalizedParent(qualifier.parent)) {
-    throw new InvalidArgumentError(`Missing required fields in the parent hierarchy [${JSON.stringify(qualifier)}].`);
+    // eslint-disable-next-line max-len
+    throw new InvalidArgumentError(`Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(qualifier)}].`);
   }
 
   if (hasBloatedLineage(qualifier)) {
@@ -430,7 +431,7 @@ const checkFieldLineageAndThrowError = (data: Record<string, unknown>, field?:st
   
   if (!isNormalizedParent(normalized_parent)) {
     // eslint-disable-next-line max-len
-    throw new InvalidArgumentError(`Missing required fields in the ${field??'parent'} hierarchy [${JSON.stringify(data)}].`);
+    throw new InvalidArgumentError(`Missing required fields (parent, _id) in the ${field??'parent'} hierarchy [${JSON.stringify(data)}].`);
   }
   if (hasBloatedLineage(hierarchyRoot)) {
     // eslint-disable-next-line max-len

--- a/shared-libs/cht-datasource/src/remote/person.ts
+++ b/shared-libs/cht-datasource/src/remote/person.ts
@@ -9,8 +9,9 @@ export namespace v1 {
 
   const getPeople = (remoteContext: RemoteDataContext) => getResources(remoteContext, 'api/v1/person');
 
-  // eslint-disable-next-line max-len
-  const createPersonPost = (remoteContext: RemoteDataContext) => postResource(remoteContext, 'api/v1/person');
+  const createPersonPost = (
+    remoteContext: RemoteDataContext
+  ) => postResource(remoteContext, 'api/v1/person');
  
   /** @internal */
   export const get = (remoteContext: RemoteDataContext) => (

--- a/shared-libs/cht-datasource/src/remote/person.ts
+++ b/shared-libs/cht-datasource/src/remote/person.ts
@@ -1,7 +1,7 @@
 import { Nullable, Page } from '../libs/core';
-import { ContactTypeQualifier, UuidQualifier } from '../qualifier';
+import { ContactTypeQualifier, PersonQualifier, UuidQualifier } from '../qualifier';
 import * as Person from '../person';
-import { getResource, getResources, RemoteDataContext } from './libs/data-context';
+import { getResource, getResources, postResource, RemoteDataContext } from './libs/data-context';
 
 /** @internal */
 export namespace v1 {
@@ -9,6 +9,9 @@ export namespace v1 {
 
   const getPeople = (remoteContext: RemoteDataContext) => getResources(remoteContext, 'api/v1/person');
 
+  // eslint-disable-next-line max-len
+  const createPersonPost = (remoteContext: RemoteDataContext) => postResource(remoteContext, 'api/v1/person');
+ 
   /** @internal */
   export const get = (remoteContext: RemoteDataContext) => (
     identifier: UuidQualifier
@@ -35,4 +38,11 @@ export namespace v1 {
     };
     return getPeople(remoteContext)(queryParams);
   };
+
+  /** @internal */
+  export const createPerson = 
+  (remoteContext: RemoteDataContext) => (
+    qualifier:PersonQualifier
+  ):Promise<Person.v1.Person> => createPersonPost(remoteContext)(qualifier);
+  
 }

--- a/shared-libs/cht-datasource/test/index.spec.ts
+++ b/shared-libs/cht-datasource/test/index.spec.ts
@@ -133,8 +133,13 @@ describe('CHT Script API - getDatasource', () => {
       beforeEach(() => person = v1.person);
 
       it('contains expected keys', () => {
-        expect(person).to.have.all.keys(['getByType', 'getByUuid', 'getByUuidWithLineage', 
-          'getPageByType', 'createPerson']);
+        expect(person).to.have.all.keys([
+          'getByType',
+          'getByUuid',
+          'getByUuidWithLineage', 
+          'getPageByType',
+          'createPerson'
+        ]);
       });
 
       it('getByUuid', async () => {

--- a/shared-libs/cht-datasource/test/index.spec.ts
+++ b/shared-libs/cht-datasource/test/index.spec.ts
@@ -133,7 +133,8 @@ describe('CHT Script API - getDatasource', () => {
       beforeEach(() => person = v1.person);
 
       it('contains expected keys', () => {
-        expect(person).to.have.all.keys(['getByType', 'getByUuid', 'getByUuidWithLineage', 'getPageByType']);
+        expect(person).to.have.all.keys(['getByType', 'getByUuid', 'getByUuidWithLineage', 
+          'getPageByType', 'createPerson']);
       });
 
       it('getByUuid', async () => {

--- a/shared-libs/cht-datasource/test/qualifier.spec.ts
+++ b/shared-libs/cht-datasource/test/qualifier.spec.ts
@@ -166,7 +166,7 @@ describe('qualifier', () => {
           type: 'person', reported_date: '2025-06-03T12:45:30Z'
         }
       ].forEach((qualifier) => expect(() => byContactQualifier(qualifier))
-        .to.throw(`Missing or empty required fields [${JSON.stringify(qualifier)}].`));
+        .to.throw(`Missing or empty required fields (name, type) for [${JSON.stringify(qualifier)}].`));
       
     });
 
@@ -261,7 +261,7 @@ describe('qualifier', () => {
         {type: 'data_record', form: ''}
       ].forEach((qualifier) => {
         expect(() => byReportQualifier(qualifier))
-          .to.throw(`Missing or empty required fields [${JSON.stringify(qualifier)}].`);
+          .to.throw(`Missing or empty required fields (type, form) in [${JSON.stringify(qualifier)}].`);
       });
     });
   });
@@ -326,7 +326,7 @@ describe('qualifier', () => {
       };
 
       expect(() => byPersonQualifier(data)).to
-        .throw(`Missing or empty required fields [${JSON.stringify(expected_data)}].`);
+        .throw(`Missing or empty required field (parent) [${JSON.stringify(expected_data)}].`);
     });
 
     it('throws an error parent lineage missing `_id` or `parent` fields', () => {
@@ -348,7 +348,7 @@ describe('qualifier', () => {
       };
 
       expect(() => byPersonQualifier(data)).to
-        .throw(`Missing required fields in the parent hierarchy [${JSON.stringify(expected_data)}].`);
+        .throw(`Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(expected_data)}].`);
     });
 
     it('throws an error on invalid contact types', () => {
@@ -656,7 +656,7 @@ describe('qualifier', () => {
         }
       ].forEach((qualifier) => {
         expect(() => byPlaceQualifier(qualifier))
-          .to.throw(`Missing or empty required fields [${JSON.stringify(qualifier)}].`);
+          .to.throw(`Missing or empty required fields (name, type) for [${JSON.stringify(qualifier)}].`);
       });
     });
 
@@ -701,7 +701,8 @@ describe('qualifier', () => {
       ].forEach((qualifier) => {
         const expected_qualifier = { ...qualifier, reported_date: CURRENT_ISO_TIMESTAMP };
         expect(() => byPlaceQualifier(qualifier))
-          .to.throw(`Missing required fields in the parent hierarchy [${JSON.stringify(expected_qualifier)}].`);
+          // eslint-disable-next-line max-len
+          .to.throw(`Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(expected_qualifier)}].`);
 
       });
 
@@ -736,7 +737,8 @@ describe('qualifier', () => {
       ].forEach((qualifier) => {
         const expected_qualifier = {...qualifier, reported_date: CURRENT_ISO_TIMESTAMP};
         expect(() => byPlaceQualifier(qualifier))
-          .to.throw(`Missing required fields in the contact hierarchy [${JSON.stringify(expected_qualifier)}].`);
+          // eslint-disable-next-line max-len
+          .to.throw(`Missing required fields (parent, _id) in the contact hierarchy [${JSON.stringify(expected_qualifier)}].`);
       });
     });
 

--- a/shared-libs/cht-datasource/test/qualifier.spec.ts
+++ b/shared-libs/cht-datasource/test/qualifier.spec.ts
@@ -150,8 +150,8 @@ describe('qualifier', () => {
     it('throws error for invalid reported_date field.', () => {
       expect(() => byContactQualifier({
         name: 'A', type: 'person', reported_date: '2025-06'
-      // eslint-disable-next-line max-len
-      })).to.throw(`Invalid reported_date. Expected format to be 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or a Unix epoch.`);
+      })).to.throw('Invalid reported_date. Expected format to be ' +
+        '\'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.');
     });
   
     it('throws error for missing or empty required fields.', () => {
@@ -238,10 +238,15 @@ describe('qualifier', () => {
 
     it('throws error for invalid reported_date.', () => {
       expect(() => byReportQualifier({
-        type: 'data_record', form: 'yes', reported_date: '2025'
-      // eslint-disable-next-line max-len
-      })).to.throw('Invalid reported_date. Expected format to be \'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.');
+        type: 'data_record',
+        form: 'yes',
+        reported_date: '2025',
+      })).to.throw(
+        'Invalid reported_date. Expected format to be \'YYYY-MM-DDTHH:mm:ssZ\', ' +
+          '\'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.'
+      );
     });
+    
 
     it('throws error if qualifier is not an object.', () => {
       [
@@ -667,8 +672,8 @@ describe('qualifier', () => {
         reported_date: '2025-10'
       };
       expect(() => byPlaceQualifier(qualifier))
-        // eslint-disable-next-line max-len
-        .to.throw(`Invalid reported_date. Expected format to be 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or a Unix epoch.`);
+        .to.throw('Invalid reported_date. Expected format to be ' +
+        '\'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.');
     });
 
     it('throws error on missing _id or parent properties in contact/parent hierarchy', () => {
@@ -700,10 +705,11 @@ describe('qualifier', () => {
         }
       ].forEach((qualifier) => {
         const expected_qualifier = { ...qualifier, reported_date: CURRENT_ISO_TIMESTAMP };
-        expect(() => byPlaceQualifier(qualifier))
-          // eslint-disable-next-line max-len
-          .to.throw(`Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(expected_qualifier)}].`);
-
+        expect(() => byPlaceQualifier(qualifier)).to.throw(
+          `Missing required fields (parent, _id) in the parent hierarchy [${JSON.stringify(
+            expected_qualifier
+          )}].`
+        );
       });
 
       [
@@ -737,8 +743,11 @@ describe('qualifier', () => {
       ].forEach((qualifier) => {
         const expected_qualifier = {...qualifier, reported_date: CURRENT_ISO_TIMESTAMP};
         expect(() => byPlaceQualifier(qualifier))
-          // eslint-disable-next-line max-len
-          .to.throw(`Missing required fields (parent, _id) in the contact hierarchy [${JSON.stringify(expected_qualifier)}].`);
+          .to.throw(
+            `Missing required fields (parent, _id) in the contact hierarchy [${JSON.stringify(
+              expected_qualifier
+            )}].`
+          );
       });
     });
 

--- a/shared-libs/cht-datasource/test/remote/person.spec.ts
+++ b/shared-libs/cht-datasource/test/remote/person.spec.ts
@@ -10,12 +10,16 @@ describe('remote person', () => {
   let getResourceOuter: SinonStub;
   let getResourcesInner: SinonStub;
   let getResourcesOuter: SinonStub;
+  let postResourceOuter: SinonStub;
+  let postResourceInner: SinonStub;
 
   beforeEach(() => {
     getResourceInner = sinon.stub();
     getResourceOuter = sinon.stub(RemoteEnv, 'getResource').returns(getResourceInner);
     getResourcesInner = sinon.stub();
     getResourcesOuter = sinon.stub(RemoteEnv, 'getResources').returns(getResourcesInner);
+    postResourceInner= sinon.stub();
+    postResourceOuter = sinon.stub(RemoteEnv, 'postResource').returns(postResourceInner);
   });
 
   afterEach(() => sinon.restore());
@@ -100,6 +104,24 @@ describe('remote person', () => {
         expect(result).to.deep.equal([]);
         expect(getResourcesOuter.calledOnceWithExactly(remoteContext, 'api/v1/person')).to.be.true;
         expect(getResourcesInner.calledOnceWithExactly(queryParam)).to.be.true;
+      });
+    });
+
+    describe('createPerson', () => {
+      it('creates a person for a valid qualifier', async () => {
+        const personQualifier = {
+          type: 'person',
+          name: 'user-1',
+          parent: {
+            _id: '1'
+          }
+        };
+        const expected_doc = {...personQualifier, _id: '2', _rev: '1'};
+        postResourceInner.resolves(expected_doc);
+        const result = await Person.v1.createPerson(remoteContext)(personQualifier);
+        expect(result).to.deep.equal(expected_doc);
+        expect(postResourceOuter.calledOnceWithExactly(remoteContext, 'api/v1/person')).to.be.true;
+        expect(postResourceInner.calledOnceWithExactly(personQualifier)).to.be.true;
       });
     });
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description
Deals with the following step:
> Expose a unified interface for the interaction from the relevant top-level [concept module](https://docs.communityhealthtoolkit.org/cht-datasource/src).


<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

