### PR TITLE
fix(#10068): fix africa's talking request body parsing (#10073)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ env:
   BRANCH: ${{ github.head_ref || github.ref_name }}
   BUILD_NUMBER: ${{ github.run_id }}
   NODE_VERSION: '22.15'
+  AFRICAS_TALKING_SANDBOX_API_KEY: ${{ secrets.AFRICAS_TALKING_SANDBOX_API_KEY }}
 
 jobs:
 

--- a/api/src/services/africas-talking.js
+++ b/api/src/services/africas-talking.js
@@ -74,14 +74,6 @@ const getUrl = sandbox => {
   return `https://api.${prefix}africastalking.com/version1/messaging`;
 };
 
-const parseResponseBody = body => {
-  try {
-    return JSON.parse(body);
-  } catch (e) {
-    return;
-  }
-};
-
 const sendMessage = (credentials, message) => {
   const url = getUrl(credentials.username === 'sandbox');
   logger.debug(`Sending message to "${url}"`);
@@ -100,10 +92,9 @@ const sendMessage = (credentials, message) => {
         Accept: 'application/json'
       }
     })
-    .then(body => {
-      const result = parseResponseBody(body);
+    .then(result => {
       if (!result) {
-        logger.error(`Unable to JSON parse response: %o`, body);
+        logger.error(`Unable to JSON parse response: %o`, result);
         return; // retry later
       }
       const validResponse = getStatus(getRecipient(result));

--- a/api/tests/mocha/services/africas-talking.spec.js
+++ b/api/tests/mocha/services/africas-talking.spec.js
@@ -5,7 +5,7 @@ const secureSettings = require('@medic/settings');
 const config = require('../../../src/config');
 const service = require('../../../src/services/africas-talking');
 
-const SUCCESS_RESPONSE = JSON.stringify({
+const SUCCESS_RESPONSE = {
   SMSMessageData: {
     Message: 'Sent to 1/1 Total Cost: KES 0.8000',
     Recipients: [{
@@ -16,9 +16,9 @@ const SUCCESS_RESPONSE = JSON.stringify({
       messageId: 'ATPid_SampleTxnId123'
     }]
   }
-});
+};
 
-const INVALID_PHONE_NUMBER_RESPONSE = JSON.stringify({
+const INVALID_PHONE_NUMBER_RESPONSE = {
   SMSMessageData: {
     Message: 'Sent to 1/1 Total Cost: KES 0.8000',
     Recipients: [{
@@ -29,9 +29,9 @@ const INVALID_PHONE_NUMBER_RESPONSE = JSON.stringify({
       messageId: 'def'
     }]
   }
-});
+};
 
-const INTERNAL_SERVER_ERROR_RESPONSE = JSON.stringify({
+const INTERNAL_SERVER_ERROR_RESPONSE = {
   SMSMessageData: {
     Message: 'Sent to 1/1 Total Cost: KES 0.8000',
     Recipients: [{
@@ -42,7 +42,7 @@ const INTERNAL_SERVER_ERROR_RESPONSE = JSON.stringify({
       messageId: 'ghi'
     }]
   }
-});
+};
 
 describe('africas talking service', () => {
 

--- a/tests/e2e/default/sms/africas-talking.wdio-spec.js
+++ b/tests/e2e/default/sms/africas-talking.wdio-spec.js
@@ -5,19 +5,36 @@ const messagesPage = require('@page-objects/default/sms/messages.wdio.page');
 const loginPage = require('@page-objects//default/login/login.wdio.page');
 const reportsPage = require('@page-objects/default/reports/reports.wdio.page');
 const smsPregnancy = require('@factories/cht/reports/sms-pregnancy');
+const pregnancyReportFactory = require('@factories/cht/reports/sms-pregnancy');
 
 describe('Africas Talking api', () => {
-  const CREDENTIAL_PASS = 'yabbadabbadoo';
-  const CREDENTIAL_KEY = 'africastalking.com:incoming';
+  const CREDENTIAL_PASS_INCOMING = 'yabbadabbadoo';
+  const CREDENTIAL_KEY_INCOMING = 'africastalking.com:incoming';
 
-  before( () => utils.saveCredentials(CREDENTIAL_KEY, CREDENTIAL_PASS) );
+  const CREDENTIAL_PASS_OUTGOING = process.env.AFRICAS_TALKING_SANDBOX_API_KEY;
+  const CREDENTIAL_KEY_OUTGOING = 'africastalking.com:outgoing';
+
+  before( async () => {
+    await utils.saveCredentials(CREDENTIAL_KEY_INCOMING, CREDENTIAL_PASS_INCOMING);
+    CREDENTIAL_PASS_OUTGOING && await utils.saveCredentials(CREDENTIAL_KEY_OUTGOING, CREDENTIAL_PASS_OUTGOING);
+    const smsSettings = {
+      outgoing_service: 'africas-talking',
+      reply_to: 'MEDIC',
+      africas_talking: {
+        username: 'sandbox',
+        from: 'MEDIC'
+      }
+    };
+    await utils.updateSettings({ sms: smsSettings }, { ignoreReload: true });
+    await loginPage.cookieLogin();
+  } );
 
   describe('Gateway submits new WT sms messages', () => {
     const submitSms = body => {
       const content = querystring.stringify(body);
       return utils.request({
         method: 'POST',
-        path: `/api/v1/sms/africastalking/incoming-messages?key=${CREDENTIAL_PASS}`,
+        path: `/api/v1/sms/africastalking/incoming-messages?key=${CREDENTIAL_PASS_INCOMING}`,
         body: content,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -27,26 +44,21 @@ describe('Africas Talking api', () => {
       });
     };
 
-    beforeEach(async () => {
-      submitSms({ from: '+64271234567', text: 'Hello', id: 'messageID' });
-      await loginPage.cookieLogin();
-    });
-
     it('should shows content', async () => {
-      const rawNumber = '+64271234567';
-      const message = 'Hello';
+      const sms = { from: '+64271234567', text: 'Hello', id: 'messageID' };
+      await submitSms(sms);
 
       await commonPage.goToMessages();
-      const { heading, summary} = await messagesPage.getMessageInListDetails(rawNumber);
-      expect(heading).to.equal(rawNumber);
-      expect(summary).to.equal(message);
+      const { heading, summary } = await messagesPage.getMessageInListDetails(sms.from);
+      expect(heading).to.equal(sms.from);
+      expect(summary).to.equal(sms.text);
 
-      await messagesPage.openMessage(rawNumber);
+      await messagesPage.openMessage(sms.from);
       const { name } = await messagesPage.getMessageHeader();
-      expect(name).to.equal(rawNumber);
+      expect(name).to.equal(sms.from);
 
       const { content, state, dataId } = await messagesPage.getMessageContent(1);
-      expect(content).to.equal(message);
+      expect(content).to.equal(sms.text);
       expect(state).to.equal('received');
 
       const doc = await utils.getDoc(dataId);
@@ -63,7 +75,7 @@ describe('Africas Talking api', () => {
       const content = querystring.stringify(body);
       return utils.request({
         method: 'POST',
-        path: `/api/v1/sms/africastalking/delivery-reports?key=${CREDENTIAL_PASS}`,
+        path: `/api/v1/sms/africastalking/delivery-reports?key=${CREDENTIAL_PASS_INCOMING}`,
         body: content,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
@@ -73,21 +85,18 @@ describe('Africas Talking api', () => {
       });
     };
 
-    beforeEach(() => {
+    beforeEach(async () => {
       testReport = smsPregnancy.pregnancy().build();
-      return utils
-        .saveDoc(testReport)
-        .then(result => {
-          savedDoc = result.id;
-          return Promise.all([
-            submitDeliveryReport({ id: testReport.tasks[0].gateway_ref, status: 'Submitted' }),
-            submitDeliveryReport({ id: testReport.scheduled_tasks[0].gateway_ref, status: 'Success' }),
-            submitDeliveryReport({
-              id: testReport.scheduled_tasks[2].gateway_ref,
-              status: 'Failed',
-              failureReason: 'InsufficientCredit' }),
-          ]);
-        });
+      const { id } = await utils.saveDoc(testReport);
+      savedDoc = id;
+
+      await submitDeliveryReport({ id: testReport.tasks[0].gateway_ref, status: 'Submitted' });
+      await submitDeliveryReport({ id: testReport.scheduled_tasks[0].gateway_ref, status: 'Success' });
+      await submitDeliveryReport({
+        id: testReport.scheduled_tasks[2].gateway_ref,
+        status: 'Failed',
+        failureReason: 'InsufficientCredit'
+      });
     });
 
     afterEach(() => utils.deleteDoc(savedDoc));
@@ -125,5 +134,39 @@ describe('Africas Talking api', () => {
       expect(failedTask.state).to.contain('failed');
     });
 
+  });
+
+  (CREDENTIAL_PASS_OUTGOING ? describe : describe.skip)('Webapp submits new GT sms messages', () => {
+    it('should update SMS statuses', async () => {
+      const pregnancyReportWithTasks = pregnancyReportFactory.pregnancy().build({
+        scheduled_tasks: [
+          { messages: [{ to: '+254711111222', message: 'message1', uuid: 'uuid1' }], state: 'pending' },
+          { messages: [{ to: '+254711111222', message: 'message2', uuid: 'uuid2' }], state: 'pending' },
+        ],
+        tasks: []
+      });
+
+      const waitForLogs = await utils.waitForApiLogs(/Sending 2 messages/);
+      await utils.saveDoc(pregnancyReportWithTasks);
+      await waitForLogs.promise;
+      // make sure the requests were sent before loading reports
+      await (await utils.waitForApiLogs(/Sending 0 messages/)).promise;
+
+      await commonPage.goToReports(pregnancyReportWithTasks._id);
+      expect(await reportsPage.rightPanelSelectors.reportTasks().isDisplayed()).to.be.true;
+      const task1 = await reportsPage.getTaskDetails(1, 1);
+      expect(task1).to.deep.include({
+        message: 'message1',
+        state: 'sent',
+        recipient: ' to +254711111222',
+      });
+
+      const task2 = await reportsPage.getTaskDetails(1, 2);
+      expect(task2).to.deep.include({
+        message: 'message2',
+        recipient: ' to +254711111222',
+        state: 'sent',
+      });
+    }); 
   });
 });

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -355,7 +355,7 @@ const saveMetaDocs = (user, docs) => {
     });
 };
 
-const getDoc = (id, rev, parameters = '') => {
+const getDoc = (id, rev = '', parameters = '') => {
   const params = {};
   if (rev) {
     params.rev = rev;


### PR DESCRIPTION


<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

No longer attempt to double parse body.
Adds CI only e2e test that interacts with Africa's Talking Sandbox server.

#10068

(cherry picked from commit fb52de8606201fdbc853e3c108f878e8640b4f7f)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10068-for-4.21/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10068-for-4.21/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10068-for-4.21/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

