### PR TITLE
feat(#10038): store parent/contact with lineage instead of string

### DIFF
--- a/api/tests/mocha/controllers/report.spec.js
+++ b/api/tests/mocha/controllers/report.spec.js
@@ -335,7 +335,7 @@ describe('Report Controller Tests', () => {
           .returns(createReport);
       });
 
-      it('throws error for missing required types, here `form`', async () => {
+      it('throws error for missing required types, here `contact`', async () => {
         isOnlineOnly.returns(true);
         hasAllPermissions.returns(true);
 
@@ -349,7 +349,7 @@ describe('Report Controller Tests', () => {
           }
         };
 
-        const error = new InvalidArgumentError(`Missing or empty required fields (type, form) in [${
+        const error = new InvalidArgumentError(`Missing or empty required field (contact) in [${
           JSON.stringify(input)
         }].`);
 
@@ -363,13 +363,14 @@ describe('Report Controller Tests', () => {
         expect(dataContextBind.notCalled).to.be.true;
       });
 
-      it('throws error for missing required types, here `form`', async () => {
+      it('returns a report doc on valid report input', async () => {
         isOnlineOnly.returns(true);
         hasAllPermissions.returns(true);
         const input = {
           type: 'report',
           reported_date: 12312312,
-          form: 'form-1'
+          form: 'form-1',
+          contact: 'c1'
         };
         req = {
           body: {

--- a/shared-libs/cht-datasource/src/input.ts
+++ b/shared-libs/cht-datasource/src/input.ts
@@ -81,7 +81,8 @@ export type ReportInput = Readonly<{
     form: string,
     reported_date?: string | number,
     _id?: string,
-    _rev?: string
+    _rev?: string,
+    contact:string
   }>;
   
 /**
@@ -92,6 +93,7 @@ export type ReportInput = Readonly<{
  * @throws Error if data is not an object
  * @throws Error if type is not provided or is empty
  * @throws Error if form is not provided or is empty
+ * @throws Error if contact is not provided or is empty
  * @throws Error if reported_date is not in a valid format.
  * Valid formats are 'YYYY-MM-DDTHH:mm:ssZ', 'YYYY-MM-DDTHH:mm:ss.SSSZ', or <unix epoch>.
  */
@@ -107,6 +109,9 @@ export const validateReportInput = (data: unknown): ReportInput => {
       'Invalid reported_date. Expected format to be ' +
           '\'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.'
     );
+  }
+  if (!hasField(input, {name: 'contact', type: 'string', ensureTruthyValue: true})){
+    throw new InvalidArgumentError(`Missing or empty required field (contact) in [${JSON.stringify(data)}].`);
   }
   if (!isReportInput(input)) {
     throw new InvalidArgumentError(`Missing or empty required fields (type, form) in [${JSON.stringify(data)}].`);

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -115,24 +115,25 @@ export namespace v1 {
         throw new InvalidArgumentError(
           `Missing or empty required field (parent) for [${JSON.stringify(input)}].`
         );
-      } else {
-        const parentWithLineage = await getDocById(medicDb)(input.parent);
-        if (parentWithLineage === null){
-          throw new InvalidArgumentError(
-            `Parent does not exist for [${JSON.stringify(input)}].`
-          );
-        }
-        // Check whether parent doc's contact_type matches with any of the allowed parents type.
-        const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
-          .find(parent => parent===(parentWithLineage as PersonInput).contact_type);
-        
-        if (!(parentTypeMatchWithAllowedParents)) {
-          throw new InvalidArgumentError(
-            `Invalid parent type for [${JSON.stringify(input)}].`
-          );
-        }
-        return parentWithLineage;
+      } 
+
+      const parentWithLineage = await getDocById(medicDb)(input.parent);
+      if (parentWithLineage === null){
+        throw new InvalidArgumentError(
+          `Parent does not exist for [${JSON.stringify(input)}].`
+        );
       }
+      // Check whether parent doc's contact_type matches with any of the allowed parents type.
+      const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
+        .find(parent => parent===(parentWithLineage as PersonInput).contact_type);
+        
+      if (!(parentTypeMatchWithAllowedParents)) {
+        throw new InvalidArgumentError(
+          `Invalid parent type for [${JSON.stringify(input)}].`
+        );
+      }
+      return parentWithLineage;
+      
     };
 
       const validatePersonParent = 

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -122,7 +122,7 @@ export namespace v1 {
           );
         }
         if (!((contactTypeObject.parents as string[])
-          .find(parent => parent===(parentWithLineage as PersonInput).type))) {
+          .find(parent => parent===(parentWithLineage as PersonInput).contact_type))) {
           throw new InvalidArgumentError(
             `Invalid parent for [${JSON.stringify(input)}].`
           );

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -111,7 +111,7 @@ export namespace v1 {
     const ensureHasValidParentFieldAndReturnParentDoc = async(
       input:Record<string, unknown>, 
       contactTypeObject: Record<string, unknown>
-    ): Promise<Doc|null> => {
+    ): Promise<Nullable<Doc>> => {
       const parentDoc = await getDocById(medicDb)(input.parent as string);
       if (parentDoc === null){
         throw new InvalidArgumentError(

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -115,7 +115,7 @@ export namespace v1 {
       const parentDoc = await getDocById(medicDb)(input.parent as string);
       if (parentDoc === null){
         throw new InvalidArgumentError(
-          `Parent does not exist for [${JSON.stringify(input)}].`
+          `Parent with _id ${input.parent as string} does not exist.` //NoSONAR
         );
       }
       // Check whether parent doc's `contact_type` or `type`(if `contact_type` is absent) 
@@ -160,7 +160,7 @@ export namespace v1 {
     
       if (parentDoc === null){
         throw new InvalidArgumentError(
-          `Parent does not exist for [${JSON.stringify(input)}].`
+          `Parent with _id ${input.parent} does not exist.`
         );
       }
       input = {...input, parent: {

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -112,9 +112,11 @@ export namespace v1 {
       const ensureHasValidParentFieldAndReturnParentWithLineage =
     async(input:Record<string, unknown>, contactTypeObject: Record<string, unknown>):Promise<Doc|null> => {
       const parentWithLineage = await getDocById(medicDb)(input.parent as string);
-      // Check whether parent doc's contact_type matches with any of the allowed parents type.
+      // Check whether parent doc's `contact_type` or `type`(if `contact_type` is absent) 
+      // matches with any of the allowed parents type.
+      const typeToMatch = (parentWithLineage as PersonInput).contact_type ?? (parentWithLineage as PersonInput).type;
       const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
-        .find(parent => parent===(parentWithLineage as PersonInput).contact_type);
+        .find(parent => parent===typeToMatch);
         
       if (!(parentTypeMatchWithAllowedParents)) {
         throw new InvalidArgumentError(
@@ -175,7 +177,7 @@ export namespace v1 {
           contact_type: input.type,
           type: 'contact'
         } as unknown as PersonInput;
-      } 
+      }
       await appendParentWithLineage();
       return await createPersonDoc(input) as Person.v1.Person;
     };

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -107,12 +107,12 @@ export namespace v1 {
     settings
   } : LocalDataContext) => {
     const createPersonDoc = createDoc(medicDb);
-
+    const getPersonDoc = getDocById(medicDb);
     const ensureHasValidParentFieldAndReturnParentDoc = async(
       input:Record<string, unknown>, 
       contactTypeObject: Record<string, unknown>
     ): Promise<Nullable<Doc>> => {
-      const parentDoc = await getDocById(medicDb)(input.parent as string);
+      const parentDoc = await getPersonDoc(input.parent as string);
       if (parentDoc === null){
         throw new InvalidArgumentError(
           `Parent with _id ${input.parent as string} does not exist.` //NoSONAR
@@ -155,7 +155,7 @@ export namespace v1 {
       if (typeFoundInSettingsContactTypes){
         parentDoc = await validatePersonParent(typeFoundInSettingsContactTypes, input);
       } else if (input.parent){
-        parentDoc = await getDocById(medicDb)(input.parent);
+        parentDoc = await getPersonDoc(input.parent);
       }
     
       if (parentDoc === null){

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -120,7 +120,8 @@ export namespace v1 {
       }
       // Check whether parent doc's `contact_type` or `type`(if `contact_type` is absent) 
       // matches with any of the allowed parents type.
-      const typeToMatch = (parentDoc as PersonInput).contact_type ?? (parentDoc as PersonInput).type;
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const typeToMatch = (parentDoc as PersonInput).contact_type || (parentDoc as PersonInput).type;
       const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
         .find(parent => parent===typeToMatch);
         

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -188,7 +188,10 @@ export namespace v1 {
           );
         }
         input = {
-          ...input, contact: contactWithLineage
+          ...input, contact: {
+            _id: input.contact,
+            parent: contactWithLineage.parent
+          }
         } as unknown as PlaceInput;
       };
       if (hasField(input, { name: '_rev', type: 'string', ensureTruthyValue: true })) {

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -97,6 +97,7 @@ export namespace v1 {
 /** @internal*/
   export const createPlace = ({medicDb, settings}: LocalDataContext) => {
     const createPlaceDoc = createDoc(medicDb);
+    const getPlaceDoc = getDocById(medicDb);
     /**
      * Ensures that places that require a parent (i.e. not at the top of the hirerarchy) 
      * have the parent field as one of the pre-configured `parents` in the `contact_types`
@@ -125,7 +126,7 @@ export namespace v1 {
           `Missing or empty required field (parent) for [${JSON.stringify(input)}].`
         );
       } 
-      const parentDoc = await getDocById(medicDb)(input.parent);
+      const parentDoc = await getPlaceDoc(input.parent);
       if (parentDoc === null){
         throw new InvalidArgumentError(
           `Parent with _id ${input.parent} does not exist.`
@@ -158,7 +159,7 @@ export namespace v1 {
       }
 
       if (input.parent) {
-        const parentDoc = await getDocById(medicDb)(input.parent);
+        const parentDoc = await getPlaceDoc(input.parent);
         if (parentDoc === null) {
           throw new InvalidArgumentError(
             `Parent with _id ${input.parent} does not exist.`
@@ -198,7 +199,7 @@ export namespace v1 {
         return input;
       }
         
-      const contactWithLineage = await getDocById(medicDb)(input.contact!); //NoSONAR
+      const contactWithLineage = await getPlaceDoc(input.contact!); //NoSONAR
       if (contactWithLineage === null){
         throw new InvalidArgumentError(
           `Contact with _id ${input.contact!} does not exist.` //NoSONAR

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -134,9 +134,11 @@ export namespace v1 {
             );
           }
 
-          // Check whether parent doc's contact_type matches with any of the allowed parents type.
+          // Check whether parent doc's `contact_type` or `type`(if `contact_type` is absent) 
+          // matches with any of the allowed parents type.
+          const typeToMatch = (parentWithLineage as PlaceInput).contact_type ?? (parentWithLineage as PlaceInput).type;
           const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
-            .find(parent => parent===(parentWithLineage as PlaceInput).contact_type);
+            .find(parent => parent===typeToMatch);
 
           if (!(parentTypeMatchWithAllowedParents)) {
             throw new InvalidArgumentError(

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -128,7 +128,7 @@ export namespace v1 {
       const parentDoc = await getDocById(medicDb)(input.parent);
       if (parentDoc === null){
         throw new InvalidArgumentError(
-          `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
+          `Parent with _id ${input.parent} does not exist.`
         );
       }
 
@@ -161,7 +161,7 @@ export namespace v1 {
         const parentDoc = await getDocById(medicDb)(input.parent);
         if (parentDoc === null) {
           throw new InvalidArgumentError(
-            `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
+            `Parent with _id ${input.parent} does not exist.`
           );
         }
         return parentDoc;
@@ -201,7 +201,7 @@ export namespace v1 {
       const contactWithLineage = await getDocById(medicDb)(input.contact!); //NoSONAR
       if (contactWithLineage === null){
         throw new InvalidArgumentError(
-          `Contact with id ${input.contact!} does not exist for [${JSON.stringify(input)}].` //NoSONAR
+          `Contact with _id ${input.contact!} does not exist.` //NoSONAR
         );
       }
       input = {

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -126,25 +126,25 @@ export namespace v1 {
             throw new InvalidArgumentError(
               `Missing or empty required field (parent) for [${JSON.stringify(input)}].`
             );
-          } else {
-            const parentWithLineage = await getDocById(medicDb)(input.parent);
-            if (parentWithLineage === null){
-              throw new InvalidArgumentError(
-                `Parent does not exist for [${JSON.stringify(input)}].`
-              );
-            }
-
-            // Check whether parent doc's contact_type matches with any of the allowed parents type.
-            const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
-              .find(parent => parent===(parentWithLineage as PlaceInput).contact_type);
-
-            if (!(parentTypeMatchWithAllowedParents)) {
-              throw new InvalidArgumentError(
-                `Invalid parent type for [${JSON.stringify(input)}].`
-              );
-            }
-            return parentWithLineage;
+          } 
+          const parentWithLineage = await getDocById(medicDb)(input.parent);
+          if (parentWithLineage === null){
+            throw new InvalidArgumentError(
+              `Parent does not exist for [${JSON.stringify(input)}].`
+            );
           }
+
+          // Check whether parent doc's contact_type matches with any of the allowed parents type.
+          const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
+            .find(parent => parent===(parentWithLineage as PlaceInput).contact_type);
+
+          if (!(parentTypeMatchWithAllowedParents)) {
+            throw new InvalidArgumentError(
+              `Invalid parent type for [${JSON.stringify(input)}].`
+            );
+          }
+          return parentWithLineage;
+         
         };
 
       const appendParentWithLineage = async () => {

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -190,10 +190,12 @@ export namespace v1 {
           return;
         }
         
-        const contactWithLineage = await getDocById(medicDb)(input.contact!);
+        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+        const contactWithLineage = await getDocById(medicDb)(input.contact as string);
         if (contactWithLineage === null){
           throw new InvalidArgumentError(
-            `Contact with id ${input.contact!} does not exist for [${JSON.stringify(input)}].`
+            // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+            `Contact with id ${input.contact as string} does not exist for [${JSON.stringify(input)}].`
           );
         }
         input = {

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -97,114 +97,126 @@ export namespace v1 {
 /** @internal*/
   export const createPlace = ({medicDb, settings}: LocalDataContext) => {
     const createPlaceDoc = createDoc(medicDb);
+    /**
+     * Ensures that places that require a parent (i.e. not at the top of the hirerarchy) 
+     * have the parent field as one of the pre-configured `parents` in the `contact_types`
+     * for that place.
+     */
+    /** @internal*/
+    const validateParentPresence = async(contactTypeObject: Record<string, unknown>
+      , input:Record<string, unknown> ):Promise<Doc | null> => {
+      if (hasField(contactTypeObject, {name: 'parents', type: 'object'})) {
+        return await ensureHasValidParentFieldAndReturnParentDoc(input, contactTypeObject);
+      } else if (hasField(input, {name: 'parent', type: 'string', ensureTruthyValue: true})){
+        // The current input type is meant to be at the top of the hierarchy.
+        throw new InvalidArgumentError(
+          `Unexpected parent for [${JSON.stringify(input)}].`
+        );
+      }
+      return null;
+    };
+
+    const ensureHasValidParentFieldAndReturnParentDoc = async(
+      input:Record<string, unknown>,
+      contactTypeObject: Record<string, unknown>
+    ): Promise<Doc> => {
+      if (!hasField(input, {name: 'parent', type: 'string', ensureTruthyValue: true})){
+        throw new InvalidArgumentError(
+          `Missing or empty required field (parent) for [${JSON.stringify(input)}].`
+        );
+      } 
+      const parentDoc = await getDocById(medicDb)(input.parent);
+      if (parentDoc === null){
+        throw new InvalidArgumentError(
+          `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
+        );
+      }
+
+      // Check whether parent doc's `contact_type` or `type`(if `contact_type` is absent) 
+      // matches with any of the allowed parents type.
+      const typeToMatch = (parentDoc as PlaceInput).contact_type ?? (parentDoc as PlaceInput).type;
+      const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
+        .find(parent => parent===typeToMatch);
+
+      if (!(parentTypeMatchWithAllowedParents)) {
+        throw new InvalidArgumentError(
+          `Invalid parent type for [${JSON.stringify(input)}].`
+        );
+      }
+      return parentDoc;
+         
+    };
+      
+    const getParentDoc = async (
+      typeFoundInSettingsContactTypes:Record<string, unknown>|undefined,
+      input:PlaceInput
+    ): Promise<Doc | null> => {
+      if (typeFoundInSettingsContactTypes) {
+        // This will throw error if parent is required and missing.
+        return await validateParentPresence(typeFoundInSettingsContactTypes, input);
+        // null is returned only when parent is not required and it is not present in the input
+      }
+
+      if (input.parent) {
+        const parentDoc = await getDocById(medicDb)(input.parent);
+        if (parentDoc === null) {
+          throw new InvalidArgumentError(
+            `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
+          );
+        }
+        return parentDoc;
+      }
+
+      return null;
+    };
+      
+    const appendParent = async (
+      typeFoundInSettingsContactTypes:Record<string, unknown>|undefined,
+      input:PlaceInput
+    ):Promise<PlaceInput> => {
+      let parentDoc: Doc | null = null;
+      parentDoc = await getParentDoc(typeFoundInSettingsContactTypes, input);
+      if (!parentDoc) {
+        return input;
+      }
+
+      input = {
+        ...input,
+        parent: {
+          _id: input.parent,
+          parent: parentDoc.parent
+        }
+      } as unknown as PlaceInput;
+      return input;
+    };
+
+
+    const appendContact = async (
+      input:PlaceInput
+    ) => {
+      if (!hasField(input, {name: 'contact', type: 'string', ensureTruthyValue: true})) {
+        return input;
+      }
+        
+      const contactWithLineage = await getDocById(medicDb)(input.contact!); //NoSONAR
+      if (contactWithLineage === null){
+        throw new InvalidArgumentError(
+          `Contact with id ${input.contact!} does not exist for [${JSON.stringify(input)}].` //NoSONAR
+        );
+      }
+      input = {
+        ...input, contact: {
+          _id: input.contact,
+          parent: contactWithLineage.parent
+        }
+      } as unknown as PlaceInput;
+      return input;
+    };
     return async(
       input: PlaceInput
     ):Promise<Place.v1.Place> => {
 
-      /**
-       * Ensures that places that require a parent (i.e. not at the top of the hirerarchy) 
-       * have the parent field as one of the pre-configured `parents` in the `contact_types`
-       * for that place.
-       */
-      /** @internal*/
-      const validateParentPresence = async(contactTypeObject: Record<string, unknown>
-        , input:Record<string, unknown> ):Promise<Doc | null> => {
-        if (hasField(contactTypeObject, {name: 'parents', type: 'object'})) {
-          return await ensureHasValidParentField(input, contactTypeObject);
-        } else if (hasField(input, {name: 'parent', type: 'string', ensureTruthyValue: true})){
-          // The current input type is meant to be at the top of the hierarchy.
-          throw new InvalidArgumentError(
-            `Unexpected parent for [${JSON.stringify(input)}].`
-          );
-        }
-        return null;
-      };
-
-      const ensureHasValidParentField = 
-        async(input:Record<string, unknown>, contactTypeObject: Record<string, unknown>):Promise<Doc> => {
-          if (!hasField(input, {name: 'parent', type: 'string', ensureTruthyValue: true})){
-            throw new InvalidArgumentError(
-              `Missing or empty required field (parent) for [${JSON.stringify(input)}].`
-            );
-          } 
-          const parentWithLineage = await getDocById(medicDb)(input.parent);
-          if (parentWithLineage === null){
-            throw new InvalidArgumentError(
-              `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
-            );
-          }
-
-          // Check whether parent doc's `contact_type` or `type`(if `contact_type` is absent) 
-          // matches with any of the allowed parents type.
-          const typeToMatch = (parentWithLineage as PlaceInput).contact_type ?? (parentWithLineage as PlaceInput).type;
-          const parentTypeMatchWithAllowedParents = (contactTypeObject.parents as string[])
-            .find(parent => parent===typeToMatch);
-
-          if (!(parentTypeMatchWithAllowedParents)) {
-            throw new InvalidArgumentError(
-              `Invalid parent type for [${JSON.stringify(input)}].`
-            );
-          }
-          return parentWithLineage;
-         
-        };
-      
-      const getParentWithLineage = async (): Promise<Doc | null> => {
-        if (typeFoundInSettingsContactTypes) {
-          // This will throw error if parent is required and missing.
-          return await validateParentPresence(typeFoundInSettingsContactTypes, input);
-          // null is returned only when parent is not required and it is not present in the input
-        }
-
-        if (input.parent) {
-          const parentDoc = await getDocById(medicDb)(input.parent);
-          if (parentDoc === null) {
-            throw new InvalidArgumentError(
-              `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
-            );
-          }
-          return parentDoc;
-        }
-
-        return null;
-      };
-      
-      const appendParentWithLineage = async () => {
-        let parentWithLineage: Doc | null = null;
-
-        parentWithLineage = await getParentWithLineage();
-        if (!parentWithLineage) {
-          return;
-        }
-
-        input = {
-          ...input,
-          parent: {
-            _id: input.parent,
-            parent: parentWithLineage.parent
-          }
-        } as unknown as PlaceInput;
-      };
-
-
-      const appendContactWithLineage = async() => {
-        if (!hasField(input, {name: 'contact', type: 'string', ensureTruthyValue: true})) {
-          return;
-        }
-        
-        const contactWithLineage = await getDocById(medicDb)(input.contact!); //NoSONAR
-        if (contactWithLineage === null){
-          throw new InvalidArgumentError(
-            `Contact with id ${input.contact!} does not exist for [${JSON.stringify(input)}].` //NoSONAR
-          );
-        }
-        input = {
-          ...input, contact: {
-            _id: input.contact,
-            parent: contactWithLineage.parent
-          }
-        } as unknown as PlaceInput;
-      };
+  
       if (hasField(input, { name: '_rev', type: 'string', ensureTruthyValue: true })) {
         throw new InvalidArgumentError('Cannot pass `_rev` when creating a place.');
       }
@@ -226,8 +238,8 @@ export namespace v1 {
         } as unknown as PlaceInput;
       }
       
-      await appendParentWithLineage();
-      await appendContactWithLineage();
+      input = await appendParent(typeFoundInSettingsContactTypes, input);
+      input = await appendContact(input);
 
       return await createPlaceDoc(input) as Place.v1.Place;
     };

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -151,6 +151,9 @@ export namespace v1 {
         let parentWithLineage: Doc | null = null;
         if (typeFoundInSettingsContactTypes){
           parentWithLineage = await validateParentPresence(typeFoundInSettingsContactTypes, input);
+          if (!parentWithLineage) {
+            return;
+          }
         } else if (input.parent){
           parentWithLineage = await getDocById(medicDb)(input.parent);
         } else if (input.contact_type === 'district_hospital') {
@@ -177,6 +180,7 @@ export namespace v1 {
         if (!hasField(input, {name: 'contact', type: 'string', ensureTruthyValue: true})) {
           return;
         }
+        
         const contactWithLineage = await getDocById(medicDb)(input.contact!);
         if (contactWithLineage === null){
           throw new InvalidArgumentError(

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -190,12 +190,10 @@ export namespace v1 {
           return;
         }
         
-        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
-        const contactWithLineage = await getDocById(medicDb)(input.contact as string);
+        const contactWithLineage = await getDocById(medicDb)(input.contact!); //NoSONAR
         if (contactWithLineage === null){
           throw new InvalidArgumentError(
-            // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
-            `Contact with id ${input.contact as string} does not exist for [${JSON.stringify(input)}].`
+            `Contact with id ${input.contact!} does not exist for [${JSON.stringify(input)}].` //NoSONAR
           );
         }
         input = {

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -130,7 +130,7 @@ export namespace v1 {
           const parentWithLineage = await getDocById(medicDb)(input.parent);
           if (parentWithLineage === null){
             throw new InvalidArgumentError(
-              `Parent does not exist for [${JSON.stringify(input)}].`
+              `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
             );
           }
 
@@ -150,27 +150,23 @@ export namespace v1 {
       const appendParentWithLineage = async () => {
         let parentWithLineage: Doc | null = null;
         if (typeFoundInSettingsContactTypes){
+          // This will throw error is parent is required and missing.
           parentWithLineage = await validateParentPresence(typeFoundInSettingsContactTypes, input);
+          // null is returned only when parent is not required and it is not present in the input
           if (!parentWithLineage) {
             return;
           }
         } else if (input.parent){
           parentWithLineage = await getDocById(medicDb)(input.parent);
-        } else if (input.contact_type === 'district_hospital') {
-          // For legacy types, `district_hospital` is at the top of the hierarchy
-          // so no need to append parent.
-          return;
+          if (parentWithLineage === null){
+            throw new InvalidArgumentError(
+              `Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`
+            );
+          }
         } else {
-          throw new InvalidArgumentError(
-            `Missing or empty required field (parent) for [${JSON.stringify(input)}].`
-          );
+          return;
         }
 
-        if (parentWithLineage === null){
-          throw new InvalidArgumentError(
-            `Parent does not exist for [${JSON.stringify(input)}].`
-          );
-        }
         input = {...input, parent: {
           _id: input.parent, parent: parentWithLineage.parent 
         } } as unknown as PlaceInput;
@@ -184,7 +180,7 @@ export namespace v1 {
         const contactWithLineage = await getDocById(medicDb)(input.contact!);
         if (contactWithLineage === null){
           throw new InvalidArgumentError(
-            `Contact does not exist for [${JSON.stringify(input)}].`
+            `Contact with id ${input.contact!} does not exist for [${JSON.stringify(input)}].`
           );
         }
         input = {

--- a/shared-libs/cht-datasource/src/local/place.ts
+++ b/shared-libs/cht-datasource/src/local/place.ts
@@ -133,7 +133,7 @@ export namespace v1 {
               );
             }
             if (!((contactTypeObject.parents as string[])
-              .find(parent => parent===(parentWithLineage as PlaceInput).type))) {
+              .find(parent => parent===(parentWithLineage as PlaceInput).contact_type))) {
               throw new InvalidArgumentError(
                 `Invalid parent for [${JSON.stringify(input)}].`
               );

--- a/shared-libs/cht-datasource/src/local/report.ts
+++ b/shared-libs/cht-datasource/src/local/report.ts
@@ -83,10 +83,11 @@ export namespace v1 {
     medicDb
   } : LocalDataContext) => {
     const createReportDoc = createDoc(medicDb);
+    const getReportDoc = getDocById(medicDb);
     const appendContact = async(
       input:ReportInput
     ): Promise<ReportInput> => {
-      const contactWithLineage = await getDocById(medicDb)(input.contact);
+      const contactWithLineage = await getReportDoc(input.contact);
       if (contactWithLineage === null){
         throw new InvalidArgumentError(
           `Contact with _id ${input.contact} does not exist.`

--- a/shared-libs/cht-datasource/src/local/report.ts
+++ b/shared-libs/cht-datasource/src/local/report.ts
@@ -89,7 +89,7 @@ export namespace v1 {
       const contactWithLineage = await getDocById(medicDb)(input.contact);
       if (contactWithLineage === null){
         throw new InvalidArgumentError(
-          `Contact with id ${input.contact} does not exist for [${JSON.stringify(input)}].`
+          `Contact with _id ${input.contact} does not exist.`
         );
       }
       input = {

--- a/shared-libs/cht-datasource/test/input.spec.ts
+++ b/shared-libs/cht-datasource/test/input.spec.ts
@@ -107,17 +107,19 @@ describe('input', () => {
   describe('validateReportInput', () => {
     it('builds a input for creation and update of a report with the required fields.', () => {
       expect(validateReportInput({
-        type: 'data_record', form: 'yes'
+        type: 'data_record', form: 'yes', contact: 'c1'
       })).to.deep.equal({
-        type: 'data_record', form: 'yes', reported_date: CURRENT_ISO_TIMESTAMP
+        type: 'data_record', form: 'yes', reported_date: CURRENT_ISO_TIMESTAMP, contact: 'c1'
       });
     });
 
     it('builds a input for creation and update of a report with the optional fields.', () => {
       expect(validateReportInput({
-        type: 'data_record', form: 'yes', _id: 'id-1', _rev: 'rev-3', reported_date: '2025-06-03T12:45:30.222Z'
+        type: 'data_record', form: 'yes', _id: 'id-1', _rev: 'rev-3', reported_date: '2025-06-03T12:45:30.222Z', 
+        contact: 'c2'
       })).to.deep.equal({
-        type: 'data_record', form: 'yes', _id: 'id-1', _rev: 'rev-3', reported_date: '2025-06-03T12:45:30.222Z'
+        type: 'data_record', form: 'yes', _id: 'id-1', _rev: 'rev-3', 
+        contact: 'c2', reported_date: '2025-06-03T12:45:30.222Z'
       });
     });
 
@@ -144,14 +146,24 @@ describe('input', () => {
 
     it('throws error if type/form is not provided or empty.', () => {
       [
-        {reported_date: 3432433},
-        {type: 'data_record', _id: 'id-1', _rev: 'rev-4', reported_date: CURRENT_ISO_TIMESTAMP},
-        {form: 'yes', _id: 'id-1', _rev: 'rev-4'},
-        {type: '', form: 'yes'},
-        {type: 'data_record', form: ''}
+        {reported_date: 3432433, contact: 'c1'},
+        {type: 'data_record', _id: 'id-1', _rev: 'rev-4', contact: 'c1', reported_date: CURRENT_ISO_TIMESTAMP},
+        {form: 'yes', _id: 'id-1', _rev: 'rev-4', contact: 'c1'},
+        {type: '', form: 'yes', contact: 'c1'},
+        {type: 'data_record', form: '', contact: 'c1'}
       ].forEach((input) => {
         expect(() => validateReportInput(input))
           .to.throw(`Missing or empty required fields (type, form) in [${JSON.stringify(input)}].`);
+      });
+    });
+
+    it('throws error if contact is not provided or empty.', () => {
+      [
+        {type: 'data_record', form: 'yes'},
+        {type: 'data_record', form: 'myform', contact: ''}
+      ].forEach((input) => {
+        expect(() => validateReportInput(input))
+          .to.throw(`Missing or empty required field (contact) in [${JSON.stringify(input)}].`);
       });
     });
   });

--- a/shared-libs/cht-datasource/test/local/person.spec.ts
+++ b/shared-libs/cht-datasource/test/local/person.spec.ts
@@ -422,6 +422,25 @@ describe('local person', () => {
             .to.be.rejectedWith(`Parent does not exist for [${JSON.stringify(input)}].`);
         });
 
+      it('throws error invalid parent id that is not present in the db', 
+        async () => {
+          settingsGetAll.returns({
+            contact_types: [{id: 'person', parents: ['hospital'] }, {id: 'hospital', parents: ['district_hospital']}]
+          });
+
+          isPerson.returns(true);
+          const input = {
+            name: 'user-1',
+            type: 'person',
+            parent: 'p1'
+          };
+
+          getDocByIdInner.resolves(null);
+          const updatedInput = {...input, type: 'contact', contact_type: 'person'};
+          await expect(Person.v1.createPerson(localContext)(input))
+            .to.be.rejectedWith(`Parent does not exist for [${JSON.stringify(updatedInput)}].`);
+        });
+
       it('throws error if type of person cannot have a parent', 
         async () => {
           settingsGetAll.returns({

--- a/shared-libs/cht-datasource/test/local/person.spec.ts
+++ b/shared-libs/cht-datasource/test/local/person.spec.ts
@@ -402,6 +402,7 @@ describe('local person', () => {
           const input_reported_date = new Date().toISOString();
           createDocInner.resolves({ reported_date: input_reported_date, ...input });
           const person = await Person.v1.createPerson(localContext)(input);
+          expect(getDocByIdInner.calledOnce).to.be.true;
           expect(Person.v1.isPerson(localContext.settings)(person)).to.be.true;
           expect(createDocInner.calledOnceWithExactly({...input, parent: parentDocReturned })).to.be.true;
         });

--- a/shared-libs/cht-datasource/test/local/person.spec.ts
+++ b/shared-libs/cht-datasource/test/local/person.spec.ts
@@ -419,7 +419,7 @@ describe('local person', () => {
           const parentDocReturned = null;
           getDocByIdInner.resolves(parentDocReturned);
           await expect( Person.v1.createPerson(localContext)(input))
-            .to.be.rejectedWith(`Parent does not exist for [${JSON.stringify(input)}].`);
+            .to.be.rejectedWith(`Parent with _id ${input.parent} does not exist.`);
         });
 
       it('throws error invalid parent id that is not present in the db', 
@@ -436,9 +436,8 @@ describe('local person', () => {
           };
 
           getDocByIdInner.resolves(null);
-          const updatedInput = {...input, type: 'contact', contact_type: 'person'};
           await expect(Person.v1.createPerson(localContext)(input))
-            .to.be.rejectedWith(`Parent does not exist for [${JSON.stringify(updatedInput)}].`);
+            .to.be.rejectedWith(`Parent with _id ${input.parent} does not exist.`);
         });
 
       it('throws error if type of person cannot have a parent', 

--- a/shared-libs/cht-datasource/test/local/place.spec.ts
+++ b/shared-libs/cht-datasource/test/local/place.spec.ts
@@ -439,7 +439,7 @@ describe('local place', () => {
         };
         
         const expectedContactDoc = {
-          _id: placeInput.contact
+          _id: placeInput.contact, parent: undefined
         };
         getDocByIdInner.resolves(expectedContactDoc);
 

--- a/shared-libs/cht-datasource/test/local/place.spec.ts
+++ b/shared-libs/cht-datasource/test/local/place.spec.ts
@@ -541,7 +541,7 @@ describe('local place', () => {
           const parentDocReturned = null;
           getDocByIdInner.resolves(parentDocReturned);
           await expect(Place.v1.createPlace(localContext)(input))
-            .to.be.rejectedWith(`Parent with id ${input.parent} does not exist for [${JSON.stringify(input)}].`);
+            .to.be.rejectedWith(`Parent with _id ${input.parent} does not exist.`);
         });
 
       it('returns plain place document if parent is not required', 
@@ -570,17 +570,10 @@ describe('local place', () => {
             type: 'hospital',
             parent: 'p1'
           };
-          const updatedInput = {
-            name: 'place-1',
-            type: 'contact',
-            parent: 'p1',
-            contact_type: 'hospital'
-          };
-              
           const parentDocReturned = null;
           getDocByIdInner.resolves(parentDocReturned);
           await expect(Place.v1.createPlace(localContext)(input))
-            .to.be.rejectedWith(`Parent with id ${input.parent} does not exist for [${JSON.stringify(updatedInput)}].`);
+            .to.be.rejectedWith(`Parent with _id ${input.parent} does not exist.`);
         });
 
       it('throws error for invalid contact id that is not present in the db', 
@@ -593,19 +586,11 @@ describe('local place', () => {
             type: 'hospital',
             contact: 'c1'
           };
-          const updatedInput = {
-            name: 'place-1',
-            type: 'contact',
-            contact: 'c1',
-            contact_type: 'hospital'
-          };
-              
+         
           const parentDocReturned = null;
           getDocByIdInner.resolves(parentDocReturned);
           await expect(Place.v1.createPlace(localContext)(input))
-            .to.be.rejectedWith(`Contact with id ${input.contact} does not exist for [${JSON.stringify(
-              updatedInput
-            )}].`);
+            .to.be.rejectedWith(`Contact with _id ${input.contact} does not exist.`);
         });
     });
 

--- a/shared-libs/cht-datasource/test/local/report.spec.ts
+++ b/shared-libs/cht-datasource/test/local/report.spec.ts
@@ -426,32 +426,73 @@ describe('local report', () => {
     });
 
     describe('createReport', () => {
+      let getDocByIdOuter: SinonStub;
+      let getDocByIdInner: SinonStub;
+
+      beforeEach(() => {
+        getDocByIdInner = sinon.stub();
+        getDocByIdOuter = sinon.stub(LocalDoc, 'getDocById').returns(getDocByIdInner);
+      });
+
       it('creates a report doc for valid report qualifier', async () => {
-        
-        const qualifier = {
+        const input = {
           type: 'data_record',
-          form: 'yes'
+          form: 'yes',
+          contact: 'c1',
+          reported_date: new Date().toISOString()
         };
-        const expected_reported_date = new Date().toISOString();
-        const expected_report = {...qualifier, _id: '1-id', _rev: '1-rev', reported_date: expected_reported_date}; 
+        const returnedContactDoc = {
+          _id: 'c1',
+          type: 'contact',
+          contact_type: 'person',
+          parent: {
+            _id: 'c2'
+          }
+        };
+        getDocByIdInner.resolves(returnedContactDoc);
+        const updatedInput = {
+          ...input, contact: {
+            _id: input.contact, parent: returnedContactDoc.parent
+          }
+        };
+        const expected_report = {...updatedInput, _id: '1-id', _rev: '1-rev'}; 
         createDocOuter.returns(createDocInner);
         createDocInner.resolves(expected_report);
       
-        const report = await Report.v1.createReport(localContext)(qualifier);
+        const report = await Report.v1.createReport(localContext)(input);
         expect(report).to.deep.equal(expected_report);
         expect(createDocOuter.calledOnce).to.be.true;
-        expect(createDocInner.calledOnceWithExactly(qualifier)).to.be.true;
+        expect(createDocInner.calledOnceWithExactly(updatedInput)).to.be.true;
+        expect(getDocByIdOuter.calledOnceWithExactly(localContext.medicDb)).to.be.true;
       });
 
-      it('throws error when _rev is passed in report qualifier', async () => {
-        
-        const qualifier = {
+      it('throws error when contact with id does not exist in the db', async () => {
+        const input = {
           type: 'data_record',
           form: 'yes',
-          _rev: '1-rev'
+          contact: 'c1',
+          reported_date: new Date().toISOString()
+        };
+        
+        getDocByIdInner.resolves(null);
+        
+        expect(createDocOuter.calledOnce).to.be.false;
+      
+        await expect(Report.v1.createReport(localContext)(input))
+          .to.be.rejectedWith(`Contact with id ${input.contact} does not exist for [${JSON.stringify(input)}].`);
+        expect(getDocByIdOuter.calledOnceWithExactly(localContext.medicDb)).to.be.true;
+      });
+
+      it('throws error when _rev is passed in report input', async () => {
+        
+        const input = {
+          type: 'data_record',
+          form: 'yes',
+          _rev: '1-rev',
+          contact: 'c1'
         };
 
-        await expect(Report.v1.createReport(localContext)(qualifier))
+        await expect(Report.v1.createReport(localContext)(input))
           .to.be.rejectedWith('Cannot pass `_rev` when creating a report.');
         expect(createDocInner.called).to.be.false;
         expect(createDocOuter.called).to.be.true;

--- a/shared-libs/cht-datasource/test/local/report.spec.ts
+++ b/shared-libs/cht-datasource/test/local/report.spec.ts
@@ -479,7 +479,7 @@ describe('local report', () => {
         expect(createDocOuter.calledOnce).to.be.false;
       
         await expect(Report.v1.createReport(localContext)(input))
-          .to.be.rejectedWith(`Contact with id ${input.contact} does not exist for [${JSON.stringify(input)}].`);
+          .to.be.rejectedWith(`Contact with _id ${input.contact} does not exist.`);
         expect(getDocByIdOuter.calledOnceWithExactly(localContext.medicDb)).to.be.true;
       });
 

--- a/shared-libs/cht-datasource/test/remote/report.spec.ts
+++ b/shared-libs/cht-datasource/test/remote/report.spec.ts
@@ -91,7 +91,8 @@ describe('remote report', () => {
         const input = {
           form: 'form-1',
           type: 'report', 
-          reported_date: 11223344
+          reported_date: 11223344,
+          contact: 'c1'
         };
 
         postResourceInner.resolves(input);

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -273,7 +273,7 @@ describe('Person API', () => {
         name: 'apoorva',
         type: 'person',
         reported_date: 12312312,
-        parent: place0._id
+        parent: place1._id
       };
       const opts = {
         path: endpoint,

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -246,7 +246,7 @@ describe('Person API', () => {
     });
   });
 
-  describe('POST /api/v1/person', async () => {
+  describe.only('POST /api/v1/person', async () => {
     const endpoint = `/api/v1/person`;
     it(`creates a person for valid personInput`, async () => {
       const personInput = {
@@ -273,7 +273,7 @@ describe('Person API', () => {
         name: 'apoorva',
         type: 'person',
         reported_date: 12312312,
-        parent: place1._id
+        parent: contact0._id
       };
       const opts = {
         path: endpoint,
@@ -289,7 +289,7 @@ describe('Person API', () => {
           name: 'apoorva',
           type: 'contact',
           reported_date: 12312312,
-          parent: place1._id,
+          parent: contact0._id,
           contact_type: 'person',
         })}].`,
       })}`;

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -272,6 +272,7 @@ describe('Person API', () => {
       const personInput = {
         name: 'apoorva',
         type: 'person',
+        reported_date: 12312312,
         parent: place0._id
       };
       const opts = {
@@ -287,8 +288,8 @@ describe('Person API', () => {
         error: `Invalid parent type for [${JSON.stringify({
           name: 'apoorva',
           type: 'contact',
-          parent: place1._id,
           reported_date: 12312312,
+          parent: place1._id,
           contact_type: 'person',
         })}].`,
       })}`;

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -248,11 +248,31 @@ describe('Person API', () => {
 
   describe('POST /api/v1/person', async () => {
     const endpoint = `/api/v1/person`;
-    it(`creates a person for valid personInput`, async () => {
+    // it(`creates a person for valid personInput`, async () => {
+    //   const personInput = {
+    //     name: 'apoorva',
+    //     type: 'chw',
+    //     parent: place0._id
+    //   };
+    //   const opts = {
+    //     path: endpoint,
+    //     method: 'POST',
+    //     headers: {
+    //       'Content-Type': 'application/json'
+    //     },
+    //     body: personInput
+    //   };
+    //   const personDoc = await utils.request(opts);
+    //   expect(personDoc).excluding(['_rev', 'reported_date', '_id'])
+    //     .to.deep.equal({...personInput, type: 'contact', contact_type: 'chw', 
+    //       parent: {_id: place0._id, parent: place0.parent}});
+    // });
+
+    it(`throws error for parent type not among allowed parents in settings.contact_types`, async () => {
       const personInput = {
         name: 'apoorva',
         type: 'person',
-        parent: 'p1'
+        parent: place0._id
       };
       const opts = {
         path: endpoint,
@@ -262,9 +282,18 @@ describe('Person API', () => {
         },
         body: personInput
       };
-      const personDoc = await utils.request(opts);
-      expect(personDoc).excluding(['_rev', 'reported_date', '_id'])
-        .to.deep.equal({...personInput, type: 'contact', contact_type: 'person'});
+      const expectedError = `400 - ${JSON.stringify({
+        code: 400,
+        error: `Invalid parent type for [${JSON.stringify({
+          name: 'apoorva',
+          type: 'contact',
+          parent: place1._id,
+          reported_date: 12312312,
+          contact_type: 'person',
+        })}].`,
+      })}`;
+      
+      await expect(utils.request(opts)).to.be.rejectedWith(expectedError);
     });
 
     it(`throws 400 error for invalid personInput, here with a missing 'parent'`, async () => {

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -246,7 +246,7 @@ describe('Person API', () => {
     });
   });
 
-  describe.only('POST /api/v1/person', async () => {
+  describe('POST /api/v1/person', async () => {
     const endpoint = `/api/v1/person`;
     it(`creates a person for valid personInput`, async () => {
       const personInput = {

--- a/tests/integration/api/controllers/person.spec.js
+++ b/tests/integration/api/controllers/person.spec.js
@@ -248,25 +248,25 @@ describe('Person API', () => {
 
   describe('POST /api/v1/person', async () => {
     const endpoint = `/api/v1/person`;
-    // it(`creates a person for valid personInput`, async () => {
-    //   const personInput = {
-    //     name: 'apoorva',
-    //     type: 'chw',
-    //     parent: place0._id
-    //   };
-    //   const opts = {
-    //     path: endpoint,
-    //     method: 'POST',
-    //     headers: {
-    //       'Content-Type': 'application/json'
-    //     },
-    //     body: personInput
-    //   };
-    //   const personDoc = await utils.request(opts);
-    //   expect(personDoc).excluding(['_rev', 'reported_date', '_id'])
-    //     .to.deep.equal({...personInput, type: 'contact', contact_type: 'chw', 
-    //       parent: {_id: place0._id, parent: place0.parent}});
-    // });
+    it(`creates a person for valid personInput`, async () => {
+      const personInput = {
+        name: 'apoorva',
+        type: 'person',
+        parent: place0._id
+      };
+      const opts = {
+        path: endpoint,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: personInput
+      };
+      const personDoc = await utils.request(opts);
+      expect(personDoc).excluding(['_rev', 'reported_date', '_id'])
+        .to.deep.equal({...personInput, type: 'contact', contact_type: 'person', 
+          parent: {_id: place0._id, parent: place0.parent}});
+    });
 
     it(`throws error for parent type not among allowed parents in settings.contact_types`, async () => {
       const personInput = {

--- a/tests/integration/api/controllers/place.spec.js
+++ b/tests/integration/api/controllers/place.spec.js
@@ -275,7 +275,7 @@ describe('Place API', () => {
       const input = {
         type: 'place',
         name: 'place-1',
-        contact: 'c1'
+        contact: contact0._id
       };
 
       const opts = {
@@ -287,7 +287,12 @@ describe('Place API', () => {
         body: input
       };
       const placeDoc = await utils.request(opts);
-      expect(placeDoc).excluding(['reported_date', '_id', '_rev']).to.deep.equal(input);
+      const updatedInput = {
+        ...input, contact: {
+          _id: contact0._id, parent: contact0.parent
+        }
+      };
+      expect(placeDoc).excluding(['reported_date', '_id', '_rev']).to.deep.equal(updatedInput);
     });
 
     it('throws error for missing fields', async () => {

--- a/tests/integration/api/controllers/report.spec.js
+++ b/tests/integration/api/controllers/report.spec.js
@@ -331,7 +331,8 @@ describe('Report API', () => {
       const input = {
         form: 'form-1',
         type: 'report',
-        reported_date: 11221122
+        reported_date: 11221122,
+        contact: place2._id
       };
       const opts = {
         path: '/api/v1/report', 
@@ -344,7 +345,7 @@ describe('Report API', () => {
       };
 
       const reportDoc = await utils.request(opts);
-      expect(reportDoc).excluding(['_rev', '_id'])
+      expect(reportDoc).excluding(['_rev', '_id', 'contact'])
         .to.deep.equal(input);
     });
 
@@ -366,7 +367,7 @@ describe('Report API', () => {
       await expect(utils.request(opts))
         .to.be.rejectedWith(`400 - ${JSON.stringify({
           code: 400,
-          error: `Missing or empty required fields (type, form) in [${JSON.stringify(input)}].`
+          error: `Missing or empty required field (contact) in [${JSON.stringify(input)}].`
         })}`);
     });
   });

--- a/tests/integration/shared-libs/cht-datasource/person.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/person.spec.js
@@ -208,7 +208,7 @@ describe('cht-datasource Person', () => {
       });
     });
 
-    describe.only('createPerson', async () => {
+    describe('createPerson', async () => {
       const createPerson = Person.v1.createPerson(dataContext);
       it('creates a person for a valid person input', async () => {
         const personInput = Input.validatePersonInput({

--- a/tests/integration/shared-libs/cht-datasource/person.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/person.spec.js
@@ -210,15 +210,31 @@ describe('cht-datasource Person', () => {
 
     describe('createPerson', async () => {
       const createPerson = Person.v1.createPerson(dataContext);
-      it('creates a person for a valid person input', async () => {
+      // it('creates a person for a valid person input', async () => {
+      //   // console.log(await utils.getSettings().contact_types);
+      //   const personInput = Input.validatePersonInput({
+      //     name: 'apoorva',
+      //     type: 'person',
+      //     parent: place1._id
+      //   });
+      //   const person = await createPerson(personInput);
+      //   expect(person).excluding([ '_rev', 'reported_date', '_id' ])
+      //     .to.deep.equal({...personInput, contact_type: 'person', type: 'contact',
+      //       parent: {_id: place1._id, parent: place1.parent}});
+      // });
+
+      it('throws error for parent type not among allowed parents in settings.contact_types', async () => {
         const personInput = Input.validatePersonInput({
           name: 'apoorva',
           type: 'person',
-          parent: 'p1'
+          parent: place1._id,
+          reported_date: 12312312
         });
-        const person = await createPerson(personInput);
-        expect(person).excluding([ '_rev', 'reported_date', '_id' ])
-          .to.deep.equal({...personInput, contact_type: 'person', type: 'contact'});
+        await expect(createPerson(personInput))
+          .to.be.rejectedWith({code: 400, 
+            error: `Invalid parent type for [${JSON.stringify(
+              {name: 'apoorva', type: 'contact', parent: place1._id, reported_date: 12312312, contact_type: 'person'}
+            )}].`});
       });
     });
   });

--- a/tests/integration/shared-libs/cht-datasource/person.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/person.spec.js
@@ -210,17 +210,17 @@ describe('cht-datasource Person', () => {
 
     describe('createPerson', async () => {
       const createPerson = Person.v1.createPerson(dataContext);
-      // it('creates a person for a valid person input', async () => {
-      //   const personInput = Input.validatePersonInput({
-      //     name: 'apoorva',
-      //     type: 'person',
-      //     parent: place0._id
-      //   });
-      //   const person = await createPerson(personInput);
-      //   expect(person).excluding([ '_rev', 'reported_date', '_id' ])
-      //     .to.deep.equal({...personInput, contact_type: 'person', type: 'contact',
-      //       parent: {_id: place0._id, parent: place0.parent}});
-      // });
+      it('creates a person for a valid person input', async () => {
+        const personInput = Input.validatePersonInput({
+          name: 'apoorva',
+          type: 'person',
+          parent: place0._id
+        });
+        const person = await createPerson(personInput);
+        expect(person).excluding([ '_rev', 'reported_date', '_id' ])
+          .to.deep.equal({...personInput, contact_type: 'person', type: 'contact',
+            parent: {_id: place0._id, parent: place0.parent}});
+      });
 
       it('throws error for parent type not among allowed parents in settings.contact_types', async () => {
         const personInput = Input.validatePersonInput({

--- a/tests/integration/shared-libs/cht-datasource/person.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/person.spec.js
@@ -211,16 +211,15 @@ describe('cht-datasource Person', () => {
     describe('createPerson', async () => {
       const createPerson = Person.v1.createPerson(dataContext);
       // it('creates a person for a valid person input', async () => {
-      //   // console.log(await utils.getSettings().contact_types);
       //   const personInput = Input.validatePersonInput({
       //     name: 'apoorva',
       //     type: 'person',
-      //     parent: place1._id
+      //     parent: place0._id
       //   });
       //   const person = await createPerson(personInput);
       //   expect(person).excluding([ '_rev', 'reported_date', '_id' ])
       //     .to.deep.equal({...personInput, contact_type: 'person', type: 'contact',
-      //       parent: {_id: place1._id, parent: place1.parent}});
+      //       parent: {_id: place0._id, parent: place0.parent}});
       // });
 
       it('throws error for parent type not among allowed parents in settings.contact_types', async () => {

--- a/tests/integration/shared-libs/cht-datasource/person.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/person.spec.js
@@ -208,7 +208,7 @@ describe('cht-datasource Person', () => {
       });
     });
 
-    describe('createPerson', async () => {
+    describe.only('createPerson', async () => {
       const createPerson = Person.v1.createPerson(dataContext);
       it('creates a person for a valid person input', async () => {
         const personInput = Input.validatePersonInput({
@@ -226,13 +226,13 @@ describe('cht-datasource Person', () => {
         const personInput = Input.validatePersonInput({
           name: 'apoorva',
           type: 'person',
-          parent: place1._id,
+          parent: contact0._id,
           reported_date: 12312312
         });
         await expect(createPerson(personInput))
           .to.be.rejectedWith({code: 400, 
             error: `Invalid parent type for [${JSON.stringify(
-              {name: 'apoorva', type: 'contact', parent: place1._id, reported_date: 12312312, contact_type: 'person'}
+              {name: 'apoorva', type: 'contact', parent: contact0._id, reported_date: 12312312, contact_type: 'person'}
             )}].`});
       });
     });

--- a/tests/integration/shared-libs/cht-datasource/place.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/place.spec.js
@@ -230,13 +230,16 @@ describe('cht-datasource Place', () => {
         const placeInput = {
           name: 'place-1',
           type: 'place',
-          parent: 'p1',
-          contact: 'c1'
+          parent: contact0._id,
+          contact: contact1._id
         };
-
+        const updatedPlaceInput = {
+          ...placeInput, parent: {_id: contact0._id, parent: contact0.parent}, 
+          contact: {_id: contact1._id, parent: contact1.parent }
+        };
         const placeDoc = await Place.v1.createPlace(dataContext)(placeInput);
         expect(placeDoc).excluding([ '_rev', 'reported_date', '_id' ])
-          .to.deep.equal(placeInput);
+          .to.deep.equal(updatedPlaceInput);
       });
     });
   });

--- a/tests/integration/shared-libs/cht-datasource/report.spec.js
+++ b/tests/integration/shared-libs/cht-datasource/report.spec.js
@@ -244,11 +244,29 @@ describe('cht-datasource Report', () => {
       it('creates a report for a valid input', async () => {
         const input = {
           form: 'form-1',
-          type: 'report'
+          type: 'report',
+          contact: contact0._id
         };
 
+        const updatedInput = {
+          ...input, contact: {
+            _id: contact0._id, parent: contact0.parent
+          }
+        };
         const reportDoc = await Report.v1.createReport(dataContext)(Input.validateReportInput(input));
-        expect(reportDoc).excluding(['_id', '_rev', 'reported_date']).to.deep.equal(input);
+        expect(reportDoc).excluding(['_id', '_rev', 'reported_date',]).to.deep.equal(updatedInput);
+      });
+
+      it('throws error for missing contact', () => {
+        const input = {
+          form: 'form-1',
+          type: 'report',
+        };
+        const action = () => Report.v1.createReport(dataContext)(Input.validateReportInput(input));
+        expect(action).to.throw(
+          InvalidArgumentError,
+          `Missing or empty required field (contact) in [${JSON.stringify(input)}].`
+        );
       });
 
       it('throws error for invalid date format via createReport',  () => {


### PR DESCRIPTION
WIP PR to store `parent` and `contact` fields with a dehydrated lineage.

We would need to fetch the parent and check its type and ensure it is one of the preconfigured/ allowedparents for the currently created place/person's contact_type
This parent if valid(meaning has a `contact_type` from one of the allowed `parents`  in the contact type object for the given input) will later be used to store `parent` field with de-hydrated lineage in a person/place doc.
Previously, we just stored the `string` containing the parent `id` instead of the de-hydrated lineage.

TODO: Store `contact` with lineage in a place, which shouldn't be as tricky given that there is no validation we'd have to do based on settings.
# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

