### PR TITLE
chore(#10117): adds couch benchmark script to scalability suite

### DIFF
--- a/tests/scalability/block-device-mapping.json
+++ b/tests/scalability/block-device-mapping.json
@@ -4,7 +4,7 @@
     "VirtualName": "ephemeral",
     "Ebs": {
       "DeleteOnTermination": true,
-      "VolumeSize": 10
+      "VolumeSize": 15
     }
   }
 ]

--- a/tests/scalability/block-device-mapping.json
+++ b/tests/scalability/block-device-mapping.json
@@ -4,7 +4,7 @@
     "VirtualName": "ephemeral",
     "Ebs": {
       "DeleteOnTermination": true,
-      "VolumeSize": 15
+      "VolumeSize": 12
     }
   }
 ]

--- a/tests/scalability/block-device-mapping.json
+++ b/tests/scalability/block-device-mapping.json
@@ -1,6 +1,6 @@
 [
   {
-    "DeviceName": "/dev/xvdf",
+    "DeviceName": "/dev/sdf",
     "VirtualName": "ephemeral",
     "Ebs": {
       "DeleteOnTermination": true,

--- a/tests/scalability/block-device-mapping.json
+++ b/tests/scalability/block-device-mapping.json
@@ -1,6 +1,6 @@
 [
   {
-    "DeviceName": "/dev/sdf",
+    "DeviceName": "/dev/sda1",
     "VirtualName": "ephemeral",
     "Ebs": {
       "DeleteOnTermination": true,

--- a/tests/scalability/block-device-mapping.json
+++ b/tests/scalability/block-device-mapping.json
@@ -4,7 +4,7 @@
     "VirtualName": "ephemeral",
     "Ebs": {
       "DeleteOnTermination": true,
-      "VolumeSize": 2
+      "VolumeSize": 10
     }
   }
 ]

--- a/tests/scalability/couchdb-benchmark/all_docs.js
+++ b/tests/scalability/couchdb-benchmark/all_docs.js
@@ -1,0 +1,66 @@
+const request = require('@medic/couch-request');
+const { performance } = require('perf_hooks');
+const utils = require('./utils');
+
+const YES = 'Yes';
+
+const scenarios = [
+  { limit: 100, include_docs: false },
+  { limit: 1000, include_docs: false },
+  { limit: 10000, include_docs: false },
+
+  { limit: 100, include_docs: true },
+  { limit: 1000, include_docs: true },
+  { limit: 10000, include_docs: true },
+
+  { limit: 10000, keys: YES, include_docs: false },
+  { limit: 10000, keys: YES, include_docs: true },
+];
+
+const docIds = [];
+
+const populateDocIds = (response) => {
+  if (docIds.length) {
+    return;
+  }
+
+  const desiredLength = scenarios.find(scenario => scenario.keys).limit;
+  if (response.rows.length === desiredLength) {
+    docIds.push(...response.rows.map(row => row.id));
+  }
+};
+
+const test = async (params) => {
+  const queryString = {
+    include_docs: params.include_docs,
+  };
+  let method = 'get';
+  const options = { uri: `${utils.db}/_all_docs`, qs: queryString };
+
+  if (params.keys) {
+    options.body = { keys: docIds };
+    method = 'post';
+  }
+
+  if (params.limit) {
+    queryString.limit = params.limit;
+  }
+
+  const start = performance.now();
+  const response = await request[method](options);
+  const end = performance.now();
+
+  populateDocIds(response);
+
+  return parseInt(end - start);
+
+};
+
+module.exports = async () => {
+  const results = [];
+  for (const scenario of scenarios) {
+    const duration = await test(scenario);
+    results.push({ scenario, duration });
+  }
+  return results;
+};

--- a/tests/scalability/couchdb-benchmark/all_docs.js
+++ b/tests/scalability/couchdb-benchmark/all_docs.js
@@ -2,7 +2,7 @@ const request = require('@medic/couch-request');
 const { performance } = require('perf_hooks');
 const utils = require('./utils');
 
-const YES = 'Yes';
+const YES = 'true';
 
 const scenarios = [
   { limit: 100, include_docs: false },

--- a/tests/scalability/couchdb-benchmark/changes.js
+++ b/tests/scalability/couchdb-benchmark/changes.js
@@ -1,0 +1,103 @@
+const request = require('@medic/couch-request');
+const { performance } = require('perf_hooks');
+const utils = require('./utils');
+
+const MID_SEQ = 'Mid Sequence';
+const YES = 'Yes';
+
+const scenarios = [
+  { limit: 100, since: 0, include_docs: false },
+  { limit: 1000, since: 0, include_docs: false },
+  { limit: 10000, since: 0, include_docs: false },
+
+  { limit: 100, since: 0, include_docs: true },
+  { limit: 1000, since: 0, include_docs: true },
+  { limit: 10000, since: 0, include_docs: true },
+
+  { limit: 100, since: 0, include_docs: false, seq_interval: 100 },
+  { limit: 1000, since: 0, include_docs: false, seq_interval: 1000 },
+  { limit: 10000, since: 0, include_docs: false, seq_interval: 10000 },
+
+  { limit: 100, since: MID_SEQ, include_docs: false },
+  { limit: 1000, since: MID_SEQ, include_docs: false },
+  { limit: 10000, since: MID_SEQ, include_docs: false },
+
+  { limit: 100, since: MID_SEQ, include_docs: true },
+  { limit: 1000, since: MID_SEQ, include_docs: true },
+  { limit: 10000, since: MID_SEQ, include_docs: true },
+
+  { limit: 100, since: MID_SEQ, include_docs: false, seq_interval: 100 },
+  { limit: 1000, since: MID_SEQ, include_docs: false, seq_interval: 1000 },
+  { limit: 10000, since: MID_SEQ, include_docs: false, seq_interval: 1000 },
+
+  { limit: 10000, keys: YES, include_docs: false },
+  { limit: 10000, keys: YES, include_docs: true },
+  { limit: 10000, keys: YES, include_docs: false, seq_interval: 10000 },
+];
+
+const docIds = [];
+let midSeq = '';
+
+const getMidSeq = async () => {
+  if (midSeq) {
+    return midSeq;
+  }
+
+  const response = await request.get({ uri: `${utils.db}/_changes?limit=20000&seq_interval=200000` });
+  midSeq = response.last_seq;
+  return midSeq;
+};
+
+const populateDocIds = (response) => {
+  if (docIds.length) {
+    return;
+  }
+
+  const desiredLength = scenarios.find(scenario => scenario.keys).limit;
+  if (response.results.length === desiredLength) {
+    docIds.push(...response.results.map(row => row.id));
+  }
+};
+
+const test = async (params) => {
+  const queryString = {
+    limit: params.limit,
+    since: params.since,
+    include_docs: params.include_docs,
+  };
+  let method = 'get';
+  const options = { uri: `${utils.db}/_changes`, qs: queryString };
+
+  if (params.keys === YES) {
+    queryString.filter = '_doc_ids';
+    delete queryString.since;
+    delete queryString.limit;
+    options.body = { doc_ids: docIds };
+    method = 'post';
+  }
+
+  if (params.since === MID_SEQ) {
+    queryString.since = await getMidSeq();
+  }
+
+  if (params.seq_interval) {
+    queryString.seq_interval = params.seq_interval;
+  }
+
+  const start = performance.now();
+  const response = await request[method](options);
+  const end = performance.now();
+
+  populateDocIds(response);
+
+  return parseInt(end - start);
+};
+
+module.exports = async () => {
+  const results = [];
+  for (const scenario of scenarios) {
+    const duration = await test(scenario);
+    results.push({ scenario, duration });
+  }
+  return results;
+};

--- a/tests/scalability/couchdb-benchmark/changes.js
+++ b/tests/scalability/couchdb-benchmark/changes.js
@@ -3,7 +3,7 @@ const { performance } = require('perf_hooks');
 const utils = require('./utils');
 
 const MID_SEQ = 'Mid Sequence';
-const YES = 'Yes';
+const YES = 'true';
 
 const scenarios = [
   { limit: 100, since: 0, include_docs: false },

--- a/tests/scalability/couchdb-benchmark/index.js
+++ b/tests/scalability/couchdb-benchmark/index.js
@@ -1,0 +1,14 @@
+const { printResults, cleanFile } = require('./utils');
+
+const testChanges = require('./changes');
+const testAllDocs = require('./all_docs');
+
+(async () => {
+  await cleanFile();
+  await printResults('_changes', await testChanges());
+  await printResults('_all_docs', await testAllDocs());
+
+  // benchmark _bulk_get
+  // benchmark db-doc get (with large attachments)
+  // benchmark db-doc get (with large attachments got separately)
+})();

--- a/tests/scalability/couchdb-benchmark/index.js
+++ b/tests/scalability/couchdb-benchmark/index.js
@@ -1,10 +1,12 @@
-const { printResults, cleanFile } = require('./utils');
+const { printResults, cleanFile, writeDbInfo } = require('./utils');
 
 const testChanges = require('./changes');
 const testAllDocs = require('./all_docs');
 
 (async () => {
   await cleanFile();
+  await writeDbInfo();
+
   await printResults('_changes', await testChanges());
   await printResults('_all_docs', await testAllDocs());
 

--- a/tests/scalability/couchdb-benchmark/tdg-design.js
+++ b/tests/scalability/couchdb-benchmark/tdg-design.js
@@ -1,0 +1,338 @@
+const now = Date.now();
+
+const getPlace = (context, type, nameSuffix) => {
+  return {
+    type,
+    name: `Joanna's ${nameSuffix}`,
+    meta: {
+      created_by: context.username,
+      created_by_person_uuid: '',
+      created_by_place_uuid: ''
+    },
+    reported_date: now,
+  };
+};
+
+const getDistrictHospital = context => getPlace(context, 'district_hospital', 'Hospital');
+const getHealthCenter = context => getPlace(context, 'health_center', 'Health Center');
+const getHousehold = context => getPlace(context, 'clinic', 'Household');
+
+const getPerson = (context, role) => {
+  return {
+    type: 'person',
+    name: 'Joanna',
+    sex: '',
+    phone_alternate: '',
+    role: role,
+    external_id: '',
+    notes: '',
+    meta: {
+      created_by: context.username,
+      created_by_person_uuid: '',
+      created_by_place_uuid: ''
+    },
+    reported_date: now,
+  };
+};
+
+const getPatient = context => getPerson(context, 'patient');
+const getWoman = context => getPerson(context, 'patient');
+const getChild = context => getPerson(context, 'patient');
+const getInfant = context => getPerson(context, 'patient');
+
+
+const getPregnancyDangerSign = (patient) => {
+  return {
+    form: 'pregnancy_danger_sign',
+    type: 'data_record',
+    content_type: 'xml',
+    reported_date: now,
+    fields: {
+      patient_age_in_years: 34,
+      patient_name: patient.name,
+      patient_id: patient.patient_id,
+      t_danger_signs_referral_follow_up: 'yes', // Intentionally 'yes'
+      danger_signs: {
+        danger_signs_note: '',
+        danger_signs_question_note: '',
+        vaginal_bleeding: 'yes', // Intentionally 'yes'
+        refer_patient_note_1: '',
+        refer_patient_note_2: '',
+      },
+    },
+  };
+};
+
+
+const deathReport = (patient) => {
+  return {
+    form: 'death_report',
+    type: 'data_record',
+    content_type: 'xml',
+    reported_date: now,
+    fields: {
+      patient_name: patient.name,
+      patient_id: patient.patient_id,
+      death_details: {
+        date_of_death: now,
+        place_of_death: 'home',
+        death_information: '',
+      },
+    },
+  };
+};
+
+const pregnancyRegistration = (patient) => {
+  return {
+    form: 'pregnancy',
+    type: 'data_record',
+    content_type: 'xml',
+    reported_date: now,
+    fields: {
+      patient_age_in_years: 34,
+      patient_name: patient.name,
+      patient_id: patient.patient_id,
+      group_llin_parity: {
+        patient_llin: 'no'
+      },
+      group_anc_visit: {
+        anc_visit: 'no',
+        anc_visit_repeat: null,
+        prophylaxis_taken: 'no',
+        last_dose: null,
+        last_dose_date: null,
+        tt_imm: 'no',
+        tt_received: null,
+        tt_date: null,
+        given_mebendazole: 'no'
+      },
+      g_nutrition_screening: {
+        muac_score: 7478903295705088,
+        mother_weight: 8257856090406912,
+        last_fed: '6',
+        last_food: [
+          [
+            'milk'
+          ]
+        ],
+        mother_hiv_status: 'o',
+        mother_arv: null
+      },
+      group_risk_factors: {
+        gravida: 1,
+        parity: 1,
+        g_risk_factors: [
+          'r8'
+        ]
+      },
+      group_danger_signs: {
+        g_danger_signs: [
+          'd8',
+          'd3',
+          'd7',
+          'd2'
+        ]
+      },
+      lmp_method: 'calendar',
+      risk_factors: [
+        'r8'
+      ],
+      danger_signs: [
+        'd8',
+        'd3',
+        'd7',
+        'd2'
+      ],
+      anc_visit_identifier: '',
+      anc_last_bp_reading: '',
+      patient_age_at_lmp: 34,
+      days_since_lmp: 40,
+      weeks_since_lmp: 4
+    },
+  };
+};
+
+const getPNCDangerSignFollowUpBaby = (patient) => {
+  return {
+    form: 'pnc_danger_sign_follow_up_baby',
+    type: 'data_record',
+    content_type: 'xml',
+    reported_date: now,
+    fields: {
+      patient_age_in_years: 32,
+      patient_uuid: patient._id,
+      patient_id: patient.patient_id,
+      patient_name: patient.name,
+      t_danger_signs_referral_follow_up: 'yes',
+      danger_signs: {
+        visit_confirm: 'yes',
+        danger_sign_present: 'yes',
+        danger_signs_question_note: '',
+        r_danger_sign_present: 'yes',
+        congratulate_no_ds_note: '',
+        refer_patient_note_1: '',
+        refer_patient_note_2: ''
+      }
+    }
+  };
+};
+
+const getPregnancyHomeVisit = (patient) => {
+  return {
+    form: 'pregnancy_home_visit',
+    type: 'data_record',
+    content_type: 'xml',
+    reported_date: now,
+    fields: {
+      patient_age_in_years: 43,
+      patient_uuid: patient._id,
+      patient_id: patient.patient_id,
+      patient_name: patient.name,
+      patient_short_name: '',
+      patient_short_name_start: '',
+      lmp_method_approx: 'approx',
+      danger_signs: {
+        vaginal_bleeding: 'yes',
+        fits: 'yes',
+        severe_abdominal_pain: 'yes',
+        severe_headache: 'yes',
+        very_pale: 'yes',
+        fever: 'yes',
+        reduced_or_no_fetal_movements: 'yes',
+        breaking_water: 'yes',
+        easily_tired: 'yes',
+        face_hand_swelling: 'yes',
+        breathlessness: 'yes',
+        r_danger_sign_present: 'yes',
+      },
+      safe_pregnancy_practices: {
+        malaria: {
+          llin_use: 'yes',
+        },
+        iron_folate: {
+          iron_folate_daily: 'yes',
+        },
+        deworming: {
+          deworming_med: 'yes',
+        },
+        hiv_status: {
+          hiv_tested: 'yes',
+        },
+        tetanus: {
+          tt_imm_received: 'yes',
+        },
+        safe_pregnancy_practices: 'yes',
+      }
+    }
+  };
+};
+
+module.exports = (context) => {
+  return [
+    {
+      designId: 'district-hospital',
+      amount: 30,
+      db: 'not-medic',
+      getDoc: () => getDistrictHospital(context),
+      children: [
+        {
+          designId: 'health-center',
+          amount: 100,
+          db: 'not-medic',
+          getDoc: () => getHealthCenter(context),
+          children: [
+            {
+              designId: 'household',
+              amount: 20,
+              db: 'not-medic',
+              getDoc: () => getHousehold(context),
+              children: [
+                {
+                  designId: 'woman-person',
+                  amount: 1,
+                  db: 'not-medic',
+                  getDoc: () => getWoman(context),
+                  children: [
+                    {
+                      designId: 'pregnancy-report',
+                      amount: 1,
+                      db: 'not-medic',
+                      getDoc: ({parent}) => pregnancyRegistration(parent),
+                    },
+                    {
+                      designId: 'pregnancy-home-visit',
+                      amount: 1,
+                      db: 'not-medic',
+                      getDoc: ({parent}) => getPregnancyHomeVisit(parent),
+                    }
+                  ]
+                },
+                {
+                  designId: 'woman-person',
+                  amount: 1,
+                  db: 'not-medic',
+                  getDoc: () => getWoman(context),
+                  children: [
+                    {
+                      designId: 'pregnancy-danger-report',
+                      amount: 1,
+                      db: 'not-medic',
+                      getDoc: ({parent}) => getPregnancyDangerSign(parent),
+                    },
+                    {
+                      designId: 'pregnancy-report',
+                      amount: 1,
+                      db: 'not-medic',
+                      getDoc: ({parent}) => pregnancyRegistration(parent),
+                    },
+
+                  ]
+                },
+                {
+                  designId: 'child-person',
+                  amount: 2,
+                  db: 'not-medic',
+                  getDoc: () => getChild(context),
+                },
+                {
+                  designId: 'infant-person',
+                  amount: 1,
+                  db: 'not-medic',
+                  getDoc: () => getInfant(context),
+                  children: [
+                    {
+                      designId: 'pnc_danger_sign_follow_up_baby-report',
+                      amount: 1,
+                      db: 'not-medic',
+                      getDoc: ({parent}) => getPNCDangerSignFollowUpBaby(parent),
+                    },
+                  ]
+                },
+                {
+                  designId: 'patient-person',
+                  amount: 2,
+                  db: 'not-medic',
+                  getDoc: () => getPatient(context),
+                },
+                {
+                  designId: 'patient-person',
+                  amount: 1,
+                  db: 'not-medic',
+                  getDoc: () => getPatient(context),
+                  children: [
+                    {
+                      designId: 'death-report',
+                      amount: 1,
+                      db: 'not-medic',
+                      getDoc: ({parent}) => deathReport(parent),
+                    }
+                  ]
+                }
+              ]
+            },
+          ]
+        },
+      ]
+    },
+  ];
+};

--- a/tests/scalability/couchdb-benchmark/tdg-design.js
+++ b/tests/scalability/couchdb-benchmark/tdg-design.js
@@ -231,7 +231,7 @@ module.exports = (context) => {
   return [
     {
       designId: 'district-hospital',
-      amount: 2,
+      amount: 30,
       db: 'not-medic',
       getDoc: () => getDistrictHospital(context),
       children: [

--- a/tests/scalability/couchdb-benchmark/tdg-design.js
+++ b/tests/scalability/couchdb-benchmark/tdg-design.js
@@ -231,7 +231,7 @@ module.exports = (context) => {
   return [
     {
       designId: 'district-hospital',
-      amount: 30,
+      amount: 2,
       db: 'not-medic',
       getDoc: () => getDistrictHospital(context),
       children: [

--- a/tests/scalability/couchdb-benchmark/utils.js
+++ b/tests/scalability/couchdb-benchmark/utils.js
@@ -1,5 +1,6 @@
 const fs = require('fs').promises;
 const path = require('path');
+const request = require('@medic/couch-request');
 
 const FILE_NAME = path.join(__dirname, '..', 'benchmark_results.md');
 
@@ -29,9 +30,31 @@ const printResults = async (endpoint, results) => {
   await fs.appendFile(FILE_NAME, formatted, 'utf8');
 };
 
+const getServerInfo = async () => {
+  const serverURL = new URL(module.exports.db);
+  serverURL.pathname = '';
+
+  return await request.get({ url: serverURL.toString() });
+};
+
+const writeDbInfo = async () => {
+  const dbInfo = await request.get({ url: module.exports.db });
+  const serverInfo = await getServerInfo();
+
+  let formatted = '# CouchDb Performance\n';
+
+  formatted += `## Database Info\n`;
+  formatted += `CouchDb version: ${serverInfo.version}\n\n`;
+  formatted += `Database doc count: ${dbInfo.doc_count}\n\n`;
+  formatted += '\n\n';
+
+  await fs.appendFile(FILE_NAME, formatted, 'utf8');
+};
+
 module.exports = {
   printResults,
   cleanFile,
+  writeDbInfo,
   db: process.env.COUCH_URL || 'http://localhost:5984/medic',
 };
 

--- a/tests/scalability/couchdb-benchmark/utils.js
+++ b/tests/scalability/couchdb-benchmark/utils.js
@@ -1,0 +1,37 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const FILE_NAME = path.join(__dirname, '..', 'benchmark_results.md');
+
+const cleanFile = () => fs.writeFile(FILE_NAME, '', 'utf8');
+
+const printResults = async (endpoint, results) => {
+  let formatted = '';
+  formatted += `## ${endpoint} \n`;
+
+  const headers = new Set();
+  results.forEach(({ scenario }) => {
+    const keys = Object.keys(scenario);
+    keys.forEach(key => headers.add(key));
+  });
+
+  headers.forEach(header => formatted += `| ${header}`);
+  formatted += '| Duration (ms) |\n';
+  formatted += Array.from({ length: headers.size + 2 }).join('|--');
+  formatted += '|\n';
+
+  results.forEach(({ scenario, duration }) => {
+    const values = [];
+    headers.forEach(key => values.push(scenario[key] || ''));
+    formatted += `| ${values.join(' | ')} | ${duration} |\n`;
+  });
+
+  await fs.appendFile(FILE_NAME, formatted, 'utf8');
+};
+
+module.exports = {
+  printResults,
+  cleanFile,
+  db: 'http://admin:pass@localhost:5984/medic'
+};
+process.env.COUCH_URL = module.exports.db; // required by @medic/environment

--- a/tests/scalability/couchdb-benchmark/utils.js
+++ b/tests/scalability/couchdb-benchmark/utils.js
@@ -8,7 +8,7 @@ const cleanFile = () => fs.writeFile(FILE_NAME, '', 'utf8');
 
 const printResults = async (endpoint, results) => {
   let formatted = '';
-  formatted += `## ${endpoint} \n`;
+  formatted += `## ${endpoint} benchmark \n`;
 
   const headers = new Set();
   results.forEach(({ scenario }) => {
@@ -27,6 +27,8 @@ const printResults = async (endpoint, results) => {
     formatted += `| ${values.join(' | ')} | ${duration} |\n`;
   });
 
+  formatted += '\n\n';
+
   await fs.appendFile(FILE_NAME, formatted, 'utf8');
 };
 
@@ -41,12 +43,11 @@ const writeDbInfo = async () => {
   const dbInfo = await request.get({ url: module.exports.db });
   const serverInfo = await getServerInfo();
 
-  let formatted = '# CouchDb Performance\n';
+  let formatted = '# CouchDb Performance benchmark \n\n';
 
-  formatted += `## Database Info\n`;
+  formatted += `## Database Info\n\n`;
   formatted += `CouchDb version: ${serverInfo.version}\n\n`;
   formatted += `Database doc count: ${dbInfo.doc_count}\n\n`;
-  formatted += '\n\n';
 
   await fs.appendFile(FILE_NAME, formatted, 'utf8');
 };

--- a/tests/scalability/couchdb-benchmark/utils.js
+++ b/tests/scalability/couchdb-benchmark/utils.js
@@ -32,6 +32,6 @@ const printResults = async (endpoint, results) => {
 module.exports = {
   printResults,
   cleanFile,
-  db: 'http://admin:pass@localhost:5984/medic'
+  db: process.env.COUCH_URL || 'http://localhost:5984/medic',
 };
-process.env.COUCH_URL = module.exports.db; // required by @medic/environment
+

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -1,66 +1,116 @@
 #!/bin/bash
+
+readonly CHT_BASE_DIR="/cht"
+
 # Fail job when script errors
 set -e
 
 shutdown -P +60
 
-mkdir -p /cht
-chmod 777 /cht
-cd cht
+updateSystem() {
+  apt-get update
 
-echo Cloning cht-core to /cht-core
-git clone --single-branch --branch "$TAG" https://github.com/medic/cht-core.git
+  echo installing JAVA
+  apt-get install default-jre -y
 
-export NODE_TLS_REJECT_UNAUTHORIZED=0
+  echo installing node
+  curl -sL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh
+  sudo bash nodesource_setup.sh # install node 22
+  apt-get install nodejs bzip2 # some npm dependency needs to be unzipped
+}
 
-apt-get update
+setupCHT() {
+  mkdir -p "$CHT_BASE_DIR"
+  chmod 777 "$CHT_BASE_DIR"
+  cd "$CHT_BASE_DIR"
 
-echo installing JAVA
-apt-get install default-jre -y
+  echo Cloning cht-core to /cht-core
+  git clone --single-branch --branch "$TAG" https://github.com/medic/cht-core.git
 
-echo installing node
-curl -sL https://deb.nodesource.com/setup_22.x -o nodesource_setup.sh
-sudo bash nodesource_setup.sh # install node 22
-apt-get install nodejs bzip2 # some npm dependency needs to be unzipped
+  cd cht-core
+  npm install patch-package
 
-cd cht-core
-npm install patch-package
-cd webapp && npm ci && cd ../
-cd tests/scalability
-echo "Changing config to match url arg"
-node -p "const fs = require('fs');var path = './config.json';var config = JSON.stringify({...require(path), url: '$MEDIC_URL'}, null, 2);fs.writeFileSync(path,config,{encoding:'utf8',flag:'w'});"
-echo "npm install for jmeter suite"
-npm ci
+  cd webapp && npm ci && cd ../ # the bootstrap scripts have some dependencies (eurodigit for example)
 
-echo "jmeter install"
-wget https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.3.tgz -O ./apache-jmeter.tgz
-mkdir -p ./jmeter
-tar -xf apache-jmeter.tgz -C ./jmeter --strip-components=1
+  cd tests/scalability
 
-echo "Installing Plugins"
-wget  https://repo1.maven.org/maven2/kg/apc/jmeter-plugins-manager/1.4/jmeter-plugins-manager-1.4.jar -O ./jmeter/lib/ext/jmeter-plugins-manager-1.4.jar
-wget 'http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar' -O ./jmeter/lib/cmdrunner-2.2.jar
-java -cp jmeter/lib/ext/jmeter-plugins-manager-1.4.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
-./jmeter/bin/PluginsManagerCMD.sh install jpgc-mergeresults
+  # Update the url field using jq and save to the config file
+  jq --arg url "$MEDIC_URL" '.url = $url' config.json > temp.json && mv temp.json config.json
+  npm ci
+}
 
-echo "jmeter do it!"
-tmp_dir=$(mktemp -d -t -p ./ report-XXXXXXXXXX)
-./jmeter/bin/jmeter -n  -t sync.jmx -Jworking_dir="$tmp_dir" -Jnode_binary="$(which node)" -Jnumber_of_threads=10 -l "$tmp_dir"/cli_run.jtl -e -o "$tmp_dir"
-mv ./jmeter.log "$tmp_dir"/jmeter.log
+setupJmeter() {
+  echo "Installing JMeter..."
+  wget https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.3.tgz -O ./apache-jmeter.tgz
+  mkdir -p ./jmeter
+  tar -xf apache-jmeter.tgz -C ./jmeter --strip-components=1
 
-cd /cht
+  echo "Installing JMeter Plugins"
+  wget  https://repo1.maven.org/maven2/kg/apc/jmeter-plugins-manager/1.4/jmeter-plugins-manager-1.4.jar -O ./jmeter/lib/ext/jmeter-plugins-manager-1.4.jar
+  wget 'http://search.maven.org/remotecontent?filepath=kg/apc/cmdrunner/2.2/cmdrunner-2.2.jar' -O ./jmeter/lib/cmdrunner-2.2.jar
+  java -cp jmeter/lib/ext/jmeter-plugins-manager-1.4.jar org.jmeterplugins.repository.PluginManagerCMDInstaller
+  ./jmeter/bin/PluginsManagerCMD.sh install jpgc-mergeresults
+}
 
-remote_repo="https://x-access-token:${GH_TOKEN}@github.com/medic/scalability-results.git"
-git clone "$remote_repo"
-cd scalability-results
-git config http.sslVerify false
-git config user.name "github-actions[bot]"
-git config user.email "github-actions[bot]@users.noreply.github.com"
-git remote set-url origin "$remote_repo"
-mkdir -p results
-rsync -rv --exclude='*/' "/cht/cht-core/tests/scalability/$tmp_dir/" results/"$DATA_PATH"
-git add -A
-git commit -m "scalability results for $TAG"
-git push origin main
+runJmeterScalabilityTest() {
+  echo "Executing JMeter test..."
+  export NODE_TLS_REJECT_UNAUTHORIZED=0
+  tmp_dir=$(mktemp -d -t -p ./ report-XXXXXXXXXX)
+  ./jmeter/bin/jmeter -n  -t sync.jmx -Jworking_dir="$tmp_dir" -Jnode_binary="$(which node)" -Jnumber_of_threads=10 -l "$tmp_dir"/cli_run.jtl -e -o "$tmp_dir"
+  mv ./jmeter.log "$tmp_dir"/jmeter.log
+}
 
-echo "FINISHED! "
+setupTestDataGenerator() {
+  cd "$CHT_BASE_DIR"
+  echo "installing test data generator"
+  git clone https://github.com/medic/test-data-generator.git
+  cd test-data-generator
+  npm ci
+  export COUCH_URL=$MEDIC_URL
+  npm run generate "$CHT_BASE_DIR"/cht-core/tests/scalability/couchdb-benchmark/tdg-design.js
+}
+
+runCouchDbBenchmark() {
+  cd "$CHT_BASE_DIR/cht-core/tests/scalability/couchdb-benchmark"
+  node index.js
+  cd ../
+  cp benchmark_results.md "$tmp_dir/benchmark_results.md"
+}
+
+uploadResults() {
+  cd "$CHT_BASE_DIR"
+
+  remote_repo="https://x-access-token:${GH_TOKEN}@github.com/medic/scalability-results.git"
+  git clone "$remote_repo"
+  cd scalability-results
+
+  # Configure git
+  git config http.sslVerify false
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git remote set-url origin "$remote_repo"
+
+  # Copy and commit results
+  mkdir -p results
+  rsync -rv --exclude='*/' "$CHT_BASE_DIR/cht-core/tests/scalability/$tmp_dir/" results/"$DATA_PATH"
+  git add -A
+  git commit -m "scalability results for $TAG"
+  git push origin main
+}
+
+# Main execution
+main() {
+  updateSystem
+  setupCHT
+
+  setupJmeter
+  runJmeterScalabilityTest
+
+  setupTestDataGenerator
+  runCouchDbBenchmark
+
+  uploadResults
+}
+
+main
+

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -66,13 +66,14 @@ setupTestDataGenerator() {
   git clone https://github.com/medic/test-data-generator.git
   cd test-data-generator
   npm ci
-  export COUCH_URL=$MEDIC_URL
+  export COUCH_URL=$MEDIC_URL_AUTH
+  curl -k -sf -X PUT "$MEDIC_URL_AUTH/not-medic"
   npm run generate "$CHT_BASE_DIR"/cht-core/tests/scalability/couchdb-benchmark/tdg-design.js
 }
 
 runCouchDbBenchmark() {
   cd "$CHT_BASE_DIR/cht-core/tests/scalability/couchdb-benchmark"
-  export COUCH_URL=$MEDIC_URL/not-medic
+  export COUCH_URL=$MEDIC_URL_AUTH/not-medic
   node index.js
   cd ../
   cp benchmark_results.md "$tmp_dir/benchmark_results.md"

--- a/tests/scalability/run_suite.sh
+++ b/tests/scalability/run_suite.sh
@@ -72,6 +72,7 @@ setupTestDataGenerator() {
 
 runCouchDbBenchmark() {
   cd "$CHT_BASE_DIR/cht-core/tests/scalability/couchdb-benchmark"
+  export COUCH_URL=$MEDIC_URL/not-medic
   node index.js
   cd ../
   cp benchmark_results.md "$tmp_dir/benchmark_results.md"

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -67,11 +67,11 @@ seedData () {
 }
 
 forwardSentinelSeq () {
-  last_seq=$(curl "$1/medic/_changes?limit=1&descending=true" -s -k | jq '.last_seq')
+  last_seq=$(curl -k -sf "$1/medic/_changes?limit=1&descending=true" | jq '.last_seq')
   # Update sentinel queue
-  sentinel_queue=$(curl -s -X GET "$1/medic-sentinel/_local/transitions-seq" | jq --arg seq "$last_seq" '.value=$seq')
+  sentinel_queue=$(curl -sf -k "$1/medic-sentinel/_local/transitions-seq" | jq --arg seq "$last_seq" '.value=$seq')
   # Put the updated sequence
-  curl -X PUT "$1/medic-sentinel/_local/transitions-seq" \
+  curl -k -sf -X PUT "$1/medic-sentinel/_local/transitions-seq" \
     -H "Content-Type: application/json" \
     --data "$sentinel_queue"
 

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -70,7 +70,7 @@ forwardSentinelSeq () {
   local interval="${2:-15}"  # Default to 30 seconds if not specified
 
   while true; do
-    active_tasks=$(curl -sf -k "$url/_active_tasks" | jq '. | length')
+    active_tasks=$(curl -sf -k "$1/_active_tasks" | jq '. | length')
 
     # Check if the request was successful and got a number
     if [ "$active_tasks" -eq 0 ]; then

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -67,6 +67,21 @@ seedData () {
 }
 
 forwardSentinelSeq () {
+  local interval="${2:-15}"  # Default to 30 seconds if not specified
+
+  while true; do
+    active_tasks=$(curl -sf -k "$url/_active_tasks" | jq '. | length')
+
+    # Check if the request was successful and got a number
+    if [ "$active_tasks" -eq 0 ]; then
+      echo "view indexing complete"
+      break
+    else
+      echo "Found $active_tasks active tasks. Waiting $interval seconds before next check..."
+      sleep "$interval"
+    fi
+  done
+
   last_seq=$(curl -k -sf "$1/medic/_changes?limit=1&descending=true" | jq '.last_seq')
   # Update sentinel queue
   sentinel_queue=$(curl -sf -k "$1/medic-sentinel/_local/transitions-seq" | jq --arg seq "$last_seq" '.value=$seq')

--- a/tests/scalability/start-ec2-cht.sh
+++ b/tests/scalability/start-ec2-cht.sh
@@ -113,6 +113,7 @@ seedData "$MEDIC_CONF_URL"
 forwardSentinelSeq "$MEDIC_CONF_URL"
 
 sed -i '4s~^~'MEDIC_URL="$url"'\n~' run_suite.sh
+sed -i '4s~^~'MEDIC_URL_AUTH="$MEDIC_CONF_URL"'\n~' run_suite.sh
 sed -i '4s~^~'TAG="$TAG"'\n~' run_suite.sh
 sed -i '4s~^~'DATA_PATH="$TAG-$GITHUB_RUN_ID"'\n~' run_suite.sh
 sed -i '4s~^~'GH_TOKEN="$SCALABILITY_RESULTS_TOKEN"'\n~' run_suite.sh


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Runs additional script during the scalability suite that benchmarks CouchDb endpoint performance. 
So far only covers _changes and _all_docs. 
The script pushes ~1mil docs to a database (to avoid view indexing) using `test-data-generator` and runs a series of requests, with diverse parameters, and records the results. 

Sample results: https://github.com/medic/scalability-results/blob/main/results/10117-couch-benchmark-16117387181/benchmark_results.md

closes #10117 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

