### PR TITLE
chore(#10125): remove server and socket options from couch config

### DIFF
--- a/couchdb/10-docker-default.ini
+++ b/couchdb/10-docker-default.ini
@@ -16,8 +16,6 @@ changes_doc_ids_optimization_threshold = 40000
 [chttpd]
 port = 5984
 bind_address = 0.0.0.0
-server_options = [{recbuf, 262144}]
-socket_options = [{sndbuf, 262144}, {nodelay, true}]
 require_valid_user = true
 
 [httpd]


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Removes server_options overriding sndbuff: https://github.com/apache/couchdb/issues/1810
Removes socket_options as they are identical with CouchDb defaults: https://github.com/apache/couchdb/blob/main/src/chttpd/src/chttpd.erl#L97

closes #10125

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10125-no-sever-options/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10125-no-sever-options/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10125-no-sever-options/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

