### PR TITLE
[4.21.x] increase downward syncs interval from 5 min to 30 min

### DIFF
--- a/webapp/src/ts/services/db-sync.service.ts
+++ b/webapp/src/ts/services/db-sync.service.ts
@@ -20,7 +20,7 @@ const READ_ONLY_IDS = ['resources', 'branding', 'service-worker-meta', 'zscore-c
 const DDOC_PREFIX = ['_design/'];
 const LAST_REPLICATED_SEQ_KEY = 'medic-last-replicated-seq';
 const LAST_REPLICATED_DATE_KEY = 'medic-last-replicated-date';
-const SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
+// const SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
 const META_SYNC_INTERVAL = 30 * 60 * 1000; // 30 minutes
 const BATCH_SIZE = 100;
 const MAX_SUCCESSIVE_SYNCS = 2;
@@ -307,7 +307,7 @@ export class DBSyncService {
     this.intervalPromises.sync = setInterval(() => {
       this.syncIsRecent = false;
       this.sync();
-    }, SYNC_INTERVAL);
+    }, META_SYNC_INTERVAL);
   }
 
   private displayUserFeedback(syncState: SyncState) {

--- a/webapp/tests/karma/ts/services/db-sync.service.spec.ts
+++ b/webapp/tests/karma/ts/services/db-sync.service.spec.ts
@@ -49,6 +49,8 @@ describe('DBSync service', () => {
 
   let clock;
 
+  const SYNC_INTERVAL = 30 * 60 * 1000;
+
   const realSetTimeout = setTimeout;
   const nextTick = () => new Promise<void>(resolve => realSetTimeout(resolve));
 
@@ -253,7 +255,7 @@ describe('DBSync service', () => {
       await service.sync();
       expectSyncCall(1);
       expect(migrationService.runMigrations.callCount).to.equal(1);
-      clock.tick(5 * 60 * 1000 + 1);
+      clock.tick(SYNC_INTERVAL + 1);
       await nextTick();
       expectSyncCall(2);
     });
@@ -370,7 +372,7 @@ describe('DBSync service', () => {
       expectSyncCall(1);
       // go offline, don't attempt to sync
       service.setOnlineStatus(false);
-      clock.tick(25 * 60 * 1000 + 1);
+      clock.tick(4 * SYNC_INTERVAL + 1);
       await nextTick();
       expectSyncCall(1);
 
@@ -389,7 +391,7 @@ describe('DBSync service', () => {
       expectSyncCall(2);
 
       // eventually, sync on the timer
-      clock.tick(5 * 60 * 1000 + 1);
+      clock.tick(SYNC_INTERVAL + 1);
       await nextTick();
 
       expectSyncCall(3);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.21.x-sync-interval-30/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.21.x-sync-interval-30/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:4.21.x-sync-interval-30/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

