### PR TITLE
fix(#9835): fix missing `reported_date` bug

### DIFF
--- a/shared-libs/cht-datasource/src/local/libs/core.ts
+++ b/shared-libs/cht-datasource/src/local/libs/core.ts
@@ -1,4 +1,4 @@
-import { hasField, isRecord, Nullable } from '../../libs/core';
+import { convertToUnixTimestamp, hasField, isRecord, Nullable } from '../../libs/core';
 import { Doc } from '../../libs/doc';
 import { InvalidArgumentError } from '../../libs/error';
 
@@ -81,6 +81,9 @@ export const ensureHasRequiredFields = (
   updateInput: Record<string, unknown>,
 ): void => {
   const missingFieldsList = [];
+  if (updateInput.reported_date){
+    updateInput.reported_date = convertToUnixTimestamp(updateInput.reported_date as string | number);
+  }
   // ensure required immutable fields have the same value as the original doc.
   for (const field of [ ...immutableFields, ...mutableFields ]) {
     if (!hasField(

--- a/shared-libs/cht-datasource/src/local/libs/core.ts
+++ b/shared-libs/cht-datasource/src/local/libs/core.ts
@@ -1,4 +1,4 @@
-import { convertToUnixTimestamp, hasField, isRecord, Nullable } from '../../libs/core';
+import { convertToUnixTimestamp, hasField, Nullable } from '../../libs/core';
 import { Doc } from '../../libs/doc';
 import { InvalidArgumentError } from '../../libs/error';
 
@@ -36,19 +36,6 @@ export const addParentToInput = <T extends HasParentOrContact>(
   return {
     ...input,
     [key]: value,
-  };
-};
-
-/** @internal*/
-export const dehydrateDoc = (lineage: Record<string, unknown>): Record<string, unknown> => {
-  if (isRecord(lineage.parent)) {
-    return {
-      _id: lineage._id,
-      parent: dehydrateDoc(lineage.parent)
-    };
-  }
-  return {
-    _id: lineage._id
   };
 };
 

--- a/shared-libs/cht-datasource/test/libs/core.spec.ts
+++ b/shared-libs/cht-datasource/test/libs/core.spec.ts
@@ -14,7 +14,8 @@ import {
   isNormalizedParent,
   isRecord,
   isString,
-  NonEmptyArray
+  NonEmptyArray,
+  convertToUnixTimestamp
 } from '../../src/libs/core';
 import sinon, { SinonStub } from 'sinon';
 
@@ -303,6 +304,41 @@ describe('core lib', () => {
         isDataObject.returns(dataObj);
         expect(isNormalizedParent(value)).to.equal(expected);
       });
+    });
+  });
+
+  describe('convertToUnixTimeStamp', () => {
+    it('should return the same number if input is already a unix epoch', () => {
+      const epoch = 1704067200000;
+      expect(convertToUnixTimestamp(epoch)).to.equal(epoch);
+    });
+  
+    it('should parse a date in \'YYYY-MM-DDTHH:mm:ssZ\' format', () => {
+      const dateStr = '2024-01-01T00:00:00Z';
+      const expected = new Date(dateStr).getTime();
+      expect(convertToUnixTimestamp(dateStr)).to.equal(expected);
+    });
+  
+    it('should parse a date in \'YYYY-MM-DDTHH:mm:ss.SSSZ\' format', () => {
+      const dateStr = '2024-01-01T12:34:56.789Z';
+      const expected = new Date(dateStr).getTime();
+      expect(convertToUnixTimestamp(dateStr)).to.equal(expected);
+    });
+  
+    it('should throw an error for invalid date strings', () => {
+      const invalid = 'not-a-date';
+      expect(() => convertToUnixTimestamp(invalid)).to.throw(
+        'Invalid reported_date. '
+        +'Expected format to be \'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.'
+      );
+    });
+  
+    it('should throw an error for non-string/number input', () => {
+      // @ts-expect-error: passing invalid type intentionally
+      expect(() => convertToUnixTimestamp({})).to.throw(
+        'Invalid reported_date. ' +
+        'Expected format to be \'YYYY-MM-DDTHH:mm:ssZ\', \'YYYY-MM-DDTHH:mm:ss.SSSZ\', or a Unix epoch.'
+      );
     });
   });
 });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

 We autoconvert the update payload's `reported_date`
 to a unix epoch before doing the validation checks
 with the original document.
    
Fixes: https://github.com/medic/cht-core/pull/10083#issuecomment-3227044948.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

