### PR TITLE
chore(#8157): remove use of translationdoc.enabled

### DIFF
--- a/api/src/migrations/remove-enabled-from-translation-docs.js
+++ b/api/src/migrations/remove-enabled-from-translation-docs.js
@@ -1,0 +1,24 @@
+const settingsService = require('../services/settings');
+const db = require('../db');
+const translations = require('../translations');
+
+module.exports = {
+  name: 'remove-enabled-from-translation-docs',
+  created: new Date('2025-09-01'),
+  run: async () => {
+    const settings = await settingsService.get();
+    if (settings.languages) {
+      return;
+    }
+
+    const translationDocs = await translations.getTranslationDocs();
+    const enabledLocales = translationDocs.filter(doc => doc.enabled).map(doc => doc.code);
+
+    const languages = Object.keys(translations.localeNames())
+      .map(code => ({ locale: code, enabled: enabledLocales.includes(code) }));
+    await settingsService.update({ languages });
+
+    translationDocs.forEach(doc => delete doc.enabled);
+    await db.medic.bulkDocs(translationDocs);
+  }
+};

--- a/api/tests/mocha/migrations/remove-enabled-from-translation-docs.spec.js
+++ b/api/tests/mocha/migrations/remove-enabled-from-translation-docs.spec.js
@@ -1,0 +1,96 @@
+const sinon = require('sinon');
+const chai = require('chai');
+
+const db = require('../../../src/db');
+const settingsService = require('../../../src/services/settings');
+const translations = require('../../../src/translations');
+const migration = require('../../../src/migrations/remove-enabled-from-translation-docs');
+
+describe('remove-enabled-from-translation-docs migration', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should have basic properties', () => {
+    chai.expect(migration.name).to.equal('remove-enabled-from-translation-docs');
+    // Compare date in a timezone-agnostic way
+    const expectedCreationDate = new Date(2025, 8, 1).toDateString();
+    chai.expect(migration.created).to.exist;
+    chai.expect(migration.created.toDateString()).to.equal(expectedCreationDate);
+    chai.expect(migration.run).to.be.a('function');
+  });
+
+  it('should be a no-op when settings already define languages', async () => {
+    sinon.stub(settingsService, 'get').resolves({ languages: [ { locale: 'en', enabled: true } ] });
+    sinon.stub(settingsService, 'update');
+    sinon.stub(translations, 'getTranslationDocs');
+    sinon.stub(db.medic, 'bulkDocs');
+
+    await migration.run();
+
+    chai.expect(settingsService.get.callCount).to.equal(1);
+    chai.expect(settingsService.update.callCount).to.equal(0);
+    chai.expect(translations.getTranslationDocs.callCount).to.equal(0);
+    chai.expect(db.medic.bulkDocs.callCount).to.equal(0);
+  });
+
+  it('should move enabled flags from translation docs into settings and remove from docs', async () => {
+    // Arrange settings with no languages configured
+    sinon.stub(settingsService, 'get').resolves({});
+    const LOCAL_NAME_MAP = { en: 'English', es: 'Español', fr: 'Français' };
+    sinon.stub(translations, 'localeNames').returns(LOCAL_NAME_MAP);
+
+    // translation documents include only some codes and enabled flags
+    const docs = [
+      { _id: 'messages-en', type: 'translations', code: 'en', name: 'English', enabled: true },
+      { _id: 'messages-es', type: 'translations', code: 'es', name: 'Español', enabled: false },
+      { _id: 'messages-fr', type: 'translations', code: 'fr', name: 'Français' }, // undefined => treated as disabled
+    ];
+
+    // Stub modules used by migration
+    sinon.stub(translations, 'getTranslationDocs').resolves(docs.map(d => ({ ...d })));
+
+    sinon.stub(settingsService, 'update').resolves();
+    sinon.stub(db.medic, 'bulkDocs').resolves();
+
+    await migration.run();
+
+    const expectedLanguages = [
+      { locale: 'en', enabled: true },
+      { locale: 'es', enabled: false },
+      { locale: 'fr', enabled: false },
+    ];
+    chai.expect(settingsService.update.callCount).to.equal(1);
+    chai.expect(settingsService.update.firstCall.args[0]).to.deep.equal({ languages: expectedLanguages });
+
+    // Assert enabled removed from docs and bulk saved
+    chai.expect(db.medic.bulkDocs.callCount).to.equal(1);
+    const savedDocs = db.medic.bulkDocs.firstCall.args[0];
+    chai.expect(savedDocs).to.have.length(3);
+    savedDocs.forEach((saved, idx) => {
+      const original = docs[idx];
+      chai.expect(saved._id).to.equal(original._id);
+      chai.expect(saved.code).to.equal(original.code);
+      chai.expect(saved).to.not.have.property('enabled');
+    });
+  });
+
+  it('should propagate errors from settings update', async () => {
+    sinon.stub(settingsService, 'get').resolves({});
+    const LOCAL_NAME_MAP = { en: 'English' };
+    sinon.stub(translations, 'localeNames').returns(LOCAL_NAME_MAP);
+    sinon.stub(translations, 'getTranslationDocs').resolves([
+      { _id: 'messages-en', type: 'translations', code: 'en', name: 'English', enabled: true },
+    ]);
+
+    const updateError = new Error('update failed');
+    sinon.stub(settingsService, 'update').rejects(updateError);
+
+    try {
+      await migration.run();
+      chai.assert.fail('should have thrown');
+    } catch (err) {
+      chai.expect(err).to.equal(updateError);
+    }
+  });
+});

--- a/api/tests/mocha/translations.spec.js
+++ b/api/tests/mocha/translations.spec.js
@@ -226,7 +226,6 @@ describe('translations', () => {
           type: 'translations',
           code: 'fr',
           name: 'Français (French)',
-          enabled: true,
           generic: {
             hello: 'Hello UPDATED',
             bye: 'Goodbye UPDATED',
@@ -267,7 +266,6 @@ describe('translations', () => {
         type: 'translations',
         code: 'ar',
         name: 'عربي (Arabic)',
-        enabled: true,
         generic: {
           hello: 'Hello UPDATED',
           bye: 'Goodbye UPDATED',
@@ -309,7 +307,6 @@ describe('translations', () => {
             added: 'ADDED'
           },
           name: 'Français (French)',
-          enabled: true,
           rtl: false,
         }
       ]);
@@ -614,19 +611,20 @@ describe('translations', () => {
     });
 
     describe('without new "languages" setting', () => {
-      it('should only return translation docs enabled in translation doc', async () => {
+      it('should only all languages', async () => {
         sinon.stub(settings, 'get').resolves({});
         sinon.stub(db.medic, 'allDocs').resolves({
           rows: [
-            { doc: { _id: 'messages-en', type: 'translations', code: 'en', generic: {}, enabled: true } },
-            { doc: { _id: 'messages-fr', type: 'translations', code: 'fr', generic: {}, enabled: false } },
-            { doc: { _id: 'messages-es', type: 'translations', code: 'es', generic: {}, enabled: true } },
+            { doc: { _id: 'messages-en', type: 'translations', code: 'en', generic: {} } },
+            { doc: { _id: 'messages-fr', type: 'translations', code: 'fr', generic: {} } },
+            { doc: { _id: 'messages-es', type: 'translations', code: 'es', generic: {} } },
           ],
         });
         const enabledLocales = await translations.getEnabledLocales();
         chai.expect(enabledLocales).to.deep.equal([
-          { _id: 'messages-en', type: 'translations', code: 'en', generic: {}, enabled: true },
-          { _id: 'messages-es', type: 'translations', code: 'es', generic: {}, enabled: true },
+          { _id: 'messages-en', type: 'translations', code: 'en', generic: {} },
+          { _id: 'messages-fr', type: 'translations', code: 'fr', generic: {} },
+          { _id: 'messages-es', type: 'translations', code: 'es', generic: {} },
         ]);
       });
     });

--- a/ddocs/medic-db/medic-client/views/doc_by_type/map.js
+++ b/ddocs/medic-db/medic-client/views/doc_by_type/map.js
@@ -1,10 +1,3 @@
 function(doc) {
-  if (doc.type === 'translations') {
-    emit([ 'translations', doc.enabled ], {
-      code: doc.code,
-      name: doc.name
-    });
-    return;
-  }
   emit([ doc.type ]);
 }

--- a/webapp/src/ts/services/languages.service.ts
+++ b/webapp/src/ts/services/languages.service.ts
@@ -14,23 +14,20 @@ export class LanguagesService {
 
   async get(): Promise<Object> {
     const settings = await this.settingsService.get();
-    if (
-      settings.languages &&
-      Array.isArray(settings.languages) &&
-      settings.languages.length > 0
-    ) {
-      const result = await this.dbService.get().query('medic-client/doc_by_type', {
-        startkey: ['translations', false],
-        endkey: ['translations', true],
-      });
-      return result.rows
-        .filter(row => settings.languages.some(
-          language => language.enabled !== false && language.locale === row.value.code,
-        ))
-        .map(row => row.value);
-    }
 
-    const result = await this.dbService.get().query('medic-client/doc_by_type', { key: ['translations', true] });
-    return result.rows.map(row => row.value);
+    const enabledLanguages = (settings.languages || [])
+      .filter(language => language.enabled !== false)
+      .map(language => language.locale);
+
+    const result = await this.dbService
+      .get()
+      .query('medic-client/doc_by_type', { key: ['translations'], include_docs: true });
+
+    return result.rows
+      .filter(row => enabledLanguages.includes(row.doc.code) || !enabledLanguages.length)
+      .map(row => ({
+        code: row.doc.code,
+        name: row.doc.name,
+      }));
   }
 }

--- a/webapp/tests/karma/ts/services/languages.service.spec.ts
+++ b/webapp/tests/karma/ts/services/languages.service.spec.ts
@@ -23,27 +23,36 @@ describe('Languages service', () => {
       rows: [
         {
           id: 'messages-es',
-          key: ['translations', false],
-          value: {
+          key: ['translations'],
+          doc: {
+            _id: 'messages-es',
             code: 'es',
-            name: 'Español (Spanish)'
+            name: 'Español (Spanish)',
+            generic: {},
+            custom: {},
           }
         },
         {
           id: 'messages-en',
-          key: ['translations', true],
-          value: {
+          key: ['translations'],
+          doc: {
+            _id: 'messages-en',
             code: 'en',
-            name: 'English'
+            name: 'English',
+            generic: {},
+            custom: {},
           }
         },
         {
           id: 'messages-fr',
-          key: ['translations', true],
-          value: {
+          key: ['translations'],
+          doc: {
+            _id: 'messages-fe',
             code: 'fr',
-            name: 'Français (French)'
-          }
+            name: 'Français (French)',
+            generic: {},
+            custom: {},
+          },
         },
       ],
     });
@@ -75,7 +84,7 @@ describe('Languages service', () => {
   });
 
   describe('without new "languages" setting', () => {
-    it('should only return translation docs enabled in translation doc', async () => {
+    it('should return all translations', async () => {
       settingsService.get.resolves({});
       const enabledLocales = await languagesService.get();
       expect(enabledLocales).to.deep.equal([


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Adds migration that stores enabled languages in config instead of translation docs and updates translation docs. 
Updates API and Webapp code. 

closes #8157 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

