### PR TITLE
fix(#9992): fix line wrapping in haproxy config

### DIFF
--- a/haproxy/entrypoint.sh
+++ b/haproxy/entrypoint.sh
@@ -21,7 +21,7 @@ setResolver() {
 
 if [[ ${#SERVERS[@]} -eq 1 ]]; then
     {
-      basic_auth=$(echo -n "$COUCHDB_USER:$COUCHDB_PASSWORD" | base64)
+      basic_auth=$(echo -n "$COUCHDB_USER:$COUCHDB_PASSWORD" | base64 -w 0)
       echo "  option httpchk"
       echo "  http-check send meth GET uri /_up hdr Authorization 'Basic ${basic_auth}'" >> "$BACKEND"
       echo "  http-check expect status 200" >> "$BACKEND"


### PR DESCRIPTION
The `base64` command by default inserts newlines every 76 characters for some strange historical reason.
This which breaks the HAProxy health config when the CouchDB username + password is too long. 

Adding the no-wrap flag prevents this and allows long credentials.
