### PR TITLE
fix(#10296): adds custom undici agent as dispatcher for fetch reques

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "semver": "^7.7.0",
         "simple-password-tester": "^1.0.0",
         "tmp-promise": "^3.0.3",
+        "undici": "^7.16.0",
         "url": "^0.11.1",
         "url-join": "^4.0.1",
         "uuid": "^10.0.0",
@@ -7853,6 +7854,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wdio/appium-service/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@wdio/appium-service/node_modules/webdriver": {
       "version": "9.19.1",
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.19.1.tgz",
@@ -8515,6 +8526,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wdio/cli/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@wdio/cli/node_modules/webdriver": {
@@ -9303,6 +9324,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@wdio/local-runner/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@wdio/local-runner/node_modules/webdriver": {
@@ -18854,6 +18885,16 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.1.0",
         "entities": "^4.5.0"
+      }
+    },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/chokidar": {
@@ -38746,13 +38787,12 @@
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "dev": true,
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -229,6 +229,7 @@
     "semver": "^7.7.0",
     "simple-password-tester": "^1.0.0",
     "tmp-promise": "^3.0.3",
+    "undici": "^7.16.0",
     "url": "^0.11.1",
     "url-join": "^4.0.1",
     "uuid": "^10.0.0",

--- a/shared-libs/couch-request/src/couch-request.js
+++ b/shared-libs/couch-request/src/couch-request.js
@@ -2,6 +2,8 @@ const environment = require('@medic/environment');
 const audit = require('@medic/audit');
 const path = require('path');
 const os = require('os');
+const undici = require('undici');
+
 let asyncLocalStorage;
 let requestIdHeader;
 
@@ -163,6 +165,12 @@ const setRequestOptions = async (options) => {
   if (!isInternalRequest(options) && !options.headers['user-agent']) {
     options.headers['user-agent'] = await getUserAgent();
   }
+
+  options.dispatcher = new undici.Agent({
+    headersTimeout: 0,
+    connectTimeout: 0,
+    bodyTimeout: 0
+  });
 };
 
 const getResponseBody = async (response, sendJson) => {

--- a/shared-libs/couch-request/test/couch-request.js
+++ b/shared-libs/couch-request/test/couch-request.js
@@ -1,6 +1,7 @@
-const chai = require('chai').use(require('chai-as-promised'));
+const chai = require('chai').use(require('chai-as-promised')).use(require('chai-exclude'));
 const expect = chai.expect;
 const sinon = require('sinon');
+const undici = require('undici');
 const rewire = require('rewire');
 
 chai.config.truncateThreshold = 0;
@@ -41,6 +42,8 @@ describe('couch-request', () => {
 
     sinon.stub(require('os'), 'platform').returns('test-platform');
     sinon.stub(require('os'), 'arch').returns('test-arch');
+
+    sinon.stub(undici, 'Agent');
 
     couchRequest = rewire('../src/couch-request');
   });
@@ -113,8 +116,11 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/test',
+        dispatcher: {},
       }
     ]);
+
+    expect(undici.Agent.args).to.deep.equal([[{ headersTimeout: 0, connectTimeout: 0, bodyTimeout: 0 }]]);
 
     expect(audit.fetchCallback.args).to.deep.equal([[
       'http://test.com:5984/medic/test',
@@ -127,6 +133,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/test',
+        dispatcher: {},
       },
       {
         ...response,
@@ -155,6 +162,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/omg',
+        dispatcher: {},
       }
     ]);
   });
@@ -178,6 +186,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/doc/attachment',
+        dispatcher: {},
       }
     ]);
   });
@@ -200,6 +209,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://www.textit.com/api/v2/broadcasts.json',
+        dispatcher: {},
       }
     ]);
   });
@@ -222,6 +232,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://www.textit.com/api/v2/broadcasts.json',
+        dispatcher: {},
       }
     ]);
   });
@@ -250,6 +261,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic?number=2&string=yes&array=%5B%22one%22%2C%22two%22%5D&boolean=true',
+        dispatcher: {},
       }
     ]);
   });
@@ -273,6 +285,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/oops',
+        dispatcher: {},
       }
     ]);
   });
@@ -296,6 +309,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/medic/omg',
+        dispatcher: {},
       }
     ]);
   });
@@ -313,6 +327,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/a',
+        dispatcher: {},
       }
     ]);
   });
@@ -335,6 +350,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://marvel.net:5984/a',
+        dispatcher: {},
       }
     ]);
   });
@@ -377,6 +393,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/a',
+        dispatcher: {},
       }
     ]);
   });
@@ -399,6 +416,7 @@ describe('couch-request', () => {
         body: JSON.stringify({ foo: 'bar' }),
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -421,6 +439,7 @@ describe('couch-request', () => {
         body: 'foo=bar&bar=baz',
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -444,6 +463,7 @@ describe('couch-request', () => {
         body: 'foo=bar&bar=baz',
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -464,6 +484,7 @@ describe('couch-request', () => {
         body: 'some random text',
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -486,6 +507,7 @@ describe('couch-request', () => {
         body: 'some random text',
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -540,6 +562,7 @@ describe('couch-request', () => {
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
         signal: AbortSignal.timeout(5000),
+        dispatcher: {},
       }
     ]);
   });
@@ -564,6 +587,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -587,6 +611,7 @@ describe('couch-request', () => {
           'content-type': 'application/json',
         },
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]);
   });
@@ -713,6 +738,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
+        dispatcher: {},
       }
     ]]);
   });
@@ -738,6 +764,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
+        dispatcher: {},
       }
     ]]);
   });
@@ -762,6 +789,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
+        dispatcher: {},
       }
     ]]);
 
@@ -776,6 +804,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/test',
+        dispatcher: {},
       },
       {
         ...response,
@@ -807,6 +836,7 @@ describe('couch-request', () => {
         },
         servername: 'test.com',
         uri: 'http://test.com:5984/b',
+        dispatcher: {},
       }
     ]]);
   });


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

#10296

(cherry picked from commit 5f8066a72a2ef64342476def4f854f820cff8ecd)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10296-for-4.x/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10296-for-4.x/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10296-for-4.x/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

