### PR TITLE
feat(#8657): remove logic for cleaning up old telemetry db

### DIFF
--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -322,7 +322,6 @@ export class TelemetryService {
     try {
       const today = this.getToday();
       const databaseNames = await this.indexedDbService.getDatabaseNames();
-      await this.deleteDeprecatedTelemetryDB(databaseNames);
       const telemetryDBs = await this.getTelemetryDBs(databaseNames);
       await this.submitIfNeeded(today, telemetryDBs);
       const currentDB = await this.getCurrentTelemetryDB(today, telemetryDBs);
@@ -332,41 +331,6 @@ export class TelemetryService {
     } catch (error) {
       console.error('Error in telemetry service', error);
     }
-  }
-
-  /**
-   * ToDo: Remove this function in a future release: https://github.com/medic/cht-core/issues/8657
-   * The way telemetry was stored in the client side changed (https://github.com/medic/cht-core/pull/8555),
-   * this function contains all the transition code where it deletes the old Telemetry DB from the DB.
-   * It was decided to not aggregate the DB content.
-   * @private
-   */
-  private async deleteDeprecatedTelemetryDB(databaseNames) { //NOSONAR
-    if (this.hasTransitionFinished) {
-      return;
-    }
-
-    databaseNames?.forEach(dbName => {
-      const nameNoPrefix = dbName?.replace(this.POUCH_PREFIX, '') || '';
-
-      // Skips new Telemetry DB, then matches malformed or the old deprecated Telemetry DB.
-      if (!this.isValidTelemetryDBName(nameNoPrefix)
-        && nameNoPrefix.includes(this.TELEMETRY_PREFIX)
-        && nameNoPrefix.includes(this.sessionService.userCtx().name)) {
-        console.warn(`Invalid telemetry database name, deleting database. Name: ${nameNoPrefix}`);
-        this.windowRef?.indexedDB.deleteDatabase(dbName);
-      }
-    });
-
-    Object
-      .keys(this.windowRef?.localStorage)
-      .forEach(key => {
-        if (key.includes('telemetry-date') || key.includes('telemetry-db')) {
-          this.windowRef?.localStorage.removeItem(key);
-        }
-      });
-
-    this.hasTransitionFinished = true;
   }
 }
 

--- a/webapp/src/ts/services/telemetry.service.ts
+++ b/webapp/src/ts/services/telemetry.service.ts
@@ -16,7 +16,6 @@ export class TelemetryService {
   // Intentionally scoped to the whole browser (for this domain). We can then tell if multiple users use the same device
   private readonly DEVICE_ID_KEY = 'medic-telemetry-device-id';
   private isAggregationRunning = false;
-  private hasTransitionFinished = false;
   private windowRef;
 
   constructor(

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -140,7 +140,6 @@ describe('TelemetryService', () => {
     it('should record a piece of telemetry', async () => {
       medicDb.query.resolves({ rows: [] });
       telemetryDb.query.resolves({ rows: [] });
-      const invalidDBNameWarning = 'Invalid telemetry database name, deleting database. Name:';
       const oldTelemetryDBNames = [
         '_pouch_medic-user-koko-telemetry-98y7c3a1-5a1a-4d3f-a076-d86ec38b1d87',
         '_pouch_medic-user-greg-telemetry-59d4c3a1-5a1a-4d3f-a076-d86ec38b1d32',

--- a/webapp/tests/karma/ts/services/telemetry.service.spec.ts
+++ b/webapp/tests/karma/ts/services/telemetry.service.spec.ts
@@ -19,7 +19,6 @@ describe('TelemetryService', () => {
   let clock;
   let telemetryDb;
   let consoleErrorSpy;
-  let consoleWarnSpy;
   let windowMock;
 
   const windowScreenOriginal = {
@@ -93,7 +92,6 @@ describe('TelemetryService', () => {
     getStub.returns(medicDb);
     dbService = { get: getStub };
     consoleErrorSpy = sinon.spy(console, 'error');
-    consoleWarnSpy = sinon.spy(console, 'warn');
     telemetryDb = {
       post: sinon.stub().resolves(),
       close: sinon.stub(),
@@ -147,22 +145,10 @@ describe('TelemetryService', () => {
         '_pouch_medic-user-koko-telemetry-98y7c3a1-5a1a-4d3f-a076-d86ec38b1d87',
         '_pouch_medic-user-greg-telemetry-59d4c3a1-5a1a-4d3f-a076-d86ec38b1d32',
       ];
-      const wrongDBNames = [
-        '_pouch_telemetry-59d4c3a1-5a1a-4d3f-a076-d86ec38b1d32',
-        '_pouch_telemetry-2018-greg',
-        '_pouch_telemetry-2018-01-greg',
-        '_pouch_telemetry-11-10-greg',
-        '_pouch_telemetry-10-greg',
-        '_pouch_telemetry-greg',
-        '_pouch_telemetry-२०२४-०२-०९-greg',
-        '_pouch_telemetry',
-        undefined,
-      ];
       indexedDbService.getDatabaseNames.resolves([
         ...oldTelemetryDBNames,
         '_pouch_telemetry-2018-11-10-greg',
         '_pouch_telemetry-2018-12-31-greg',
-        ...wrongDBNames,
         '_pouch_telemetry-2019-1-1-greg',
         '_pouch_telemetry-2019-1-22-greg',
         '_pouch_some-other-db',
@@ -172,26 +158,6 @@ describe('TelemetryService', () => {
       await service.record('test', 100);
 
       expect(consoleErrorSpy.notCalled).to.be.true;
-      expect(consoleWarnSpy.callCount).to.equal(7);
-      expect(consoleWarnSpy.args).to.have.deep.members([
-        [ `${invalidDBNameWarning} medic-user-greg-telemetry-59d4c3a1-5a1a-4d3f-a076-d86ec38b1d32` ],
-        [ `${invalidDBNameWarning} telemetry-2018-greg` ],
-        [ `${invalidDBNameWarning} telemetry-2018-01-greg` ],
-        [ `${invalidDBNameWarning} telemetry-11-10-greg` ],
-        [ `${invalidDBNameWarning} telemetry-10-greg` ],
-        [ `${invalidDBNameWarning} telemetry-greg` ],
-        [ `${invalidDBNameWarning} telemetry-२०२४-०२-०९-greg` ],
-      ]);
-      expect(windowMock.indexedDB.deleteDatabase.callCount).to.equal(7);
-      expect(windowMock.indexedDB.deleteDatabase.args).to.have.deep.members([
-        [ '_pouch_medic-user-greg-telemetry-59d4c3a1-5a1a-4d3f-a076-d86ec38b1d32' ],
-        [ '_pouch_telemetry-2018-greg' ],
-        [ '_pouch_telemetry-2018-01-greg' ],
-        [ '_pouch_telemetry-11-10-greg' ],
-        [ '_pouch_telemetry-10-greg' ],
-        [ '_pouch_telemetry-greg' ],
-        [ '_pouch_telemetry-२०२४-०२-०९-greg' ],
-      ]);
       expect(telemetryDb.post.calledOnce).to.be.true;
       expect(telemetryDb.post.args[0][0]).to.deep.include({ key: 'test', value: 100 });
       expect(telemetryDb.post.args[0][0].date_recorded).to.be.above(0);


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

- The temporary [deleteDeprecatedTelemetryDB function](https://github.com/medic/cht-core/blob/601d992394983f589ae627f3fe11a4b080bc5b42/webapp/src/ts/services/telemetry.service.ts#L344) was deleted and it's calls.
- All unit tests that fails because of this change were fix.

<!-- ISSUE NUMBER -->
Closes [#8657](https://github.com/medic/cht-core/issues/8657)

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

