### PR TITLE
chore: add ngx dependencies to angular dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,8 @@ updates:
         - "@ngrx/*"
         - "rxjs"
         - "zone.js"
+        - "ngx-bootstrap"
+        - "ngx-cookie-service"
     ignore:
       - dependency-name: "bootstrap" # https://github.com/medic/cht-core/issues/8176
       - dependency-name: "bootstrap-daterangepicker" # https://github.com/medic/cht-core/issues/8176


### PR DESCRIPTION
# Description

Both [ngx-bootstrap](https://www.npmjs.com/package/ngx-bootstrap) and [ngx-cookie-service](https://www.npmjs.com/package/ngx-cookie-service) target their major versions to the compatible major version of Angular. 

The goal is to avoid PRs like: https://github.com/medic/cht-core/pull/10287 where it is trying to upgrade `ngx-bootstrap` to `20.x` when we have not updated Angular yet.


# Code review checklist
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

