### PR TITLE
chore(#10309): refine logging when checking for existence of ddoc in cht-datasource

### DIFF
--- a/shared-libs/cht-datasource/src/local/libs/doc.ts
+++ b/shared-libs/cht-datasource/src/local/libs/doc.ts
@@ -180,7 +180,7 @@ export const fetchAndFilterUuids = (
 };
 
 /** @internal */
-const isPouchDBNotFoundError = (error: unknown): error is { status: number, name: string } => {
+const isPouchDBNotFoundError = (error: unknown): error is { status: 404, name: string } => {
   return (
     typeof error === 'object' && error !== null &&
     'status' in error && (error as { status: number }).status === 404

--- a/shared-libs/cht-datasource/src/local/libs/doc.ts
+++ b/shared-libs/cht-datasource/src/local/libs/doc.ts
@@ -180,12 +180,24 @@ export const fetchAndFilterUuids = (
 };
 
 /** @internal */
+const isPouchDBNotFoundError = (error: unknown): error is { status: number, name: string } => {
+  return (
+    typeof error === 'object' && error !== null &&
+    'status' in error && (error as { status: number }).status === 404
+  );
+}
+
+/** @internal */
 export const ddocExists = async (db: PouchDB.Database<Doc>, ddocId: string): Promise<boolean> => {
   try {
     await db.get(ddocId);
     return true;
   } catch (err) {
-    logger.debug(err);
+    if (isPouchDBNotFoundError(err)) {
+      return false;
+    }
+
+    logger.error(`Unexpected error while checking ddoc ${ddocId}:`, err);
     return false;
   }
 };

--- a/shared-libs/cht-datasource/src/local/libs/doc.ts
+++ b/shared-libs/cht-datasource/src/local/libs/doc.ts
@@ -185,7 +185,7 @@ const isPouchDBNotFoundError = (error: unknown): error is { status: number, name
     typeof error === 'object' && error !== null &&
     'status' in error && (error as { status: number }).status === 404
   );
-}
+};
 
 /** @internal */
 export const ddocExists = async (db: PouchDB.Database<Doc>, ddocId: string): Promise<boolean> => {

--- a/shared-libs/cht-datasource/test/local/libs/doc.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/doc.spec.ts
@@ -606,14 +606,14 @@ describe('local doc lib', () => {
       // Assert
       expect(result).to.be.true;
       expect(dbGet.calledOnceWithExactly(ddocId)).to.be.true;
-      expect(debug.called).to.be.false;
+      expect(error.notCalled).to.be.true;
     });
 
     it('should return false when the document does not exist', async () => {
       // Arrange
       const ddocId = '_design/non-existent-doc';
-      const error = { status: 404, message: 'not_found' };
-      dbGet.withArgs(ddocId).rejects(error);
+      const errorObject = { status: 404, message: 'not_found' };
+      dbGet.withArgs(ddocId).rejects(errorObject);
 
       // Act
       const result = await ddocExists(db, ddocId);
@@ -621,14 +621,14 @@ describe('local doc lib', () => {
       // Assert
       expect(result).to.be.false;
       expect(dbGet.calledOnceWithExactly(ddocId)).to.be.true;
-      expect(debug.calledOnceWithExactly(error)).to.be.true;
+      expect(error.notCalled).to.be.true;
     });
 
     it('should return false when an error occurs during get operation', async () => {
       // Arrange
       const ddocId = '_design/some-doc';
-      const error = new Error('Connection error');
-      dbGet.withArgs(ddocId).rejects(error);
+      const errorObject = new Error('Connection error');
+      dbGet.withArgs(ddocId).rejects(errorObject);
 
       // Act
       const result = await ddocExists(db, ddocId);
@@ -636,7 +636,7 @@ describe('local doc lib', () => {
       // Assert
       expect(result).to.be.false;
       expect(dbGet.calledOnce).to.be.true;
-      expect(debug.calledOnceWithExactly(error)).to.be.true;
+      expect(error.calledOnceWithExactly(`Unexpected error while checking ddoc ${ddocId}:`, errorObject)).to.be.true;
     });
 
     it('should work with different document IDs', async () => {
@@ -652,7 +652,7 @@ describe('local doc lib', () => {
       expect(await ddocExists(db, nonExistingDdocId)).to.be.false;
 
       expect(dbGet.calledTwice).to.be.true;
-      expect(debug.calledOnce).to.be.true;
+      expect(error.notCalled).to.be.true;
     });
   });
 

--- a/shared-libs/cht-datasource/test/local/libs/doc.spec.ts
+++ b/shared-libs/cht-datasource/test/local/libs/doc.spec.ts
@@ -23,7 +23,6 @@ describe('local doc lib', () => {
   let db: PouchDB.Database<Doc.Doc>;
   let isDoc: SinonStub;
   let error: SinonStub;
-  let debug: SinonStub;
 
   beforeEach(() => {
     dbGet = sinon.stub();
@@ -36,7 +35,6 @@ describe('local doc lib', () => {
     } as unknown as PouchDB.Database<Doc.Doc>;
     isDoc = sinon.stub(Doc, 'isDoc');
     error = sinon.stub(logger, 'error');
-    debug = sinon.stub(logger, 'debug');
   });
 
   afterEach(() => sinon.restore());


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: chore, feat, fix, perf.

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Changes how logging is done in `cht-datasource`'s `src/local/libs/doc.ts` when checking for existence of a `ddoc`.

Addresses #10309 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10309-refine-log-message/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10309-refine-log-message/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10309-refine-log-message/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

