### PR TITLE
perf(#10960): optimize O(n*m) lookups in contact report loading

### DIFF
--- a/webapp/src/ts/services/contact-view-model-generator.service.ts
+++ b/webapp/src/ts/services/contact-view-model-generator.service.ts
@@ -277,8 +277,8 @@ export class ContactViewModelGeneratorService {
   }
 
   private async addHeading(reports, forms) {
-    const formsMap = new Map(forms.map(form => [form.code, form]));
-    const reportsById = new Map(reports.map(report => [report._id, report]));
+    const formsMap: Map<string, any> = new Map(forms.map(form => [form.code, form]));
+    const reportsById: Map<string, any> = new Map(reports.map(report => [report._id, report]));
     const summaries = await this.getDataRecordsService.getDocsSummaries(reports);
     summaries?.forEach(summary => {
       const report = reportsById.get(summary._id);
@@ -293,7 +293,7 @@ export class ContactViewModelGeneratorService {
     const subjectIds: string[] = [];
     contactDocs.forEach(doc => subjectIds.push(...registrationUtils.getSubjectIds(doc)));
 
-    const contactsByPatientId = new Map(
+    const contactsByPatientId: Map<string, any> = new Map(
       contactDocs
         .filter(doc => doc?.patient_id)
         .map(doc => [doc.patient_id, doc])

--- a/webapp/src/ts/services/contact-view-model-generator.service.ts
+++ b/webapp/src/ts/services/contact-view-model-generator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import { find as _find, groupBy as _groupBy, partial as _partial, } from 'lodash-es';
+import { groupBy as _groupBy, partial as _partial, } from 'lodash-es';
 
 import registrationUtils from '@medic/registration-utils';
 
@@ -262,8 +262,8 @@ export class ContactViewModelGeneratorService {
       });
   }
 
-  private getHeading(report, forms) {
-    const form = _find(forms, { code: report.form });
+  private getHeading(report, formsMap: Map<string, any>) {
+    const form = formsMap.get(report.form);
     if (form && form.subjectKey) {
       return this.translateService.instant(form.subjectKey, report);
     }
@@ -277,11 +277,13 @@ export class ContactViewModelGeneratorService {
   }
 
   private async addHeading(reports, forms) {
+    const formsMap = new Map(forms.map(form => [form.code, form]));
+    const reportsById = new Map(reports.map(report => [report._id, report]));
     const summaries = await this.getDataRecordsService.getDocsSummaries(reports);
     summaries?.forEach(summary => {
-      const report = reports.find(report => report._id === summary._id);
+      const report = reportsById.get(summary._id);
       if (report) {
-        report.heading = this.getHeading(summary, forms);
+        report.heading = this.getHeading(summary, formsMap);
       }
     });
     return reports;
@@ -290,6 +292,12 @@ export class ContactViewModelGeneratorService {
   private getReports(contactDocs) {
     const subjectIds: string[] = [];
     contactDocs.forEach(doc => subjectIds.push(...registrationUtils.getSubjectIds(doc)));
+
+    const contactsByPatientId = new Map(
+      contactDocs
+        .filter(doc => doc?.patient_id)
+        .map(doc => [doc.patient_id, doc])
+    );
 
     return this.searchService
       .search('reports', { subjectIds }, { include_docs: true, limit: this.LIMIT_SELECT_ALL_REPORTS })
@@ -301,7 +309,7 @@ export class ContactViewModelGeneratorService {
             return;
           }
           const patientId = report.fields.patient_id || report.patient_id;
-          const patient = contactDocs.find(contact => contact?.patient_id === patientId);
+          const patient = contactsByPatientId.get(patientId);
           if (patient) {
             report.fields.patient_name = patient.name;
           }


### PR DESCRIPTION
## Description

Fixes #10960

The contact detail page is the most frequently visited page in the CHT webapp. When loading reports for a contact, `ContactViewModelGeneratorService` was performing repeated `Array.find()` calls inside loops, resulting in O(n * m) time complexity that scales poorly as report and contact counts grow.

With `LIMIT_SELECT_ALL_REPORTS = 500` and potentially hundreds of child contacts under a facility, the worst case was ~250,000 comparisons per page load on the critical rendering path.

## Changes

### 1. `addHeading()` — report and form lookups

**Before:** For each summary, linearly scans the full reports array and uses lodash `_find` to scan the forms array.
```typescript
summaries?.forEach(summary => {
  const report = reports.find(report => report._id === summary._id);
  // getHeading() internally does: _find(forms, { code: report.form })
});
```

**After:** Pre-builds `Map<id, report>` and `Map<code, form>` for O(1) lookups.
```typescript
const formsMap = new Map(forms.map(form => [form.code, form]));
const reportsById = new Map(reports.map(report => [report._id, report]));
summaries?.forEach(summary => {
  const report = reportsById.get(summary._id);
  // getHeading() now does: formsMap.get(report.form)
});
```

### 2. `getReports()` — patient name resolution

**Before:** For each report, linearly scans all contact docs to find the matching patient.
```typescript
reports.forEach(report => {
  const patient = contactDocs.find(contact => contact?.patient_id === patientId);
});
```

**After:** Pre-builds `Map<patientId, contact>` for O(1) lookups.
```typescript
const contactsByPatientId = new Map(
  contactDocs.filter(doc => doc?.patient_id).map(doc => [doc.patient_id, doc])
);
reports.forEach(report => {
  const patient = contactsByPatientId.get(patientId);
});
```

### 3. Removed unused lodash `_find` import

The `find` import from lodash-es is no longer needed after replacing it with native Map lookups, slightly reducing the bundle dependency surface.

## Complexity analysis

| Method | Before | After |
|--------|--------|-------|
| `addHeading()` report lookup | O(summaries * reports) | O(summaries + reports) |
| `getHeading()` form lookup | O(forms) per call | O(1) per call |
| `getReports()` patient lookup | O(reports * contacts) | O(reports + contacts) |

## Test plan

- [x] Existing unit tests in `contact-view-model-generator.service.spec.ts` cover all modified code paths (heading resolution, patient name assignment, report sorting)
- [ ] Verify contact detail page loads correctly with reports showing proper headings and patient names
- [ ] Spot check a contact with many reports to confirm no regressions