### PR TITLE
fix(#8653): re-trigger db-object-widget when field becomes relevant

### DIFF
--- a/webapp/src/js/enketo/widgets/db-object-widget.js
+++ b/webapp/src/js/enketo/widgets/db-object-widget.js
@@ -17,7 +17,30 @@ class Dbobjectwidget extends Widget {
   }
 
   _init() {
-    construct(this.element);
+    const refs = construct(this.element);
+    this._$textInput = refs.$textInput;
+    this._$selectInput = refs.$selectInput;
+    this._contactTypes = refs.contactTypes;
+    this._allowNew = refs.allowNew;
+    this._filterByParent = refs.filterByParent;
+  }
+
+  // When the field becomes relevant with a pre-populated value, load the contact data.
+  enable() {
+    const currentValue = this._$textInput && this._$textInput.val();
+    if (!currentValue) {
+      return;
+    }
+    const selected = this._$selectInput.select2('data');
+    const alreadyLoaded = selected && selected[0] && selected[0].doc;
+    if (!alreadyLoaded) {
+      const Select2Search = window.CHTCore.Select2Search;
+      Select2Search.init(this._$selectInput, this._contactTypes, {
+        allowNew: this._allowNew,
+        filterByParent: this._filterByParent,
+        initialValue: currentValue,
+      });
+    }
   }
 
   list() {
@@ -60,6 +83,8 @@ const construct = ( element ) => {
     // select2 doesn't understand readonly
     $selectInput.prop('disabled', $textInput.prop('readonly'));
   });
+
+  return { $textInput, $selectInput, contactTypes, allowNew, filterByParent };
 };
 
 const getContactTypes = function($question, $textInput) {

--- a/webapp/src/js/enketo/widgets/db-object-widget.js
+++ b/webapp/src/js/enketo/widgets/db-object-widget.js
@@ -27,12 +27,12 @@ class Dbobjectwidget extends Widget {
 
   // When the field becomes relevant with a pre-populated value, load the contact data.
   enable() {
-    const currentValue = this._$textInput && this._$textInput.val();
+    const currentValue = this._$textInput?.val();
     if (!currentValue) {
       return;
     }
     const selected = this._$selectInput.select2('data');
-    const alreadyLoaded = selected && selected[0] && selected[0].doc;
+    const alreadyLoaded = selected?.[0]?.doc;
     if (!alreadyLoaded) {
       const Select2Search = window.CHTCore.Select2Search;
       Select2Search.init(this._$selectInput, this._contactTypes, {

--- a/webapp/tests/karma/js/enketo/widgets/db-object-widget.spec.ts
+++ b/webapp/tests/karma/js/enketo/widgets/db-object-widget.spec.ts
@@ -61,4 +61,77 @@ describe('Enketo: DB Object Widget', () => {
 
   });
 
+  describe('enable', () => {
+    let select2SearchInit;
+    let widget;
+    let originalCHTCore;
+
+    const makeSelectInput = (doc?) => ({
+      select2: sinon.stub().returns(doc ? [{ id: 'some-id', doc }] : []),
+    });
+
+    beforeEach(() => {
+      select2SearchInit = sinon.stub().resolves();
+      originalCHTCore = (window as any).CHTCore;
+      (window as any).CHTCore = { Select2Search: { init: select2SearchInit } };
+
+      widget = {
+        _contactTypes: ['person'],
+        _allowNew: false,
+        _filterByParent: false,
+        enable: dbObjectWidget.prototype.enable,
+      };
+    });
+
+    afterEach(() => {
+      (window as any).CHTCore = originalCHTCore;
+    });
+
+    it('should call Select2Search.init() with the pre-populated value when field becomes relevant', () => {
+      const contactId = 'contact-uuid-123';
+      widget._$textInput = { val: sinon.stub().returns(contactId) };
+      widget._$selectInput = makeSelectInput();
+
+      widget.enable();
+
+      expect(select2SearchInit.callCount).to.equal(1);
+      expect(select2SearchInit.args[0][0]).to.equal(widget._$selectInput);
+      expect(select2SearchInit.args[0][1]).to.deep.equal(['person']);
+      expect(select2SearchInit.args[0][2]).to.deep.include({
+        allowNew: false,
+        filterByParent: false,
+        initialValue: contactId,
+      });
+    });
+
+    it('should NOT call Select2Search.init() when the contact doc is already loaded', () => {
+      const contactId = 'contact-uuid-123';
+      widget._$textInput = { val: sinon.stub().returns(contactId) };
+      widget._$selectInput = makeSelectInput({ _id: contactId, name: 'Test Contact' });
+
+      widget.enable();
+
+      expect(select2SearchInit.callCount).to.equal(0);
+    });
+
+    it('should NOT call Select2Search.init() when text input is empty', () => {
+      widget._$textInput = { val: sinon.stub().returns('') };
+      widget._$selectInput = makeSelectInput();
+
+      widget.enable();
+
+      expect(select2SearchInit.callCount).to.equal(0);
+    });
+
+    it('should NOT call Select2Search.init() when _$textInput is not set', () => {
+      widget._$textInput = undefined;
+      widget._$selectInput = makeSelectInput();
+
+      widget.enable();
+
+      expect(select2SearchInit.callCount).to.equal(0);
+    });
+
+  });
+
 });


### PR DESCRIPTION
# Description

When a `select-contact` field has its value pre-populated via a `calculation` and the field is initially non-relevant, the `db-object-widget` never loads the contact data. This happens because the `change` event that triggers `changeHandler()` is never fired when the field transitions from non-relevant to relevant it only fires when the user manually selects a contact.

This fix overrides the `enable()` method on the widget, which Enketo calls exactly when a field transitions from non-relevant to relevant. Inside `enable()`, if the hidden text input already has a pre-populated contact ID and the contact doc hasn't been loaded yet, we re-initialize Select2 with that value as `initialValue`. This triggers `getDoc()` → `setDoc()` → `change` event → `changeHandler()` → `updateFields()`, which correctly loads the contact data into the form.

<!-- ISSUE NUMBER -->
Fix #8653

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR. In the remaining boxes, replace the [ ] with [x]. -->
- [x] Realistic: Confirmed, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/contribute/contributing-guidelines)

<!-- COMPOSE LFS ID HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
