### PR TITLE
test( #Medic-infra-1394): graviton testing do not merge

### DIFF
--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -21,6 +21,22 @@ set_hostname(){
   hostnamectl set-hostname $1
 }
 
+output_system_info(){
+  BUILD=$1
+  lines="-----------------"
+  echo $lines > system.info.txt
+  date >> system.info.txt
+  echo $lines >> system.info.txt
+  echo "Running CHT Core ${BUILD}" >> system.info.txt
+  echo $lines >> system.info.txt
+  uname -a >> system.info.txt
+  echo $lines >> system.info.txt
+  lsb_release -a >> system.info.txt
+  echo $lines >> system.info.txt
+  ec2metadata >> system.info.txt
+  echo $lines >> system.info.txt
+}
+
 install_docker(){
   echo "starting install_docker"
   curl -fsSL https://get.docker.com -o get-docker.sh
@@ -109,4 +125,7 @@ install_cht "$CHT_VERSION"
 install_node_exporter
 enable_node_exporter
 install_local_ip_cert
-echo "DONE"
+output_system_info "$CHT_VERSION"
+echo
+echo "DONE! System Info saved to disk in system.info.tx"
+cat system.info.txt

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -23,18 +23,21 @@ set_hostname(){
 
 output_system_info(){
   BUILD=$1
+  FILE=system.info.txt
   lines="-----------------"
-  echo $lines > system.info.txt
-  date >> system.info.txt
-  echo $lines >> system.info.txt
-  echo "Running CHT Core ${BUILD}" >> system.info.txt
-  echo $lines >> system.info.txt
-  uname -a >> system.info.txt
-  echo $lines >> system.info.txt
-  lsb_release -a >> system.info.txt
-  echo $lines >> system.info.txt
-  ec2metadata >> system.info.txt
-  echo $lines >> system.info.txt
+  echo $lines > $FILE
+  date >> $FILE
+  echo $lines >> $FILE
+  echo "Running CHT Core ${BUILD}" >> $FILE
+  echo $lines >> $FILE
+  uname -a >> $FILE
+  echo $lines >> $FILE
+  lsb_release -a >> $FILE
+  echo $lines >> $FILE
+  docker version >> $FILE
+  echo $lines >> $FILE
+  ec2metadata >> $FILE
+  echo $lines >> $FILE
 }
 
 install_docker(){

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -23,7 +23,7 @@ DOCKER_CONFIG_PATH=/home/.docker
 CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
-docker compose up -d
+docker compose --progress quiet up --detach
 curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
 
 max=120
@@ -44,10 +44,8 @@ arch=$(dpkg --print-architecture)
 node_exp_url='https://github.com/prometheus/node_exporter/releases/download/v1.11.1/node_exporter-1.11.1.linux-'
 if [[ "$arch" == "amd64" ]]; then
   node_exp_url="${node_exp_url}amd64.tar.gz"
-  echo "found amd64"
 elif [[ "$arch" == "arm64" ]]; then
   node_exp_url="${node_exp_url}arm64.tar.gz"
-  echo "found arm64"
 else
   echo "${node_exp_url} not found, exiting"
   exit 1

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -2,35 +2,17 @@
 set -e
 
 shutdown -P +60
-mkdir -p /cht
-chmod 777 /cht;
-
-# Install Docker CE
-apt-get update
-apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release \
-
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-
-mkdir -p /cht/upgrade-service
-mkdir -p /cht/compose
-
+mkdir -p /cht/upgrade-service  /cht/compose
+curl -fsSL https://get.docker.com -o get-docker.sh
+sh ./get-docker.sh
+BUILD="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:5.1.0"
 curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
   -o /cht/upgrade-service/docker-compose.yml
 curl -s "$BUILD"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
 curl -s "$BUILD"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
 
 cd /cht/upgrade-service/
-cat > ./.env << EOF
+cat > /cht/upgrade-service//.env << EOF
 DOCKER_CONFIG_PATH=/home/.docker
 CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# This script can be called remotely with:
+# sudo su -
+# source <(curl -s https://raw.githubusercontent.com/medic/cht-core/refs/heads/medic-infra-1394-graviton-do-not-merge/tests/scalability/prepare-ec2.sh)
+
+
 shutdown -P +60
 mkdir -p /cht/upgrade-service  /cht/compose
 curl -fsSL https://get.docker.com -o get-docker.sh
@@ -45,3 +50,22 @@ else
   exit 1
 fi
 curl -Os ${node_exp_url}
+tar xvzf node_exporter-1.11.1.linux-*.tar.gz
+mv node_exporter/bin/node_exporter /usr/local/bin/node_exporter
+
+bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/node_exporter
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+
+systemctl daemon-reload
+systemctl enable node_exporter
+systemctl start node_exporter

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -18,5 +18,30 @@ CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
 docker compose up -d
-sleep 60
-/root/cht-core/scripts/add-local-ip-certs-to-docker.sh  cht-nginx-1
+curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
+
+max=120
+count=0
+while [[ count -le max  ]]; do
+  nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
+  if [[ "$nginx" == "cht-nginx-1" ]]; then
+    bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
+    count=max
+  fi
+  ((count=count+1))
+done
+
+arch=$(dpkg --print-architecture)
+
+node_exp_url='https://github.com/prometheus/node_exporter/releases/download/v1.11.1/node_exporter-1.11.1.linux-'
+if [[ "$arch" == "amd64" ]]; then
+  node_exp_url="${node_exp_url}amd64.tar.gz"
+  echo "found amd64"
+elif [[ "$arch" e==q "arm64" ]]; then
+  node_exp_url="${node_exp_url}arm64.tar.gz"
+  echo "found arm64"
+else
+  echo "${node_exp_url} not found, exiting"
+  exit 1
+fi
+curl -Os ${node_exp_url}

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -42,16 +42,17 @@ node_exp_url='https://github.com/prometheus/node_exporter/releases/download/v1.1
 if [[ "$arch" == "amd64" ]]; then
   node_exp_url="${node_exp_url}amd64.tar.gz"
   echo "found amd64"
-elif [[ "$arch" e==q "arm64" ]]; then
+elif [[ "$arch" == "arm64" ]]; then
   node_exp_url="${node_exp_url}arm64.tar.gz"
   echo "found arm64"
 else
   echo "${node_exp_url} not found, exiting"
   exit 1
 fi
-curl -Os ${node_exp_url}
+echo "fetching from ${node_exp_url} "
+curl -sLO ${node_exp_url}
 tar xvzf node_exporter-1.11.1.linux-*.tar.gz
-mv node_exporter/bin/node_exporter /usr/local/bin/node_exporter
+mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
 
 bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
 [Unit]

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -2,28 +2,38 @@
 set -e
 
 add_ssh_keys(){
+  echo "starting add_ssh_keys"
+  mkdir -p /home/ubuntu/.ssh/
+  touch /home/ubuntu/.ssh/authorized_keys
+  echo "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCeiJ17mk+U7EOPqs5jKCBS+WpobaoH78co52rLv83JARJZA/1o9PscdwkojPpvaOrc7ZMaACwjtzueUzTIczSyI1pSM7b7C55bcua03oST0AxoJ5jgaYWFDLPjHRw/MinfYtF1KCDYNJ5RyqHEo2dRVVgbfa/tJU4IBT1Y4CKFWbBVLPPtTSxotoBTqFhl5tPfGko7S/idsOx1SHL2Qbw4D99zdeggCkQPHiXuf585BFTgi9AH/4rxhGWKyc0zoWyAn18ujcJ/F6qRGCckyH/mkjv/qm4gYP9dliPyfjbxuTumCINUbcoAYQf5IxFO1nxAv2gVgkUskgFTJQ1J+JsBx3yLRUd+0faX4mo90NWC+cuS5Z7xqfucz8Mt3+Jb65ri0tAurZCNzMW68qJmPYeNS273eJiu2tZUNcm9vCdarwpsTNoZQ/w1fQ0kxV5nRIs9YE5kHqj3tB0L8EkRvUlMxu2bAeng1GkL0/QXgK+pmhpdZ1ZmGhgHicntMqq+osE= diana@laptop" >> /home/ubuntu/.ssh/authorized_keys
   echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIARW6HBO5RDEHDPBOLsajCEAxP/Cn+uGQwPdBz89q5D3 mrjones@airbuntu2" >> /home/ubuntu/.ssh/authorized_keys
   echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSPFnouayrnP39+7Y3CrMOco8BFCVQitOLwnwFEgFOi mrjones@theplip" >> /home/ubuntu/.ssh/authorized_keys
   echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKlJwZnBVjIpPgUu2GF34cPwUIFXapstbch8XfLn3rfR mrjones@plip.com" >> /home/ubuntu/.ssh/authorized_keys
 }
 
 set_hostname(){
+  echo "starting set_hostname"
   sudo hostnamectl set-hostname $1
 }
 
 install_docker(){
+  echo "starting install_docker"
   curl -fsSL https://get.docker.com -o get-docker.sh
   sh ./get-docker.sh
 }
 
 install_cht(){
-  COMPOSE_URL="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:${BUILD}"
+  echo "starting install_cht"
+  BUILD=$1
+  COMPOSE_URL="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:$BUILD"
   mkdir -p /cht/upgrade-service  /cht/compose
   curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
     -o /cht/upgrade-service/docker-compose.yml
-  curl -s "$BUILD"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
-  curl -s "$BUILD"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
+  curl -s "$COMPOSE_URL"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
+  curl -s "$COMPOSE_URL"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
 
+  echo "    install_cht got compose files"
+  echo "    install_cht starting CHT"
   cd /cht/upgrade-service/
   cat > /cht/upgrade-service//.env <<- EOF
 DOCKER_CONFIG_PATH=/home/.docker
@@ -31,26 +41,29 @@ CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
   docker compose --progress quiet up --detach
+  echo "    install_cht CHT started"
 }
 
 install_local_ip_cert(){
+  echo "starting install_local_ip_cert"
   max=500
   count=0
+  echo -n "waiting for nginx to be ready..."
   while [[ count -le max  ]]; do
     nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
     if [[ "$nginx" == "cht-nginx-1" ]]; then
-
       curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
       bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
       count=max
     fi
     ((count=count+1))
-    echo "waiting for nginx to be ready..."
+    echo -n "."
     sleep 1
   done
 }
 
 install_node_exporter(){
+  echo "starting install_node_exporter"
   arch=$(dpkg --print-architecture)
   node_exp_url='https://github.com/prometheus/node_exporter/releases/download/v1.11.1/node_exporter-1.11.1.linux-'
   if [[ "$arch" == "amd64" ]]; then
@@ -67,32 +80,34 @@ install_node_exporter(){
   mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
 }
 
-enabe_node_exporter(){
+enable_node_exporter(){
+  echo "starting enable_node_exporter"
   bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
-  [Unit]
-  Description=Node Exporter
-  After=network.target
+[Unit]
+Description=Node Exporter
+After=network.target
 
-  [Service]
-  Type=simple
-  ExecStart=/usr/local/bin/node_exporter
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/node_exporter
 
-  [Install]
-  WantedBy=multi-user.target
-  EOF'
+[Install]
+WantedBy=multi-user.target
+EOF'
 
   systemctl daemon-reload
   systemctl enable node_exporter
   systemctl start node_exporter
 }
 
-CHT_VERSION=$2
-HOST_NAME=$3
-sudo su -
+CHT_VERSION=$1
+HOST_NAME=$2
+echo "START, CHT_VERSION ${CHT_VERSION} hostname ${HOST_NAME}"
 set_hostname "$HOST_NAME"
 add_ssh_keys
 install_docker
 install_cht "$CHT_VERSION"
 install_node_exporter
-enabe_node_exporter
+enable_node_exporter
 install_local_ip_cert
+echo "DONE"

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -46,25 +46,14 @@ CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
   docker compose --progress quiet up --detach
+  cd
   echo "    install_cht CHT started"
 }
 
 install_local_ip_cert(){
   echo "starting install_local_ip_cert"
-  max=500
-  count=0
-  echo -n "waiting for nginx to be ready..."
-  while [[ count -le max  ]]; do
-    nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
-    if [[ "$nginx" == "cht-nginx-1" ]]; then
-      curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
-      bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
-      count=max
-    fi
-    ((count=count+1))
-    echo -n "."
-    sleep 1
-  done
+  curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
+  bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
 }
 
 install_node_exporter(){

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -3,7 +3,8 @@ set -e
 
 # This script can be called remotely with:
 # sudo su -
-# source <(curl -s https://raw.githubusercontent.com/medic/cht-core/refs/heads/medic-infra-1394-graviton-do-not-merge/tests/scalability/prepare-ec2.sh)
+# curl -O https://raw.githubusercontent.com/medic/cht-core/refs/heads/medic-infra-1394-graviton-do-not-merge/tests/scalability/prepare-ec2.sh
+# bash prepare-ec2.sh
 
 
 shutdown -P +60
@@ -34,6 +35,8 @@ while [[ count -le max  ]]; do
     count=max
   fi
   ((count=count+1))
+  echo "waiting for nginx to be ready..."
+  sleep 1
 done
 
 arch=$(dpkg --print-architecture)

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -18,3 +18,5 @@ CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
 docker compose up -d
+sleep 60
+/root/cht-core/scripts/add-local-ip-certs-to-docker.sh  cht-nginx-1

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Call this remotely by curling it then passing in CHT version and machine name:
+#   curl -O https://raw.githubusercontent.com/medic/cht-core/refs/heads/medic-infra-1394-graviton-do-not-merge/tests/scalability/prepare-ec2.sh
+#   bash prepare-ec2.sh 5.1.0 mrjones-test-deleteme
+
+
 add_ssh_keys(){
   echo "starting add_ssh_keys"
   mkdir -p /home/ubuntu/.ssh/
@@ -26,11 +31,11 @@ install_cht(){
   echo "starting install_cht"
   BUILD=$1
   COMPOSE_URL="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:$BUILD"
-  mkdir -p /cht/upgrade-service  /cht/compose
-  curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
+  sudo mkdir -p /cht/upgrade-service  /cht/compose
+  sudo curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
     -o /cht/upgrade-service/docker-compose.yml
-  curl -s "$COMPOSE_URL"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
-  curl -s "$COMPOSE_URL"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
+  sudo curl -s "$COMPOSE_URL"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
+  sudo curl -s "$COMPOSE_URL"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
 
   echo "    install_cht got compose files"
   echo "    install_cht starting CHT"
@@ -40,7 +45,7 @@ DOCKER_CONFIG_PATH=/home/.docker
 CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
-  docker compose --progress quiet up --detach
+  sudo docker compose --progress quiet up --detach
   echo "    install_cht CHT started"
 }
 
@@ -53,7 +58,7 @@ install_local_ip_cert(){
     nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
     if [[ "$nginx" == "cht-nginx-1" ]]; then
       curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
-      bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
+      sudo bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
       count=max
     fi
     ((count=count+1))
@@ -77,12 +82,12 @@ install_node_exporter(){
   echo "fetching from ${node_exp_url} "
   curl -sLO ${node_exp_url}
   tar xvzf node_exporter-1.11.1.linux-*.tar.gz
-  mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
+  sudo mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
 }
 
 enable_node_exporter(){
   echo "starting enable_node_exporter"
-  bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
+  sudo bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
 [Unit]
 Description=Node Exporter
 After=network.target
@@ -95,9 +100,9 @@ ExecStart=/usr/local/bin/node_exporter
 WantedBy=multi-user.target
 EOF'
 
-  systemctl daemon-reload
-  systemctl enable node_exporter
-  systemctl start node_exporter
+  sudo systemctl daemon-reload
+  sudo systemctl enable node_exporter
+  sudo systemctl start node_exporter
 }
 
 CHT_VERSION=$1

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -18,7 +18,7 @@ add_ssh_keys(){
 
 set_hostname(){
   echo "starting set_hostname"
-  sudo hostnamectl set-hostname $1
+  hostnamectl set-hostname $1
 }
 
 install_docker(){
@@ -31,11 +31,11 @@ install_cht(){
   echo "starting install_cht"
   BUILD=$1
   COMPOSE_URL="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:$BUILD"
-  sudo mkdir -p /cht/upgrade-service  /cht/compose
-  sudo curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
+  mkdir -p /cht/upgrade-service  /cht/compose
+  curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
     -o /cht/upgrade-service/docker-compose.yml
-  sudo curl -s "$COMPOSE_URL"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
-  sudo curl -s "$COMPOSE_URL"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
+  curl -s "$COMPOSE_URL"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
+  curl -s "$COMPOSE_URL"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
 
   echo "    install_cht got compose files"
   echo "    install_cht starting CHT"
@@ -45,7 +45,7 @@ DOCKER_CONFIG_PATH=/home/.docker
 CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
-  sudo docker compose --progress quiet up --detach
+  docker compose --progress quiet up --detach
   echo "    install_cht CHT started"
 }
 
@@ -58,7 +58,7 @@ install_local_ip_cert(){
     nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
     if [[ "$nginx" == "cht-nginx-1" ]]; then
       curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
-      sudo bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
+      bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
       count=max
     fi
     ((count=count+1))
@@ -82,12 +82,12 @@ install_node_exporter(){
   echo "fetching from ${node_exp_url} "
   curl -sLO ${node_exp_url}
   tar xvzf node_exporter-1.11.1.linux-*.tar.gz
-  sudo mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
+  mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
 }
 
 enable_node_exporter(){
   echo "starting enable_node_exporter"
-  sudo bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
+  bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
 [Unit]
 Description=Node Exporter
 After=network.target
@@ -100,10 +100,15 @@ ExecStart=/usr/local/bin/node_exporter
 WantedBy=multi-user.target
 EOF'
 
-  sudo systemctl daemon-reload
-  sudo systemctl enable node_exporter
-  sudo systemctl start node_exporter
+  systemctl daemon-reload
+  systemctl enable node_exporter
+  systemctl start node_exporter
 }
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
 
 CHT_VERSION=$1
 HOST_NAME=$2

--- a/tests/scalability/prepare-ec2.sh
+++ b/tests/scalability/prepare-ec2.sh
@@ -1,73 +1,98 @@
 #!/bin/bash
 set -e
 
-# This script can be called remotely with:
-# sudo su -
-# curl -O https://raw.githubusercontent.com/medic/cht-core/refs/heads/medic-infra-1394-graviton-do-not-merge/tests/scalability/prepare-ec2.sh
-# bash prepare-ec2.sh
+add_ssh_keys(){
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIARW6HBO5RDEHDPBOLsajCEAxP/Cn+uGQwPdBz89q5D3 mrjones@airbuntu2" >> /home/ubuntu/.ssh/authorized_keys
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHSPFnouayrnP39+7Y3CrMOco8BFCVQitOLwnwFEgFOi mrjones@theplip" >> /home/ubuntu/.ssh/authorized_keys
+  echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKlJwZnBVjIpPgUu2GF34cPwUIFXapstbch8XfLn3rfR mrjones@plip.com" >> /home/ubuntu/.ssh/authorized_keys
+}
 
+set_hostname(){
+  sudo hostnamectl set-hostname $1
+}
 
-shutdown -P +60
-mkdir -p /cht/upgrade-service  /cht/compose
-curl -fsSL https://get.docker.com -o get-docker.sh
-sh ./get-docker.sh
-BUILD="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:5.1.0"
-curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
-  -o /cht/upgrade-service/docker-compose.yml
-curl -s "$BUILD"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
-curl -s "$BUILD"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
+install_docker(){
+  curl -fsSL https://get.docker.com -o get-docker.sh
+  sh ./get-docker.sh
+}
 
-cd /cht/upgrade-service/
-cat > /cht/upgrade-service//.env << EOF
+install_cht(){
+  COMPOSE_URL="https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:${BUILD}"
+  mkdir -p /cht/upgrade-service  /cht/compose
+  curl -s https://raw.githubusercontent.com/medic/cht-upgrade-service/main/docker-compose.yml \
+    -o /cht/upgrade-service/docker-compose.yml
+  curl -s "$BUILD"/docker-compose/cht-core.yml -o /cht/compose/cht-core.yml
+  curl -s "$BUILD"/docker-compose/cht-couchdb.yml -o /cht/compose/cht-couchdb.yml
+
+  cd /cht/upgrade-service/
+  cat > /cht/upgrade-service//.env <<- EOF
 DOCKER_CONFIG_PATH=/home/.docker
 CHT_COMPOSE_PATH=/cht/compose
 COUCHDB_PASSWORD=medicScalability
 EOF
-docker compose --progress quiet up --detach
-curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
+  docker compose --progress quiet up --detach
+}
 
-max=120
-count=0
-while [[ count -le max  ]]; do
-  nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
-  if [[ "$nginx" == "cht-nginx-1" ]]; then
-    bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
-    count=max
+install_local_ip_cert(){
+  max=500
+  count=0
+  while [[ count -le max  ]]; do
+    nginx=$(docker ps --format "table {{.Names}}" | grep cht-nginx-1)
+    if [[ "$nginx" == "cht-nginx-1" ]]; then
+
+      curl -sO https://raw.githubusercontent.com/medic/cht-core/refs/heads/master/scripts/add-local-ip-certs-to-docker.sh
+      bash ./add-local-ip-certs-to-docker.sh cht-nginx-1
+      count=max
+    fi
+    ((count=count+1))
+    echo "waiting for nginx to be ready..."
+    sleep 1
+  done
+}
+
+install_node_exporter(){
+  arch=$(dpkg --print-architecture)
+  node_exp_url='https://github.com/prometheus/node_exporter/releases/download/v1.11.1/node_exporter-1.11.1.linux-'
+  if [[ "$arch" == "amd64" ]]; then
+    node_exp_url="${node_exp_url}amd64.tar.gz"
+  elif [[ "$arch" == "arm64" ]]; then
+    node_exp_url="${node_exp_url}arm64.tar.gz"
+  else
+    echo "${node_exp_url} not found, exiting"
+    exit 1
   fi
-  ((count=count+1))
-  echo "waiting for nginx to be ready..."
-  sleep 1
-done
+  echo "fetching from ${node_exp_url} "
+  curl -sLO ${node_exp_url}
+  tar xvzf node_exporter-1.11.1.linux-*.tar.gz
+  mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
+}
 
-arch=$(dpkg --print-architecture)
+enabe_node_exporter(){
+  bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
+  [Unit]
+  Description=Node Exporter
+  After=network.target
 
-node_exp_url='https://github.com/prometheus/node_exporter/releases/download/v1.11.1/node_exporter-1.11.1.linux-'
-if [[ "$arch" == "amd64" ]]; then
-  node_exp_url="${node_exp_url}amd64.tar.gz"
-elif [[ "$arch" == "arm64" ]]; then
-  node_exp_url="${node_exp_url}arm64.tar.gz"
-else
-  echo "${node_exp_url} not found, exiting"
-  exit 1
-fi
-echo "fetching from ${node_exp_url} "
-curl -sLO ${node_exp_url}
-tar xvzf node_exporter-1.11.1.linux-*.tar.gz
-mv node_exporter-1.11.1.linux-*/node_exporter /usr/local/bin/node_exporter
+  [Service]
+  Type=simple
+  ExecStart=/usr/local/bin/node_exporter
 
-bash -c 'cat <<EOF > /etc/systemd/system/node_exporter.service
-[Unit]
-Description=Node Exporter
-After=network.target
+  [Install]
+  WantedBy=multi-user.target
+  EOF'
 
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/node_exporter
+  systemctl daemon-reload
+  systemctl enable node_exporter
+  systemctl start node_exporter
+}
 
-[Install]
-WantedBy=multi-user.target
-EOF'
-
-systemctl daemon-reload
-systemctl enable node_exporter
-systemctl start node_exporter
+CHT_VERSION=$2
+HOST_NAME=$3
+sudo su -
+set_hostname "$HOST_NAME"
+add_ssh_keys
+install_docker
+install_cht "$CHT_VERSION"
+install_node_exporter
+enabe_node_exporter
+install_local_ip_cert


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

Try to get a cross architecture CHT Core bootstrap script to do performance testing on arm64 & amd64 ec2 instances

See https://github.com/medic/medic-infrastructure/issues/1394

<!-- ISSUE NUMBER -->

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:medic-infra-1394-graviton-do-not-merge/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:medic-infra-1394-graviton-do-not-merge/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:medic-infra-1394-graviton-do-not-merge/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

