### PR TITLE
chore(#10543): add PERSON contact type constant and replace magic strings

### DIFF
--- a/admin/src/js/services/import-contacts.js
+++ b/admin/src/js/services/import-contacts.js
@@ -22,7 +22,7 @@ angular.module('services').factory('ImportContacts',
           }
           return $q.reject(new Error(`Unknown type "${provided}"" for person named "${contact.name}"`));
         }
-        if (types.find(type => type.id === constants.CONTACT_TYPES.PERSON)) {
+        if (types.some(type => type.id === constants.CONTACT_TYPES.PERSON)) {
           // retained for backwards compatibility
           return constants.CONTACT_TYPES.PERSON;
         }

--- a/admin/src/js/services/import-contacts.js
+++ b/admin/src/js/services/import-contacts.js
@@ -1,3 +1,4 @@
+const constants = require('@medic/constants');
 angular.module('services').factory('ImportContacts',
   function(
     $http,
@@ -21,9 +22,9 @@ angular.module('services').factory('ImportContacts',
           }
           return $q.reject(new Error(`Unknown type "${provided}"" for person named "${contact.name}"`));
         }
-        if (types.find(type => type.id === 'person')) {
+        if (types.find(type => type.id === constants.CONTACT_TYPES.PERSON)) {
           // retained for backwards compatibility
-          return 'person';
+          return constants.CONTACT_TYPES.PERSON;
         }
         return $q.reject(new Error(`Undefined type for person named "${contact.name}"`));
       });
@@ -37,7 +38,7 @@ angular.module('services').factory('ImportContacts',
             phone: doc.contact.phone,
             parent: doc
           };
-          if (type === 'person') {
+          if (type === constants.CONTACT_TYPES.PERSON) {
             person.type = type;
           } else {
             person.type = 'contact';

--- a/shared-libs/cht-datasource/src/local/person.ts
+++ b/shared-libs/cht-datasource/src/local/person.ts
@@ -15,7 +15,7 @@ import { assertPersonInput } from '../libs/parameter-validators';
 import { CONTACT_TYPES } from '@medic/constants';
 
 const DEFAULT_PERSON_TYPE = {
-  id: 'person',
+  id: CONTACT_TYPES.PERSON,
   parents: [
     CONTACT_TYPES.DISTRICT_HOSPITAL,
     'health_center',

--- a/shared-libs/constants/src/index.js
+++ b/shared-libs/constants/src/index.js
@@ -19,6 +19,7 @@ const CONTACT_TYPES = {
   HEALTH_CENTER: 'health_center',
   CLINIC: 'clinic',
   DISTRICT_HOSPITAL: 'district_hospital',
+  PERSON: 'person',
 };
 
 // Document Types

--- a/shared-libs/contact-types-utils/src/index.js
+++ b/shared-libs/contact-types-utils/src/index.js
@@ -1,11 +1,11 @@
 const { CONTACT_TYPES } = require('@medic/constants');
 
-const HARDCODED_PERSON_TYPE = 'person';
+const HARDCODED_PERSON_TYPE = CONTACT_TYPES.PERSON;
 const HARDCODED_TYPES = [
   CONTACT_TYPES.DISTRICT_HOSPITAL,
   CONTACT_TYPES.HEALTH_CENTER,
   CONTACT_TYPES.CLINIC,
-  'person'
+  CONTACT_TYPES.PERSON
 ];
 
 const getContactTypes = config => {

--- a/shared-libs/contacts/src/people.js
+++ b/shared-libs/contacts/src/people.js
@@ -7,6 +7,7 @@ const places = require('./places');
 const lineage = require('./libs/lineage');
 const { Person, Qualifier } = require('@medic/cht-datasource');
 const contactTypeUtils = require('@medic/contact-types-utils');
+const { CONTACT_TYPES } = require('@medic/constants');
 
 const getPerson = id => dataContext
   .bind(Person.v1.getWithLineage)(Qualifier.byUuid(id))
@@ -20,7 +21,7 @@ const getPerson = id => dataContext
 const isAPerson = person => contactTypeUtils.isPerson(config.get(), person);
 
 const getDefaultPersonType = () => {
-  const type = contactTypeUtils.getTypeById(config.get(), 'person');
+  const type = contactTypeUtils.getTypeById(config.get(), CONTACT_TYPES.PERSON);
   return type && type.id;
 };
 

--- a/shared-libs/transitions/src/transitions/registration.js
+++ b/shared-libs/transitions/src/transitions/registration.js
@@ -20,7 +20,7 @@ const NAME = 'registration';
 const PARENT_NOT_FOUND = 'parent_not_found';
 const PARENT_FIELD_NOT_PROVIDED = 'parent_field_not_provided';
 const PARENT_INVALID = 'parent_invalid';
-const { DOC_TYPES } = require('@medic/constants');
+const { CONTACT_TYPES, DOC_TYPES } = require('@medic/constants');
 
 const findFirstDefinedValue = (doc, fields) => {
   const definedField = fields.find(field => doc.fields[field] !== undefined && doc.fields[field] !== null);
@@ -489,7 +489,7 @@ const addPatient = (options) => {
     patient.type = 'contact';
     patient.contact_type = options.params.contact_type;
   } else {
-    patient.type = 'person';
+    patient.type = CONTACT_TYPES.PERSON;
   }
 
 
@@ -631,7 +631,7 @@ module.exports = {
                 `patient_id_field cannot be set to patient_id`
               );
             }
-            const typeId = params.contact_type || 'person';
+            const typeId = params.contact_type || CONTACT_TYPES.PERSON;
             const contactType = contactTypesUtils.getTypeById(config.getAll(), typeId);
             if (!contactType) {
               throw new Error(

--- a/webapp/src/ts/services/contact-save.service.ts
+++ b/webapp/src/ts/services/contact-save.service.ts
@@ -7,6 +7,7 @@ import { EnketoTranslationService } from '@mm-services/enketo-translation.servic
 import { ExtractLineageService } from '@mm-services/extract-lineage.service';
 import { AttachmentService } from '@mm-services/attachment.service';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
+import { CONTACT_TYPES } from '@medic/constants';
 import { Contact, Qualifier } from '@medic/cht-datasource';
 import { Xpath } from '@mm-providers/xpath-element-path.provider';
 import FileManager from '../../js/enketo/file-manager';
@@ -267,7 +268,7 @@ export class ContactSaveService {
     // by default all siblings are "person" types but can be overridden
     // by specifying the type and contact_type in the form
     if (!preparedSibling.type) {
-      preparedSibling.type = 'person';
+      preparedSibling.type = CONTACT_TYPES.PERSON;
     }
 
     if (preparedSibling.parent === 'PARENT') {

--- a/webapp/web-components/cht-form/src/app.component.ts
+++ b/webapp/web-components/cht-form/src/app.component.ts
@@ -26,7 +26,7 @@ export class AppComponent {
     CONTACT_TYPES.DISTRICT_HOSPITAL,
     CONTACT_TYPES.HEALTH_CENTER,
     'clinic',
-    'person'
+    CONTACT_TYPES.PERSON
   ];
 
   private readonly chtDataSourceService: CHTDatasourceServiceStub;


### PR DESCRIPTION
## Description
Adds a `PERSON` constant to `CONTACT_TYPES` in `@medic/constants`, and replaces hardcoded `'person'` magic strings with `CONTACT_TYPES.PERSON` across the codebase where the string represents a **contact/doc type check** (not an id, and not inside a CouchDB view function).

## Changes
- `shared-libs/constants/src/index.js`: added `PERSON: 'person'` to `CONTACT_TYPES`
- `shared-libs/contact-types-utils/src/index.js`
- `shared-libs/transitions/src/transitions/registration.js`
- `shared-libs/cht-datasource/src/local/person.ts`
- `shared-libs/contacts/src/people.js`
- `webapp/web-components/cht-form/src/app.component.ts`
- `webapp/src/ts/services/contact-save.service.ts`
- `admin/src/js/services/import-contacts.js`

## Intentionally not changed
- `ddocs/medic-db/medic-client/views/contacts_by_type/map.js` and `contacts_by_parent/map.js`, and `webapp/src/js/bootstrapper/offline-ddocs/medic-offline-freetext/*.js`: these are CouchDB map functions that get serialized via `.toString()` and executed by CouchDB in complete isolation — they cannot `require()` shared constants.
- Occurrences where `'person'` is used as an **id value** rather than a type check (e.g. test fixtures, `contact: 'person'`).
- `config/demo/**` and `config/default/**` sample app configuration files, which aren't part of the `@medic/*` shared-lib ecosystem.

## Testing
Ran unit tests for every affected package locally, all passing:
- `shared-libs/contact-types-utils`: 56 passing, 100% coverage
- `shared-libs/transitions`: 879 passing
- `shared-libs/cht-datasource`: 1055 passing
- `shared-libs/contacts`: 83 passing, 100% coverage
- `webapp` (incl. `cht-form`): 2796 passing
- `admin`: 431 passing

Also ran `eslint` on all changed files with no errors.

## AI Disclosure
Used Claude to review code changes as this was my first open source contribution.

Fixes #10543