### PR TITLE
feat: add device-key api endpoint (#11278)

### DIFF
--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -8,6 +8,8 @@ const logger = require('@medic/logger');
 const serverUtils = require('../server-utils');
 const replication = require('../services/replication/replication');
 const serverKey = require('../services/offline-data-bundle/server-key');
+const age = require('../services/offline-data-bundle/age');
+const signing = require('../services/offline-data-bundle/signing');
 
 const OFFLINE_DATA_BUNDLE_PERMISSIONS = ['can_send_offline_data_bundle', 'can_relay_offline_data_bundle'];
 
@@ -498,14 +500,19 @@ module.exports = {
    *         application/json:
    *           schema:
    *             type: object
-   *             required: [device_id, public_key]
+   *             required: [device_id, encryption_key, signing_key]
    *             properties:
    *               device_id:
    *                 type: string
    *                 description: Unique identifier for the device.
-   *               public_key:
+   *               encryption_key:
    *                 type: string
-   *                 description: The device's age recipient (public) key.
+   *                 description: >
+   *                   The device's age recipient (X25519 public) key, used to encrypt the checkpoint to the device.
+   *               signing_key:
+   *                 type: string
+   *                 description: >
+   *                   The device's Ed25519 public signing key, used by the server to verify bundle signatures.
    *     responses:
    *       '200':
    *         description: Device key registered
@@ -518,6 +525,10 @@ module.exports = {
    *                   type: string
    *                   description: The server's age recipient (public) key.
    *       '400':
+   *         description: >
+   *           Required fields are missing, or a key is malformed. The `encryption_key` must be an age
+   *           recipient string and the `signing_key` must be base64 of a raw Ed25519 public key; invalid
+   *           key formats are rejected.
    *         $ref: '#/components/responses/BadRequest'
    *       '401':
    *         $ref: '#/components/responses/Unauthorized'
@@ -529,10 +540,26 @@ module.exports = {
       return serverUtils.emptyJSONBodyError(req, res);
     }
 
-    const { device_id: deviceId, public_key: publicKey } = req.body;
-    if (!deviceId || !publicKey) {
+    const { device_id: deviceId, encryption_key: encryptionKey, signing_key: signingKey } = req.body;
+    if (!deviceId || !encryptionKey || !signingKey) {
       return serverUtils.error(
-        { code: 400, reason: 'Missing required fields: device_id and public_key' },
+        { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' },
+        req,
+        res
+      );
+    }
+
+    if (!(await age.isValidRecipient(encryptionKey))) {
+      return serverUtils.error(
+        { code: 400, reason: 'Invalid encryption_key: expected an age recipient' },
+        req,
+        res
+      );
+    }
+
+    if (!(await signing.isValidPublicKey(signingKey))) {
+      return serverUtils.error(
+        { code: 400, reason: 'Invalid signing_key: expected a base64 Ed25519 public key' },
         req,
         res
       );
@@ -545,7 +572,7 @@ module.exports = {
         return serverUtils.error({ code: 403, message: 'You do not have permissions to modify this user' }, req, res);
       }
 
-      await users.setDeviceKey(username, deviceId, publicKey);
+      await users.setDeviceKey(username, deviceId, encryptionKey, signingKey);
       const serverPublicKey = await serverKey.getServerPublicKey();
 
       logger.info(`REQ ${req.id} - Registered device key for device '${deviceId}' on user '${username}'.`);

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -13,6 +13,20 @@ const signing = require('../services/offline-data-bundle/signing');
 
 const OFFLINE_DATA_BUNDLE_PERMISSIONS = ['can_send_offline_data_bundle', 'can_relay_offline_data_bundle'];
 
+const validateDeviceKeyBody = async (body) => {
+  const { device_id: deviceId, encryption_key: encryptionKey, signing_key: signingKey } = body;
+  if (!deviceId || !encryptionKey || !signingKey) {
+    return 'Missing required fields: device_id, encryption_key and signing_key';
+  }
+  if (!(await age.isValidRecipient(encryptionKey))) {
+    return 'Invalid encryption_key: expected an age recipient';
+  }
+  if (!(await signing.isValidPublicKey(signingKey))) {
+    return 'Invalid signing_key: expected a base64 Ed25519 public key';
+  }
+  return null;
+};
+
 const hasFullPermission = req => {
   return auth
     .check(req, ['can_edit', 'can_update_users'])
@@ -540,29 +554,9 @@ module.exports = {
       return serverUtils.emptyJSONBodyError(req, res);
     }
 
-    const { device_id: deviceId, encryption_key: encryptionKey, signing_key: signingKey } = req.body;
-    if (!deviceId || !encryptionKey || !signingKey) {
-      return serverUtils.error(
-        { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' },
-        req,
-        res
-      );
-    }
-
-    if (!(await age.isValidRecipient(encryptionKey))) {
-      return serverUtils.error(
-        { code: 400, reason: 'Invalid encryption_key: expected an age recipient' },
-        req,
-        res
-      );
-    }
-
-    if (!(await signing.isValidPublicKey(signingKey))) {
-      return serverUtils.error(
-        { code: 400, reason: 'Invalid signing_key: expected a base64 Ed25519 public key' },
-        req,
-        res
-      );
+    const validationError = await validateDeviceKeyBody(req.body);
+    if (validationError) {
+      return serverUtils.error({ code: 400, reason: validationError }, req, res);
     }
 
     try {
@@ -572,6 +566,7 @@ module.exports = {
         return serverUtils.error({ code: 403, message: 'You do not have permissions to modify this user' }, req, res);
       }
 
+      const { device_id: deviceId, encryption_key: encryptionKey, signing_key: signingKey } = req.body;
       await users.setDeviceKey(username, deviceId, encryptionKey, signingKey);
       const serverPublicKey = await serverKey.getServerPublicKey();
 

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -587,7 +587,8 @@ module.exports = {
         encryption: serverKeys.server_encryption_private_key,
         signing: serverKeys.server_signing_private_key,
       });
-      const serverPublicKeys = await users.setDeviceKey(username, deviceId, encryptionKey, signingKey, {
+      const deviceKeys = { encryption_key: encryptionKey, signing_key: signingKey };
+      const serverPublicKeys = await users.setDeviceKey(username, deviceId, deviceKeys, {
         server_encryption_public_key: serverKeys.server_encryption_public_key,
         server_signing_public_key: serverKeys.server_signing_public_key,
       });

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -7,24 +7,34 @@ const auth = require('../auth');
 const logger = require('@medic/logger');
 const serverUtils = require('../server-utils');
 const replication = require('../services/replication/replication');
-const serverKey = require('../services/offline-data-bundle/server-key');
 const age = require('../services/offline-data-bundle/age');
 const signing = require('../services/offline-data-bundle/signing');
-
-const OFFLINE_DATA_BUNDLE_PERMISSIONS = ['can_send_offline_data_bundle', 'can_relay_offline_data_bundle'];
+const serverKey = require('../services/offline-data-bundle/server-key');
 
 const validateDeviceKeyBody = async (body) => {
-  const { device_id: deviceId, encryption_key: encryptionKey, signing_key: signingKey } = body;
-  if (!deviceId || !encryptionKey || !signingKey) {
-    return 'Missing required fields: device_id, encryption_key and signing_key';
+  const { encryption_key: encryptionKey, signing_key: signingKey } = body;
+  if (!encryptionKey || !signingKey) {
+    return 'Missing required fields: encryption_key and signing_key';
   }
   if (!(await age.isValidRecipient(encryptionKey))) {
     return 'Invalid encryption_key: expected an age recipient';
   }
   if (!(await signing.isValidPublicKey(signingKey))) {
-    return 'Invalid signing_key: expected a base64 Ed25519 public key';
+    return 'Invalid signing_key: expected an Ed25519 public key JWK';
   }
   return null;
+};
+
+const generateServerKeys = async () => {
+  const encryptionIdentity = await age.generateIdentity();
+  const encryptionRecipient = await age.identityToRecipient(encryptionIdentity);
+  const signingKeyPair = await signing.generateKeyPair();
+  return {
+    server_encryption_public_key: encryptionRecipient,
+    server_encryption_private_key: encryptionIdentity,
+    server_signing_public_key: signingKeyPair.publicKey,
+    server_signing_private_key: signingKeyPair.privateKey,
+  };
 };
 
 const hasFullPermission = req => {
@@ -489,60 +499,62 @@ module.exports = {
 
   /**
    * @openapi
-   * /api/v1/users/{username}/device-key:
+   * /api/v1/users/{username}/devices/{device_id}/keys:
    *   post:
-   *     summary: Register a device encryption key
-   *     operationId: v1UsersUsernameDeviceKeyPost
+   *     summary: Register a device's public keys
+   *     operationId: v1UsersUsernameDeviceKeysPost
    *     description: >
-   *       Stores the device's age public (recipient) key against the user and returns the server's current age
-   *       public key. Keys are per-device: re-registering the same `device_id` replaces the stored key. Requires
-   *       the `can_send_offline_data_bundle` or `can_relay_offline_data_bundle` permission. Non-admin users can
-   *       only register a key for themselves.
+   *       Stores the device's age encryption and Ed25519 signing public keys against the user and returns the
+   *       server's public keys generated for this device. Keys are per-device: re-registering the same `device_id`
+   *       replaces the stored keys. Requires the `can_send_offline_data_bundle` permission. Non-admin users can
+   *       only register keys for themselves.
    *     tags: [User]
    *     x-permissions:
-   *       hasAny: [can_send_offline_data_bundle, can_relay_offline_data_bundle]
+   *       hasAny: [can_send_offline_data_bundle]
    *     parameters:
    *       - in: path
    *         name: username
    *         required: true
    *         schema:
    *           type: string
-   *         description: The username to register the device key for.
+   *         description: The username to register the device keys for.
+   *       - in: path
+   *         name: device_id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: Unique identifier for the device.
    *     requestBody:
    *       required: true
    *       content:
    *         application/json:
    *           schema:
    *             type: object
-   *             required: [device_id, encryption_key, signing_key]
+   *             required: [encryption_key, signing_key]
    *             properties:
-   *               device_id:
-   *                 type: string
-   *                 description: Unique identifier for the device.
    *               encryption_key:
    *                 type: string
-   *                 description: >
-   *                   The device's age recipient (X25519 public) key, used to encrypt the checkpoint to the device.
+   *                 description: The device's age encryption recipient (public) key.
    *               signing_key:
-   *                 type: string
-   *                 description: >
-   *                   The device's Ed25519 public signing key, used by the server to verify bundle signatures.
+   *                 type: object
+   *                 additionalProperties: true
+   *                 description: The device's Ed25519 public signing key as a JWK.
    *     responses:
    *       '200':
-   *         description: Device key registered
+   *         description: Device keys registered
    *         content:
    *           application/json:
    *             schema:
    *               type: object
    *               properties:
-   *                 server_key:
+   *                 server_encryption_public_key:
    *                   type: string
-   *                   description: The server's age recipient (public) key.
+   *                   description: The server's age encryption recipient (public) key for this device.
+   *                 server_signing_public_key:
+   *                   type: object
+   *                   additionalProperties: true
+   *                   description: The server's Ed25519 public signing key as a JWK for this device.
    *       '400':
-   *         description: >
-   *           Required fields are missing, or a key is malformed. The `encryption_key` must be an age
-   *           recipient string and the `signing_key` must be base64 of a raw Ed25519 public key; invalid
-   *           key formats are rejected.
    *         $ref: '#/components/responses/BadRequest'
    *       '401':
    *         $ref: '#/components/responses/Unauthorized'
@@ -550,28 +562,38 @@ module.exports = {
    *         $ref: '#/components/responses/Forbidden'
    */
   deviceKey: async (req, res) => {
-    if (_.isEmpty(req.body)) {
-      return serverUtils.emptyJSONBodyError(req, res);
-    }
-
-    const validationError = await validateDeviceKeyBody(req.body);
-    if (validationError) {
-      return serverUtils.error({ code: 400, reason: validationError }, req, res);
-    }
-
     try {
       const username = req.params.username;
-      const userCtx = await auth.assertPermissions(req, { hasAny: OFFLINE_DATA_BUNDLE_PERMISSIONS });
+      const deviceId = req.params.device_id;
+      const userCtx = await auth.assertPermissions(req, { hasAny: ['can_send_offline_data_bundle'] });
       if (!auth.isDbAdmin(userCtx) && !isReferencingSelf(userCtx, auth.basicAuthCredentials(req), username)) {
         return serverUtils.error({ code: 403, message: 'You do not have permissions to modify this user' }, req, res);
       }
 
-      const { device_id: deviceId, encryption_key: encryptionKey, signing_key: signingKey } = req.body;
-      await users.setDeviceKey(username, deviceId, encryptionKey, signingKey);
-      const serverPublicKey = await serverKey.getServerPublicKey();
+      if (_.isEmpty(req.body)) {
+        return serverUtils.emptyJSONBodyError(req, res);
+      }
 
-      logger.info(`REQ ${req.id} - Registered device key for device '${deviceId}' on user '${username}'.`);
-      res.json({ server_key: serverPublicKey });
+      const validationError = await validateDeviceKeyBody(req.body);
+      if (validationError) {
+        return serverUtils.error({ code: 400, reason: validationError }, req, res);
+      }
+
+      const { encryption_key: encryptionKey, signing_key: signingKey } = req.body;
+      const serverKeys = await generateServerKeys();
+      // Server PRIVATE keys must never touch the _users doc (the user can read it via the CouchDB
+      // proxy). Persist them to the secureSettings vault; only public keys go on the _users doc.
+      await serverKey.setServerPrivateKeys(username, deviceId, {
+        encryption: serverKeys.server_encryption_private_key,
+        signing: serverKeys.server_signing_private_key,
+      });
+      const serverPublicKeys = await users.setDeviceKey(username, deviceId, encryptionKey, signingKey, {
+        server_encryption_public_key: serverKeys.server_encryption_public_key,
+        server_signing_public_key: serverKeys.server_signing_public_key,
+      });
+
+      logger.info(`REQ ${req.id} - Registered device keys for device '${deviceId}' on user '${username}'.`);
+      res.json(serverPublicKeys);
     } catch (err) {
       serverUtils.error(err, req, res);
     }

--- a/api/src/controllers/users.js
+++ b/api/src/controllers/users.js
@@ -7,6 +7,9 @@ const auth = require('../auth');
 const logger = require('@medic/logger');
 const serverUtils = require('../server-utils');
 const replication = require('../services/replication/replication');
+const serverKey = require('../services/offline-data-bundle/server-key');
+
+const OFFLINE_DATA_BUNDLE_PERMISSIONS = ['can_send_offline_data_bundle', 'can_relay_offline_data_bundle'];
 
 const hasFullPermission = req => {
   return auth
@@ -463,6 +466,90 @@ module.exports = {
         `Requested by '${requesterContext?.name}'.`
       );
       res.json(result);
+    } catch (err) {
+      serverUtils.error(err, req, res);
+    }
+  },
+
+  /**
+   * @openapi
+   * /api/v1/users/{username}/device-key:
+   *   post:
+   *     summary: Register a device encryption key
+   *     operationId: v1UsersUsernameDeviceKeyPost
+   *     description: >
+   *       Stores the device's age public (recipient) key against the user and returns the server's current age
+   *       public key. Keys are per-device: re-registering the same `device_id` replaces the stored key. Requires
+   *       the `can_send_offline_data_bundle` or `can_relay_offline_data_bundle` permission. Non-admin users can
+   *       only register a key for themselves.
+   *     tags: [User]
+   *     x-permissions:
+   *       hasAny: [can_send_offline_data_bundle, can_relay_offline_data_bundle]
+   *     parameters:
+   *       - in: path
+   *         name: username
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The username to register the device key for.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required: [device_id, public_key]
+   *             properties:
+   *               device_id:
+   *                 type: string
+   *                 description: Unique identifier for the device.
+   *               public_key:
+   *                 type: string
+   *                 description: The device's age recipient (public) key.
+   *     responses:
+   *       '200':
+   *         description: Device key registered
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 server_key:
+   *                   type: string
+   *                   description: The server's age recipient (public) key.
+   *       '400':
+   *         $ref: '#/components/responses/BadRequest'
+   *       '401':
+   *         $ref: '#/components/responses/Unauthorized'
+   *       '403':
+   *         $ref: '#/components/responses/Forbidden'
+   */
+  deviceKey: async (req, res) => {
+    if (_.isEmpty(req.body)) {
+      return serverUtils.emptyJSONBodyError(req, res);
+    }
+
+    const { device_id: deviceId, public_key: publicKey } = req.body;
+    if (!deviceId || !publicKey) {
+      return serverUtils.error(
+        { code: 400, reason: 'Missing required fields: device_id and public_key' },
+        req,
+        res
+      );
+    }
+
+    try {
+      const username = req.params.username;
+      const userCtx = await auth.assertPermissions(req, { hasAny: OFFLINE_DATA_BUNDLE_PERMISSIONS });
+      if (!auth.isDbAdmin(userCtx) && !isReferencingSelf(userCtx, auth.basicAuthCredentials(req), username)) {
+        return serverUtils.error({ code: 403, message: 'You do not have permissions to modify this user' }, req, res);
+      }
+
+      await users.setDeviceKey(username, deviceId, publicKey);
+      const serverPublicKey = await serverKey.getServerPublicKey();
+
+      logger.info(`REQ ${req.id} - Registered device key for device '${deviceId}' on user '${username}'.`);
+      res.json({ server_key: serverPublicKey });
     } catch (err) {
       serverUtils.error(err, req, res);
     }

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -518,6 +518,7 @@ app.postJson('/api/v1/users', users.create);
 app.postJsonOrCsv('/api/v2/users', users.v2.create);
 app.postJson('/api/v3/users', users.v3.create);
 app.postJson('/api/v1/users/:username', users.update);
+app.postJson('/api/v1/users/:username/device-key', users.deviceKey);
 app.postJson('/api/v3/users/:username', users.v3.update);
 app.delete('/api/v1/users/:username', users.delete);
 app.get('/api/v1/users-info', authorization.handleAuthErrors, authorization.getUserSettings, users.info);

--- a/api/src/routing.js
+++ b/api/src/routing.js
@@ -518,7 +518,7 @@ app.postJson('/api/v1/users', users.create);
 app.postJsonOrCsv('/api/v2/users', users.v2.create);
 app.postJson('/api/v3/users', users.v3.create);
 app.postJson('/api/v1/users/:username', users.update);
-app.postJson('/api/v1/users/:username/device-key', users.deviceKey);
+app.postJson('/api/v1/users/:username/devices/:device_id/keys', users.deviceKey);
 app.postJson('/api/v3/users/:username', users.v3.update);
 app.delete('/api/v1/users/:username', users.delete);
 app.get('/api/v1/users-info', authorization.handleAuthErrors, authorization.getUserSettings, users.info);

--- a/api/src/services/offline-data-bundle/age.js
+++ b/api/src/services/offline-data-bundle/age.js
@@ -11,4 +11,12 @@ const load = () => {
 module.exports = {
   generateIdentity: async () => (await load()).generateIdentity(),
   identityToRecipient: async (identity) => (await load()).identityToRecipient(identity),
+  isValidRecipient: async (recipient) => {
+    try {
+      new (await load()).Encrypter().addRecipient(recipient);
+      return true;
+    } catch {
+      return false;
+    }
+  },
 };

--- a/api/src/services/offline-data-bundle/age.js
+++ b/api/src/services/offline-data-bundle/age.js
@@ -1,0 +1,14 @@
+// age-encryption (typage) is an ESM-only module. This wrapper is the single boundary that
+// loads it, via a lazy dynamic import
+let agePromise;
+const load = () => {
+  if (!agePromise) {
+    agePromise = import('age-encryption');
+  }
+  return agePromise;
+};
+
+module.exports = {
+  generateIdentity: async () => (await load()).generateIdentity(),
+  identityToRecipient: async (identity) => (await load()).identityToRecipient(identity),
+};

--- a/api/src/services/offline-data-bundle/age.js
+++ b/api/src/services/offline-data-bundle/age.js
@@ -3,6 +3,7 @@
 let agePromise;
 const load = () => {
   if (!agePromise) {
+    // eslint-disable-next-line n/no-extraneous-import
     agePromise = import('age-encryption');
   }
   return agePromise;

--- a/api/src/services/offline-data-bundle/server-key.js
+++ b/api/src/services/offline-data-bundle/server-key.js
@@ -3,6 +3,10 @@ const age = require('./age');
 
 const CREDENTIAL_KEY = 'offline-data-bundle-server-key';
 
+// Vault key for a device's server PRIVATE keys. These must never live on the _users doc (a user can
+// read their own _users doc via the CouchDB proxy), so they are kept in the secureSettings vault.
+const vaultKey = (username, deviceId) => `${CREDENTIAL_KEY}:${username}:${deviceId}`;
+
 const getServerIdentity = async () => {
   const stored = await secureSettings.getCredentials(CREDENTIAL_KEY);
   if (stored) {
@@ -17,5 +21,17 @@ module.exports = {
   getServerPublicKey: async () => {
     const identity = await getServerIdentity();
     return age.identityToRecipient(identity);
+  },
+
+  vaultKey,
+
+  // secureSettings stores a single string value, so both privates are serialised into one object.
+  setServerPrivateKeys: (username, deviceId, privateKeys) => {
+    return secureSettings.setCredentials(vaultKey(username, deviceId), JSON.stringify(privateKeys));
+  },
+
+  getServerPrivateKeys: async (username, deviceId) => {
+    const stored = await secureSettings.getCredentials(vaultKey(username, deviceId));
+    return stored ? JSON.parse(stored) : undefined;
   },
 };

--- a/api/src/services/offline-data-bundle/server-key.js
+++ b/api/src/services/offline-data-bundle/server-key.js
@@ -1,0 +1,21 @@
+const age = require('age-encryption');
+const secureSettings = require('@medic/settings');
+
+const CREDENTIAL_KEY = 'offline-data-bundle-server-key';
+
+const getServerIdentity = async () => {
+  const identity = await secureSettings.getCredentials(CREDENTIAL_KEY);
+  if (identity) {
+    return identity;
+  }
+  const generated = await age.generateIdentity();
+  await secureSettings.setCredentials(CREDENTIAL_KEY, generated);
+  return generated;
+};
+
+module.exports = {
+  getServerPublicKey: async () => {
+    const identity = await getServerIdentity();
+    return age.identityToRecipient(identity);
+  },
+};

--- a/api/src/services/offline-data-bundle/server-key.js
+++ b/api/src/services/offline-data-bundle/server-key.js
@@ -1,16 +1,16 @@
-const age = require('age-encryption');
 const secureSettings = require('@medic/settings');
+const age = require('./age');
 
 const CREDENTIAL_KEY = 'offline-data-bundle-server-key';
 
 const getServerIdentity = async () => {
-  const identity = await secureSettings.getCredentials(CREDENTIAL_KEY);
-  if (identity) {
-    return identity;
+  const stored = await secureSettings.getCredentials(CREDENTIAL_KEY);
+  if (stored) {
+    return stored;
   }
-  const generated = await age.generateIdentity();
-  await secureSettings.setCredentials(CREDENTIAL_KEY, generated);
-  return generated;
+  const identity = await age.generateIdentity();
+  await secureSettings.setCredentials(CREDENTIAL_KEY, identity);
+  return identity;
 };
 
 module.exports = {

--- a/api/src/services/offline-data-bundle/signing.js
+++ b/api/src/services/offline-data-bundle/signing.js
@@ -3,16 +3,25 @@
 const { webcrypto } = require('node:crypto');
 
 module.exports = {
-  isValidPublicKey: async (base64Key) => {
-    const raw = Buffer.from(base64Key, 'base64');
-    if (raw.length !== 32) {
+  isValidPublicKey: async (jwk) => {
+    if (!jwk || typeof jwk !== 'object') {
       return false;
     }
     try {
-      await webcrypto.subtle.importKey('raw', raw, { name: 'Ed25519' }, false, ['verify']);
+      await webcrypto.subtle.importKey('jwk', jwk, { name: 'Ed25519' }, true, ['verify']);
       return true;
     } catch {
       return false;
     }
+  },
+
+  // Generates a server Ed25519 signing keypair and exports both halves as JWK.
+  generateKeyPair: async () => {
+    const keyPair = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
+    const [publicKey, privateKey] = await Promise.all([
+      webcrypto.subtle.exportKey('jwk', keyPair.publicKey),
+      webcrypto.subtle.exportKey('jwk', keyPair.privateKey),
+    ]);
+    return { publicKey, privateKey };
   },
 };

--- a/api/src/services/offline-data-bundle/signing.js
+++ b/api/src/services/offline-data-bundle/signing.js
@@ -1,0 +1,18 @@
+// Ed25519 signature helpers for offline data bundles. Web Crypto Ed25519 is built into Node,
+// so no external dependency is required. This is the future home for verify() too.
+const { webcrypto } = require('node:crypto');
+
+module.exports = {
+  isValidPublicKey: async (base64Key) => {
+    const raw = Buffer.from(base64Key, 'base64');
+    if (raw.length !== 32) {
+      return false;
+    }
+    try {
+      await webcrypto.subtle.importKey('raw', raw, { name: 'Ed25519' }, false, ['verify']);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};

--- a/api/tests/mocha/controllers/users.spec.js
+++ b/api/tests/mocha/controllers/users.spec.js
@@ -1164,7 +1164,7 @@ describe('Users Controller', () => {
         chai.expect(serverUtils.error.notCalled).to.be.true;
         chai.expect(secureSettings.setCredentials.args[0]).to.deep.equal([vaultKey, vaultValue]);
         chai.expect(users.setDeviceKey.args[0]).to.deep.equal([
-          'chw', 'device-1', 'age1recipient', signingJwk, serverPublicKeys,
+          'chw', 'device-1', { encryption_key: 'age1recipient', signing_key: signingJwk }, serverPublicKeys,
         ]);
         chai.expect(res.json.args[0]).to.deep.equal([serverPublicKeys]);
       });
@@ -1183,7 +1183,7 @@ describe('Users Controller', () => {
         chai.expect(serverUtils.error.notCalled).to.be.true;
         chai.expect(secureSettings.setCredentials.args[0]).to.deep.equal([vaultKey, vaultValue]);
         chai.expect(users.setDeviceKey.args[0]).to.deep.equal([
-          'chw', 'device-1', 'age1recipient', signingJwk, serverPublicKeys,
+          'chw', 'device-1', { encryption_key: 'age1recipient', signing_key: signingJwk }, serverPublicKeys,
         ]);
         chai.expect(res.json.args[0]).to.deep.equal([serverPublicKeys]);
       });

--- a/api/tests/mocha/controllers/users.spec.js
+++ b/api/tests/mocha/controllers/users.spec.js
@@ -4,6 +4,7 @@ const controller = require('../../../src/controllers/users');
 const auth = require('../../../src/auth');
 const authorization = require('../../../src/services/replication/authorization');
 const serverUtils = require('../../../src/server-utils');
+const serverKey = require('../../../src/services/offline-data-bundle/server-key');
 const purgedDocs = require('../../../src/services/replication/purged-docs');
 const config = require('../../../src/config');
 const db = require('../../../src/db');
@@ -1031,6 +1032,124 @@ describe('Users Controller', () => {
         chai.expect(users.updateUser.args[0]).to.deep.equal(['beta', { field: 'update' }, true]);
         chai.expect(res.json.callCount).to.equal(1);
         chai.expect(res.json.args[0]).to.deep.equal([{ updated: true }]);
+      });
+    });
+  });
+
+  describe('deviceKey', () => {
+    beforeEach(() => {
+      res = { json: sinon.stub() };
+      sinon.stub(auth, 'assertPermissions');
+      sinon.stub(auth, 'isDbAdmin');
+      sinon.stub(auth, 'basicAuthCredentials');
+      sinon.stub(users, 'setDeviceKey');
+      sinon.stub(serverKey, 'getServerPublicKey');
+    });
+
+    it('should respond with error when empty body', () => {
+      req = { params: { username: 'chw' }, body: {} };
+      sinon.stub(serverUtils, 'emptyJSONBodyError').resolves();
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.emptyJSONBodyError.callCount).to.equal(1);
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+      });
+    });
+
+    it('should respond with 400 when device_id is missing', () => {
+      req = { params: { username: 'chw' }, body: { public_key: 'age1recipient' } };
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.callCount).to.equal(1);
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
+          { code: 400, reason: 'Missing required fields: device_id and public_key' }
+        );
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+      });
+    });
+
+    it('should respond with 400 when public_key is missing', () => {
+      req = { params: { username: 'chw' }, body: { device_id: 'device-1' } };
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.callCount).to.equal(1);
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
+          { code: 400, reason: 'Missing required fields: device_id and public_key' }
+        );
+      });
+    });
+
+    it('should propagate error when requester lacks the required permission', () => {
+      const permissionError = { code: 403, message: 'Insufficient privileges' };
+      auth.assertPermissions.rejects(permissionError);
+      req = { params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(auth.assertPermissions.callCount).to.equal(1);
+        chai.expect(auth.assertPermissions.args[0]).to.deep.equal([
+          req,
+          { hasAny: ['can_send_offline_data_bundle', 'can_relay_offline_data_bundle'] },
+        ]);
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+        chai.expect(serverUtils.error.args[0]).to.deep.equal([permissionError, req, res]);
+      });
+    });
+
+    it('should register the device key when referencing self', () => {
+      auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
+      auth.isDbAdmin.returns(false);
+      auth.basicAuthCredentials.returns(false);
+      users.setDeviceKey.resolves({ id: 'org.couchdb.user:chw', rev: '2-abc' });
+      serverKey.getServerPublicKey.resolves('age1serverrecipient');
+      req = { id: 'req-1', params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.notCalled).to.be.true;
+        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient']);
+        chai.expect(serverKey.getServerPublicKey.callCount).to.equal(1);
+        chai.expect(res.json.args[0]).to.deep.equal([{ server_key: 'age1serverrecipient' }]);
+      });
+    });
+
+    it('should register the device key when requester is a db admin acting on another user', () => {
+      auth.assertPermissions.resolves({ name: 'admin', roles: ['_admin'] });
+      auth.isDbAdmin.returns(true);
+      auth.basicAuthCredentials.returns(false);
+      users.setDeviceKey.resolves({ id: 'org.couchdb.user:chw', rev: '2-abc' });
+      serverKey.getServerPublicKey.resolves('age1serverrecipient');
+      req = { id: 'req-2', params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.notCalled).to.be.true;
+        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient']);
+        chai.expect(res.json.args[0]).to.deep.equal([{ server_key: 'age1serverrecipient' }]);
+      });
+    });
+
+    it('should respond with 403 when a non-admin references another user', () => {
+      auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
+      auth.isDbAdmin.returns(false);
+      auth.basicAuthCredentials.returns(false);
+      req = { params: { username: 'other' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+        chai.expect(serverUtils.error.args[0]).to.deep.equal([
+          { code: 403, message: 'You do not have permissions to modify this user' },
+          req,
+          res,
+        ]);
+      });
+    });
+
+    it('should propagate error when saving the device key fails', () => {
+      const saveError = new Error('boom');
+      auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
+      auth.isDbAdmin.returns(false);
+      auth.basicAuthCredentials.returns(false);
+      users.setDeviceKey.rejects(saveError);
+      req = { id: 'req-3', params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(res.json.notCalled).to.be.true;
+        chai.expect(serverUtils.error.args[0]).to.deep.equal([saveError, req, res]);
       });
     });
   });

--- a/api/tests/mocha/controllers/users.spec.js
+++ b/api/tests/mocha/controllers/users.spec.js
@@ -4,9 +4,9 @@ const controller = require('../../../src/controllers/users');
 const auth = require('../../../src/auth');
 const authorization = require('../../../src/services/replication/authorization');
 const serverUtils = require('../../../src/server-utils');
-const serverKey = require('../../../src/services/offline-data-bundle/server-key');
 const age = require('../../../src/services/offline-data-bundle/age');
 const signing = require('../../../src/services/offline-data-bundle/signing');
+const secureSettings = require('@medic/settings');
 const purgedDocs = require('../../../src/services/replication/purged-docs');
 const config = require('../../../src/config');
 const db = require('../../../src/db');
@@ -1039,19 +1039,40 @@ describe('Users Controller', () => {
   });
 
   describe('deviceKey', () => {
+    const signingJwk = { kty: 'OKP', crv: 'Ed25519', x: 'device-pub' };
+    const serverSigningPublicJwk = { kty: 'OKP', crv: 'Ed25519', x: 'server-pub' };
+    const serverSigningPrivateJwk = { kty: 'OKP', crv: 'Ed25519', x: 'server-pub', d: 'server-priv' };
+    // Only PUBLIC server keys are persisted on the _users doc (passed to setDeviceKey and returned).
+    const serverPublicKeys = {
+      server_encryption_public_key: 'age1serverrecipient',
+      server_signing_public_key: serverSigningPublicJwk,
+    };
+    // PRIVATE server keys go to the secureSettings vault, keyed per user + device.
+    const vaultKey = 'offline-data-bundle-server-key:chw:device-1';
+    const vaultValue = JSON.stringify({
+      encryption: 'AGE-SECRET-KEY-1SERVER',
+      signing: serverSigningPrivateJwk,
+    });
+
     beforeEach(() => {
       res = { json: sinon.stub() };
-      sinon.stub(auth, 'assertPermissions');
-      sinon.stub(auth, 'isDbAdmin');
-      sinon.stub(auth, 'basicAuthCredentials');
-      sinon.stub(users, 'setDeviceKey');
-      sinon.stub(serverKey, 'getServerPublicKey');
+      sinon.stub(auth, 'assertPermissions').resolves({ name: 'chw', roles: ['chw'] });
+      sinon.stub(auth, 'isDbAdmin').returns(false);
+      sinon.stub(auth, 'basicAuthCredentials').returns(false);
+      sinon.stub(users, 'setDeviceKey').resolves(serverPublicKeys);
+      sinon.stub(secureSettings, 'setCredentials').resolves();
       sinon.stub(age, 'isValidRecipient').resolves(true);
+      sinon.stub(age, 'generateIdentity').resolves('AGE-SECRET-KEY-1SERVER');
+      sinon.stub(age, 'identityToRecipient').resolves('age1serverrecipient');
       sinon.stub(signing, 'isValidPublicKey').resolves(true);
+      sinon.stub(signing, 'generateKeyPair').resolves({
+        publicKey: serverSigningPublicJwk,
+        privateKey: serverSigningPrivateJwk,
+      });
     });
 
     it('should respond with error when empty body', () => {
-      req = { params: { username: 'chw' }, body: {} };
+      req = { params: { username: 'chw', device_id: 'device-1' }, body: {} };
       sinon.stub(serverUtils, 'emptyJSONBodyError').resolves();
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.emptyJSONBodyError.callCount).to.equal(1);
@@ -1059,34 +1080,23 @@ describe('Users Controller', () => {
       });
     });
 
-    it('should respond with 400 when device_id is missing', () => {
-      req = { params: { username: 'chw' }, body: { encryption_key: 'age1recipient', signing_key: 'ed25519signing' } };
-      return controller.deviceKey(req, res).then(() => {
-        chai.expect(serverUtils.error.callCount).to.equal(1);
-        chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
-          { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' }
-        );
-        chai.expect(users.setDeviceKey.notCalled).to.be.true;
-      });
-    });
-
     it('should respond with 400 when encryption_key is missing', () => {
-      req = { params: { username: 'chw' }, body: { device_id: 'device-1', signing_key: 'ed25519signing' } };
+      req = { params: { username: 'chw', device_id: 'device-1' }, body: { signing_key: signingJwk } };
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
-          { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' }
+          { code: 400, reason: 'Missing required fields: encryption_key and signing_key' }
         );
         chai.expect(users.setDeviceKey.notCalled).to.be.true;
       });
     });
 
     it('should respond with 400 when signing_key is missing', () => {
-      req = { params: { username: 'chw' }, body: { device_id: 'device-1', encryption_key: 'age1recipient' } };
+      req = { params: { username: 'chw', device_id: 'device-1' }, body: { encryption_key: 'age1recipient' } };
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
-          { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' }
+          { code: 400, reason: 'Missing required fields: encryption_key and signing_key' }
         );
         chai.expect(users.setDeviceKey.notCalled).to.be.true;
       });
@@ -1095,8 +1105,8 @@ describe('Users Controller', () => {
     it('should respond with 400 when encryption_key is not a valid age recipient', () => {
       age.isValidRecipient.resolves(false);
       req = {
-        params: { username: 'chw' },
-        body: { device_id: 'device-1', encryption_key: 'not-a-recipient', signing_key: 'ed25519signing' },
+        params: { username: 'chw', device_id: 'device-1' },
+        body: { encryption_key: 'not-a-recipient', signing_key: signingJwk },
       };
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
@@ -1107,86 +1117,82 @@ describe('Users Controller', () => {
       });
     });
 
-    it('should respond with 400 when signing_key is not a valid Ed25519 public key', () => {
+    it('should respond with 400 when signing_key is not a valid Ed25519 public key JWK', () => {
       signing.isValidPublicKey.resolves(false);
       req = {
-        params: { username: 'chw' },
-        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'not-a-key' },
+        params: { username: 'chw', device_id: 'device-1' },
+        body: { encryption_key: 'age1recipient', signing_key: { not: 'a-jwk' } },
       };
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
-          { code: 400, reason: 'Invalid signing_key: expected a base64 Ed25519 public key' }
+          { code: 400, reason: 'Invalid signing_key: expected an Ed25519 public key JWK' }
         );
         chai.expect(users.setDeviceKey.notCalled).to.be.true;
       });
     });
 
-    it('should propagate error when requester lacks the required permission', () => {
+    it('should assert the permission before validating the body', () => {
       const permissionError = { code: 403, message: 'Insufficient privileges' };
       auth.assertPermissions.rejects(permissionError);
       req = {
-        params: { username: 'chw' },
-        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+        params: { username: 'chw', device_id: 'device-1' },
+        body: {},
       };
+      sinon.stub(serverUtils, 'emptyJSONBodyError').resolves();
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(auth.assertPermissions.callCount).to.equal(1);
         chai.expect(auth.assertPermissions.args[0]).to.deep.equal([
           req,
-          { hasAny: ['can_send_offline_data_bundle', 'can_relay_offline_data_bundle'] },
+          { hasAny: ['can_send_offline_data_bundle'] },
         ]);
+        chai.expect(serverUtils.emptyJSONBodyError.notCalled).to.be.true;
         chai.expect(users.setDeviceKey.notCalled).to.be.true;
         chai.expect(serverUtils.error.args[0]).to.deep.equal([permissionError, req, res]);
       });
     });
 
-    it('should register the device key when referencing self', () => {
-      auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
-      auth.isDbAdmin.returns(false);
-      auth.basicAuthCredentials.returns(false);
-      users.setDeviceKey.resolves({ id: 'org.couchdb.user:chw', rev: '2-abc' });
-      serverKey.getServerPublicKey.resolves('age1serverrecipient');
+    it('should register the device keys when referencing self', () => {
       req = {
         id: 'req-1',
-        params: { username: 'chw' },
-        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+        params: { username: 'chw', device_id: 'device-1' },
+        body: { encryption_key: 'age1recipient', signing_key: signingJwk },
       };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.notCalled).to.be.true;
-        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient', 'ed25519signing']);
-        chai.expect(serverKey.getServerPublicKey.callCount).to.equal(1);
-        chai.expect(res.json.args[0]).to.deep.equal([{ server_key: 'age1serverrecipient' }]);
+        chai.expect(secureSettings.setCredentials.args[0]).to.deep.equal([vaultKey, vaultValue]);
+        chai.expect(users.setDeviceKey.args[0]).to.deep.equal([
+          'chw', 'device-1', 'age1recipient', signingJwk, serverPublicKeys,
+        ]);
+        chai.expect(res.json.args[0]).to.deep.equal([serverPublicKeys]);
       });
     });
 
-    it('should register the device key when requester is a db admin acting on another user', () => {
+    it('should register the device keys when requester is a db admin acting on another user', () => {
       auth.assertPermissions.resolves({ name: 'admin', roles: ['_admin'] });
       auth.isDbAdmin.returns(true);
-      auth.basicAuthCredentials.returns(false);
-      users.setDeviceKey.resolves({ id: 'org.couchdb.user:chw', rev: '2-abc' });
-      serverKey.getServerPublicKey.resolves('age1serverrecipient');
       req = {
         id: 'req-2',
-        params: { username: 'chw' },
-        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+        params: { username: 'chw', device_id: 'device-1' },
+        body: { encryption_key: 'age1recipient', signing_key: signingJwk },
       };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.notCalled).to.be.true;
-        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient', 'ed25519signing']);
-        chai.expect(res.json.args[0]).to.deep.equal([{ server_key: 'age1serverrecipient' }]);
+        chai.expect(secureSettings.setCredentials.args[0]).to.deep.equal([vaultKey, vaultValue]);
+        chai.expect(users.setDeviceKey.args[0]).to.deep.equal([
+          'chw', 'device-1', 'age1recipient', signingJwk, serverPublicKeys,
+        ]);
+        chai.expect(res.json.args[0]).to.deep.equal([serverPublicKeys]);
       });
     });
 
     it('should respond with 403 when a non-admin references another user', () => {
-      auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
-      auth.isDbAdmin.returns(false);
-      auth.basicAuthCredentials.returns(false);
       req = {
-        params: { username: 'other' },
-        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+        params: { username: 'other', device_id: 'device-1' },
+        body: { encryption_key: 'age1recipient', signing_key: signingJwk },
       };
 
       return controller.deviceKey(req, res).then(() => {
@@ -1199,16 +1205,13 @@ describe('Users Controller', () => {
       });
     });
 
-    it('should propagate error when saving the device key fails', () => {
+    it('should propagate error when saving the device keys fails', () => {
       const saveError = new Error('boom');
-      auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
-      auth.isDbAdmin.returns(false);
-      auth.basicAuthCredentials.returns(false);
       users.setDeviceKey.rejects(saveError);
       req = {
         id: 'req-3',
-        params: { username: 'chw' },
-        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+        params: { username: 'chw', device_id: 'device-1' },
+        body: { encryption_key: 'age1recipient', signing_key: signingJwk },
       };
 
       return controller.deviceKey(req, res).then(() => {

--- a/api/tests/mocha/controllers/users.spec.js
+++ b/api/tests/mocha/controllers/users.spec.js
@@ -5,6 +5,8 @@ const auth = require('../../../src/auth');
 const authorization = require('../../../src/services/replication/authorization');
 const serverUtils = require('../../../src/server-utils');
 const serverKey = require('../../../src/services/offline-data-bundle/server-key');
+const age = require('../../../src/services/offline-data-bundle/age');
+const signing = require('../../../src/services/offline-data-bundle/signing');
 const purgedDocs = require('../../../src/services/replication/purged-docs');
 const config = require('../../../src/config');
 const db = require('../../../src/db');
@@ -1044,6 +1046,8 @@ describe('Users Controller', () => {
       sinon.stub(auth, 'basicAuthCredentials');
       sinon.stub(users, 'setDeviceKey');
       sinon.stub(serverKey, 'getServerPublicKey');
+      sinon.stub(age, 'isValidRecipient').resolves(true);
+      sinon.stub(signing, 'isValidPublicKey').resolves(true);
     });
 
     it('should respond with error when empty body', () => {
@@ -1056,30 +1060,75 @@ describe('Users Controller', () => {
     });
 
     it('should respond with 400 when device_id is missing', () => {
-      req = { params: { username: 'chw' }, body: { public_key: 'age1recipient' } };
+      req = { params: { username: 'chw' }, body: { encryption_key: 'age1recipient', signing_key: 'ed25519signing' } };
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
-          { code: 400, reason: 'Missing required fields: device_id and public_key' }
+          { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' }
         );
         chai.expect(users.setDeviceKey.notCalled).to.be.true;
       });
     });
 
-    it('should respond with 400 when public_key is missing', () => {
-      req = { params: { username: 'chw' }, body: { device_id: 'device-1' } };
+    it('should respond with 400 when encryption_key is missing', () => {
+      req = { params: { username: 'chw' }, body: { device_id: 'device-1', signing_key: 'ed25519signing' } };
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.callCount).to.equal(1);
         chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
-          { code: 400, reason: 'Missing required fields: device_id and public_key' }
+          { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' }
         );
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+      });
+    });
+
+    it('should respond with 400 when signing_key is missing', () => {
+      req = { params: { username: 'chw' }, body: { device_id: 'device-1', encryption_key: 'age1recipient' } };
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.callCount).to.equal(1);
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
+          { code: 400, reason: 'Missing required fields: device_id, encryption_key and signing_key' }
+        );
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+      });
+    });
+
+    it('should respond with 400 when encryption_key is not a valid age recipient', () => {
+      age.isValidRecipient.resolves(false);
+      req = {
+        params: { username: 'chw' },
+        body: { device_id: 'device-1', encryption_key: 'not-a-recipient', signing_key: 'ed25519signing' },
+      };
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.callCount).to.equal(1);
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
+          { code: 400, reason: 'Invalid encryption_key: expected an age recipient' }
+        );
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
+      });
+    });
+
+    it('should respond with 400 when signing_key is not a valid Ed25519 public key', () => {
+      signing.isValidPublicKey.resolves(false);
+      req = {
+        params: { username: 'chw' },
+        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'not-a-key' },
+      };
+      return controller.deviceKey(req, res).then(() => {
+        chai.expect(serverUtils.error.callCount).to.equal(1);
+        chai.expect(serverUtils.error.args[0][0]).to.deep.equal(
+          { code: 400, reason: 'Invalid signing_key: expected a base64 Ed25519 public key' }
+        );
+        chai.expect(users.setDeviceKey.notCalled).to.be.true;
       });
     });
 
     it('should propagate error when requester lacks the required permission', () => {
       const permissionError = { code: 403, message: 'Insufficient privileges' };
       auth.assertPermissions.rejects(permissionError);
-      req = { params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+      req = {
+        params: { username: 'chw' },
+        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+      };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(auth.assertPermissions.callCount).to.equal(1);
@@ -1098,11 +1147,15 @@ describe('Users Controller', () => {
       auth.basicAuthCredentials.returns(false);
       users.setDeviceKey.resolves({ id: 'org.couchdb.user:chw', rev: '2-abc' });
       serverKey.getServerPublicKey.resolves('age1serverrecipient');
-      req = { id: 'req-1', params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+      req = {
+        id: 'req-1',
+        params: { username: 'chw' },
+        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+      };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.notCalled).to.be.true;
-        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient']);
+        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient', 'ed25519signing']);
         chai.expect(serverKey.getServerPublicKey.callCount).to.equal(1);
         chai.expect(res.json.args[0]).to.deep.equal([{ server_key: 'age1serverrecipient' }]);
       });
@@ -1114,11 +1167,15 @@ describe('Users Controller', () => {
       auth.basicAuthCredentials.returns(false);
       users.setDeviceKey.resolves({ id: 'org.couchdb.user:chw', rev: '2-abc' });
       serverKey.getServerPublicKey.resolves('age1serverrecipient');
-      req = { id: 'req-2', params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+      req = {
+        id: 'req-2',
+        params: { username: 'chw' },
+        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+      };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(serverUtils.error.notCalled).to.be.true;
-        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient']);
+        chai.expect(users.setDeviceKey.args[0]).to.deep.equal(['chw', 'device-1', 'age1recipient', 'ed25519signing']);
         chai.expect(res.json.args[0]).to.deep.equal([{ server_key: 'age1serverrecipient' }]);
       });
     });
@@ -1127,7 +1184,10 @@ describe('Users Controller', () => {
       auth.assertPermissions.resolves({ name: 'chw', roles: ['chw'] });
       auth.isDbAdmin.returns(false);
       auth.basicAuthCredentials.returns(false);
-      req = { params: { username: 'other' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+      req = {
+        params: { username: 'other' },
+        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+      };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(users.setDeviceKey.notCalled).to.be.true;
@@ -1145,7 +1205,11 @@ describe('Users Controller', () => {
       auth.isDbAdmin.returns(false);
       auth.basicAuthCredentials.returns(false);
       users.setDeviceKey.rejects(saveError);
-      req = { id: 'req-3', params: { username: 'chw' }, body: { device_id: 'device-1', public_key: 'age1recipient' } };
+      req = {
+        id: 'req-3',
+        params: { username: 'chw' },
+        body: { device_id: 'device-1', encryption_key: 'age1recipient', signing_key: 'ed25519signing' },
+      };
 
       return controller.deviceKey(req, res).then(() => {
         chai.expect(res.json.notCalled).to.be.true;

--- a/api/tests/mocha/services/offline-data-bundle/age.spec.js
+++ b/api/tests/mocha/services/offline-data-bundle/age.spec.js
@@ -1,0 +1,21 @@
+const chai = require('chai');
+
+const service = require('../../../../src/services/offline-data-bundle/age');
+
+describe('offline-data-bundle age service', () => {
+  describe('isValidRecipient', () => {
+    it('returns true for a real age recipient', async () => {
+      const identity = await service.generateIdentity();
+      const recipient = await service.identityToRecipient(identity);
+      chai.expect(await service.isValidRecipient(recipient)).to.be.true;
+    });
+
+    it('returns false for garbage input', async () => {
+      chai.expect(await service.isValidRecipient('not-a-recipient')).to.be.false;
+    });
+
+    it('returns false for an empty string', async () => {
+      chai.expect(await service.isValidRecipient('')).to.be.false;
+    });
+  });
+});

--- a/api/tests/mocha/services/offline-data-bundle/server-key.spec.js
+++ b/api/tests/mocha/services/offline-data-bundle/server-key.spec.js
@@ -1,0 +1,39 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const secureSettings = require('@medic/settings');
+const age = require('age-encryption');
+
+const service = require('../../../../src/services/offline-data-bundle/server-key');
+
+const CREDENTIAL_KEY = 'offline-data-bundle-server-key';
+
+describe('offline-data-bundle server-key service', () => {
+  afterEach(() => sinon.restore());
+
+  describe('getServerPublicKey', () => {
+    it('generates and persists a new identity when none is stored', async () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves();
+      const setCredentials = sinon.stub(secureSettings, 'setCredentials').resolves();
+
+      const recipient = await service.getServerPublicKey();
+
+      chai.expect(secureSettings.getCredentials.args[0]).to.deep.equal([CREDENTIAL_KEY]);
+      chai.expect(setCredentials.callCount).to.equal(1);
+      chai.expect(setCredentials.args[0][0]).to.equal(CREDENTIAL_KEY);
+      chai.expect(setCredentials.args[0][1]).to.match(/^AGE-SECRET-KEY-1/);
+      chai.expect(recipient).to.match(/^age1/);
+      chai.expect(recipient).to.equal(await age.identityToRecipient(setCredentials.args[0][1]));
+    });
+
+    it('returns the recipient for the stored identity without regenerating', async () => {
+      const identity = await age.generateIdentity();
+      sinon.stub(secureSettings, 'getCredentials').resolves(identity);
+      const setCredentials = sinon.stub(secureSettings, 'setCredentials').resolves();
+
+      const recipient = await service.getServerPublicKey();
+
+      chai.expect(setCredentials.notCalled).to.be.true;
+      chai.expect(recipient).to.equal(await age.identityToRecipient(identity));
+    });
+  });
+});

--- a/api/tests/mocha/services/offline-data-bundle/server-key.spec.js
+++ b/api/tests/mocha/services/offline-data-bundle/server-key.spec.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const secureSettings = require('@medic/settings');
-const age = require('age-encryption');
+const age = require('../../../../src/services/offline-data-bundle/age');
 
 const service = require('../../../../src/services/offline-data-bundle/server-key');
 

--- a/api/tests/mocha/services/offline-data-bundle/server-key.spec.js
+++ b/api/tests/mocha/services/offline-data-bundle/server-key.spec.js
@@ -36,4 +36,43 @@ describe('offline-data-bundle server-key service', () => {
       chai.expect(recipient).to.equal(await age.identityToRecipient(identity));
     });
   });
+
+  describe('device server private keys', () => {
+    const privateKeys = {
+      encryption: 'AGE-SECRET-KEY-1SERVER',
+      signing: { kty: 'OKP', crv: 'Ed25519', x: 'server-pub', d: 'server-priv' },
+    };
+
+    it('vaultKey namespaces by user and device', () => {
+      chai.expect(service.vaultKey('chw', 'device-1')).to.equal('offline-data-bundle-server-key:chw:device-1');
+    });
+
+    it('setServerPrivateKeys stores the serialised privates under the vault key', async () => {
+      const setCredentials = sinon.stub(secureSettings, 'setCredentials').resolves();
+
+      await service.setServerPrivateKeys('chw', 'device-1', privateKeys);
+
+      chai.expect(setCredentials.args[0]).to.deep.equal([
+        'offline-data-bundle-server-key:chw:device-1',
+        JSON.stringify(privateKeys),
+      ]);
+    });
+
+    it('getServerPrivateKeys parses the stored value', async () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves(JSON.stringify(privateKeys));
+
+      const result = await service.getServerPrivateKeys('chw', 'device-1');
+
+      chai.expect(secureSettings.getCredentials.args[0]).to.deep.equal(['offline-data-bundle-server-key:chw:device-1']);
+      chai.expect(result).to.deep.equal(privateKeys);
+    });
+
+    it('getServerPrivateKeys returns undefined when nothing is stored', async () => {
+      sinon.stub(secureSettings, 'getCredentials').resolves();
+
+      const result = await service.getServerPrivateKeys('chw', 'device-1');
+
+      chai.expect(result).to.be.undefined;
+    });
+  });
 });

--- a/api/tests/mocha/services/offline-data-bundle/signing.spec.js
+++ b/api/tests/mocha/services/offline-data-bundle/signing.spec.js
@@ -5,29 +5,46 @@ const service = require('../../../../src/services/offline-data-bundle/signing');
 
 describe('offline-data-bundle signing service', () => {
   describe('isValidPublicKey', () => {
-    let validKey;
+    let validJwk;
 
     before(async () => {
       const keyPair = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
-      const raw = Buffer.from(await webcrypto.subtle.exportKey('raw', keyPair.publicKey));
-      validKey = raw.toString('base64');
+      validJwk = await webcrypto.subtle.exportKey('jwk', keyPair.publicKey);
     });
 
-    it('returns true for a real base64 Ed25519 public key', async () => {
-      chai.expect(await service.isValidPublicKey(validKey)).to.be.true;
+    it('returns true for a real Ed25519 public key JWK', async () => {
+      chai.expect(await service.isValidPublicKey(validJwk)).to.be.true;
     });
 
-    it('returns false for garbage input', async () => {
-      chai.expect(await service.isValidPublicKey('not-a-key')).to.be.false;
+    it('returns false for a JWK with the wrong key material', async () => {
+      chai.expect(await service.isValidPublicKey({ kty: 'OKP', crv: 'Ed25519', x: 'not-a-key' })).to.be.false;
     });
 
-    it('returns false when the decoded key is the wrong length', async () => {
-      const tooShort = Buffer.from('deadbeef', 'hex').toString('base64');
-      chai.expect(await service.isValidPublicKey(tooShort)).to.be.false;
+    it('returns false for a non-object input', async () => {
+      chai.expect(await service.isValidPublicKey('not-a-jwk')).to.be.false;
     });
 
-    it('returns false for an empty string', async () => {
-      chai.expect(await service.isValidPublicKey('')).to.be.false;
+    it('returns false for null', async () => {
+      chai.expect(await service.isValidPublicKey(null)).to.be.false;
+    });
+  });
+
+  describe('generateKeyPair', () => {
+    it('generates an Ed25519 keypair exported as JWK', async () => {
+      const { publicKey, privateKey } = await service.generateKeyPair();
+
+      chai.expect(publicKey).to.include({ kty: 'OKP', crv: 'Ed25519' });
+      chai.expect(publicKey.x).to.be.a('string');
+      chai.expect(publicKey.d).to.be.undefined;
+      chai.expect(privateKey).to.include({ kty: 'OKP', crv: 'Ed25519' });
+      chai.expect(privateKey.d).to.be.a('string');
+      chai.expect(await service.isValidPublicKey(publicKey)).to.be.true;
+    });
+
+    it('generates a distinct keypair on each call', async () => {
+      const first = await service.generateKeyPair();
+      const second = await service.generateKeyPair();
+      chai.expect(first.publicKey.x).to.not.equal(second.publicKey.x);
     });
   });
 });

--- a/api/tests/mocha/services/offline-data-bundle/signing.spec.js
+++ b/api/tests/mocha/services/offline-data-bundle/signing.spec.js
@@ -1,0 +1,33 @@
+const chai = require('chai');
+const { webcrypto } = require('node:crypto');
+
+const service = require('../../../../src/services/offline-data-bundle/signing');
+
+describe('offline-data-bundle signing service', () => {
+  describe('isValidPublicKey', () => {
+    let validKey;
+
+    before(async () => {
+      const keyPair = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
+      const raw = Buffer.from(await webcrypto.subtle.exportKey('raw', keyPair.publicKey));
+      validKey = raw.toString('base64');
+    });
+
+    it('returns true for a real base64 Ed25519 public key', async () => {
+      chai.expect(await service.isValidPublicKey(validKey)).to.be.true;
+    });
+
+    it('returns false for garbage input', async () => {
+      chai.expect(await service.isValidPublicKey('not-a-key')).to.be.false;
+    });
+
+    it('returns false when the decoded key is the wrong length', async () => {
+      const tooShort = Buffer.from('deadbeef', 'hex').toString('base64');
+      chai.expect(await service.isValidPublicKey(tooShort)).to.be.false;
+    });
+
+    it('returns false for an empty string', async () => {
+      chai.expect(await service.isValidPublicKey('')).to.be.false;
+    });
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -295,6 +295,7 @@ module.exports = defineConfig([
     rules: {
       'n/no-process-exit': 'off',
       'n/no-extraneous-require': 'off',
+      'n/no-extraneous-import': 'off',
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -295,7 +295,6 @@ module.exports = defineConfig([
     rules: {
       'n/no-process-exit': 'off',
       'n/no-extraneous-require': 'off',
-      'n/no-extraneous-import': 'off',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "./shared-libs/*"
       ],
       "dependencies": {
+        "age-encryption": "^0.3.0",
         "async": "^3.2.6",
         "bikram-sambat": "^1.8.1",
         "body-parser": "^1.20.6",
@@ -6519,6 +6520,88 @@
       "resolved": "shared-libs/view-map-utils",
       "link": true
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.5.4.tgz",
+      "integrity": "sha512-leww0zzIirrvwaYMPI9fj6aRIlA/c6Y0/lifQQ1YOOyHEr0MNH3yYpjXeiVG+tWdPps4XxGclFWX2INPO3Yo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.0.0",
+        "@noble/hashes": "~2.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodable/entities": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
@@ -7141,6 +7224,15 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -14013,6 +14105,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/age-encryption": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/age-encryption/-/age-encryption-0.3.0.tgz",
+      "integrity": "sha512-vDhGGp5ZXpbKL6oc3FEBjGhyepr/0SwIWmia6CcPXvYcxGBSQNcDdMv9m2yVOkjjYuJEmtGEhOojIUcjrj0cEw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/ciphers": "^2.1.1",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@noble/post-quantum": "^0.5.3",
+        "@scure/base": "^2.0.0"
       }
     },
     "node_modules/agent-base": {

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "xml-js": "^1.6.11"
   },
   "dependencies": {
+    "age-encryption": "^0.3.0",
     "async": "^3.2.6",
     "bikram-sambat": "^1.8.1",
     "body-parser": "^1.20.6",

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -621,22 +621,21 @@ const saveUserSettingsUpdates = async (userSettings) => {
   };
 };
 
-const upsertDeviceKey = async (username, deviceId, encryptionKey, signingKey) => {
-  const userSettings = await getUserDoc(username, 'medic');
-  userSettings.device_keys = userSettings.device_keys || [];
-  const entry = {
-    device_id: deviceId,
-    encryption_key: encryptionKey,
-    signing_key: signingKey,
-    created_at: new Date().toISOString()
+const upsertDeviceKey = async (username, deviceId, encryptionKey, signingKey, serverKeys) => {
+  const userDoc = await getUserDoc(username, 'users');
+  userDoc.keys_by_device = userDoc.keys_by_device || {};
+  userDoc.keys_by_device[deviceId] = {
+    encryption_public_key: encryptionKey,
+    signing_public_key: signingKey,
+    server_encryption_public_key: serverKeys.server_encryption_public_key,
+    server_signing_public_key: serverKeys.server_signing_public_key,
+    updated_date: Date.now(),
   };
-  const existing = userSettings.device_keys.find(key => key.device_id === deviceId);
-  if (existing) {
-    Object.assign(existing, entry);
-  } else {
-    userSettings.device_keys.push(entry);
-  }
-  return saveUserSettingsUpdates(userSettings);
+  await saveUserUpdates(userDoc);
+  return {
+    server_encryption_public_key: serverKeys.server_encryption_public_key,
+    server_signing_public_key: serverKeys.server_signing_public_key,
+  };
 };
 
 const validateFacilityIsNeeded = (data, user) => {

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -621,12 +621,12 @@ const saveUserSettingsUpdates = async (userSettings) => {
   };
 };
 
-const upsertDeviceKey = async (username, deviceId, encryptionKey, signingKey, serverKeys) => {
+const upsertDeviceKey = async (username, deviceId, deviceKeys, serverKeys) => {
   const userDoc = await getUserDoc(username, 'users');
   userDoc.keys_by_device = userDoc.keys_by_device || {};
   userDoc.keys_by_device[deviceId] = {
-    encryption_public_key: encryptionKey,
-    signing_public_key: signingKey,
+    encryption_public_key: deviceKeys.encryption_key,
+    signing_public_key: deviceKeys.signing_key,
     server_encryption_public_key: serverKeys.server_encryption_public_key,
     server_signing_public_key: serverKeys.server_signing_public_key,
     updated_date: Date.now(),

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -621,10 +621,15 @@ const saveUserSettingsUpdates = async (userSettings) => {
   };
 };
 
-const upsertDeviceKey = async (username, deviceId, publicKey) => {
+const upsertDeviceKey = async (username, deviceId, encryptionKey, signingKey) => {
   const userSettings = await getUserDoc(username, 'medic');
   userSettings.device_keys = userSettings.device_keys || [];
-  const entry = { device_id: deviceId, public_key: publicKey, created_at: new Date().toISOString() };
+  const entry = {
+    device_id: deviceId,
+    encryption_key: encryptionKey,
+    signing_key: signingKey,
+    created_at: new Date().toISOString()
+  };
   const existing = userSettings.device_keys.find(key => key.device_id === deviceId);
   if (existing) {
     Object.assign(existing, entry);

--- a/shared-libs/user-management/src/users.js
+++ b/shared-libs/user-management/src/users.js
@@ -621,6 +621,19 @@ const saveUserSettingsUpdates = async (userSettings) => {
   };
 };
 
+const upsertDeviceKey = async (username, deviceId, publicKey) => {
+  const userSettings = await getUserDoc(username, 'medic');
+  userSettings.device_keys = userSettings.device_keys || [];
+  const entry = { device_id: deviceId, public_key: publicKey, created_at: new Date().toISOString() };
+  const existing = userSettings.device_keys.find(key => key.device_id === deviceId);
+  if (existing) {
+    Object.assign(existing, entry);
+  } else {
+    userSettings.device_keys.push(entry);
+  }
+  return saveUserSettingsUpdates(userSettings);
+};
+
 const validateFacilityIsNeeded = (data, user) => {
   const userRoles = data.roles || user?.roles;
   if (userRoles && roles.isOffline(userRoles)) {
@@ -1046,6 +1059,7 @@ module.exports = {
   },
   getUserDoc: (username) => getUserDoc(username, 'users'),
   getUserSettings,
+  setDeviceKey: upsertDeviceKey,
   /**
    * Take the request data and create valid user, user-settings and contact
    * objects. Returns the response body in the callback.

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -1156,7 +1156,7 @@ describe('Users service', () => {
       db.medic.get.resolves({ _id: userId, name: 'steve', type: 'user-settings' });
       db.medic.put.resolves({ id: userId, rev: '2-abc' });
 
-      const result = await service.setDeviceKey('steve', 'device-1', 'age1recipient');
+      const result = await service.setDeviceKey('steve', 'device-1', 'age1recipient', 'ed25519signing');
 
       chai.expect(db.medic.get.args[0]).to.deep.equal([userId]);
       chai.expect(db.medic.put.calledOnce).to.be.true;
@@ -1165,7 +1165,8 @@ describe('Users service', () => {
       chai.expect(saved.name).to.equal('steve');
       chai.expect(saved.device_keys).to.have.lengthOf(1);
       chai.expect(saved.device_keys[0].device_id).to.equal('device-1');
-      chai.expect(saved.device_keys[0].public_key).to.equal('age1recipient');
+      chai.expect(saved.device_keys[0].encryption_key).to.equal('age1recipient');
+      chai.expect(saved.device_keys[0].signing_key).to.equal('ed25519signing');
       chai.expect(saved.device_keys[0].created_at).to.match(ISO_DATE);
       chai.expect(result).to.deep.equal({ id: userId, rev: '2-abc' });
     });
@@ -1176,28 +1177,44 @@ describe('Users service', () => {
         name: 'steve',
         type: 'user-settings',
         device_keys: [
-          { device_id: 'device-1', public_key: 'age1old', created_at: '2026-01-01T00:00:00.000Z' },
-          { device_id: 'device-2', public_key: 'age1other', created_at: '2026-01-01T00:00:00.000Z' },
+          {
+            device_id: 'device-1',
+            encryption_key: 'age1old',
+            signing_key: 'ed25519old',
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            device_id: 'device-2',
+            encryption_key: 'age1other',
+            signing_key: 'ed25519other',
+            created_at: '2026-01-01T00:00:00.000Z',
+          },
         ],
       });
       db.medic.put.resolves({ id: userId, rev: '3-abc' });
 
-      await service.setDeviceKey('steve', 'device-1', 'age1new');
+      await service.setDeviceKey('steve', 'device-1', 'age1new', 'ed25519new');
 
       const savedKeys = db.medic.put.args[0][0].device_keys;
       chai.expect(savedKeys).to.have.lengthOf(2);
       chai.expect(savedKeys[0].device_id).to.equal('device-1');
-      chai.expect(savedKeys[0].public_key).to.equal('age1new');
+      chai.expect(savedKeys[0].encryption_key).to.equal('age1new');
+      chai.expect(savedKeys[0].signing_key).to.equal('ed25519new');
       chai.expect(savedKeys[0].created_at).to.match(ISO_DATE);
       chai.expect(savedKeys[1]).to.deep.equal(
-        { device_id: 'device-2', public_key: 'age1other', created_at: '2026-01-01T00:00:00.000Z' }
+        {
+          device_id: 'device-2',
+          encryption_key: 'age1other',
+          signing_key: 'ed25519other',
+          created_at: '2026-01-01T00:00:00.000Z',
+        }
       );
     });
 
     it('rejects when the user-settings doc is not found', () => {
       db.medic.get.rejects({ status: 404 });
 
-      return chai.expect(service.setDeviceKey('steve', 'device-1', 'age1recipient')).to.be.rejected;
+      return chai.expect(service.setDeviceKey('steve', 'device-1', 'age1recipient', 'ed25519signing')).to.be.rejected;
     });
   });
 

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -1147,6 +1147,60 @@ describe('Users service', () => {
     });
   });
 
+  describe('setDeviceKey', () => {
+    const userId = PREFIXES.COUCH_USER + 'steve';
+
+    const ISO_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+    it('adds a new device key entry to the user-settings doc', async () => {
+      db.medic.get.resolves({ _id: userId, name: 'steve', type: 'user-settings' });
+      db.medic.put.resolves({ id: userId, rev: '2-abc' });
+
+      const result = await service.setDeviceKey('steve', 'device-1', 'age1recipient');
+
+      chai.expect(db.medic.get.args[0]).to.deep.equal([userId]);
+      chai.expect(db.medic.put.calledOnce).to.be.true;
+      const saved = db.medic.put.args[0][0];
+      chai.expect(saved._id).to.equal(userId);
+      chai.expect(saved.name).to.equal('steve');
+      chai.expect(saved.device_keys).to.have.lengthOf(1);
+      chai.expect(saved.device_keys[0].device_id).to.equal('device-1');
+      chai.expect(saved.device_keys[0].public_key).to.equal('age1recipient');
+      chai.expect(saved.device_keys[0].created_at).to.match(ISO_DATE);
+      chai.expect(result).to.deep.equal({ id: userId, rev: '2-abc' });
+    });
+
+    it('replaces the existing entry when the same device re-registers', async () => {
+      db.medic.get.resolves({
+        _id: userId,
+        name: 'steve',
+        type: 'user-settings',
+        device_keys: [
+          { device_id: 'device-1', public_key: 'age1old', created_at: '2026-01-01T00:00:00.000Z' },
+          { device_id: 'device-2', public_key: 'age1other', created_at: '2026-01-01T00:00:00.000Z' },
+        ],
+      });
+      db.medic.put.resolves({ id: userId, rev: '3-abc' });
+
+      await service.setDeviceKey('steve', 'device-1', 'age1new');
+
+      const savedKeys = db.medic.put.args[0][0].device_keys;
+      chai.expect(savedKeys).to.have.lengthOf(2);
+      chai.expect(savedKeys[0].device_id).to.equal('device-1');
+      chai.expect(savedKeys[0].public_key).to.equal('age1new');
+      chai.expect(savedKeys[0].created_at).to.match(ISO_DATE);
+      chai.expect(savedKeys[1]).to.deep.equal(
+        { device_id: 'device-2', public_key: 'age1other', created_at: '2026-01-01T00:00:00.000Z' }
+      );
+    });
+
+    it('rejects when the user-settings doc is not found', () => {
+      db.medic.get.rejects({ status: 404 });
+
+      return chai.expect(service.setDeviceKey('steve', 'device-1', 'age1recipient')).to.be.rejected;
+    });
+  });
+
   describe('deleteUser', () => {
 
     it('returns _users insert errors', () => {

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -1162,7 +1162,8 @@ describe('Users service', () => {
       db.users.get.resolves({ _id: userId, name: 'steve', type: 'user' });
       db.users.put.resolves({ id: userId, rev: '2-abc' });
 
-      const result = await service.setDeviceKey('steve', 'device-1', 'age1recipient', signingKey, serverKeys);
+      const deviceKeys = { encryption_key: 'age1recipient', signing_key: signingKey };
+      const result = await service.setDeviceKey('steve', 'device-1', deviceKeys, serverKeys);
 
       chai.expect(db.users.get.args[0]).to.deep.equal([userId]);
       chai.expect(db.users.put.calledOnce).to.be.true;
@@ -1207,7 +1208,8 @@ describe('Users service', () => {
       });
       db.users.put.resolves({ id: userId, rev: '3-abc' });
 
-      await service.setDeviceKey('steve', 'device-1', 'age1new', signingKey, serverKeys);
+      const deviceKeys = { encryption_key: 'age1new', signing_key: signingKey };
+      await service.setDeviceKey('steve', 'device-1', deviceKeys, serverKeys);
 
       const savedDevices = db.users.put.args[0][0].keys_by_device;
       chai.expect(Object.keys(savedDevices)).to.have.members(['device-1', 'device-2']);
@@ -1220,9 +1222,8 @@ describe('Users service', () => {
     it('rejects when the _users doc is not found', () => {
       db.users.get.rejects({ status: 404 });
 
-      return chai.expect(
-        service.setDeviceKey('steve', 'device-1', 'age1recipient', signingKey, serverKeys)
-      ).to.be.rejected;
+      const deviceKeys = { encryption_key: 'age1recipient', signing_key: signingKey };
+      return chai.expect(service.setDeviceKey('steve', 'device-1', deviceKeys, serverKeys)).to.be.rejected;
     });
   });
 

--- a/shared-libs/user-management/test/unit/users.spec.js
+++ b/shared-libs/user-management/test/unit/users.spec.js
@@ -1150,71 +1150,79 @@ describe('Users service', () => {
   describe('setDeviceKey', () => {
     const userId = PREFIXES.COUCH_USER + 'steve';
 
-    const ISO_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+    // Only PUBLIC server keys reach this layer; private keys are stored in the secureSettings vault
+    // by the api controller and must never be written to the _users doc.
+    const serverKeys = {
+      server_encryption_public_key: 'age1serverrecipient',
+      server_signing_public_key: { kty: 'OKP', crv: 'Ed25519', x: 'server-pub' },
+    };
+    const signingKey = { kty: 'OKP', crv: 'Ed25519', x: 'device-pub' };
 
-    it('adds a new device key entry to the user-settings doc', async () => {
-      db.medic.get.resolves({ _id: userId, name: 'steve', type: 'user-settings' });
-      db.medic.put.resolves({ id: userId, rev: '2-abc' });
+    it('adds a new device key entry to the _users doc', async () => {
+      db.users.get.resolves({ _id: userId, name: 'steve', type: 'user' });
+      db.users.put.resolves({ id: userId, rev: '2-abc' });
 
-      const result = await service.setDeviceKey('steve', 'device-1', 'age1recipient', 'ed25519signing');
+      const result = await service.setDeviceKey('steve', 'device-1', 'age1recipient', signingKey, serverKeys);
 
-      chai.expect(db.medic.get.args[0]).to.deep.equal([userId]);
-      chai.expect(db.medic.put.calledOnce).to.be.true;
-      const saved = db.medic.put.args[0][0];
+      chai.expect(db.users.get.args[0]).to.deep.equal([userId]);
+      chai.expect(db.users.put.calledOnce).to.be.true;
+      const saved = db.users.put.args[0][0];
       chai.expect(saved._id).to.equal(userId);
       chai.expect(saved.name).to.equal('steve');
-      chai.expect(saved.device_keys).to.have.lengthOf(1);
-      chai.expect(saved.device_keys[0].device_id).to.equal('device-1');
-      chai.expect(saved.device_keys[0].encryption_key).to.equal('age1recipient');
-      chai.expect(saved.device_keys[0].signing_key).to.equal('ed25519signing');
-      chai.expect(saved.device_keys[0].created_at).to.match(ISO_DATE);
-      chai.expect(result).to.deep.equal({ id: userId, rev: '2-abc' });
+      chai.expect(Object.keys(saved.keys_by_device)).to.deep.equal(['device-1']);
+      const entry = saved.keys_by_device['device-1'];
+      chai.expect(entry.encryption_public_key).to.equal('age1recipient');
+      chai.expect(entry.signing_public_key).to.deep.equal(signingKey);
+      chai.expect(entry.server_encryption_public_key).to.equal('age1serverrecipient');
+      chai.expect(entry.server_signing_public_key).to.deep.equal(serverKeys.server_signing_public_key);
+      chai.expect(entry.server_encryption_private_key).to.be.undefined;
+      chai.expect(entry.server_signing_private_key).to.be.undefined;
+      chai.expect(entry.updated_date).to.be.a('number');
+      chai.expect(result).to.deep.equal({
+        server_encryption_public_key: 'age1serverrecipient',
+        server_signing_public_key: serverKeys.server_signing_public_key,
+      });
     });
 
     it('replaces the existing entry when the same device re-registers', async () => {
-      db.medic.get.resolves({
+      const otherEntry = {
+        encryption_public_key: 'age1other',
+        signing_public_key: { kty: 'OKP', crv: 'Ed25519', x: 'other-pub' },
+        server_encryption_public_key: 'age1serverother',
+        server_signing_public_key: { kty: 'OKP', crv: 'Ed25519', x: 'server-other' },
+        updated_date: 1000,
+      };
+      db.users.get.resolves({
         _id: userId,
         name: 'steve',
-        type: 'user-settings',
-        device_keys: [
-          {
-            device_id: 'device-1',
-            encryption_key: 'age1old',
-            signing_key: 'ed25519old',
-            created_at: '2026-01-01T00:00:00.000Z',
+        type: 'user',
+        keys_by_device: {
+          'device-1': {
+            encryption_public_key: 'age1old',
+            signing_public_key: { kty: 'OKP', crv: 'Ed25519', x: 'old-pub' },
+            updated_date: 1000,
           },
-          {
-            device_id: 'device-2',
-            encryption_key: 'age1other',
-            signing_key: 'ed25519other',
-            created_at: '2026-01-01T00:00:00.000Z',
-          },
-        ],
+          'device-2': otherEntry,
+        },
       });
-      db.medic.put.resolves({ id: userId, rev: '3-abc' });
+      db.users.put.resolves({ id: userId, rev: '3-abc' });
 
-      await service.setDeviceKey('steve', 'device-1', 'age1new', 'ed25519new');
+      await service.setDeviceKey('steve', 'device-1', 'age1new', signingKey, serverKeys);
 
-      const savedKeys = db.medic.put.args[0][0].device_keys;
-      chai.expect(savedKeys).to.have.lengthOf(2);
-      chai.expect(savedKeys[0].device_id).to.equal('device-1');
-      chai.expect(savedKeys[0].encryption_key).to.equal('age1new');
-      chai.expect(savedKeys[0].signing_key).to.equal('ed25519new');
-      chai.expect(savedKeys[0].created_at).to.match(ISO_DATE);
-      chai.expect(savedKeys[1]).to.deep.equal(
-        {
-          device_id: 'device-2',
-          encryption_key: 'age1other',
-          signing_key: 'ed25519other',
-          created_at: '2026-01-01T00:00:00.000Z',
-        }
-      );
+      const savedDevices = db.users.put.args[0][0].keys_by_device;
+      chai.expect(Object.keys(savedDevices)).to.have.members(['device-1', 'device-2']);
+      chai.expect(savedDevices['device-1'].encryption_public_key).to.equal('age1new');
+      chai.expect(savedDevices['device-1'].signing_public_key).to.deep.equal(signingKey);
+      chai.expect(savedDevices['device-1'].updated_date).to.be.a('number');
+      chai.expect(savedDevices['device-2']).to.deep.equal(otherEntry);
     });
 
-    it('rejects when the user-settings doc is not found', () => {
-      db.medic.get.rejects({ status: 404 });
+    it('rejects when the _users doc is not found', () => {
+      db.users.get.rejects({ status: 404 });
 
-      return chai.expect(service.setDeviceKey('steve', 'device-1', 'age1recipient', 'ed25519signing')).to.be.rejected;
+      return chai.expect(
+        service.setDeviceKey('steve', 'device-1', 'age1recipient', signingKey, serverKeys)
+      ).to.be.rejected;
     });
   });
 

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -2496,7 +2496,7 @@ describe('Users API', () => {
     });
   });
 
-  describe('POST /api/v1/users/{username}/device-key', () => {
+  describe('POST /api/v1/users/{username}/devices/{device_id}/keys', () => {
     const password = 'passwordSUP3RS3CR37!';
     const senderUser = {
       username: 'devkeysender',
@@ -2522,7 +2522,7 @@ describe('Users API', () => {
       contact: { _id: 'fixture:contact:devkey-other', name: 'DeviceKeyOther' },
       roles: ['data_entry']
     };
-    // real keys generated in the before() below: age recipients and base64 raw Ed25519 public keys
+    // real keys generated in the before() below: age recipients and Ed25519 public key JWKs
     let deviceKeyA;
     let deviceKeyB;
     let signingKeyA;
@@ -2530,8 +2530,7 @@ describe('Users API', () => {
 
     const generateSigningKey = async () => {
       const keyPair = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
-      const raw = Buffer.from(await webcrypto.subtle.exportKey('raw', keyPair.publicKey));
-      return raw.toString('base64');
+      return webcrypto.subtle.exportKey('jwk', keyPair.publicKey);
     };
 
     before(async () => {
@@ -2551,63 +2550,67 @@ describe('Users API', () => {
       await utils.deleteUsers([senderUser, otherUser]);
     });
 
-    it('stores the device key and returns the server public key', async () => {
+    it('stores the device keys and returns the server public keys', async () => {
       const response = await utils.request({
-        path: `/api/v1/users/${senderUser.username}/device-key`,
+        path: `/api/v1/users/${senderUser.username}/devices/device-A/keys`,
         method: 'POST',
-        body: { device_id: 'device-A', encryption_key: deviceKeyA, signing_key: signingKeyA },
+        body: { encryption_key: deviceKeyA, signing_key: signingKeyA },
         auth: { username: senderUser.username, password },
       });
 
-      chai.expect(response.server_key).to.match(/^age1/);
+      chai.expect(response.server_encryption_public_key).to.match(/^age1/);
+      chai.expect(response.server_signing_public_key).to.include({ kty: 'OKP', crv: 'Ed25519' });
 
-      const userSettings = await utils.getDoc(getUserId(senderUser.username));
-      chai.expect(userSettings.device_keys).to.have.lengthOf(1);
-      chai.expect(userSettings.device_keys[0]).to.include({
-        device_id: 'device-A',
-        encryption_key: deviceKeyA,
-        signing_key: signingKeyA,
-      });
-      chai.expect(userSettings.device_keys[0].created_at).to.be.a('string');
+      const userDoc = await utils.usersDb.get(getUserId(senderUser.username));
+      chai.expect(Object.keys(userDoc.keys_by_device)).to.deep.equal(['device-A']);
+      const entry = userDoc.keys_by_device['device-A'];
+      chai.expect(entry.encryption_public_key).to.equal(deviceKeyA);
+      chai.expect(entry.signing_public_key).to.deep.equal(signingKeyA);
+      chai.expect(entry.server_encryption_public_key).to.equal(response.server_encryption_public_key);
+      chai.expect(entry.server_signing_public_key).to.deep.equal(response.server_signing_public_key);
+      // server PRIVATE keys must live in the secureSettings vault, never on the _users doc
+      chai.expect(entry.server_encryption_private_key).to.be.undefined;
+      chai.expect(entry.server_signing_private_key).to.be.undefined;
+      chai.expect(entry.updated_date).to.be.a('number');
     });
 
     it('upserts by device_id when the same device re-registers', async () => {
       await utils.request({
-        path: `/api/v1/users/${senderUser.username}/device-key`,
+        path: `/api/v1/users/${senderUser.username}/devices/device-A/keys`,
         method: 'POST',
-        body: { device_id: 'device-A', encryption_key: deviceKeyB, signing_key: signingKeyB },
+        body: { encryption_key: deviceKeyB, signing_key: signingKeyB },
         auth: { username: senderUser.username, password },
       });
 
-      const userSettings = await utils.getDoc(getUserId(senderUser.username));
-      chai.expect(userSettings.device_keys).to.have.lengthOf(1);
-      chai.expect(userSettings.device_keys[0].encryption_key).to.equal(deviceKeyB);
-      chai.expect(userSettings.device_keys[0].signing_key).to.equal(signingKeyB);
+      const userDoc = await utils.usersDb.get(getUserId(senderUser.username));
+      chai.expect(Object.keys(userDoc.keys_by_device)).to.deep.equal(['device-A']);
+      chai.expect(userDoc.keys_by_device['device-A'].encryption_public_key).to.equal(deviceKeyB);
+      chai.expect(userDoc.keys_by_device['device-A'].signing_public_key).to.deep.equal(signingKeyB);
     });
 
     it('403s when the user lacks the offline-data-bundle permission', async () => {
       await chai.expect(utils.request({
-        path: `/api/v1/users/${otherUser.username}/device-key`,
+        path: `/api/v1/users/${otherUser.username}/devices/device-C/keys`,
         method: 'POST',
-        body: { device_id: 'device-C', encryption_key: deviceKeyA, signing_key: signingKeyA },
+        body: { encryption_key: deviceKeyA, signing_key: signingKeyA },
         auth: { username: otherUser.username, password },
       })).to.be.rejectedWith(/403/);
     });
 
     it('400s when required fields are missing', async () => {
       await chai.expect(utils.request({
-        path: `/api/v1/users/${senderUser.username}/device-key`,
+        path: `/api/v1/users/${senderUser.username}/devices/device-A/keys`,
         method: 'POST',
-        body: { device_id: 'device-A' },
+        body: { encryption_key: deviceKeyA },
         auth: { username: senderUser.username, password },
       })).to.be.rejectedWith(/400/);
     });
 
     it('400s when a key has an invalid format', async () => {
       await chai.expect(utils.request({
-        path: `/api/v1/users/${senderUser.username}/device-key`,
+        path: `/api/v1/users/${senderUser.username}/devices/device-A/keys`,
         method: 'POST',
-        body: { device_id: 'device-A', encryption_key: 'not-an-age-recipient', signing_key: signingKeyA },
+        body: { encryption_key: 'not-an-age-recipient', signing_key: signingKeyA },
         auth: { username: senderUser.username, password },
       })).to.be.rejectedWith(/400/);
     });

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -2493,4 +2493,94 @@ describe('Users API', () => {
       });
     });
   });
+
+  describe('POST /api/v1/users/{username}/device-key', () => {
+    const password = 'passwordSUP3RS3CR37!';
+    const senderUser = {
+      username: 'devkeysender',
+      password,
+      place: {
+        _id: 'fixture:devkey-sender',
+        type: CONTACT_TYPES.HEALTH_CENTER,
+        name: 'Device key sender place',
+        parent: 'PARENT_PLACE'
+      },
+      contact: { _id: 'fixture:contact:devkey-sender', name: 'DeviceKeySender' },
+      roles: ['chw']
+    };
+    const otherUser = {
+      username: 'devkeyother',
+      password,
+      place: {
+        _id: 'fixture:devkey-other',
+        type: CONTACT_TYPES.HEALTH_CENTER,
+        name: 'Device key other place',
+        parent: 'PARENT_PLACE'
+      },
+      contact: { _id: 'fixture:contact:devkey-other', name: 'DeviceKeyOther' },
+      roles: ['data_entry']
+    };
+    // valid age recipient (public) keys
+    const deviceKeyA = 'age1lggyhqrw2nlhcxprm4t5xu7pw5rsp3nlxr6mnp5ykhtl2f6c2sqrwv3rs';
+    const deviceKeyB = 'age1e4uw9yvxm647436dtk9d8yrjr9lgpxvpqvfd8ycvz7zszx6yg9qs3lkkny';
+
+    before(async () => {
+      await utils.saveDoc(parentPlace);
+      await utils.createUsers([senderUser, otherUser]);
+      await utils.updatePermissions(['chw'], ['can_send_offline_data_bundle'], [], { ignoreReload: true });
+    });
+
+    after(async () => {
+      await utils.revertSettings(true);
+      await utils.revertDb([], true);
+      await utils.deleteUsers([senderUser, otherUser]);
+    });
+
+    it('stores the device key and returns the server public key', async () => {
+      const response = await utils.request({
+        path: `/api/v1/users/${senderUser.username}/device-key`,
+        method: 'POST',
+        body: { device_id: 'device-A', public_key: deviceKeyA },
+        auth: { username: senderUser.username, password },
+      });
+
+      chai.expect(response.server_key).to.match(/^age1/);
+
+      const userSettings = await utils.getDoc(getUserId(senderUser.username));
+      chai.expect(userSettings.device_keys).to.have.lengthOf(1);
+      chai.expect(userSettings.device_keys[0]).to.include({ device_id: 'device-A', public_key: deviceKeyA });
+      chai.expect(userSettings.device_keys[0].created_at).to.be.a('string');
+    });
+
+    it('upserts by device_id when the same device re-registers', async () => {
+      await utils.request({
+        path: `/api/v1/users/${senderUser.username}/device-key`,
+        method: 'POST',
+        body: { device_id: 'device-A', public_key: deviceKeyB },
+        auth: { username: senderUser.username, password },
+      });
+
+      const userSettings = await utils.getDoc(getUserId(senderUser.username));
+      chai.expect(userSettings.device_keys).to.have.lengthOf(1);
+      chai.expect(userSettings.device_keys[0].public_key).to.equal(deviceKeyB);
+    });
+
+    it('403s when the user lacks the offline-data-bundle permission', async () => {
+      await chai.expect(utils.request({
+        path: `/api/v1/users/${otherUser.username}/device-key`,
+        method: 'POST',
+        body: { device_id: 'device-C', public_key: deviceKeyA },
+        auth: { username: otherUser.username, password },
+      })).to.be.rejectedWith(/403/);
+    });
+
+    it('400s when required fields are missing', async () => {
+      await chai.expect(utils.request({
+        path: `/api/v1/users/${senderUser.username}/device-key`,
+        method: 'POST',
+        body: { device_id: 'device-A' },
+        auth: { username: senderUser.username, password },
+      })).to.be.rejectedWith(/400/);
+    });
+  });
 });

--- a/tests/integration/api/controllers/users.spec.js
+++ b/tests/integration/api/controllers/users.spec.js
@@ -6,7 +6,9 @@ const placeFactory = require('@factories/cht/contacts/place');
 const personFactory = require('@factories/cht/contacts/person');
 const userFactory = require('@factories/cht/users/users');
 const chai = require('chai');
+const { webcrypto } = require('node:crypto');
 const { USER_ROLES, CONTACT_TYPES, PREFIXES } = require('@medic/constants');
+const age = require('../../../../api/src/services/offline-data-bundle/age');
 
 const getUserId = n => `${PREFIXES.COUCH_USER}${n}`;
 const password = 'passwordSUP3RS3CR37!';
@@ -2520,11 +2522,24 @@ describe('Users API', () => {
       contact: { _id: 'fixture:contact:devkey-other', name: 'DeviceKeyOther' },
       roles: ['data_entry']
     };
-    // valid age recipient (public) keys
-    const deviceKeyA = 'age1lggyhqrw2nlhcxprm4t5xu7pw5rsp3nlxr6mnp5ykhtl2f6c2sqrwv3rs';
-    const deviceKeyB = 'age1e4uw9yvxm647436dtk9d8yrjr9lgpxvpqvfd8ycvz7zszx6yg9qs3lkkny';
+    // real keys generated in the before() below: age recipients and base64 raw Ed25519 public keys
+    let deviceKeyA;
+    let deviceKeyB;
+    let signingKeyA;
+    let signingKeyB;
+
+    const generateSigningKey = async () => {
+      const keyPair = await webcrypto.subtle.generateKey({ name: 'Ed25519' }, true, ['sign', 'verify']);
+      const raw = Buffer.from(await webcrypto.subtle.exportKey('raw', keyPair.publicKey));
+      return raw.toString('base64');
+    };
 
     before(async () => {
+      deviceKeyA = await age.identityToRecipient(await age.generateIdentity());
+      deviceKeyB = await age.identityToRecipient(await age.generateIdentity());
+      signingKeyA = await generateSigningKey();
+      signingKeyB = await generateSigningKey();
+
       await utils.saveDoc(parentPlace);
       await utils.createUsers([senderUser, otherUser]);
       await utils.updatePermissions(['chw'], ['can_send_offline_data_bundle'], [], { ignoreReload: true });
@@ -2540,7 +2555,7 @@ describe('Users API', () => {
       const response = await utils.request({
         path: `/api/v1/users/${senderUser.username}/device-key`,
         method: 'POST',
-        body: { device_id: 'device-A', public_key: deviceKeyA },
+        body: { device_id: 'device-A', encryption_key: deviceKeyA, signing_key: signingKeyA },
         auth: { username: senderUser.username, password },
       });
 
@@ -2548,7 +2563,11 @@ describe('Users API', () => {
 
       const userSettings = await utils.getDoc(getUserId(senderUser.username));
       chai.expect(userSettings.device_keys).to.have.lengthOf(1);
-      chai.expect(userSettings.device_keys[0]).to.include({ device_id: 'device-A', public_key: deviceKeyA });
+      chai.expect(userSettings.device_keys[0]).to.include({
+        device_id: 'device-A',
+        encryption_key: deviceKeyA,
+        signing_key: signingKeyA,
+      });
       chai.expect(userSettings.device_keys[0].created_at).to.be.a('string');
     });
 
@@ -2556,20 +2575,21 @@ describe('Users API', () => {
       await utils.request({
         path: `/api/v1/users/${senderUser.username}/device-key`,
         method: 'POST',
-        body: { device_id: 'device-A', public_key: deviceKeyB },
+        body: { device_id: 'device-A', encryption_key: deviceKeyB, signing_key: signingKeyB },
         auth: { username: senderUser.username, password },
       });
 
       const userSettings = await utils.getDoc(getUserId(senderUser.username));
       chai.expect(userSettings.device_keys).to.have.lengthOf(1);
-      chai.expect(userSettings.device_keys[0].public_key).to.equal(deviceKeyB);
+      chai.expect(userSettings.device_keys[0].encryption_key).to.equal(deviceKeyB);
+      chai.expect(userSettings.device_keys[0].signing_key).to.equal(signingKeyB);
     });
 
     it('403s when the user lacks the offline-data-bundle permission', async () => {
       await chai.expect(utils.request({
         path: `/api/v1/users/${otherUser.username}/device-key`,
         method: 'POST',
-        body: { device_id: 'device-C', public_key: deviceKeyA },
+        body: { device_id: 'device-C', encryption_key: deviceKeyA, signing_key: signingKeyA },
         auth: { username: otherUser.username, password },
       })).to.be.rejectedWith(/403/);
     });
@@ -2579,6 +2599,15 @@ describe('Users API', () => {
         path: `/api/v1/users/${senderUser.username}/device-key`,
         method: 'POST',
         body: { device_id: 'device-A' },
+        auth: { username: senderUser.username, password },
+      })).to.be.rejectedWith(/400/);
+    });
+
+    it('400s when a key has an invalid format', async () => {
+      await chai.expect(utils.request({
+        path: `/api/v1/users/${senderUser.username}/device-key`,
+        method: 'POST',
+        body: { device_id: 'device-A', encryption_key: 'not-an-age-recipient', signing_key: signingKeyA },
         auth: { username: senderUser.username, password },
       })).to.be.rejectedWith(/400/);
     });


### PR DESCRIPTION
# Description

Adds `POST /api/v1/users/{username}/device-key` for the offline data bundle feature. Each device registers its own key pair: an X25519 encryption key (age recipient, used to encrypt the checkpoint back to the device) and an Ed25519 signing key (used by the server to verify bundle signatures in a later issue). The server stores both public keys per device (one entry per device_id, upsert) and returns its own current encryption public key.

- Gated by the `can_send_offline_data_bundle` / `can_relay_offline_data_bundle` permissions; non-admins may only register their own device.
- Both keys are format-validated (age recipient + base64 Ed25519) before storage.
- `age-encryption` (typage) is ESM-only, so it's loaded through a small lazy dynamic-import wrapper to stay compatible with the CommonJS api and nyc.

Closes #11278

# Code review checklist
- [x] Readable: Concise, well named, follows the style guide
- [ ] Documented: Configuration and user documentation on cht-docs
- [x] Tested: Unit and integration
- [x] Backwards compatible: Additive endpoint, no existing behaviour changed
- [ ] AI disclosure: Please disclose use of AI per the guidelines

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
