### PR TITLE
fix(#11324): recognise closing keywords on non-default-branch PRs

### DIFF
--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -42,6 +42,15 @@ const stripComments = (text) => {
   return text;
 };
 
+// GitHub does not linkify inside code, so neither should the fallback: a body that
+// merely documents the syntax must not read as a link. Fences go first so that a
+// backtick inside one can't pair with a later one and swallow real prose.
+const stripCode = (text) => {
+  return text
+    .replace(/^[^\S\n]*(```+|~~~+)[\s\S]*?^[^\S\n]*\1[^\S\n]*$/gm, '')
+    .replace(/(`+)[^`]*?\1/g, '');
+};
+
 const HEADING_PREFIX = '# ';
 const HEADING_REGEX = new RegExp(`^${HEADING_PREFIX}.+$`, 'gm');
 
@@ -101,9 +110,15 @@ const MAX_LINKED_ISSUES = 20;
 // `#123`, `owner/repo#123`, and a full issue URL.
 // https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
 const CLOSING_KEYWORDS = 'close[sd]?|fix(?:e[sd])?|resolve[sd]?';
-const REPO_NAME = String.raw`[\w.-]+`;
+// At least one character that isn't a dot, so `..` can't reach the API as a path segment.
+const REPO_NAME = String.raw`[\w.-]*[\w-][\w.-]*`;
+// `:?[^\S\n]+` rather than `\s*:?\s+`: the latter is ambiguous between its two
+// whitespace quantifiers and backtracks quadratically on a long run of spaces
+// (~4s at GitHub's 65536 body limit, re-run on every `edited` event). Excluding
+// newlines also stops a keyword ending one line binding to a `#N` on the next,
+// which GitHub does not link.
 const CLOSING_REFERENCE_REGEX = new RegExp(
-  String.raw`\b(?:${CLOSING_KEYWORDS})\b\s*:?\s+` +
+  String.raw`\b(?:${CLOSING_KEYWORDS})\b:?[^\S\n]+` +
   String.raw`(?:https?://github\.com/(${REPO_NAME})/(${REPO_NAME})/issues/(\d+)` +
   String.raw`|(?:(${REPO_NAME})/(${REPO_NAME}))?#(\d+))`,
   'gi'
@@ -113,12 +128,18 @@ const CLOSING_REFERENCE_REGEX = new RegExp(
 // repository's default branch; on any other base the field is empty even though the
 // contributor linked the issue correctly. Parsing the body covers that case.
 const parseClosingReferences = (body, context) => {
-  const matches = stripComments(body || '').matchAll(CLOSING_REFERENCE_REGEX);
-  const references = [...matches].map(([, urlOwner, urlRepo, urlNumber, owner, repo, number]) => ({
-    owner: urlOwner || owner || context.repo.owner,
-    repo: urlRepo || repo || context.repo.repo,
-    number: Number(urlNumber || number),
-  }));
+  const matches = stripCode(stripComments(body || '')).matchAll(CLOSING_REFERENCE_REGEX);
+  const references = [...matches]
+    .map(([, urlOwner, urlRepo, urlNumber, owner, repo, number]) => ({
+      owner: urlOwner || owner || context.repo.owner,
+      repo: urlRepo || repo || context.repo.repo,
+      // Leading zeros are not autolinked by GitHub, and a digit run long enough to
+      // lose precision would reach the API as exponential notation.
+      number: /^[1-9]\d*$/.test(urlNumber || number)
+        ? Number(urlNumber || number)
+        : Number.NaN,
+    }))
+    .filter(reference => Number.isSafeInteger(reference.number));
 
   // Owner and repo names are case-insensitive on GitHub, so the key is too.
   const seen = new Set();
@@ -166,27 +187,34 @@ const resolveReferencedIssues = async (github, context, core, references) => {
       if (!MISSING_ISSUE_STATUSES.has(err.status)) {
         throw err;
       }
+      // 404 also covers "the token cannot see this repository", so a reference to a
+      // private in-org repo lands here. Warn rather than info so a dropped reference is
+      // visible in the job summary instead of only deep in the log.
       const name = `${reference.owner}/${reference.repo}#${reference.number.toString()}`;
-      core.info(`Ignoring referenced issue ${name}: not found.`);
+      core.warning(`Ignoring referenced issue ${name}: not found or not visible.`);
       return null;
     }
   }));
   return issues.filter(Boolean);
 };
 
+const isAssignedTo = (issue, login) => {
+  return issue.assignees.nodes.some(assignee => assignee.login === login);
+};
+
 const getLinkedIssues = async (github, context, core) => {
   const query = `
-    query ($owner: String!, $repo: String!, $number: Int!) {
+    query ($owner: String!, $repo: String!, $number: Int!, $limit: Int!) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $number) {
-          closingIssuesReferences(first: 20) {
+          closingIssuesReferences(first: $limit) {
             nodes {
               number
               repository {
                 nameWithOwner
                 owner { login }
               }
-              assignees(first: 20) {
+              assignees(first: $limit) {
                 nodes { login }
               }
             }
@@ -198,38 +226,62 @@ const getLinkedIssues = async (github, context, core) => {
     owner: context.repo.owner,
     repo: context.repo.repo,
     number: context.payload.pull_request.number,
+    limit: MAX_LINKED_ISSUES,
   });
   // Issues linked from repositories outside the org don't count as linked.
   const isInOrg = owner => owner.toLowerCase() === context.repo.owner.toLowerCase();
+  const author = context.payload.pull_request.user.login;
   const linkedIssues = result.repository.pullRequest.closingIssuesReferences.nodes
     .filter(issue => isInOrg(issue.repository.owner.login));
-  if (linkedIssues.length) {
+
+  // Only short-circuit on a link that would actually pass. closingIssuesReferences is
+  // fed by both closing keywords and the Development sidebar, and the sidebar works on
+  // any base branch — so a sidebar-linked epic can fill this while the contributor's own
+  // keyword link goes unread, leaving them a failure they cannot clear from the PR.
+  if (linkedIssues.some(issue => isAssignedTo(issue, author))) {
     return linkedIssues;
   }
 
-  const references = parseClosingReferences(context.payload.pull_request.body, context)
-    .filter(reference => isInOrg(reference.owner))
-    .slice(0, MAX_LINKED_ISSUES);
-  if (!references.length) {
-    return [];
+  const parsed = parseClosingReferences(context.payload.pull_request.body, context)
+    .filter(reference => isInOrg(reference.owner));
+  if (parsed.length > MAX_LINKED_ISSUES) {
+    core.warning(
+      `Only the first ${MAX_LINKED_ISSUES.toString()} referenced issues are checked; ` +
+      `${(parsed.length - MAX_LINKED_ISSUES).toString()} later reference(s) were ignored.`
+    );
   }
-  return resolveReferencedIssues(github, context, core, references);
+  const references = parsed.slice(0, MAX_LINKED_ISSUES);
+  if (!references.length) {
+    return linkedIssues;
+  }
+
+  const resolved = await resolveReferencedIssues(github, context, core, references);
+  // Re-filter: an issue transferred out of the org comes back under its new owner.
+  return [...linkedIssues, ...resolved.filter(issue => isInOrg(issue.repository.owner.login))];
 };
 
 const getLinkedIssueFailure = (pr, linkedIssues) => {
   if (!linkedIssues.length) {
     return getMessage('missing-linked-issue');
   }
-  const isAssigned = linkedIssues
-    .some(issue => issue.assignees.nodes.some(assignee => assignee.login === pr.user.login));
-  if (isAssigned) {
+  if (linkedIssues.some(issue => isAssignedTo(issue, pr.user.login))) {
     return null;
   }
 
+  // The GraphQL and parsed sets can name the same issue; list it once.
+  const seen = new Set();
   const issueList = linkedIssues
     .map(issue => issue.repository.nameWithOwner === pr.base.repo.full_name
       ? `#${issue.number}`
       : `${issue.repository.nameWithOwner}#${issue.number}`)
+    .filter(name => {
+      const key = name.toLowerCase();
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
     .join(', ');
   return getMessage('not-assigned', { issueList });
 };

--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -42,51 +42,55 @@ const stripComments = (text) => {
   return text;
 };
 
-const FENCE_REGEX = /^\s*(```+|~~~+)/;
+// Only a fence that is actually closed delimits a block. An opener with no matching close
+// matches nothing and so strips nothing, which is what keeps this bounded: the alternative —
+// running an unclosed fence to the end of the document, as a renderer does — means one
+// misread line silently discards every reference below it, and the contributor cannot tell
+// why the link they wrote is not being seen. The failure directions are not equal. Reading
+// code as prose lets a PR that only *documents* a link past a check that still requires the
+// author be assigned to that issue; reading prose as code blocks a real contributor with no
+// way to clear it. Everything ambiguous here is therefore resolved toward stripping less.
+//
+// That asymmetry is also why no CommonMark subtleties are encoded: an info string with a
+// backtick (``` ```sh make test``` ```, an inline span, not a block), a four-space indent
+// making a fence literal, a close carrying its own info string. Each would only ever cause
+// this to strip *more*, and unpaired markers already strip nothing.
+const FENCED_BLOCK_REGEX = /^ {0,3}(```+|~~~+)[^\n]*\n[\s\S]*?^ {0,3}\1[^\n]*$/gm;
 const CODE_SPAN_REGEX = /(`+)[^`\n]*?\1/g;
+const COMMENT_REGEX = /<!--[\s\S]*?-->/g;
+// Carries no comment marker and starts no heading, but is not empty.
+const CODE_BLOCK_PLACEHOLDER = '\ncode\n';
 
 // GitHub does not linkify inside comments or code, so neither should the fallback: a body
-// that merely documents the syntax must not read as a link. Handled line by line, because
-// every subtlety here is a line-level rule — an unclosed fence runs to the end of the
-// document, a `~~~` block is not closed by a ``` one, and a code span cannot span lines.
+// that merely documents the syntax must not read as a link.
+//
+// The order is load-bearing. A `<!--` inside a fenced block is literal and closes nothing, so
+// blocks go first; stripping comments first let such a marker pair with the next `-->` below
+// it — in practice the PR template's own — and delete the issue link in between. An XML or
+// HTML sample in a cht-core PR body makes that an ordinary body, not a contrived one.
 //
 // Every removal leaves a newline behind. Deleting outright splices the prose either side
 // together, so `does not fix ` + `#1234` reads as a reference; a space doesn't help since
 // the closing-reference regex spans those. A newline is the one separator it won't cross.
 //
-// One pass over comments is enough here, unlike stripComments above: that one loops
-// because deleting can splice a new marker out of the remains (`<!-<!-- x -->- y -->`),
-// and the newline left behind is what stops that.
-const stripNonProse = (text) => {
-  let openFence = null;
-  // Fences do not nest — the first matching close ends the block, so this tracks one open
-  // marker rather than a stack. A stack would need two closes to exit an inner marker and
-  // would swallow every real reference after the block.
-  return text
-    .replace(/<!--[\s\S]*?-->/g, '\n')
-    .split('\n')
-    .map(line => {
-      const fence = FENCE_REGEX.exec(line)?.[1];
-      if (openFence) {
-        if (fence?.startsWith(openFence)) {
-          openFence = null;
-        }
-        return '';
-      }
-      if (fence) {
-        openFence = fence;
-        return '';
-      }
-      return line.replace(CODE_SPAN_REGEX, '\n');
-    })
-    .join('\n');
-};
+// One pass over comments is enough here, unlike stripComments above: that one loops because
+// deleting can splice a new marker out of the remains (`<!-<!-- x -->- y -->`), and the
+// newline left behind is what stops that.
+const stripNonProse = (text) => text
+  .replace(FENCED_BLOCK_REGEX, '\n')
+  .replace(CODE_SPAN_REGEX, '\n')
+  .replace(COMMENT_REGEX, '\n');
 
 const HEADING_PREFIX = '# ';
 const HEADING_REGEX = new RegExp(`^${HEADING_PREFIX}.+$`, 'gm');
 
 const parseSections = (text) => {
-  text = stripComments(text);
+  // A fenced block's content is literal, so neither the `<!--` of an XML sample nor the `#` of
+  // a shell one means anything here — but left in place the first pairs with the template's
+  // next `-->` and swallows a heading, and the second reads as one. Reducing each block to a
+  // placeholder keeps both out of the scan while still counting as content, so a section
+  // filled only with a code sample is not then judged empty.
+  text = stripComments(text.replace(FENCED_BLOCK_REGEX, CODE_BLOCK_PLACEHOLDER));
   const headings = [...text.matchAll(HEADING_REGEX)];
   return headings.map((match, index) => ({
     heading: match[0].trim().replace(HEADING_PREFIX, ''),
@@ -141,8 +145,12 @@ const MAX_LINKED_ISSUES = 20;
 // `#123`, `owner/repo#123`, and a full issue URL.
 // https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
 const CLOSING_KEYWORDS = 'close[sd]?|fix(?:e[sd])?|resolve[sd]?';
-// At least one character that isn't a dot, so `..` can't reach the API as a path segment.
-const REPO_NAME = String.raw`[\w.-]*[\w-][\w.-]*`;
+const PATH_SEGMENT_REGEX = /^\.+$/;
+// Kept unambiguous. Splitting this to require a non-dot character (`[\w.-]*[\w-][\w.-]*`)
+// makes the two quantifiers able to divide a word run between them; with two names either
+// side of a `/` the failure path is cubic, and a 65KB body — the API's own limit — takes
+// hours rather than the 29ms this does. `..` is rejected after parsing instead.
+const REPO_NAME = String.raw`[\w.-]+`;
 // `:?[^\S\n]+` rather than `\s*:?\s+`: the latter is ambiguous between its two
 // whitespace quantifiers and backtracks quadratically on a long run of spaces
 // (~4s at GitHub's 65536 body limit, re-run on every `edited` event). Excluding
@@ -170,7 +178,12 @@ const parseClosingReferences = (body, context) => {
         ? Number(urlNumber || number)
         : Number.NaN,
     }))
-    .filter(reference => Number.isSafeInteger(reference.number));
+    .filter(reference => Number.isSafeInteger(reference.number))
+    // `.` and `..` are legal in the character class but are path segments, not names, so
+    // they would traverse in the request URL rather than 404. Nothing else needs excluding:
+    // any other name is merely one that does not exist.
+    .filter(reference => !PATH_SEGMENT_REGEX.test(reference.owner) &&
+      !PATH_SEGMENT_REGEX.test(reference.repo));
 
   // Owner and repo names are case-insensitive on GitHub, so the key is too.
   const seen = new Set();

--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -42,13 +42,44 @@ const stripComments = (text) => {
   return text;
 };
 
-// GitHub does not linkify inside code, so neither should the fallback: a body that
-// merely documents the syntax must not read as a link. Fences go first so that a
-// backtick inside one can't pair with a later one and swallow real prose.
-const stripCode = (text) => {
+const FENCE_REGEX = /^\s*(```+|~~~+)/;
+const CODE_SPAN_REGEX = /(`+)[^`\n]*?\1/g;
+
+// GitHub does not linkify inside comments or code, so neither should the fallback: a body
+// that merely documents the syntax must not read as a link. Handled line by line, because
+// every subtlety here is a line-level rule — an unclosed fence runs to the end of the
+// document, a `~~~` block is not closed by a ``` one, and a code span cannot span lines.
+//
+// Every removal leaves a newline behind. Deleting outright splices the prose either side
+// together, so `does not fix ` + `#1234` reads as a reference; a space doesn't help since
+// the closing-reference regex spans those. A newline is the one separator it won't cross.
+//
+// One pass over comments is enough here, unlike stripComments above: that one loops
+// because deleting can splice a new marker out of the remains (`<!-<!-- x -->- y -->`),
+// and the newline left behind is what stops that.
+const stripNonProse = (text) => {
+  let openFence = null;
+  // Fences do not nest — the first matching close ends the block, so this tracks one open
+  // marker rather than a stack. A stack would need two closes to exit an inner marker and
+  // would swallow every real reference after the block.
   return text
-    .replace(/^[^\S\n]*(```+|~~~+)[\s\S]*?^[^\S\n]*\1[^\S\n]*$/gm, '')
-    .replace(/(`+)[^`]*?\1/g, '');
+    .replace(/<!--[\s\S]*?-->/g, '\n')
+    .split('\n')
+    .map(line => {
+      const fence = FENCE_REGEX.exec(line)?.[1];
+      if (openFence) {
+        if (fence?.startsWith(openFence)) {
+          openFence = null;
+        }
+        return '';
+      }
+      if (fence) {
+        openFence = fence;
+        return '';
+      }
+      return line.replace(CODE_SPAN_REGEX, '\n');
+    })
+    .join('\n');
 };
 
 const HEADING_PREFIX = '# ';
@@ -128,7 +159,7 @@ const CLOSING_REFERENCE_REGEX = new RegExp(
 // repository's default branch; on any other base the field is empty even though the
 // contributor linked the issue correctly. Parsing the body covers that case.
 const parseClosingReferences = (body, context) => {
-  const matches = stripCode(stripComments(body || '')).matchAll(CLOSING_REFERENCE_REGEX);
+  const matches = stripNonProse(body || '').matchAll(CLOSING_REFERENCE_REGEX);
   const references = [...matches]
     .map(([, urlOwner, urlRepo, urlNumber, owner, repo, number]) => ({
       owner: urlOwner || owner || context.repo.owner,

--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -101,11 +101,11 @@ const MAX_LINKED_ISSUES = 20;
 // `#123`, `owner/repo#123`, and a full issue URL.
 // https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
 const CLOSING_KEYWORDS = 'close[sd]?|fix(?:e[sd])?|resolve[sd]?';
-const REPO_NAME = '[\\w.-]+';
+const REPO_NAME = String.raw`[\w.-]+`;
 const CLOSING_REFERENCE_REGEX = new RegExp(
-  `\\b(?:${CLOSING_KEYWORDS})\\b\\s*:?\\s+` +
-  `(?:https?://github\\.com/(${REPO_NAME})/(${REPO_NAME})/issues/(\\d+)` +
-  `|(?:(${REPO_NAME})/(${REPO_NAME}))?#(\\d+))`,
+  String.raw`\b(?:${CLOSING_KEYWORDS})\b\s*:?\s+` +
+  String.raw`(?:https?://github\.com/(${REPO_NAME})/(${REPO_NAME})/issues/(\d+)` +
+  String.raw`|(?:(${REPO_NAME})/(${REPO_NAME}))?#(\d+))`,
   'gi'
 );
 

--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -95,7 +95,85 @@ const matchesLicense = (prBody, template) => {
   return bodyLicenseSections.every(section => section.content.startsWith(templateLicenseSection.content));
 };
 
-const getLinkedIssues = async (github, context) => {
+const MAX_LINKED_ISSUES = 20;
+
+// GitHub's documented closing keywords, and the three reference forms they accept:
+// `#123`, `owner/repo#123`, and a full issue URL.
+// https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+const CLOSING_KEYWORDS = 'close[sd]?|fix(?:e[sd])?|resolve[sd]?';
+const REPO_NAME = '[\\w.-]+';
+const CLOSING_REFERENCE_REGEX = new RegExp(
+  `\\b(?:${CLOSING_KEYWORDS})\\b\\s*:?\\s+` +
+  `(?:https?://github\\.com/(${REPO_NAME})/(${REPO_NAME})/issues/(\\d+)` +
+  `|(?:(${REPO_NAME})/(${REPO_NAME}))?#(\\d+))`,
+  'gi'
+);
+
+// GitHub only populates closingIssuesReferences from keywords when the PR targets the
+// repository's default branch; on any other base the field is empty even though the
+// contributor linked the issue correctly. Parsing the body covers that case.
+const parseClosingReferences = (body, context) => {
+  const matches = stripComments(body || '').matchAll(CLOSING_REFERENCE_REGEX);
+  const references = [...matches].map(([, urlOwner, urlRepo, urlNumber, owner, repo, number]) => ({
+    owner: urlOwner || owner || context.repo.owner,
+    repo: urlRepo || repo || context.repo.repo,
+    number: Number(urlNumber || number),
+  }));
+
+  // Owner and repo names are case-insensitive on GitHub, so the key is too.
+  const seen = new Set();
+  return references.filter(reference => {
+    const key = `${reference.owner}/${reference.repo}#${reference.number.toString()}`.toLowerCase();
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+};
+
+// Shapes a REST issue like a closingIssuesReferences node so the callers can't tell them apart.
+// The names come from repository_url where possible, so they carry GitHub's canonical casing
+// rather than whatever the contributor typed.
+const toIssueNode = (issue, reference) => {
+  const [, owner, repo] = /\/repos\/([^/]+)\/([^/]+)$/.exec(issue.repository_url || '') || [];
+  const nameWithOwner = `${owner || reference.owner}/${repo || reference.repo}`;
+  return {
+    number: issue.number,
+    repository: { nameWithOwner, owner: { login: owner || reference.owner } },
+    assignees: { nodes: (issue.assignees || []).map(assignee => ({ login: assignee.login })) },
+  };
+};
+
+// A referenced issue that genuinely does not exist is not a link. Any other failure means we
+// could not tell, and blaming the contributor for that is the very false-fail this check is
+// meant to avoid — so those are reported separately rather than folded into "not linked".
+const resolveReferencedIssues = async (github, context, core, references) => {
+  let inconclusive = false;
+  const issues = await Promise.all(references.map(async (reference) => {
+    const name = `${reference.owner}/${reference.repo}#${reference.number.toString()}`;
+    try {
+      const { data } = await github.rest.issues.get({
+        owner: reference.owner,
+        repo: reference.repo,
+        issue_number: reference.number,
+      });
+      // A pull request is also an issue on this endpoint, but referencing one is not a link.
+      return data.pull_request ? null : toIssueNode(data, reference);
+    } catch (err) {
+      if (err.status === 404) {
+        core.info(`Ignoring referenced issue ${name}: not found.`);
+      } else {
+        inconclusive = true;
+        core.warning(`Could not read referenced issue ${name}: ${err.message}`);
+      }
+      return null;
+    }
+  }));
+  return { issues: issues.filter(Boolean), inconclusive };
+};
+
+const getLinkedIssues = async (github, context, core) => {
   const query = `
     query ($owner: String!, $repo: String!, $number: Int!) {
       repository(owner: $owner, name: $repo) {
@@ -121,9 +199,20 @@ const getLinkedIssues = async (github, context) => {
     number: context.payload.pull_request.number,
   });
   // Issues linked from repositories outside the org don't count as linked.
-  return result.repository.pullRequest.closingIssuesReferences.nodes.filter(
-    issue => issue.repository.owner.login === context.repo.owner
-  );
+  const isInOrg = owner => owner.toLowerCase() === context.repo.owner.toLowerCase();
+  const linkedIssues = result.repository.pullRequest.closingIssuesReferences.nodes
+    .filter(issue => isInOrg(issue.repository.owner.login));
+  if (linkedIssues.length) {
+    return { issues: linkedIssues, inconclusive: false };
+  }
+
+  const references = parseClosingReferences(context.payload.pull_request.body, context)
+    .filter(reference => isInOrg(reference.owner))
+    .slice(0, MAX_LINKED_ISSUES);
+  if (!references.length) {
+    return { issues: [], inconclusive: false };
+  }
+  return resolveReferencedIssues(github, context, core, references);
 };
 
 const getLinkedIssueFailure = (pr, linkedIssues) => {
@@ -144,7 +233,7 @@ const getLinkedIssueFailure = (pr, linkedIssues) => {
   return getMessage('not-assigned', { issueList });
 };
 
-const getFailures = async (github, context) => {
+const getFailures = async (github, context, core) => {
   const pr = context.payload.pull_request;
   const failures = [];
 
@@ -157,7 +246,14 @@ const getFailures = async (github, context) => {
     failures.push(getMessage('license-changed'));
   }
 
-  const linkedIssues = await getLinkedIssues(github, context);
+  const { issues: linkedIssues, inconclusive } = await getLinkedIssues(github, context, core);
+  if (inconclusive && !linkedIssues.length) {
+    // Failing the PR here would blame the contributor for a GitHub outage. The warning keeps
+    // the run visible without stranding a correctly-linked PR behind an infrastructure blip.
+    core.warning('Could not verify the linked issue, skipping that check.');
+    return failures;
+  }
+
   const linkedIssueFailure = getLinkedIssueFailure(pr, linkedIssues);
   if (linkedIssueFailure) {
     failures.push(linkedIssueFailure);
@@ -278,7 +374,7 @@ const runAndraBot = async ({ github, context, core }) => {
     return;
   }
 
-  const failures = await getFailures(github, context);
+  const failures = await getFailures(github, context, core);
   const existingComment = await findExistingComment(github, context);
 
   if (!failures.length) {

--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -145,13 +145,15 @@ const toIssueNode = (issue, reference) => {
   };
 };
 
-// A referenced issue that genuinely does not exist is not a link. Any other failure means we
-// could not tell, and blaming the contributor for that is the very false-fail this check is
-// meant to avoid — so those are reported separately rather than folded into "not linked".
+// A referenced issue that does not exist is not a link, so 404 (and 410, for issues that were
+// transferred or deleted) means the reference simply does not count. Anything else is left to
+// throw: the job goes red without a comment or a label change, exactly as it already does for
+// every other API call here, and the next `synchronize` re-runs it. Swallowing those would be
+// the one path that can hand a genuinely unlinked PR its `Ready for review` label.
+const MISSING_ISSUE_STATUSES = new Set([404, 410]);
+
 const resolveReferencedIssues = async (github, context, core, references) => {
-  let inconclusive = false;
   const issues = await Promise.all(references.map(async (reference) => {
-    const name = `${reference.owner}/${reference.repo}#${reference.number.toString()}`;
     try {
       const { data } = await github.rest.issues.get({
         owner: reference.owner,
@@ -161,16 +163,15 @@ const resolveReferencedIssues = async (github, context, core, references) => {
       // A pull request is also an issue on this endpoint, but referencing one is not a link.
       return data.pull_request ? null : toIssueNode(data, reference);
     } catch (err) {
-      if (err.status === 404) {
-        core.info(`Ignoring referenced issue ${name}: not found.`);
-      } else {
-        inconclusive = true;
-        core.warning(`Could not read referenced issue ${name}: ${err.message}`);
+      if (!MISSING_ISSUE_STATUSES.has(err.status)) {
+        throw err;
       }
+      const name = `${reference.owner}/${reference.repo}#${reference.number.toString()}`;
+      core.info(`Ignoring referenced issue ${name}: not found.`);
       return null;
     }
   }));
-  return { issues: issues.filter(Boolean), inconclusive };
+  return issues.filter(Boolean);
 };
 
 const getLinkedIssues = async (github, context, core) => {
@@ -203,14 +204,14 @@ const getLinkedIssues = async (github, context, core) => {
   const linkedIssues = result.repository.pullRequest.closingIssuesReferences.nodes
     .filter(issue => isInOrg(issue.repository.owner.login));
   if (linkedIssues.length) {
-    return { issues: linkedIssues, inconclusive: false };
+    return linkedIssues;
   }
 
   const references = parseClosingReferences(context.payload.pull_request.body, context)
     .filter(reference => isInOrg(reference.owner))
     .slice(0, MAX_LINKED_ISSUES);
   if (!references.length) {
-    return { issues: [], inconclusive: false };
+    return [];
   }
   return resolveReferencedIssues(github, context, core, references);
 };
@@ -246,14 +247,7 @@ const getFailures = async (github, context, core) => {
     failures.push(getMessage('license-changed'));
   }
 
-  const { issues: linkedIssues, inconclusive } = await getLinkedIssues(github, context, core);
-  if (inconclusive && !linkedIssues.length) {
-    // Failing the PR here would blame the contributor for a GitHub outage. The warning keeps
-    // the run visible without stranding a correctly-linked PR behind an infrastructure blip.
-    core.warning('Could not verify the linked issue, skipping that check.');
-    return failures;
-  }
-
+  const linkedIssues = await getLinkedIssues(github, context, core);
   const linkedIssueFailure = getLinkedIssueFailure(pr, linkedIssues);
   if (linkedIssueFailure) {
     failures.push(linkedIssueFailure);

--- a/scripts/ci/andra-bot.js
+++ b/scripts/ci/andra-bot.js
@@ -55,7 +55,12 @@ const stripComments = (text) => {
 // backtick (``` ```sh make test``` ```, an inline span, not a block), a four-space indent
 // making a fence literal, a close carrying its own info string. Each would only ever cause
 // this to strip *more*, and unpaired markers already strip nothing.
-const FENCED_BLOCK_REGEX = /^ {0,3}(```+|~~~+)[^\n]*\n[\s\S]*?^ {0,3}\1[^\n]*$/gm;
+// The lookahead makes the opening run atomic: it is taken whole and never retried shorter.
+// Letting it shorten is both wrong and slow — wrong because ````` would accept ``` as its
+// close, which CommonMark forbids (a close is at least as long as its opener), and slow
+// because every candidate length rescans the line, which is quadratic: 3.5s on a body of
+// backticks at the 65536-character limit, against 0.1ms here.
+const FENCED_BLOCK_REGEX = /^ {0,3}(?=(```+|~~~+))\1[^\n]*\n[\s\S]*?^ {0,3}\1[^\n]*$/gm;
 const CODE_SPAN_REGEX = /(`+)[^`\n]*?\1/g;
 const COMMENT_REGEX = /<!--[\s\S]*?-->/g;
 // Carries no comment marker and starts no heading, but is not empty.

--- a/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
@@ -891,6 +891,19 @@ describe('AndraBot', () => {
       });
     });
 
+    it('still passes a PR whose link sits between markers of unequal length', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+      // A closing fence is at least as long as its opener, so these two do not pair and the
+      // line between them is ordinary prose. Letting the opening run be retried shorter finds
+      // a pair anyway and deletes the link — and costs a rescan of the line per candidate
+      // length, which is what makes a body of backticks quadratic.
+
+      await run(getPr({ body: withIssueReference('`````\nCloses #1234\n```') }));
+
+      expect(core.setFailed.called).to.be.false;
+      expect(github.rest.issues.addLabels.args[0][0].labels).to.deep.equal([SUCCESS_LABEL]);
+    });
+
     it('still passes a PR whose body reaches GitHub\'s size limit', async () => {
       setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
       // Two 32k path segments either side of a `/`, and deliberately *no* trailing `#number`:

--- a/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
@@ -64,6 +64,14 @@ describe('AndraBot', () => {
     .replace('<!-- DESCRIPTION -->', 'Fixes the date conversion by using the local format.')
     .replace('<!-- ISSUE NUMBER -->', 'Closes #1234');
 
+  // Same as filledTemplate but with no issue reference at all, for the cases that need a body
+  // the closing-keyword fallback cannot resolve.
+  const bodyWithoutIssue = TEMPLATE
+    .replace('<!-- DESCRIPTION -->', 'Fixes the date conversion by using the local format.')
+    .replace('<!-- ISSUE NUMBER -->', 'No issue for this one.');
+
+  const withIssueReference = (reference) => filledTemplate.replace('Closes #1234', reference);
+
   const linkedIssue = (number, assigneeLogins, repo = 'medic/cht-core') => ({
     number,
     repository: { nameWithOwner: repo, owner: { login: repo.split('/')[0] } },
@@ -74,6 +82,26 @@ describe('AndraBot', () => {
     github.graphql.resolves({
       repository: { pullRequest: { closingIssuesReferences: { nodes: issues } } },
     });
+  };
+
+  // The REST shape returned by issues.get, which the fallback normalizes.
+  // GitHub resolves owner/repo case-insensitively, so the stub matches the same way — the
+  // action passes through whatever the contributor typed.
+  const matchesIssue = (owner, repo, number) => sinon.match(args => {
+    return args.owner.toLowerCase() === owner.toLowerCase() &&
+      args.repo.toLowerCase() === repo.toLowerCase() &&
+      args.issue_number === number;
+  });
+
+  const setReferencedIssue = ({ owner = 'medic', repo = 'cht-core', number, assignees = [], isPr = false }) => {
+    return github.rest.issues.get
+      .withArgs(matchesIssue(owner, repo, number))
+      .resolves({ data: {
+        number,
+        repository_url: `https://api.github.com/repos/${owner}/${repo}`,
+        assignees: assignees.map(login => ({ login })),
+        ...(isPr ? { pull_request: { url: 'https://api.github.com/pulls/1' } } : {}),
+      } });
   };
 
   const setComments = (comments) => github.paginate
@@ -98,6 +126,8 @@ describe('AndraBot', () => {
           listLabelsOnIssue: sinon.stub(),
           addLabels: sinon.stub().resolves(),
           removeLabel: sinon.stub().resolves(),
+          // Not found by default; tests that exercise the fallback opt in via setReferencedIssue.
+          get: sinon.stub().rejects(Object.assign(new Error('Not Found'), { status: 404 })),
         },
       },
     };
@@ -305,13 +335,14 @@ describe('AndraBot', () => {
 
   describe('linked issue check', () => {
     it('should fail when no issue is linked', async () => {
-      await run(getPr({ body: filledTemplate }));
+      await run(getPr({ body: bodyWithoutIssue }));
 
       expect(core.setFailed.calledOnce).to.be.true;
       const commentBody = github.rest.issues.createComment.args[0][0].body;
       expect(commentBody).to.contain(getMessage('missing-linked-issue'));
       expect(commentBody).to.not.contain(templateMismatchMessage());
     });
+
 
     it('should query the PR from the event payload', async () => {
       await run(getPr({ body: filledTemplate }));
@@ -334,11 +365,179 @@ describe('AndraBot', () => {
 
     it('should not count an issue linked from a repo outside the org', async () => {
       setLinkedIssues([linkedIssue(1234, ['external-dev'], 'external-dev/cht-core')]);
+      await run(getPr({ body: bodyWithoutIssue }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+  });
+
+  // GitHub only populates closingIssuesReferences for PRs targeting the default branch, so a
+  // correctly keyword-linked PR on any other base arrives here with an empty list.
+  describe('closing-keyword fallback for non-default-branch PRs', () => {
+    it('should accept a keyword-linked issue when GitHub reports no linkage', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: filledTemplate }));
+
+      expect(core.setFailed.called).to.be.false;
+      expect(github.rest.issues.get.calledOnceWithExactly({
+        owner: 'medic',
+        repo: 'cht-core',
+        issue_number: 1234,
+      })).to.be.true;
+    });
+
+    it('should still report the assignee failure for a keyword-linked issue', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['someone-else'] });
+
+      await run(getPr({ body: filledTemplate }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('not-assigned', { issueList: '#1234' }));
+    });
+
+    ['Closes #1234', 'closes: #1234', 'Fixes #1234', 'resolved #1234'].forEach(reference => {
+      it(`should recognise "${reference}"`, async () => {
+        setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+        await run(getPr({ body: withIssueReference(reference) }));
+
+        expect(core.setFailed.called).to.be.false;
+      });
+    });
+
+    it('should recognise an owner/repo#number reference in the same org', async () => {
+      setReferencedIssue({ repo: 'cht-android', number: 99, assignees: ['external-dev'] });
+
+      await run(getPr({ body: withIssueReference('Closes medic/cht-android#99') }));
+
+      expect(core.setFailed.called).to.be.false;
+    });
+
+    it('should recognise a full issue URL', async () => {
+      setReferencedIssue({ repo: 'cht-android', number: 99, assignees: ['external-dev'] });
+
+      await run(getPr({ body: withIssueReference('Closes https://github.com/medic/cht-android/issues/99') }));
+
+      expect(core.setFailed.called).to.be.false;
+    });
+
+    it('should ignore a reference to a repo outside the org', async () => {
+      await run(getPr({ body: withIssueReference('Closes external-dev/cht-core#1234') }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+      // Reaching out to a repo outside the org is itself the thing to avoid, not just an
+      // implementation detail — the token has no business reading it.
+      expect(github.rest.issues.get.called).to.be.false;
+    });
+
+    it('should ignore references inside HTML comments', async () => {
+      await run(getPr({ body: withIssueReference('<!-- Closes #1234 -->') }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+
+    it('should ignore the example reference in the unfilled template', async () => {
+      // The template's own comment block contains "feat(#1234): add hat wobble"; an empty
+      // template must not read as a linked PR.
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: TEMPLATE }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+
+    it('should ignore a reference that points at a pull request', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'], isPr: true });
+
       await run(getPr({ body: filledTemplate }));
 
       expect(core.setFailed.calledOnce).to.be.true;
       const commentBody = github.rest.issues.createComment.args[0][0].body;
       expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+
+    it('should ignore a reference to an issue that does not exist', async () => {
+      await run(getPr({ body: filledTemplate }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+
+    // GitHub owner and repo names are case-insensitive, so a reference that differs only in
+    // case is still a valid link and must not be dropped.
+    ['Closes Medic/cht-core#1234', 'Closes MEDIC/CHT-Core#1234'].forEach(reference => {
+      it(`should accept "${reference}" regardless of case`, async () => {
+        setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+        await run(getPr({ body: withIssueReference(reference) }));
+
+        expect(core.setFailed.called).to.be.false;
+      });
+    });
+
+    it('should report a same-repo issue as #number even when referenced with different case', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['someone-else'] });
+
+      await run(getPr({ body: withIssueReference('Closes MEDIC/CHT-Core#1234') }));
+
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('not-assigned', { issueList: '#1234' }));
+    });
+
+    describe('when the issue cannot be read', () => {
+      const failGet = (status) => github.rest.issues.get
+        .rejects(Object.assign(new Error('Server Error'), { status }));
+
+      [500, 403].forEach(status => {
+        it(`should not claim the PR is unlinked after a ${status.toString()}`, async () => {
+          failGet(status);
+
+          await run(getPr({ body: filledTemplate }));
+
+          expect(core.setFailed.called).to.be.false;
+          expect(core.warning.called).to.be.true;
+        });
+      });
+
+      it('should still run the template check when the lookup fails', async () => {
+        failGet(500);
+
+        // Body has a closing reference (so the lookup is attempted) but no template sections.
+        await run(getPr({ body: 'Closes #1234' }));
+
+        expect(core.setFailed.calledOnce).to.be.true;
+        const commentBody = github.rest.issues.createComment.args[0][0].body;
+        expect(commentBody).to.contain(templateMismatchMessage());
+        expect(commentBody).to.not.contain(getMessage('missing-linked-issue'));
+      });
+    });
+
+    it('should look each referenced issue up only once', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: withIssueReference('Closes #1234, closes #1234') }));
+
+      expect(github.rest.issues.get.calledOnce).to.be.true;
+    });
+
+    it('should not fall back when GitHub already reports a linked issue', async () => {
+      setLinkedIssues([linkedIssue(1234, ['external-dev'])]);
+
+      await run(getPr({ body: filledTemplate }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.called).to.be.false;
     });
   });
 

--- a/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
@@ -343,7 +343,6 @@ describe('AndraBot', () => {
       expect(commentBody).to.not.contain(templateMismatchMessage());
     });
 
-
     it('should query the PR from the event payload', async () => {
       await run(getPr({ body: filledTemplate }));
 
@@ -870,6 +869,51 @@ describe('AndraBot', () => {
 
       expect(github.rest.issues.get.called).to.be.false;
       expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    it('is not fooled by an unclosed fence', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      // Raw body, not the filled template: the template's own backticks can pair with the
+      // fence marker and strip the reference by accident, which would make this pass for
+      // the wrong reason.
+      await run(getPr({ body: 'How to link:\n\n```\nCloses #1234' }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    it('is not fooled by a ~~~ block closed with backticks', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: '~~~\nCloses #1234\n```' }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    it('does not splice prose either side of a removed span into a reference', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: 'This does not fix `anything` #1234 related.' }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    it('still finds a real link when an unbalanced backtick appears above it', async () => {
+      // One stray backtick used to pair with the next one anywhere below and delete the
+      // reference in between — a false failure the contributor could not clear.
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+      const body = filledTemplate.replace(
+        'Fixes the date conversion by using the local format.',
+        'Switch to `Intl.DateTimeFormat for parsing.'
+      );
+
+      await run(getPr({ body }));
+
+      expect(github.rest.issues.get.called).to.be.true;
+      expect(core.setFailed.called).to.be.false;
     });
 
     it('warns rather than silently dropping references past the limit', async () => {

--- a/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
@@ -495,31 +495,33 @@ describe('AndraBot', () => {
       expect(commentBody).to.contain(getMessage('not-assigned', { issueList: '#1234' }));
     });
 
-    describe('when the issue cannot be read', () => {
-      const failGet = (status) => github.rest.issues.get
-        .rejects(Object.assign(new Error('Server Error'), { status }));
+    it('should ignore a reference to an issue that was deleted or transferred', async () => {
+      github.rest.issues.get.rejects(Object.assign(new Error('Gone'), { status: 410 }));
 
+      await run(getPr({ body: filledTemplate }));
+
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+
+    /*
+     * Anything other than "the issue is not there" is left to throw, so the job goes red with
+     * no comment and no label change and the next synchronize re-runs it. Swallowing these is
+     * the one path that could hand a genuinely unlinked PR its Ready for review label.
+     */
+    describe('when the issue lookup fails for another reason', () => {
       [500, 403].forEach(status => {
-        it(`should not claim the PR is unlinked after a ${status.toString()}`, async () => {
-          failGet(status);
+        it(`should propagate a ${status.toString()} rather than treat it as unlinked`, async () => {
+          const err = Object.assign(new Error('Server Error'), { status });
+          github.rest.issues.get.rejects(err);
 
-          await run(getPr({ body: filledTemplate }));
+          await expect(run(getPr({ body: filledTemplate }))).to.be.rejectedWith('Server Error');
 
-          expect(core.setFailed.called).to.be.false;
-          expect(core.warning.called).to.be.true;
+          expect(github.rest.issues.createComment.called).to.be.false;
+          expect(github.rest.issues.addLabels.called).to.be.false;
+          expect(github.rest.issues.removeLabel.called).to.be.false;
         });
-      });
-
-      it('should still run the template check when the lookup fails', async () => {
-        failGet(500);
-
-        // Body has a closing reference (so the lookup is attempted) but no template sections.
-        await run(getPr({ body: 'Closes #1234' }));
-
-        expect(core.setFailed.calledOnce).to.be.true;
-        const commentBody = github.rest.issues.createComment.args[0][0].body;
-        expect(commentBody).to.contain(templateMismatchMessage());
-        expect(commentBody).to.not.contain(getMessage('missing-linked-issue'));
       });
     });
 

--- a/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
@@ -353,6 +353,7 @@ describe('AndraBot', () => {
         owner: 'medic',
         repo: 'cht-core',
         number: 42,
+        limit: 20,
       });
     });
 
@@ -469,6 +470,7 @@ describe('AndraBot', () => {
     it('should ignore a reference to an issue that does not exist', async () => {
       await run(getPr({ body: filledTemplate }));
 
+      expect(github.rest.issues.get.called).to.be.true;
       expect(core.setFailed.calledOnce).to.be.true;
       const commentBody = github.rest.issues.createComment.args[0][0].body;
       expect(commentBody).to.contain(getMessage('missing-linked-issue'));
@@ -500,6 +502,7 @@ describe('AndraBot', () => {
 
       await run(getPr({ body: filledTemplate }));
 
+      expect(github.rest.issues.get.called).to.be.true;
       expect(core.setFailed.calledOnce).to.be.true;
       const commentBody = github.rest.issues.createComment.args[0][0].body;
       expect(commentBody).to.contain(getMessage('missing-linked-issue'));
@@ -798,6 +801,86 @@ describe('AndraBot', () => {
       expect(core.setFailed.called).to.be.false;
       expect(github.rest.issues.addLabels.args[0][0].labels).to.deep.equal([SUCCESS_LABEL]);
       expect(github.rest.issues.removeLabel.args[0][0].name).to.equal(FAILURE_LABEL);
+    });
+  });
+
+  describe('review follow-ups on #11332', () => {
+    it('does not treat a reference inside a code span as a link', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: withIssueReference('Write `Closes #1234` in the description.') }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('missing-linked-issue'));
+    });
+
+    it('does not treat a reference inside a fenced block as a link', async () => {
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+      const body = withIssueReference('Example:\n\n```\nCloses #1234\n```');
+
+      await run(getPr({ body }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    it('reads the body when the linked issue is assigned to someone else', async () => {
+      // A sidebar-linked epic fills closingIssuesReferences on any base branch. Short-
+      // circuiting on it would hide the contributor's own keyword link behind a failure
+      // they cannot clear.
+      setLinkedIssues([linkedIssue(999, ['someone-else'])]);
+      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+
+      await run(getPr({ body: filledTemplate }));
+
+      expect(github.rest.issues.get.called).to.be.true;
+      expect(core.setFailed.called).to.be.false;
+    });
+
+    it('lists an issue once when both sources name it', async () => {
+      setLinkedIssues([linkedIssue(1234, ['someone-else'])]);
+      setReferencedIssue({ number: 1234, assignees: ['someone-else'] });
+
+      await run(getPr({ body: filledTemplate }));
+
+      const commentBody = github.rest.issues.createComment.args[0][0].body;
+      expect(commentBody).to.contain(getMessage('not-assigned', { issueList: '#1234' }));
+    });
+
+    it('does not bind a keyword across a newline', async () => {
+      await run(getPr({ body: withIssueReference('Closes\n#1234') }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    ['Closes #01234', 'Closes #99999999999999999999999'].forEach(reference => {
+      it(`ignores the malformed number in "${reference}"`, async () => {
+        await run(getPr({ body: withIssueReference(reference) }));
+
+        expect(github.rest.issues.get.called).to.be.false;
+        expect(core.setFailed.calledOnce).to.be.true;
+      });
+    });
+
+    it('ignores a repo name made only of dots', async () => {
+      await run(getPr({ body: withIssueReference('Closes medic/..#1234') }));
+
+      expect(github.rest.issues.get.called).to.be.false;
+      expect(core.setFailed.calledOnce).to.be.true;
+    });
+
+    it('warns rather than silently dropping references past the limit', async () => {
+      const refs = Array.from({ length: 22 }, (_, i) => `Closes #${(i + 1).toString()}`).join(' ');
+      github.rest.issues.get.rejects(Object.assign(new Error('Not Found'), { status: 404 }));
+
+      await run(getPr({ body: withIssueReference(refs) }));
+
+      expect(github.rest.issues.get.callCount).to.equal(20);
+      expect(core.warning.args.some(([msg]) => msg.includes('2 later reference(s) were ignored')))
+        .to.be.true;
     });
   });
 });

--- a/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
+++ b/webapp/tests/mocha/unit/testingtests/andra-bot.spec.js
@@ -871,25 +871,42 @@ describe('AndraBot', () => {
       expect(core.setFailed.calledOnce).to.be.true;
     });
 
-    it('is not fooled by an unclosed fence', async () => {
-      setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+    // Each of these is a body whose issue link is genuine but which an over-eager code
+    // stripper discarded, failing a contributor with no way to clear it — the link they are
+    // told to add is the link already there. Only a fence that is actually closed delimits a
+    // block, so an unpaired marker cannot reach past itself to swallow any of them.
+    [
+      ['an unbalanced <!-- inside a fenced block', '```xml\n<instance> <!-- see docs\n</instance>\n```'],
+      ['a fence marker whose info string holds backticks', '```bash npm test```'],
+      ['an unpaired fence marker', 'How to link:\n\n```'],
+      ['a ~~~ marker that only backticks follow', '~~~\nsample\n```'],
+    ].forEach(([name, sample]) => {
+      it(`still passes a PR whose link follows ${name}`, async () => {
+        setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
 
-      // Raw body, not the filled template: the template's own backticks can pair with the
-      // fence marker and strip the reference by accident, which would make this pass for
-      // the wrong reason.
-      await run(getPr({ body: 'How to link:\n\n```\nCloses #1234' }));
+        await run(getPr({ body: withIssueReference(`${sample}\n\nCloses #1234`) }));
 
-      expect(github.rest.issues.get.called).to.be.false;
-      expect(core.setFailed.calledOnce).to.be.true;
+        expect(core.setFailed.called).to.be.false;
+        expect(github.rest.issues.addLabels.args[0][0].labels).to.deep.equal([SUCCESS_LABEL]);
+      });
     });
 
-    it('is not fooled by a ~~~ block closed with backticks', async () => {
+    it('still passes a PR whose body reaches GitHub\'s size limit', async () => {
       setReferencedIssue({ number: 1234, assignees: ['external-dev'] });
+      // Two 32k path segments either side of a `/`, and deliberately *no* trailing `#number`:
+      // the cost is in the failed match, so a reference that resolves never reaches it. A
+      // repo-name pattern requiring a non-dot character (`[\w.-]*[\w-][\w.-]*`) lets its two
+      // quantifiers divide that run between them, which is cubic — ~29s at 8k, and hours at
+      // the 65536-character body limit this sits just inside, on a pull_request_target body
+      // re-parsed on every edit. The keyword cannot bind across the newline, so this stays a
+      // failed match. Mocha's own timeout cannot fire on a blocked event loop, so the process
+      // watchdog is the real assertion; the linear form returns in about a millisecond.
+      const segment = 'a'.repeat(32000);
 
-      await run(getPr({ body: '~~~\nCloses #1234\n```' }));
+      await run(getPr({ body: withIssueReference(`Closes ${segment}/${segment}\n\nCloses #1234`) }));
 
-      expect(github.rest.issues.get.called).to.be.false;
-      expect(core.setFailed.calledOnce).to.be.true;
+      expect(core.setFailed.called).to.be.false;
+      expect(github.rest.issues.addLabels.args[0][0].labels).to.deep.equal([SUCCESS_LABEL]);
     });
 
     it('does not splice prose either side of a removed span into a reference', async () => {


### PR DESCRIPTION
# Description

The linked-issue check reads GitHub's GraphQL `closingIssuesReferences`, which GitHub only populates for PRs targeting the repository's default branch. On any other base the field is empty even when the contributor linked the issue correctly — so AndraBot failed the PR and asked them to add a closing keyword they had already added, with no way to clear it. That's what happened to @megha1807 on #11320.

When GitHub reports no linkage, `getLinkedIssues` now falls back to parsing the PR body for closing keywords and resolving each reference through the issues API. The results are shaped like `closingIssuesReferences` nodes, so the existing same-org filter and the assignee check work on them unchanged.

Recognised: `#123`, `owner/repo#123`, and full issue URLs, with GitHub's documented keyword set (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`).

Closes #11324

## Since your review, @sugat009

All nine findings are fixed. Your two blocking ones were exactly right and I'd argued against half of one in the original body — the note there that unstripped code fences were "largely self-limiting" was wrong, because I'd missed that `.some()` made the assignment check pass on any mentioned issue.

Three things you should know before re-reading, because the diff has moved a long way:

**I reverted one of the fixes you'd effectively asked for.** Stripping code led to a first attempt that ran an unclosed fence to the end of the body, the way a renderer does. Three subsequent review passes showed that cure was worse than the disease: it produced three separate ways to discard a *genuine* issue link, each failing a contributor with a message telling them to add the link they had already added. Only a fence that actually **closes** now delimits a block, so an unpaired marker strips nothing.

That is a deliberate trade in one direction. Reading code as prose lets a PR that merely *documents* a link past a check that still requires the author be assigned to that issue. Reading prose as code blocks a real contributor with no way to clear it. The second is much worse, so every ambiguity now resolves toward stripping less. If you disagree with that ordering, this is the decision to push back on.

**I introduced two performance defects while fixing performance defects, and you should weigh that.** Fixing your `..` finding by requiring a non-dot character (`[\w.-]*[\w-][\w.-]*`) made the quantifiers ambiguous and the failed match **cubic** — 68s on an 8k body, hours at the 65,536-character limit, on a `pull_request_target` body re-parsed on every edit. That was strictly worse than the ReDoS your own finding #3 was about. `..` is now rejected after parsing instead, and the pattern is linear again.

Fixing *that* left the fence regex **quadratic** — 3.5s on a body of backticks at the same limit, where the previous implementation was linear. The opening run is now taken atomically via a lookahead, which also fixes a correctness bug I wasn't looking for: CommonMark requires a closing fence be at least as long as its opener, so ` ````` ` is not closed by ` ``` `, but a backtracking opener shortened itself to three to force a pair and deleted the prose between them.

Both were caught by review, not by me, and neither would have been caught by reading the code.

**The code-stripping logic is now three bounded replacements** rather than the line scanner you'd have seen mid-review — 23 executable lines down to 8. Making only closing fences delimit blocks removed the need to encode CommonMark's rules for info strings, indent limits and closing markers, since each could only ever cause it to strip *more*, and unpaired markers already strip nothing.

## Details worth a look

**Prior art.** [`nearform-actions/github-action-check-linked-issues`](https://github.com/nearform-actions/github-action-check-linked-issues) (MIT) tackles the same GitHub limitation, which was useful confirmation the fallback is the right shape. @sugat009 read its source on the issue and found three reasons not to adopt it that are stronger than my own: its `loose-matching` is a mode switch rather than a fallback, so it ignores `closingIssuesReferences` entirely and a sidebar-linked PR reads as unlinked; it cannot do the assignee half of this check, so we would still fetch every issue ourselves on top of the GraphQL call; and its per-lookup bare `catch` turns a rate limit or 5xx into "not a valid issue", which is the bug this PR is fixing. Two things were worth taking from it: the optional colon in the keyword regex (`Closes: #10` links on GitHub, so the fallback must accept it), and a `no-issue` skip label as a possible future escape hatch — out of scope here.

**Ordering in the stripper is load-bearing.** A `<!--` inside a fenced block is literal and closes nothing, so blocks are removed first. Stripping comments first let such a marker pair with the PR template's own `-->` and delete the issue link between them — and an XML or HTML sample in a cht-core PR body makes that an ordinary body, not a contrived one. `parseSections` masks blocks for the same reason: that path failed the *template* check on the same input, which is a second bug the same root cause was causing.

**Every removal leaves a newline behind.** Deleting outright splices the prose either side together, so `does not fix ` + `#1234` reads as a reference. A space doesn't help, since the closing-reference regex spans those.

**Case-insensitivity.** GitHub owner and repo names are case-insensitive, so `Closes Medic/cht-android#99` is a valid link. The org filter, the dedupe key and the same-repo comparison all compare case-insensitively, and the issue's canonical names are taken from the API response's `repository_url` rather than from what the contributor typed — otherwise a same-repo issue referenced as `MEDIC/CHT-Core#1234` would render as `MEDIC/CHT-Core#1234` instead of `#1234` in the not-assigned message.

**Failed lookups.** Only `404` and `410` count as "the issue is not there". Anything else throws, so the job goes red with no comment and no label change — matching how the script already treats every other API call — and the next `synchronize` re-runs it. An earlier draft warned and skipped the check instead; @sugat009 pointed out on the issue that this was the one path that could hand a genuinely unlinked PR its `Ready for review` label.

**Scope decisions, both confirmed on the issue:** the fallback runs whenever `closingIssuesReferences` is empty rather than being gated on the base branch, so it behaves the same as the linkage path beside it. Matching is keyword-anchored only, so a "related to #123" aside does not register as a link.

**Changed existing tests — worth reviewing that hunk closely.** `should fail when no issue is linked` and `should not count an issue linked from a repo outside the org` both used a body containing `Closes #1234`. Under the new behaviour their names no longer describe what they test, so I repointed them at a new `bodyWithoutIssue` fixture. The stub for `issues.get` also matches owner/repo case-insensitively, because an exact-match double is stricter than the real API.

## Known gaps, stated rather than left to be found

1. **An unpaired fence strips nothing**, so a body documenting `Closes #N` under a malformed or never-closed fence counts as a link. Deliberate, per the trade above, and still gated on the author being assigned to that issue.
2. **Four-space-indented code blocks are not handled at all.** A reference inside one counts. Same safe direction; never handled by any revision of this PR.
3. **The fence indent bound (`^ {0,3}`) has no test.** I wrote one and deleted it: the "only closing fences count" rule already subsumes that class, so the test only fired on a hand-built body with an indented opener and an unindented close. It pinned the regex, not a behaviour.
4. **The ReDoS guard fails by hanging rather than failing.** A synchronous regex blocks the event loop, so mocha's own timeout cannot fire; a regression there would stall the job until it times out rather than reporting a red test. The test still catches it, just noisily.

## Tests

84 in `andra-bot.spec.js`. The full `webapp` mocha suite is 482 passing with 1 failure in `tests/mocha/unit/testingtests/e2e/utils.spec.js:152` (`expected Glob{…} to be an array`) — a glob-library API shape, in a file this branch does not touch.

Tests assert what a contributor observes — whether the PR is failed and which label it gets — rather than whether a particular lookup happened. The exceptions are where the external call *is* the behaviour: that an out-of-org reference is never fetched, and that the 20-reference cap performs exactly 20 lookups.

Every new test was checked by mutating the source and confirming it goes red. Baseline 84 passing:

| Mutation | Tests failed |
| --- | --- |
| Unpaired fence reaches end of body (the reverted design) | 4 |
| `REPO_NAME` ambiguously quantified (the cubic path) | job hangs — killed at 60s, against a 50ms baseline |
| `parseSections` stops masking code blocks | 1 |
| `stripNonProse` strips nothing | 2 |
| Opening fence run may backtrack shorter | 1 |

This is worth doing rather than eyeballing: **three tests I wrote during this round were vacuous on the first attempt** and every one passed review by eye. Two put the issue link where it survived the mutation either way; one asserted a size limit using a reference that matched immediately and so never reached the expensive path at all. Your own mutation run on the previous revision is what taught me to do this, and it has since caught more than reading has.

# Code review checklist

<!-- UI/UX backwards compatible: not applicable, no UI changes in this PR. -->
<!-- Internationalised: not applicable, no user-facing text in this PR. -->
<!-- Documented: not applicable, CI-internal behaviour with no configuration surface. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit and/or e2e where appropriate — see the Tests section above, including the mutation table showing each new test discriminates.
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes. — the fallback only runs when GitHub reports no linkage, so PRs that already pass are unaffected; no configuration or workflow changes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

**AI Disclosure:** Written with Claude Code (Claude Opus) — exploring the code path, drafting the fix and its tests, running the suites, and running the mutations above. I reviewed the result at each stage and I'm accountable for it.

That review is also where most of the defects above came from, and the pattern is worth disclosing plainly: several were introduced *by* a previous fix rather than being present in the original draft. The cubic `REPO_NAME` was written to close a review finding and was worse than the finding. The quadratic fence regex was written to close that one. Both looked correct, passed the suite, and were found only by measuring. Earlier revisions also had a capturing group in the keyword alternation that shifted every match index and produced `issue_number: NaN` — the lookup 404'd, the error was swallowed, and the check reported "not linked" exactly as before, so it looked like a working no-op.

I'd rather you review this knowing that than assume the current state arrived cleanly.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
