### PR TITLE
fix(#9011): backfill patient IDs on related reports

### DIFF
--- a/shared-libs/transitions/src/transitions/generate_shortcode_on_contacts.js
+++ b/shared-libs/transitions/src/transitions/generate_shortcode_on_contacts.js
@@ -1,12 +1,66 @@
 const config = require('../config');
+const db = require('../db');
+const utils = require('../lib/utils');
 const transitionUtils = require('./utils');
 const contactTypeUtils = require('@medic/contact-types-utils');
+const { DOC_TYPES } = require('@medic/constants');
 const NAME = 'generate_shortcode_on_contacts';
+
+const hasReportPatientId = doc => Boolean(doc.patient_id || doc.fields?.patient_id);
+
+const getReportPatientId = doc => doc.patient?.patient_id;
+
+const getReportPatientUuid = doc => doc.patient_uuid || doc.fields?.patient_uuid;
+
+const hasReportPatientUuid = doc => Boolean(getReportPatientUuid(doc));
+
+const shouldUpdateReportPatientId = doc => Boolean(
+  doc &&
+  doc.type === DOC_TYPES.DATA_RECORD &&
+  hasReportPatientUuid(doc) &&
+  getReportPatientId(doc) &&
+  !hasReportPatientId(doc)
+);
+
+const addPatientIdToReport = (doc, patientId) => {
+  if (!patientId || hasReportPatientId(doc)) {
+    return false;
+  }
+
+  if (doc.fields) {
+    doc.fields.patient_id = patientId;
+  } else {
+    doc.patient_id = patientId;
+  }
+
+  return true;
+};
+
+const updateReports = doc => {
+  if (!doc._id || !doc.patient_id) {
+    return Promise.resolve();
+  }
+
+  return utils.getReportsBySubject({ id: doc._id }).then(reports => {
+    const updatedReports = reports.filter(report => {
+      return getReportPatientUuid(report) === doc._id && addPatientIdToReport(report, doc.patient_id);
+    });
+    if (!updatedReports.length) {
+      return;
+    }
+
+    return db.medic.bulkDocs(updatedReports);
+  });
+};
 
 module.exports = {
   name: NAME,
   asynchronousOnly: true,
   filter: ({ doc }) => {
+    if (shouldUpdateReportPatientId(doc)) {
+      return true;
+    }
+
     const contactType = contactTypeUtils.getContactType(config.getAll(), doc);
     if (!contactType) {
       return;
@@ -23,13 +77,22 @@ module.exports = {
     return true;
   },
   onMatch: change => {
+    if (shouldUpdateReportPatientId(change.doc)) {
+      addPatientIdToReport(change.doc, getReportPatientId(change.doc));
+      return Promise.resolve(true);
+    }
+
     return transitionUtils
       .getUniqueId()
       .then(id => {
         const isPerson = contactTypeUtils.isPerson(config.getAll(), change.doc);
         const prop = isPerson ? 'patient_id' : 'place_id';
         change.doc[prop] = id;
-        return true;
+        if (!isPerson) {
+          return true;
+        }
+
+        return updateReports(change.doc).then(() => true);
       });
   }
 };

--- a/shared-libs/transitions/test/unit/transitions/generate_shortcode_on_contacts.js
+++ b/shared-libs/transitions/test/unit/transitions/generate_shortcode_on_contacts.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const assert = require('chai').assert;
 const config = require('../../../src/config');
+const { DOC_TYPES } = require('@medic/constants');
 
 const types = [
   { id: 'person', person: true },
@@ -9,11 +10,15 @@ const types = [
 
 describe('generate_shortcode_on_contacts transition', () => {
   let transitionUtils;
+  let utils;
+  let db;
   let transition;
 
   beforeEach(() => {
     config.init({ getAll: sinon.stub().returns({ contact_types: types }), });
     transitionUtils = require('../../../src/transitions/utils');
+    utils = require('../../../src/lib/utils');
+    db = require('../../../src/db');
     transition = require('../../../src/transitions/generate_shortcode_on_contacts');
   });
 
@@ -54,6 +59,47 @@ describe('generate_shortcode_on_contacts transition', () => {
       const doc = { };
       assert.equal(!!transition.filter({ doc }), false);
     });
+
+    it('accepts reports with a patient uuid and hydrated patient_id but no patient_id', () => {
+      const doc = {
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid' },
+        patient: { _id: 'patient-uuid', patient_id: '12345' },
+      };
+
+      assert.equal(!!transition.filter({ doc }), true);
+    });
+
+    it('ignores reports that already have patient_id', () => {
+      const reportWithFieldPatientId = {
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid', patient_id: '12345' },
+        patient: { _id: 'patient-uuid', patient_id: '12345' },
+      };
+      const reportWithPatientId = {
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        patient_id: '12345',
+        fields: { patient_uuid: 'patient-uuid' },
+        patient: { _id: 'patient-uuid', patient_id: '12345' },
+      };
+
+      assert.equal(!!transition.filter({ doc: reportWithFieldPatientId }), false);
+      assert.equal(!!transition.filter({ doc: reportWithPatientId }), false);
+    });
+
+    it('ignores reports when the hydrated patient does not have patient_id', () => {
+      const doc = {
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid' },
+        patient: { _id: 'patient-uuid' },
+      };
+
+      assert.equal(!!transition.filter({ doc }), false);
+    });
   });
 
   describe('onMatch', () => {
@@ -72,6 +118,133 @@ describe('generate_shortcode_on_contacts transition', () => {
       return transition.onMatch({ doc }).then(result => {
         assert.equal(result, true);
         assert.deepEqual(doc, { type: 'contact', contact_type: 'place', place_id: 'the_unique_id' });
+      });
+    });
+
+    it('should add patient_id to late-arriving reports with patient_uuid', () => {
+      const doc = {
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid' },
+        patient: { _id: 'patient-uuid', patient_id: '12345' },
+      };
+      sinon.stub(transitionUtils, 'getUniqueId');
+      sinon.stub(db.medic, 'bulkDocs');
+
+      return transition.onMatch({ doc }).then(result => {
+        assert.equal(result, true);
+        assert.deepEqual(doc, {
+          type: DOC_TYPES.DATA_RECORD,
+          form: 'pregnancy',
+          fields: { patient_uuid: 'patient-uuid', patient_id: '12345' },
+          patient: { _id: 'patient-uuid', patient_id: '12345' },
+        });
+        assert.equal(transitionUtils.getUniqueId.callCount, 0);
+        assert.equal(db.medic.bulkDocs.callCount, 0);
+      });
+    });
+
+    it('should add generated patient_id to existing reports for the person', () => {
+      const doc = { _id: 'patient-uuid', type: 'contact', contact_type: 'person' };
+      const reportWithoutPatientId = {
+        _id: 'report-without-patient-id',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid' },
+      };
+      const reportWithPatientId = {
+        _id: 'report-with-patient-id',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid', patient_id: 'existing' },
+      };
+      const reportWithTopLevelPatientId = {
+        _id: 'report-with-top-level-patient-id',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        patient_id: 'existing',
+        fields: { patient_uuid: 'patient-uuid' },
+      };
+      const reportWithoutPatientUuid = {
+        _id: 'report-without-patient-uuid',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { place_uuid: 'patient-uuid' },
+      };
+
+      sinon.stub(transitionUtils, 'getUniqueId').resolves('the_unique_id');
+      sinon
+        .stub(utils, 'getReportsBySubject')
+        .withArgs({ id: 'patient-uuid' })
+        .resolves([
+          reportWithoutPatientId,
+          reportWithPatientId,
+          reportWithTopLevelPatientId,
+          reportWithoutPatientUuid,
+        ]);
+      sinon.stub(db.medic, 'bulkDocs').resolves();
+
+      return transition.onMatch({ doc }).then(result => {
+        assert.equal(result, true);
+        assert.deepEqual(doc, {
+          _id: 'patient-uuid',
+          type: 'contact',
+          contact_type: 'person',
+          patient_id: 'the_unique_id',
+        });
+        assert.equal(utils.getReportsBySubject.callCount, 1);
+        assert.deepEqual(utils.getReportsBySubject.args[0], [{ id: 'patient-uuid' }]);
+        assert.equal(db.medic.bulkDocs.callCount, 1);
+        assert.deepEqual(db.medic.bulkDocs.args[0], [[{
+          _id: 'report-without-patient-id',
+          type: DOC_TYPES.DATA_RECORD,
+          form: 'pregnancy',
+          fields: { patient_uuid: 'patient-uuid', patient_id: 'the_unique_id' },
+        }]]);
+        assert.equal(reportWithPatientId.fields.patient_id, 'existing');
+        assert.equal(reportWithTopLevelPatientId.fields.patient_id, undefined);
+        assert.equal(reportWithoutPatientUuid.fields.patient_id, undefined);
+      });
+    });
+
+    it('should not update reports when generating place_id', () => {
+      const doc = { _id: 'place-uuid', type: 'contact', contact_type: 'place' };
+      sinon.stub(transitionUtils, 'getUniqueId').resolves('the_unique_id');
+      sinon.stub(utils, 'getReportsBySubject');
+      sinon.stub(db.medic, 'bulkDocs');
+
+      return transition.onMatch({ doc }).then(result => {
+        assert.equal(result, true);
+        assert.deepEqual(doc, { _id: 'place-uuid', type: 'contact', contact_type: 'place', place_id: 'the_unique_id' });
+        assert.equal(utils.getReportsBySubject.callCount, 0);
+        assert.equal(db.medic.bulkDocs.callCount, 0);
+      });
+    });
+
+    it('should skip report bulk update when all reports already have patient_id', () => {
+      const doc = { _id: 'patient-uuid', type: 'contact', contact_type: 'person' };
+      const reportWithPatientId = {
+        _id: 'report-with-patient-id',
+        type: DOC_TYPES.DATA_RECORD,
+        form: 'pregnancy',
+        fields: { patient_uuid: 'patient-uuid', patient_id: 'existing' },
+      };
+
+      sinon.stub(transitionUtils, 'getUniqueId').resolves('the_unique_id');
+      sinon.stub(utils, 'getReportsBySubject').resolves([reportWithPatientId]);
+      sinon.stub(db.medic, 'bulkDocs').resolves();
+
+      return transition.onMatch({ doc }).then(result => {
+        assert.equal(result, true);
+        assert.deepEqual(doc, {
+          _id: 'patient-uuid',
+          type: 'contact',
+          contact_type: 'person',
+          patient_id: 'the_unique_id',
+        });
+        assert.equal(utils.getReportsBySubject.callCount, 1);
+        assert.equal(db.medic.bulkDocs.callCount, 0);
+        assert.equal(reportWithPatientId.fields.patient_id, 'existing');
       });
     });
   });

--- a/tests/integration/sentinel/transitions/generate-shortcode-on-contacts.spec.js
+++ b/tests/integration/sentinel/transitions/generate-shortcode-on-contacts.spec.js
@@ -175,6 +175,42 @@ describe('generate_shortcode_on_contacts', () => {
       });
   });
 
+  it('should add patient_id to a report submitted after the patient receives one', async () => {
+    const settings = {
+      transitions: { generate_shortcode_on_contacts: true },
+    };
+
+    const person = {
+      _id: uuid(),
+      type: 'person',
+      reported_date: new Date().getTime(),
+    };
+    const report = {
+      _id: uuid(),
+      type: DOC_TYPES.DATA_RECORD,
+      form: 'pregnancy',
+      fields: { patient_uuid: person._id },
+      contact: { _id: person._id },
+      reported_date: new Date().getTime(),
+    };
+
+    await utils.updateSettings(settings, { ignoreReload: 'sentinel' });
+    await utils.saveDoc(person);
+    await sentinelUtils.waitForSentinel(person._id);
+
+    const patient = await utils.getDoc(person._id);
+    expect(patient.patient_id).to.be.a('string');
+
+    await utils.saveDoc(report);
+    await sentinelUtils.waitForSentinel(report._id);
+
+    const updatedReport = await utils.getDoc(report._id);
+    expect(updatedReport.fields).to.include({
+      patient_uuid: person._id,
+      patient_id: patient.patient_id,
+    });
+  });
+
   it('should add place_id', () => {
     const settings = {
       transitions: { generate_shortcode_on_contacts: true },


### PR DESCRIPTION
<details>

<summary>AI Disclaimer</summary>

This pull request was primarily developed with assistance from OpenAI Codex, an AI coding agent. For this PR, Codex analyzed issue #9011, inspected the relevant CHT Core transition and Sentinel code, implemented the report patient ID backfill, added regression coverage, and ran the reported validation commands under the supervision of `jmtdev0`.

Human involvement in this PR was very low.

If you do not agree with the use of AI assistance or with the level of human involvement in this PR, please feel free to disregard it, close it, or request changes. I will fully respect that decision.

</details>

# Description

When Sentinel generates a `patient_id` for a person, related reports that were already synchronized without the ID are updated with the missing value. Reports synchronized later are also handled through the normal hydrated transition path.

This keeps existing report IDs unchanged, leaves place handling untouched, and covers both the backfill and late-arriving report scenarios.

Fixes #9011

# Code review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.