### PR TITLE
fix(#11338): wait for parallel XForm transforms

### DIFF
--- a/api/src/services/generate-xform.js
+++ b/api/src/services/generate-xform.js
@@ -230,8 +230,14 @@ const getEnketoForm = doc => {
 };
 
 const generate = formXml => {
-  return Promise.all([ generateForm(formXml), generateModel(formXml) ])
-    .then(([ form, model ]) => ({ form, model }));
+  return Promise.allSettled([ generateForm(formXml), generateModel(formXml) ])
+    .then(([formResult, modelResult]) => {
+      const failedResult = [formResult, modelResult].find(result => result.status === 'rejected');
+      if (failedResult) {
+        throw failedResult.reason;
+      }
+      return { form: formResult.value, model: modelResult.value };
+    });
 };
 
 const addGeneratedAttachments = (doc, updated, outdated) => {

--- a/api/tests/mocha/services/generate-xform.spec.js
+++ b/api/tests/mocha/services/generate-xform.spec.js
@@ -90,11 +90,15 @@ describe('generate-xform service', () => {
         if (stdErr) {
           spawned.stderr.on.args[0][1](stdErr);
           spawned.on.args[0][1](100);
+          spawned.stderr.on.args[1][1](stdErr);
+          spawned.on.args[2][1](100);
         } else if (errIn) {
           spawned.stdin.on.args[0][1](errIn);
           spawned.on.args[0][1](100);
+          spawned.stdin.on.args[1][1](errIn);
         } else if (errOn) {
           spawned.on.args[1][1](errOn);
+          spawned.on.args[3][1](errOn);
         } else if (successClose) {
           // child process outputs then closes with code 0
           spawned.stdout.on.args[0][1](files.givenForm);
@@ -129,6 +133,39 @@ describe('generate-xform service', () => {
           'xsltproc stderr output:\nsome error'
         );
       }
+    });
+
+    it('should wait for both transforms to finish before rejecting', async () => {
+      const firstTransform = spawned;
+      const secondTransform = {
+        stdout: { on: sinon.stub() },
+        stderr: { on: sinon.stub() },
+        stdin: {
+          setEncoding: sinon.stub(),
+          write: sinon.stub(),
+          end: sinon.stub(),
+          on: sinon.stub(),
+        },
+        on: sinon.stub()
+      };
+      sinon.stub(childProcess, 'spawn')
+        .onFirstCall().returns(firstTransform)
+        .onSecondCall().returns(secondTransform);
+
+      const generate = service.generate('<my-xml/>');
+      firstTransform.stderr.on.args[0][1]('some error');
+      firstTransform.on.args[0][1](100);
+
+      let settled = false;
+      generate.catch(() => settled = true);
+      await new Promise(resolve => setImmediate(resolve));
+      expect(settled).to.equal(false);
+
+      secondTransform.stderr.on.args[0][1]('some error');
+      secondTransform.on.args[0][1](100);
+      await generate.catch(err => {
+        expect(err.message).to.include('xsltproc returned code "100"');
+      });
     });
 
     it('should fail when xsltproc command not found in Node v8 and v16+', async () => {


### PR DESCRIPTION
# Description

### What does this PR do?

This PR fixes a race in XForm generation when the form and model transforms run in parallel. The previous implementation could reject as soon as one transform failed, before the sibling transform had settled, leaving the generation flow with incomplete process state.

The implementation now waits for both transforms to settle, then propagates the first transform error while preserving the successful result contract.

### Why are we doing this?

An invalid form should produce a deterministic generation failure without allowing the outcome to depend on which parallel transform finishes first.

### How to test?

The regression test delays the sibling transform and verifies that the generation promise remains pending until both transforms have settled.

Focused validation completed:

- generate-xform tests: 51 passing
- config-watcher tests: 19 passing
- Focused ESLint
- git diff --check

The full Docker-based integration suite was not run because Docker is unavailable in the validation environment.

### Related issue

Fixes #11338

# Code review checklist

- [x] Readable: Concise, well named, follows the style guide.
- [x] Tested: Unit and/or e2e where appropriate.
- [x] Backwards compatible: Works with existing data and configuration.
- [x] AI disclosure: Please disclose use of AI per the project guidelines.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

<details>
<summary>AI Disclaimer</summary>

This pull request was primarily developed with assistance from OpenAI Codex, an AI coding agent. For this PR, Codex analyzed issue #11338, inspected the relevant CHT Core code, implemented the fix, added the regression test, and ran the reported validation commands under the supervision of jmtdev0.

Human involvement in this PR was very low.

If you do not agree with the use of AI assistance or with the level of human involvement in this PR, please feel free to disregard it, close it, or request changes. I will fully respect that decision.

</details>

### Tracking

Issue #11338 is now assigned to @jmtdev0.