### PR TITLE
fix(#11326): dont create missing infodocs

### DIFF
--- a/shared-libs/infodoc/src/infodoc.js
+++ b/shared-libs/infodoc/src/infodoc.js
@@ -1,5 +1,14 @@
 const db = {}; // to be filled in by the initLib function exported below
 
+// Every save below refetches and retries when it conflicts. The retries are capped so a document
+// that conflicts persistently fails loudly instead of spinning forever.
+const MAX_CONFLICT_RETRIES = 10;
+const conflictError = ids => {
+  const err = new Error(`Infodocs still conflicting after ${MAX_CONFLICT_RETRIES} retries: ${ids}`);
+  err.status = 409;
+  return err;
+};
+
 const getInfoDocId = id => id + '-info';
 const getDocId = infoDocId => infoDocId.slice(0, -5);
 const blankInfoDoc = (docId, knownReplicationDate) => {
@@ -109,7 +118,7 @@ const clearTransitionsStarted = (id) => {
 
 // Applies `modify` to an existing infodoc and saves it, retrying on conflict.
 // Throws a 404 if the infodoc doesn't exist; creating one is left to the caller.
-const modifyInfoDoc = async (id, modify) => {
+const modifyInfoDoc = async (id, modify, retriesLeft = MAX_CONFLICT_RETRIES) => {
   const infoDoc = await db.sentinel.get(getInfoDocId(id));
 
   modify(infoDoc);
@@ -117,14 +126,14 @@ const modifyInfoDoc = async (id, modify) => {
   try {
     return await db.sentinel.put(infoDoc);
   } catch (err) {
-    if (err.status !== 409) {
+    if (err.status !== 409 || !retriesLeft) {
       throw err;
     }
-    return modifyInfoDoc(id, modify);
+    return modifyInfoDoc(id, modify, retriesLeft - 1);
   }
 };
 
-const bulkUpdate = infoDocs => {
+const bulkUpdate = (infoDocs, retriesLeft = MAX_CONFLICT_RETRIES) => {
   if (!infoDocs || !infoDocs.length) {
     return Promise.resolve();
   }
@@ -140,6 +149,10 @@ const bulkUpdate = infoDocs => {
     });
 
     if (conflictingInfoDocs.length > 0) {
+      if (!retriesLeft) {
+        throw conflictError(conflictingInfoDocs.map(d => d._id));
+      }
+
       // Attempt an intelligent merge based on responsibilities: callers of this function own
       // everything *except* replication date metadata, which is managed by API on write (who calls
       // recordDocumentWrite[s]), and completed_tasks which is managed by outbound callers manually
@@ -154,14 +167,14 @@ const bulkUpdate = infoDocs => {
             conflictingInfoDocs[idx].completed_tasks = freshInfoDoc.completed_tasks;
           });
 
-          return bulkUpdate(conflictingInfoDocs);
+          return bulkUpdate(conflictingInfoDocs, retriesLeft - 1);
         });
     }
     return infoDocs;
   });
 };
 
-const recordDocumentWrite = (id, date) => {
+const recordDocumentWrite = (id, date, retriesLeft = MAX_CONFLICT_RETRIES) => {
   return db.sentinel.get(getInfoDocId(id))
     .catch(err => {
       if (err.status !== 404) {
@@ -174,8 +187,8 @@ const recordDocumentWrite = (id, date) => {
       infoDoc.latest_replication_date = date;
       return db.sentinel.put(infoDoc)
         .catch(err => {
-          if (err.status === 409) {
-            return recordDocumentWrite(id, date);
+          if (err.status === 409 && retriesLeft) {
+            return recordDocumentWrite(id, date, retriesLeft - 1);
           }
 
           throw err;
@@ -183,7 +196,7 @@ const recordDocumentWrite = (id, date) => {
     });
 };
 
-const recordDocumentWrites = (ids, date) => {
+const recordDocumentWrites = (ids, date, retriesLeft = MAX_CONFLICT_RETRIES) => {
   const infoDocIds = ids.map(getInfoDocId);
 
   return db.sentinel.allDocs({
@@ -205,7 +218,11 @@ const recordDocumentWrites = (ids, date) => {
           .map(r => getDocId(r.id));
 
         if (conflictingIds.length > 0) {
-          return recordDocumentWrites(conflictingIds, date);
+          if (!retriesLeft) {
+            throw conflictError(conflictingIds.map(getInfoDocId));
+          }
+
+          return recordDocumentWrites(conflictingIds, date, retriesLeft - 1);
         }
       });
   });

--- a/shared-libs/infodoc/src/infodoc.js
+++ b/shared-libs/infodoc/src/infodoc.js
@@ -84,44 +84,33 @@ const saveTransitions = change => {
     infoDoc.transitions = change.info?.transitions || {};
     delete infoDoc.transitions_started;
   };
-  return modifyInfoDoc(change.id, modify, change.info);
+  return modifyInfoDoc(change.id, modify);
 };
 
 const saveCompletedTasks = (id, infodoc, completedTasks = []) => {
   return modifyInfoDoc(id, infoDoc => {
     infoDoc.completed_tasks = infodoc?.completed_tasks || completedTasks;
-  }, infodoc);
+  });
 };
 
 const markTransitionsStarted = (id) => {
   const modify = infoDoc => {
     infoDoc.transitions_started = new Date().toISOString();
   };
-  return modifyInfoDoc(id, modify, blankInfoDoc(id));
+  return modifyInfoDoc(id, modify);
 };
 
 const clearTransitionsStarted = (id) => {
   const modify = infoDoc => {
     delete infoDoc.transitions_started;
   };
-  return modifyInfoDoc(id, modify, blankInfoDoc(id));
+  return modifyInfoDoc(id, modify);
 };
 
-// Fetch the infodoc. If it is missing, return `fallback` (to be created) when provided;
-const fetchInfoDoc = async (id, fallback) => {
-  try {
-    return await db.sentinel.get(getInfoDocId(id));
-  } catch (err) {
-    if (err.status === 404 && fallback) {
-      return fallback;
-    }
-    throw err;
-  }
-};
-
-// Fetch the infodoc, apply `modify`, and save, retrying on conflict
-const modifyInfoDoc = async (id, modify, fallback) => {
-  const infoDoc = await fetchInfoDoc(id, fallback);
+// Applies `modify` to an existing infodoc and saves it, retrying on conflict.
+// Throws a 404 if the infodoc doesn't exist; creating one is left to the caller.
+const modifyInfoDoc = async (id, modify) => {
+  const infoDoc = await db.sentinel.get(getInfoDocId(id));
 
   modify(infoDoc);
 
@@ -131,7 +120,7 @@ const modifyInfoDoc = async (id, modify, fallback) => {
     if (err.status !== 409) {
       throw err;
     }
-    return modifyInfoDoc(id, modify, fallback);
+    return modifyInfoDoc(id, modify);
   }
 };
 

--- a/shared-libs/infodoc/test/infodoc.js
+++ b/shared-libs/infodoc/test/infodoc.js
@@ -344,6 +344,23 @@ describe('infodoc', () => {
           assert.deepEqual(secondWrite.transitions, {'new': 'transition data'});
         });
     });
+
+    it('gives up once the conflict retries are exhausted', () => {
+      const infoDocs = [{ _id: 'test-info', _rev: '1-abc' }];
+
+      sinon.stub(db.sentinel, 'bulkDocs').resolves([
+        { id: 'test-info', error: 'conflict', reason: 'Document update conflict.' }
+      ]);
+      sinon.stub(db.sentinel, 'allDocs').resolves({ rows: [{ doc: { _id: 'test-info', _rev: '1-bca' } }] });
+
+      return lib.bulkUpdate(infoDocs)
+        .then(() => assert.fail('should have thrown'))
+        .catch(err => {
+          assert.equal(err.status, 409);
+          assert.include(err.message, 'test-info');
+          assert.equal(db.sentinel.bulkDocs.callCount, 11);
+        });
+    });
   });
 
   describe('updateTransition(s)', () => {
@@ -489,12 +506,12 @@ describe('infodoc', () => {
       sinon.stub(db.sentinel, 'get').resolves(info);
       const sentinelPut = sinon.stub(db.sentinel, 'put');
       sentinelPut.rejects({ status: 409 });
-      sentinelPut.onCall(20).resolves();
+      sentinelPut.onCall(3).resolves();
 
       return lib.saveTransitions(change).then(() => {
-        assert.equal(db.sentinel.get.callCount, 21);
-        assert.equal(db.sentinel.put.callCount, 21);
-        assert.deepEqual(db.sentinel.put.args[20], [{ ...info, transitions: change.info.transitions }]);
+        assert.equal(db.sentinel.get.callCount, 4);
+        assert.equal(db.sentinel.put.callCount, 4);
+        assert.deepEqual(db.sentinel.put.args[3], [{ ...info, transitions: change.info.transitions }]);
       });
     });
 
@@ -561,17 +578,16 @@ describe('infodoc', () => {
       });
     });
 
-    it('retries on 409 conflict indefinitely (no retry limit)', () => {
-      const info = { _id: 'some-info', doc_id: 'some' };
-      sinon.stub(db.sentinel, 'get').resolves(info);
-      const put = sinon.stub(db.sentinel, 'put');
-      // conflict on every attempt except the 101st - a retry limit below this would fail
-      put.rejects({ status: 409 });
-      put.onCall(100).resolves();
+    it('gives up once the conflict retries are exhausted', () => {
+      sinon.stub(db.sentinel, 'get').resolves({ _id: 'some-info', doc_id: 'some' });
+      sinon.stub(db.sentinel, 'put').rejects({ status: 409 });
 
-      return lib.markTransitionsStarted('some').then(() => {
-        assert.equal(db.sentinel.put.callCount, 101);
-      });
+      return lib.markTransitionsStarted('some')
+        .then(() => assert.fail('should have thrown'))
+        .catch(err => {
+          assert.equal(err.status, 409);
+          assert.equal(db.sentinel.put.callCount, 11);
+        });
     });
 
     it('throws non-409 errors', () => {
@@ -608,7 +624,7 @@ describe('infodoc', () => {
       sinon.stub(db.sentinel, 'get').resolves(serverInfo);
       const sentinelPut = sinon.stub(db.sentinel, 'put');
       sentinelPut.rejects({ status: 409 });
-      sentinelPut.onCall(45).resolves();
+      sentinelPut.onCall(3).resolves();
 
       const providedInfo = {
         _id: 'some-info',
@@ -617,9 +633,9 @@ describe('infodoc', () => {
       };
 
       return lib.saveCompletedTasks('some', providedInfo).then(() => {
-        assert.equal(db.sentinel.get.callCount, 46);
-        assert.equal(db.sentinel.put.callCount, 46);
-        assert.deepEqual(db.sentinel.put.args[45], [{ ...serverInfo, completed_tasks: providedInfo.completed_tasks }]);
+        assert.equal(db.sentinel.get.callCount, 4);
+        assert.equal(db.sentinel.put.callCount, 4);
+        assert.deepEqual(db.sentinel.put.args[3], [{ ...serverInfo, completed_tasks: providedInfo.completed_tasks }]);
       });
     });
   });
@@ -652,6 +668,18 @@ describe('infodoc', () => {
           .then(() => assert.fail('should have thrown'))
           .catch(err => {
             assert.equal(err.status, 500);
+          });
+      });
+
+      it('gives up once the conflict retries are exhausted', () => {
+        sentinelGet.resolves({ _id: 'blah-info', latest_replication_date: 'old' });
+        sentinelPut.rejects({ status: 409 });
+
+        return lib.recordDocumentWrite('blah')
+          .then(() => assert.fail('should have thrown'))
+          .catch(err => {
+            assert.equal(err.status, 409);
+            assert.equal(sentinelPut.callCount, 11);
           });
       });
 
@@ -779,6 +807,23 @@ describe('infodoc', () => {
             assert.equal(sentinelBulkDocs.args[0][0][1].initial_replication_date, 'ages ago');
           });
       });
+      it('gives up once the conflict retries are exhausted', () => {
+        sentinelAllDocs.resolves({
+          rows: [{ id: 'blah-info', key: 'blah-info', doc: { _id: 'blah-info', _rev: '1-abc' } }]
+        });
+        sentinelBulkDocs.resolves([
+          { id: 'blah-info', error: 'conflict', reason: 'Document update conflict.' }
+        ]);
+
+        return lib.recordDocumentWrites(['blah'])
+          .then(() => assert.fail('should have thrown'))
+          .catch(err => {
+            assert.equal(err.status, 409);
+            assert.include(err.message, 'blah-info');
+            assert.equal(sentinelBulkDocs.callCount, 11);
+          });
+      });
+
       it('Correctly works through and resolves conflicts when editing or creating infodocs', () => {
         // Attempting against two new docs and two existing
         sentinelAllDocs.onFirstCall().resolves({

--- a/shared-libs/infodoc/test/infodoc.js
+++ b/shared-libs/infodoc/test/infodoc.js
@@ -416,21 +416,24 @@ describe('infodoc', () => {
       });
     });
 
-    it('should use infodoc directly when sentinel returns 404', () => {
+    it('should throw when the infodoc has been deleted, instead of recreating it', () => {
       const change = {
         id: 'some',
         info: {
           _id: 'some-info',
+          _rev: '1-abc',
           transitions: { one: { ok: true } }
         }
       };
       sinon.stub(db.sentinel, 'get').rejects({ status: 404 });
       sinon.stub(db.sentinel, 'put').resolves();
 
-      return lib.saveTransitions(change).then(() => {
-        assert.equal(db.sentinel.put.callCount, 1);
-        assert.deepEqual(db.sentinel.put.args[0][0], change.info);
-      });
+      return lib.saveTransitions(change)
+        .then(() => assert.fail('should have thrown'))
+        .catch(err => {
+          assert.equal(err.status, 404);
+          assert.equal(db.sentinel.put.callCount, 0);
+        });
     });
 
     it('should use default value when infodoc property is falsy', () => {
@@ -444,7 +447,7 @@ describe('infodoc', () => {
       });
     });
 
-    it('should throw non-404 errors from sentinel get', () => {
+    it('should throw errors from sentinel get', () => {
       const change = { id: 'some', info: { transitions: {} } };
       sinon.stub(db.sentinel, 'get').rejects({ status: 500 });
 
@@ -493,6 +496,22 @@ describe('infodoc', () => {
         assert.equal(db.sentinel.put.callCount, 21);
         assert.deepEqual(db.sentinel.put.args[20], [{ ...info, transitions: change.info.transitions }]);
       });
+    });
+
+    it('should stop retrying conflicts once the infodoc has been deleted', () => {
+      const change = { id: 'some', info: { transitions: { one: { ok: true } } } };
+      const sentinelGet = sinon.stub(db.sentinel, 'get');
+      sentinelGet.resolves({ _id: 'some-info', _rev: '1-abc', doc_id: 'some' });
+      // the infodoc is deleted between the conflicting put and the next fetch
+      sentinelGet.onCall(1).rejects({ status: 404 });
+      sinon.stub(db.sentinel, 'put').rejects({ status: 409 });
+
+      return lib.saveTransitions(change)
+        .then(() => assert.fail('should have thrown'))
+        .catch(err => {
+          assert.equal(err.status, 404);
+          assert.equal(db.sentinel.put.callCount, 1);
+        });
     });
 
     it('clears the transitions_started marker when committing transitions', () => {

--- a/shared-libs/transitions/src/transitions/index.js
+++ b/shared-libs/transitions/src/transitions/index.js
@@ -57,10 +57,23 @@ const isMidWriteStale = infoDoc => {
     Date.now() - Date.parse(infoDoc.transitions_started) >= MID_WRITE_STALE_INTERVAL;
 };
 
+// Infodoc updates throw a 404 once background cleanup has deleted the infodoc of a deleted document.
+// There is nothing left to record against, so log and carry on.
+const ignoreDeletedInfoDoc = async (id, infoDocUpdate) => {
+  try {
+    return await infoDocUpdate;
+  } catch (err) {
+    if (err.status !== 404) {
+      throw err;
+    }
+    logger.warn(`transitions: infodoc for ${id} has been deleted, skipping infodoc update`);
+  }
+};
+
 // the transitions_started marker is stale, so clear it and process the doc anyway
 const clearStaleMarker = async (change, infoDocForChange) => {
   logger.warn(`transitions: clearing stale transitions_started marker on infodoc for ${change.id}`);
-  await infodoc.clearTransitionsStarted(change.id);
+  await ignoreDeletedInfoDoc(change.id, infodoc.clearTransitionsStarted(change.id));
   delete infoDocForChange.transitions_started;
 };
 
@@ -294,7 +307,7 @@ const finalizeChange = async ({ change, results, markStarted }) => {
     logger.debug(`nothing changed skipping saveDoc for doc ${change.id} seq ${change.seq}`);
     // info.transitions is how we know Sentinel has processed a doc; record it even when nothing ran.
     if (change.initialProcessing) {
-      await infodoc.saveTransitions(change);
+      await ignoreDeletedInfoDoc(change.id, infodoc.saveTransitions(change));
     }
     return;
   }
@@ -308,7 +321,7 @@ const finalizeChange = async ({ change, results, markStarted }) => {
 const saveForSentinel = async change => {
   const result = await saveDoc(change);
   logger.info(`saved changes on doc ${change.id} seq ${change.seq}`);
-  await infodoc.saveTransitions(change);
+  await ignoreDeletedInfoDoc(change.id, infodoc.saveTransitions(change));
   return result;
 };
 
@@ -316,11 +329,11 @@ const saveForSentinel = async change => {
 // sentinel read detects it and waits. The marker is cleared as part of the transitions write on
 // success, or rolled back on any failure after it's set.
 const saveForApi = async change => {
-  await infodoc.markTransitionsStarted(change.id);
+  await ignoreDeletedInfoDoc(change.id, infodoc.markTransitionsStarted(change.id));
   try {
     const result = await saveDoc(change);
     logger.info(`saved changes on doc ${change.id} seq ${change.seq}`);
-    await infodoc.saveTransitions(change);
+    await ignoreDeletedInfoDoc(change.id, infodoc.saveTransitions(change));
     return result;
   } catch (err) {
     await infodoc

--- a/shared-libs/transitions/test/unit/finalize-transition.js
+++ b/shared-libs/transitions/test/unit/finalize-transition.js
@@ -75,6 +75,60 @@ describe('finalize transition', () => {
     );
   });
 
+  it('should save the doc even when the infodoc has been deleted (API branch)', done => {
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({ ok: true, rev: '2' });
+    sinon.stub(infodoc, 'markTransitionsStarted').rejects({ status: 404 });
+    sinon.stub(infodoc, 'saveTransitions').rejects({ status: 404 });
+    const clearTransitionsStarted = sinon.stub(infodoc, 'clearTransitionsStarted').resolves();
+    transitions.finalize(
+      {
+        change: { id: 'abc', doc: { _rev: '1' } },
+        results: [null, null, true],
+        markStarted: true,
+      },
+      (err, result) => {
+        assert(!err);
+        assert.deepEqual(result, { ok: true, rev: '2' });
+        assert.equal(saveDoc.callCount, 1);
+        assert.equal(clearTransitionsStarted.callCount, 0);
+        done();
+      }
+    );
+  });
+
+  it('should save the doc even when the infodoc has been deleted (sentinel branch)', done => {
+    const saveDoc = sinon.stub(db.medic, 'put').resolves({ ok: true, rev: '2' });
+    sinon.stub(infodoc, 'saveTransitions').rejects({ status: 404 });
+    transitions.finalize(
+      {
+        change: { id: 'abc', doc: { _rev: '1' } },
+        results: [null, null, true],
+      },
+      (err, result) => {
+        assert(!err);
+        assert.deepEqual(result, { ok: true, rev: '2' });
+        assert.equal(saveDoc.callCount, 1);
+        done();
+      }
+    );
+  });
+
+  it('should callback with non-404 infodoc errors', done => {
+    sinon.stub(db.medic, 'put').resolves({ ok: true, rev: '2' });
+    sinon.stub(infodoc, 'saveTransitions').rejects({ status: 500 });
+    transitions.finalize(
+      {
+        change: { id: 'abc', doc: { _rev: '1' } },
+        results: [null, null, true],
+      },
+      (err, result) => {
+        assert.deepEqual(err, { status: 500 });
+        assert(!result);
+        done();
+      }
+    );
+  });
+
   it('applyTransition creates transitions property', done => {
     const doc = { _rev: '1' };
     const info = {};


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->

modifyInfoDoc currently attempts to create infoDocs if it gets a 404 when attempting to get the existing infodoc.
It appears, although needs more careful review, that this is never actually intended; the infoDoc should always exist before being modified.
So this PR removes that behavior, if the infodoc doesn't exist before attempting to modify it, the 404 error is thrown to callers.
Also, this PR adds a limit to the number of retries on 409; infinite 409s is not exxpected, but #11326 demonstrates that it is possible, and limiting the number of retries makes hanging processes impossible no matter even if there is some unexpected behavior causing infinit 409s.

<!-- ISSUE NUMBER -->
closes #11326 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [ ] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [ ] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [ ] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [ ] Tested: Unit and/or e2e where appropriate
- [ ] Internationalised: All user facing text
- [ ] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11326-dont-create-missing-infodocs/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11326-dont-create-missing-infodocs/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11326-dont-create-missing-infodocs/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

