### PR TITLE
fix(#10748): don't GET twice for docs that can't be hydrated

### DIFF
--- a/shared-libs/lineage/src/hydration.js
+++ b/shared-libs/lineage/src/hydration.js
@@ -256,29 +256,31 @@ module.exports = function(Promise, DB) {
       });
   };
 
-  const fetchLineageById = function(id) {
+  const fetchDocWithLineage = function(id) {
     return DB.get(id)
       .then(function(doc) {
         const ids = lineageIds(doc);
         if (!ids.length) {
-          return [];
+          return { doc, lineage: [] };
         }
 
         const parentIds = ids.slice(1);
         if (!parentIds.length) {
-          return [doc];
+          return { doc, lineage: [doc] };
         }
 
         return fetchDocs(parentIds)
-          .then(ancestors => [ doc, ...orderDocsByIds(parentIds, ancestors) ]);
+          .then(ancestors => ({ doc, lineage: [ doc, ...orderDocsByIds(parentIds, ancestors) ] }));
       })
       .catch(function(err) {
         if (err.status === 404) {
-          return [];
+          return { doc: null, lineage: [] };
         }
         throw err;
       });
   };
+
+  const fetchLineageById = id => fetchDocWithLineage(id).then(({ lineage }) => lineage);
 
   const fetchLineageByIds = function(ids) {
     return fetchDocs(ids).then(function(docs) {
@@ -317,19 +319,19 @@ module.exports = function(Promise, DB) {
       throwWhenMissingLineage: false,
     });
 
-    return fetchLineageById(id)
+    return fetchDocWithLineage(id)
       .then(function(result) {
-        lineage = result;
+        lineage = result.lineage;
 
         if (lineage.length === 0) {
           if (options.throwWhenMissingLineage) {
             const err = new Error(`Document not found: ${id}`);
             err.code = 404;
             throw err;
-          } else {
-            // Not a doc that has lineage, just do a normal fetch.
-            return fetchDoc(id);
           }
+          // Not a doc that has lineage, so nothing to hydrate. Reuse the doc we already have, falling back to
+          // fetchDoc so that a missing doc still rejects with a 404.
+          return result.doc || fetchDoc(id);
         }
 
         return fetchSubjectLineage(lineage[0])

--- a/shared-libs/lineage/src/hydration.js
+++ b/shared-libs/lineage/src/hydration.js
@@ -274,7 +274,7 @@ module.exports = function(Promise, DB) {
       })
       .catch(function(err) {
         if (err.status === 404) {
-          return { doc: null, lineage: [] };
+          return { doc: null, lineage: [], missing: err };
         }
         throw err;
       });
@@ -294,16 +294,6 @@ module.exports = function(Promise, DB) {
         return docsList;
       });
     });
-  };
-
-  const fetchDoc = function(id) {
-    return DB.get(id)
-      .catch(function(err) {
-        if (err.status === 404) {
-          err.statusCode = 404;
-        }
-        throw err;
-      });
   };
 
   const fetchHydratedDoc = function(id, options = {}, callback = undefined) {
@@ -329,9 +319,12 @@ module.exports = function(Promise, DB) {
             err.code = 404;
             throw err;
           }
-          // Not a doc that has lineage, so nothing to hydrate. Reuse the doc we already have, falling back to
-          // fetchDoc so that a missing doc still rejects with a 404.
-          return result.doc || fetchDoc(id);
+          if (result.missing) {
+            result.missing.statusCode = 404;
+            throw result.missing;
+          }
+          // Not a doc that has lineage, so nothing to hydrate. Reuse the doc we already have.
+          return result.doc;
         }
 
         return fetchSubjectLineage(lineage[0])

--- a/shared-libs/lineage/test/hydration.spec.js
+++ b/shared-libs/lineage/test/hydration.spec.js
@@ -261,6 +261,30 @@ describe('Lineage', function() {
       });
     });
 
+    it('returns docs without lineage without fetching them again', function() {
+      const doc = { _id: 'a', type: DOC_TYPES.TRANSLATIONS };
+      get.resolves(doc);
+
+      return lineage.fetchHydratedDoc('a').then(result => {
+        chai.expect(result).to.deep.equal(doc);
+        chai.expect(get.callCount).to.equal(1);
+        chai.expect(allDocs.callCount).to.equal(0);
+        chai.expect(query.callCount).to.equal(0);
+      });
+    });
+
+    it('rejects with a 404 when the doc is missing', function() {
+      const err = new Error('missing');
+      err.status = 404;
+      get.rejects(err);
+
+      return lineage.fetchHydratedDoc('a')
+        .then(() => chai.expect.fail('should have thrown'))
+        .catch(e => {
+          chai.expect(e.statusCode).to.equal(404);
+        });
+    });
+
     it('throws when lineage is empty and throwWhenMissingLineage is true', function() {
       get.resolves({ _id: 'a', type: DOC_TYPES.TRANSLATIONS });
 


### PR DESCRIPTION
<!--
Please use semantic PR titles that respect this format:

<type>(#<issue number>): <subject>

Quick example:

feat(#1234): add hat wobble
^--^(#^--^): ^------------^
|     |      |
|     |      + - > subject
|     |
|     + -------- > issue number
|
+ -------------- > type: build|feat|fix|perf|refactor|test|chore

https://docs.communityhealthtoolkit.org/contribute/code/workflow/#commit-message-format
-->

# Description

<!-- DESCRIPTION -->
#11319 introduced a small prefromance regression where it fetches a document twice when the document has no lineage. Previously, it would be a call to the `docs_by_lineage_id` view which would return no results.

Its not a major issue, but since sentinel will run this for every document, worth fixing quickly before its released.

<!-- ISSUE NUMBER -->

Closes #10748 

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] UI/UX backwards compatible: Test it works for the new design (enabled by default). And test it works in the old design, enable `can_view_old_navigation` permission to see the old design. Test it has appropriate design for RTL languages. 
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Internationalised: All user facing text
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10748-double-get-hydration/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10748-double-get-hydration/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:10748-double-get-hydration/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

