### PR TITLE
feat(#11370): index submitter with `docs_by_replication_key`

### DIFF
--- a/ddocs/medic-db/medic/nouveau/docs_by_replication_key/index.js
+++ b/ddocs/medic-db/medic/nouveau/docs_by_replication_key/index.js
@@ -14,7 +14,7 @@ function(doc) {
     return;
   }
 
-  const indexableFields = ['key', 'type', 'subject'];
+  const indexableFields = ['key', 'type', 'subject', 'submitter'];
   const isTruthy = (value) => value === true || value === 'true';
   const maxLength = 1000;
 

--- a/ddocs/medic-db/medic/nouveau/reports_by_freetext/index.js
+++ b/ddocs/medic-db/medic/nouveau/reports_by_freetext/index.js
@@ -51,9 +51,6 @@ function(doc) {
       indexField(key, doc.fields[key]);
     });
   }
-  if (doc.contact && doc.contact._id && typeof doc.contact._id === 'string') {
-    indexMaybe('string', 'exact_match', 'contact:' + doc.contact._id.toLowerCase());
-  }
   var reportedDate = doc.reported_date && typeof doc.reported_date === 'number' ? doc.reported_date : 0;
   index('double', 'reported_date', reportedDate, { store: true });
 }

--- a/tests/integration/couchdb/views/docs-by-replication-key.spec.js
+++ b/tests/integration/couchdb/views/docs-by-replication-key.spec.js
@@ -427,6 +427,40 @@ describe('docs_by_replication_key', () => {
     });
   });
 
+  describe('Documents associated with submitter', () => {
+    const getBySubmitter = async (submitter) => {
+      const opts = {
+        limit: nouveau.RESULTS_LIMIT,
+        q: `submitter:${nouveau.escapeKeys(submitter)}`,
+      };
+
+      return await utils
+        .requestOnTestDb({
+          path: '/_design/medic/_nouveau/docs_by_replication_key',
+          method: 'POST',
+          body: opts,
+        })
+        .then(response => response.hits.map(doc => doc.id));
+    };
+
+    it('should return reports submitted by the contact', async () => {
+      const submitted = await getBySubmitter('testuser');
+      expect(submitted).to.include('report_with_contact');
+      expect(submitted).to.include('report_with_unknown_patient_id');
+      expect(submitted).to.include('report_with_invalid_patient_id');
+
+      expect(submitted).to.not.include('report_about_patient');
+      expect(submitted).to.not.include('test_kujua_message');
+      expect(submitted).to.not.include('test_data_record_wrong_user');
+      expect(submitted).to.not.include('report_with_contact_deleted____tombstone');
+    });
+
+    it('should not return reports for a submitter with no reports', async () => {
+      const submitted = await getBySubmitter('not_the_testuser');
+      expect(submitted).to.be.empty;
+    });
+  });
+
   describe('Documents associated with user id', () => {
     it('should return task docs', () => {
       expect(docByPlaceIds).to.include('task_created_by_user');

--- a/tests/integration/couchdb/views/reports-by-freetext.spec.js
+++ b/tests/integration/couchdb/views/reports-by-freetext.spec.js
@@ -36,15 +36,6 @@ describe('reports_by_freetext', () => {
       reported_date: 1,
       fields: { patient_name: 'fxtnullfield', note: null },
     },
-    {
-      // A null contact._id must be skipped without breaking indexing; the report stays findable
-      _id: 'fxt_report_null_contact',
-      type: DOC_TYPES.DATA_RECORD,
-      form: 'F',
-      reported_date: 1,
-      fields: { patient_name: 'fxtnullcontact' },
-      contact: { _id: null },
-    },
   ];
 
   const queryFreetext = async (q) => {
@@ -90,11 +81,5 @@ describe('reports_by_freetext', () => {
     expect(ids).to.include('fxt_report_null_field');
     const byField = await queryFreetext('fxtnullfield*');
     expect(byField).to.include('fxt_report_null_field');
-  });
-
-  it('should still index a report whose contact._id is null', async () => {
-    expect(ids).to.include('fxt_report_null_contact');
-    const byField = await queryFreetext('fxtnullcontact*');
-    expect(byField).to.include('fxt_report_null_contact');
   });
 });

--- a/webapp/src/js/bootstrapper/offline-ddocs/medic-offline-freetext/reports_by_freetext.js
+++ b/webapp/src/js/bootstrapper/offline-ddocs/medic-offline-freetext/reports_by_freetext.js
@@ -48,7 +48,4 @@ module.exports.map = (doc) => {
       .keys(doc.fields)
       .forEach((key) => emitField(key, doc.fields[key], doc.reported_date));
   }
-  if (doc.contact && doc.contact._id) {
-    emitMaybe(`contact:${doc.contact._id.toLowerCase()}`, doc.reported_date);
-  }
 };


### PR DESCRIPTION
# Description

Closes #11370

cht-conf PR: https://github.com/medic/cht-conf/pull/838

## AI Disclosure

Done with Claude.  I have reviewed/confirmed all changes.

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [X] Tested: Unit and/or e2e where appropriate
- [X] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [X] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

<!-- COMPOSE URLS GO HERE - DO NOT CHANGE -->

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

