### PR TITLE
fix(#11370): find authored reports by submitter, not freetext contact

### DIFF
--- a/api/src/services/move-contact.js
+++ b/api/src/services/move-contact.js
@@ -76,23 +76,38 @@ const buildNewLineage = (id, parentById, sourceId, replacementLineage) => nestLi
 );
 
 /**
- * Ids of the reports the moved contacts authored. A report caches its author's lineage in `contact`,
- * which goes stale the moment the author moves. The nouveau index emits `contact:<lowercased id>` for
- * every report and is standard in cht-core, so there is no view fallback to maintain. Results are
- * paged with the bookmark rather than capped, so a prolific author is not silently truncated.
+ * Reports the moved contacts authored, each paired with the author whose lineage it caches. A report
+ * caches its author's lineage in `contact`, which goes stale the moment the author moves.
+ *
+ * `docs_by_replication_key` indexes that author as a searchable `submitter` and stores it, so a
+ * single query returns both the report and the value its operation has to be checked against. This
+ * used to be two reads, a freetext query for `contact:<id>` followed by an `_id` lookup here for the
+ * author, because `submitter` was stored but not searchable. #11370 moved the author indexing out of
+ * `reports_by_freetext` and made it searchable here, which removed the emission the first read
+ * relied on and made the second read sufficient on its own.
+ *
+ * Ids are matched verbatim rather than lowercased, because this index uses the keyword analyzer.
+ * Results are paged with the bookmark rather than capped, so a prolific author is not silently
+ * truncated.
  */
-const addReportIdsForChunk = async (chunk, ids) => {
-  const terms = chunk.map(id => `"contact:${escapePhrase(id.toLowerCase())}"`);
-  const q = `exact_match:(${terms.join(' OR ')})`;
+const addReportPairsForChunk = async (chunk, pairs, seen) => {
+  const terms = chunk.map(id => `"${escapePhrase(id)}"`);
+  const q = `submitter:(${terms.join(' OR ')})`;
   let bookmark = null;
 
   do {
     const response = await request.post({
-      uri: `${environment.couchUrl}/_design/medic/_nouveau/reports_by_freetext`,
+      uri: `${environment.couchUrl}/_design/medic/_nouveau/docs_by_replication_key`,
       body: { q, limit: nouveau.RESULTS_LIMIT, bookmark },
     });
     const hits = response.hits ?? [];
-    hits.forEach(hit => ids.add(hit.id));
+    hits.forEach(hit => {
+      if (seen.has(hit.id)) {
+        return;
+      }
+      seen.add(hit.id);
+      pairs.push({ id: hit.id, current_contact_id: hit.fields?.submitter });
+    });
     // A bookmark that does not advance means the index has no more to give; without this the loop
     // would spin forever inside the request.
     const exhausted = hits.length < nouveau.RESULTS_LIMIT || response.bookmark === bookmark;
@@ -100,41 +115,13 @@ const addReportIdsForChunk = async (chunk, ids) => {
   } while (bookmark);
 };
 
-const getReportIdsByCreator = async (contactIds) => {
+const getReportAuthorPairs = async (contactIds) => {
   const remaining = [ ...contactIds ];
-  const ids = new Set();
-
-  while (remaining.length) {
-    await addReportIdsForChunk(remaining.splice(0, nouveau.BATCH_LIMIT), ids);
-  }
-
-  return [ ...ids ];
-};
-
-/**
- * Pairs each report with the author whose lineage it caches. `docs_by_replication_key` stores that
- * author under `submitter`, so the ids the freetext query returned become pairs with a second index
- * read rather than a document read. The two indexes cover the same reports: the freetext one only
- * emits `contact:<id>` when a report has an author, and this one stores `submitter` whenever it does.
- * Ids are matched verbatim rather than lowercased, because `_id` is indexed exactly as it is.
- */
-const addReportAuthorsForChunk = async (chunk, pairs) => {
-  const terms = chunk.map(id => `"${escapePhrase(id)}"`);
-  const response = await request.post({
-    uri: `${environment.couchUrl}/_design/medic/_nouveau/docs_by_replication_key`,
-    body: { q: `_id:(${terms.join(' OR ')})`, limit: chunk.length },
-  });
-  (response.hits ?? []).forEach(
-    hit => pairs.push({ id: hit.id, current_contact_id: hit.fields?.submitter })
-  );
-};
-
-const getReportAuthorIds = async (reportIds) => {
-  const remaining = [ ...reportIds ];
   const pairs = [];
+  const seen = new Set();
 
   while (remaining.length) {
-    await addReportAuthorsForChunk(remaining.splice(0, nouveau.BATCH_LIMIT), pairs);
+    await addReportPairsForChunk(remaining.splice(0, nouveau.BATCH_LIMIT), pairs, seen);
   }
 
   return pairs;
@@ -209,7 +196,7 @@ const moveContactHierarchy = async (source, destination, { dryRun } = {}) => {
   const replacementLineage = lineage.minifyLineage(destination) || undefined;
   const [ parentById, reportPairs, places ] = await Promise.all([
     getParentIds(contactIds, source),
-    getReportIdsByCreator(contactIds).then(getReportAuthorIds),
+    getReportAuthorPairs(contactIds),
     getPlacesToRefresh(contactIds),
   ]);
 

--- a/api/src/services/move-contact.js
+++ b/api/src/services/move-contact.js
@@ -76,21 +76,10 @@ const buildNewLineage = (id, parentById, sourceId, replacementLineage) => nestLi
 );
 
 /**
- * Reports the moved contacts authored, each paired with the author whose lineage it caches. A report
+ * Adds the reports the moved contacts authored, each paired with the author whose lineage it caches. A report
  * caches its author's lineage in `contact`, which goes stale the moment the author moves.
- *
- * `docs_by_replication_key` indexes that author as a searchable `submitter` and stores it, so a
- * single query returns both the report and the value its operation has to be checked against. This
- * used to be two reads, a freetext query for `contact:<id>` followed by an `_id` lookup here for the
- * author, because `submitter` was stored but not searchable. #11370 moved the author indexing out of
- * `reports_by_freetext` and made it searchable here, which removed the emission the first read
- * relied on and made the second read sufficient on its own.
- *
- * Ids are matched verbatim rather than lowercased, because this index uses the keyword analyzer.
- * Results are paged with the bookmark rather than capped, so a prolific author is not silently
- * truncated.
  */
-const addReportPairsForChunk = async (chunk, pairs, seen) => {
+const addReportPairsForChunk = async (chunk, pairs) => {
   const terms = chunk.map(id => `"${escapePhrase(id)}"`);
   const q = `submitter:(${terms.join(' OR ')})`;
   let bookmark = null;
@@ -102,14 +91,8 @@ const addReportPairsForChunk = async (chunk, pairs, seen) => {
     });
     const hits = response.hits ?? [];
     hits.forEach(hit => {
-      if (seen.has(hit.id)) {
-        return;
-      }
-      seen.add(hit.id);
       pairs.push({ id: hit.id, current_contact_id: hit.fields?.submitter });
     });
-    // A bookmark that does not advance means the index has no more to give; without this the loop
-    // would spin forever inside the request.
     const exhausted = hits.length < nouveau.RESULTS_LIMIT || response.bookmark === bookmark;
     bookmark = exhausted ? null : response.bookmark;
   } while (bookmark);
@@ -118,10 +101,9 @@ const addReportPairsForChunk = async (chunk, pairs, seen) => {
 const getReportAuthorPairs = async (contactIds) => {
   const remaining = [ ...contactIds ];
   const pairs = [];
-  const seen = new Set();
 
   while (remaining.length) {
-    await addReportPairsForChunk(remaining.splice(0, nouveau.BATCH_LIMIT), pairs, seen);
+    await addReportPairsForChunk(remaining.splice(0, nouveau.BATCH_LIMIT), pairs);
   }
 
   return pairs;
@@ -159,10 +141,6 @@ const buildSetParentOperations = (contactIds, parentById, sourceId, replacementL
  * stepped over.
  */
 const buildSetContactOperations = (pairs, parentById, sourceId, replacementLineage) => pairs
-  // Only rewrite a cached copy whose contact is really in the moved subtree. The freetext query
-  // matches a lowercased id and the author can change between the two index reads, so a report can
-  // come back whose author is not moving at all; rebuilding that one from the destination lineage
-  // would corrupt an unrelated report. parentById is keyed on the whole subtree.
   .filter(({ current_contact_id: contactId }) => parentById.has(contactId))
   .map(({ id, current_contact_id: contactId }) => ({
     id,

--- a/api/tests/mocha/services/move-contact.spec.js
+++ b/api/tests/mocha/services/move-contact.spec.js
@@ -25,9 +25,8 @@ const UNDER_HC_B = { _id: 'hc-b', parent: { _id: 'district' } };
 const subtreeOf = sinon.match(opts => Array.isArray(opts.key));
 const atDepthOne = sinon.match(opts => Array.isArray(opts.keys));
 
-// Two nouveau indexes are queried in turn, so the stubs split on which one the uri names.
-const freetextQuery = sinon.match(opts => opts.uri.endsWith('reports_by_freetext'));
-const authorQuery = sinon.match(opts => opts.uri.endsWith('docs_by_replication_key'));
+// One nouveau index carries both the report and its author, so a single matcher covers it.
+const reportQuery = sinon.match(opts => opts.uri.endsWith('docs_by_replication_key'));
 
 const buildRes = () => {
   const res = {};
@@ -47,8 +46,7 @@ describe('move-contact service', () => {
   let contactGet;
   let handler;
   let queue;
-  let freetext;
-  let authors;
+  let reports;
 
   beforeEach(() => {
     contactGet = sinon.stub().resolves(healthCenterB);
@@ -68,8 +66,7 @@ describe('move-contact service', () => {
     db.medic.query.withArgs('medic/contacts_by_primary_contact').resolves({ rows: [] });
 
     sinon.stub(request, 'post');
-    freetext = request.post.withArgs(freetextQuery).resolves({ hits: [] });
-    authors = request.post.withArgs(authorQuery).resolves({ hits: [] });
+    reports = request.post.withArgs(reportQuery).resolves({ hits: [] });
 
     handler = moveContact.handleMove({ get: sinon.stub().resolves(clinic), type: 'Place' });
   });
@@ -105,8 +102,7 @@ describe('move-contact service', () => {
 
   it('answers everything from indexes without reading a single document', async () => {
     const allDocs = sinon.stub(db.medic, 'allDocs').resolves({ rows: [] });
-    freetext.resolves({ hits: [ { id: 'report-1' } ] });
-    authors.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'person-1' } } ] });
+    reports.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'person-1' } } ] });
 
     await handler(buildReq(), buildRes());
 
@@ -151,8 +147,7 @@ describe('move-contact service', () => {
   });
 
   it('refreshes the cached lineage on reports the moved contacts authored', async () => {
-    freetext.resolves({ hits: [ { id: 'report-1' } ] });
-    authors.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'person-1' } } ] });
+    reports.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'person-1' } } ] });
     const res = buildRes();
 
     await handler(buildReq(), res);
@@ -166,50 +161,44 @@ describe('move-contact service', () => {
     expect(res.json.args[0][0].summary['set-contact']).to.deep.equal({ reports: 1, places: 0 });
   });
 
-  it('looks the report authors up by id in the replication key index', async () => {
-    freetext.resolves({ hits: [ { id: 'report-1' }, { id: 'report-2' } ] });
-
+  it('looks reports up by submitter in the replication key index', async () => {
     await handler(buildReq(), buildRes());
 
-    const { uri, body } = authors.args[0][0];
+    const { uri, body } = reports.args[0][0];
     expect(uri).to.include('_design/medic/_nouveau/docs_by_replication_key');
-    expect(body).to.deep.equal({ q: '_id:("report-1" OR "report-2")', limit: 2 });
+    expect(body.q).to.equal('submitter:("clinic-1" OR "person-1")');
   });
 
-  it('matches the report ids verbatim, unlike the lowercased freetext contact terms', async () => {
-    freetext.resolves({ hits: [ { id: 'RePort-1' } ] });
+  it('matches submitter ids verbatim, because the index uses the keyword analyzer', async () => {
+    db.medic.query.withArgs('medic/contacts_by_depth', subtreeOf)
+      .resolves({ rows: [ { id: 'PeRson-1' } ] });
 
     await handler(buildReq(), buildRes());
 
-    expect(authors.args[0][0].body.q).to.equal('_id:("RePort-1")');
+    expect(reports.args[0][0].body.q).to.equal('submitter:("PeRson-1")');
   });
 
-  it('chunks the author lookup rather than asking for every report at once', async () => {
-    // shrunk so the test does not have to build a real page of results
-    sinon.stub(nouveau, 'RESULTS_LIMIT').value(3);
-    sinon.stub(nouveau, 'BATCH_LIMIT').value(2);
-    freetext.onFirstCall().resolves({ hits: [ { id: 'r-1' }, { id: 'r-2' }, { id: 'r-3' } ], bookmark: 'page-2' });
-    freetext.onSecondCall().resolves({ hits: [ { id: 'r-4' } ] });
+  it('chunks the submitter query rather than naming every contact at once', async () => {
+    sinon.stub(nouveau, 'BATCH_LIMIT').value(1);
 
     await handler(buildReq(), buildRes());
 
-    expect(authors.args.map(([ opts ]) => opts.body.limit)).to.deep.equal([ 2, 2 ]);
+    expect(reports.args.map(([ opts ]) => opts.body.q))
+      .to.deep.equal([ 'submitter:("clinic-1")', 'submitter:("person-1")' ]);
   });
 
-  it('skips a report whose author the index does not report', async () => {
-    freetext.resolves({ hits: [ { id: 'report-1' } ] });
-    authors.resolves({ hits: [ { id: 'report-1', fields: {} } ] });
+  it('skips a report whose submitter the index does not report', async () => {
+    reports.resolves({ hits: [ { id: 'report-1', fields: {} } ] });
 
     await handler(buildReq(), buildRes());
 
     expect(queue.args[0][0][1].operations).to.deep.equal([]);
   });
 
-  it('skips a report whose author is not in the moved subtree', async () => {
-    // The freetext term is lowercased, so a contact whose id differs only by case matches too, and
-    // the author can change between the two index reads. Either way that report is not moving.
-    freetext.resolves({ hits: [ { id: 'report-1' } ] });
-    authors.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'PERSON-1' } } ] });
+  it('skips a report whose submitter is not in the moved subtree', async () => {
+    // Defensive: the query only names contacts in the subtree, but an author can change between the
+    // index read and the write, and a stale index can answer with one that has already moved away.
+    reports.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'outsider' } } ] });
     const res = buildRes();
 
     await handler(buildReq(), res);
@@ -218,36 +207,39 @@ describe('move-contact service', () => {
     expect(res.json.args[0][0].summary['set-contact']).to.deep.equal({ reports: 0, places: 0 });
   });
 
-  it('queries the nouveau index by lowercased contact id', async () => {
-    await handler(buildReq(), buildRes());
+  it('does not queue the same report twice when two chunks both match it', async () => {
+    sinon.stub(nouveau, 'BATCH_LIMIT').value(1);
+    reports.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'person-1' } } ] });
+    const res = buildRes();
 
-    const { uri, body } = freetext.args[0][0];
-    expect(uri).to.include('_design/medic/_nouveau/reports_by_freetext');
-    expect(body.q).to.equal('exact_match:("contact:clinic-1" OR "contact:person-1")');
+    await handler(buildReq(), res);
+
+    expect(queue.args[0][0][1].operations).to.have.lengthOf(1);
+    expect(res.json.args[0][0].summary['set-contact']).to.deep.equal({ reports: 1, places: 0 });
   });
 
   it('pages the nouveau results with the bookmark rather than capping them', async () => {
     sinon.stub(nouveau, 'RESULTS_LIMIT').value(2);
-    freetext.onFirstCall().resolves({ hits: [ { id: 'r-1' }, { id: 'r-2' } ], bookmark: 'page-2' });
-    freetext.onSecondCall().resolves({ hits: [ { id: 'r-3' } ] });
+    reports.onFirstCall().resolves({ hits: [ { id: 'r-1' }, { id: 'r-2' } ], bookmark: 'page-2' });
+    reports.onSecondCall().resolves({ hits: [ { id: 'r-3' } ] });
 
     await handler(buildReq(), buildRes());
 
-    expect(freetext.callCount).to.equal(2);
-    expect(freetext.args[0][0].body.bookmark).to.be.null;
-    expect(freetext.args[1][0].body.bookmark).to.equal('page-2');
+    expect(reports.callCount).to.equal(2);
+    expect(reports.args[0][0].body.bookmark).to.be.null;
+    expect(reports.args[1][0].body.bookmark).to.equal('page-2');
     // the whole result set is asked for in one page rather than in batches
-    expect(freetext.args[0][0].body.limit).to.equal(nouveau.RESULTS_LIMIT);
+    expect(reports.args[0][0].body.limit).to.equal(nouveau.RESULTS_LIMIT);
   });
 
   it('stops paging when the bookmark does not advance, rather than looping forever', async () => {
     sinon.stub(nouveau, 'RESULTS_LIMIT').value(2);
     // A misbehaving index that keeps returning a full page and the same bookmark.
-    freetext.resolves({ hits: [ { id: 'r-1' }, { id: 'r-2' } ], bookmark: 'stuck' });
+    reports.resolves({ hits: [ { id: 'r-1' }, { id: 'r-2' } ], bookmark: 'stuck' });
 
     await handler(buildReq(), buildRes());
 
-    expect(freetext.callCount).to.equal(2);
+    expect(reports.callCount).to.equal(2);
   });
 
   it('escapes quotes and backslashes in ids before they reach the query', async () => {
@@ -256,15 +248,7 @@ describe('move-contact service', () => {
 
     await handler(buildReq(), buildRes());
 
-    expect(freetext.args[0][0].body.q).to.equal('exact_match:("contact:we\\"ird\\\\id")');
-  });
-
-  it('escapes quotes and backslashes in report ids too', async () => {
-    freetext.resolves({ hits: [ { id: 'we"ird\\report' } ] });
-
-    await handler(buildReq(), buildRes());
-
-    expect(authors.args[0][0].body.q).to.equal('_id:("we\\"ird\\\\report")');
+    expect(reports.args[0][0].body.q).to.equal('submitter:("we\\"ird\\\\id")');
   });
 
   it('rejects a parent_id that is not a string', async () => {

--- a/api/tests/mocha/services/move-contact.spec.js
+++ b/api/tests/mocha/services/move-contact.spec.js
@@ -207,17 +207,6 @@ describe('move-contact service', () => {
     expect(res.json.args[0][0].summary['set-contact']).to.deep.equal({ reports: 0, places: 0 });
   });
 
-  it('does not queue the same report twice when two chunks both match it', async () => {
-    sinon.stub(nouveau, 'BATCH_LIMIT').value(1);
-    reports.resolves({ hits: [ { id: 'report-1', fields: { submitter: 'person-1' } } ] });
-    const res = buildRes();
-
-    await handler(buildReq(), res);
-
-    expect(queue.args[0][0][1].operations).to.have.lengthOf(1);
-    expect(res.json.args[0][0].summary['set-contact']).to.deep.equal({ reports: 1, places: 0 });
-  });
-
   it('pages the nouveau results with the bookmark rather than capping them', async () => {
     sinon.stub(nouveau, 'RESULTS_LIMIT').value(2);
     reports.onFirstCall().resolves({ hits: [ { id: 'r-1' }, { id: 'r-2' } ], bookmark: 'page-2' });


### PR DESCRIPTION
# Description

Move stopped finding the reports its contacts authored after the feature branch was synced with master. Four integration tests catch it, all the same way:

```
set-contact: { places: 1, reports: 0 }   actual
set-contact: { places: 1, reports: 1 }   expected
```

The cause is #11371. It removed the `contact:<id>` emission from `reports_by_freetext`, on the grounds that a contact mapping had nothing to do with freetext search, and made `submitter` searchable on `docs_by_replication_key` instead. Move queries exactly that removed emission with `exact_match:"contact:<lowercased id>"`. #11371 landed on master on 26 August and move (#11311) merged into the feature branch on 26 August, so the two crossed and neither side saw the other. cht-conf's equivalent consumer was already migrated in medic/cht-conf#838.

Worth being explicit about the failure mode: nothing errors. A move silently skips every report its contacts authored and leaves them caching a lineage that no longer holds.

## The fix, which is also a simplification

Finding those reports previously took two index reads: a freetext query for the report ids, then an `_id` query on `docs_by_replication_key` to read the author out of stored fields, because `submitter` was stored but not searchable. Now that it is searchable, one query by `submitter` returns both the report and the author its guard has to check, so `getReportIdsByCreator` and `getReportAuthorIds` collapse into a single `getReportAuthorPairs`.

Two details the single query changes:

- Ids are matched **verbatim** rather than lowercased, because this index uses the keyword analyser. That is what the #11370 test for `submitter` does.
- Because chunked queries can each return the same report, hits are de-duplicated as they arrive rather than relying on a `Set` of ids built by a first pass.

## Blast radius

Move was the only cht-core consumer of the removed emission. The other `reports_by_freetext` references (`shared-libs/cht-datasource/src/local/report.ts`, `local/libs/nouveau.ts`, `api/src/services/monitoring.js`) are genuine freetext search and unaffected.

## Verification

- 25 unit tests passing in `api/tests/mocha/services/move-contact.spec.js`, rewritten for the single-query design
- `unit-api` 1729 passing, coverage above every threshold
- ESLint clean

The four integration tests that currently fail on #11275 are the regression test for this; they should pass with this change.

## Why this matters now

#11275 cannot go to master while move is broken on the feature branch.

Closes #10706

# Code review checklist
<!-- Remove or comment out any items that do not apply to this PR; in the remaining boxes, replace the [ ] with [x]. -->
- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in the release notes.
- [ ] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
