### PR TITLE
fix(#11413): handle Nepali locale when calculating BS dates

### DIFF
--- a/shared-libs/calendar-interval/src/index.js
+++ b/shared-libs/calendar-interval/src/index.js
@@ -60,7 +60,7 @@ const getBSEnd = (bikramSambat, year, month, intervalStartDate) => {
 
 const getBikramSambatInterval = (intervalStartDate, referenceDate) => {
   const bikramSambat = require('bikram-sambat');
-  const bsRef = bikramSambat.toBik(referenceDate.format('YYYY-MM-DD'));
+  const bsRef = bikramSambat.toBik(referenceDate.clone().locale('en').format('YYYY-MM-DD'));
 
   let startBS;
   let endBS;

--- a/shared-libs/calendar-interval/test/index.js
+++ b/shared-libs/calendar-interval/test/index.js
@@ -633,6 +633,24 @@ describe('CalendarInterval', () => {
       });
     });
 
+    it('calculates BS intervals when the Nepali locale renders dates with Devanagari digits', () => {
+      const previousLocale = moment.locale();
+      moment.locale('ne');
+      try {
+        const timestamp = moment('2026-07-05 12:00:00').valueOf();
+        const expectedStart = moment('2026-06-15 00:00:00').valueOf();
+        const expectedEnd = moment('2026-07-16 23:59:59.999').valueOf();
+
+        chai.expect(service.getInterval(1, timestamp, true)).to.deep.equal({
+          start: expectedStart,
+          end: expectedEnd
+        });
+        chai.expect(moment.locale()).to.equal('ne');
+      } finally {
+        moment.locale(previousLocale);
+      }
+    });
+
     it('returns n-th of current BS month when start day is n <= today\'s BS day', () => {
       // 2026-07-05 is BS 2083-03-21 (Ashadh 21).
       // Start day 15 <= 21, so start is BS 2083-03-15 (Ashadh 15 = 2026-06-29)

--- a/shared-libs/rules-engine/src/provider-wireup.js
+++ b/shared-libs/rules-engine/src/provider-wireup.js
@@ -287,16 +287,16 @@ const getTargetDocTag = (filterInterval) => {
     return 'latest';
   }
   if (!rulesStateStore.getUseBikramSambatMonths()) {
-    return moment(filterInterval.end).format('YYYY-MM');
+    return moment(filterInterval.end).locale('en').format('YYYY-MM');
   }
   try {
     const { toBik } = require('bikram-sambat');
-    const bsEnd = toBik(moment(filterInterval.end).format('YYYY-MM-DD'));
+    const bsEnd = toBik(moment(filterInterval.end).locale('en').format('YYYY-MM-DD'));
     return `${bsEnd.year}-${String(bsEnd.month).padStart(2, '0')}`;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn('Failed to parse BS date for target document tag, falling back to Gregorian tag:', err);
-    return moment(filterInterval.end).format('YYYY-MM');
+    return moment(filterInterval.end).locale('en').format('YYYY-MM');
   }
 };
 
@@ -315,4 +315,3 @@ const storeTargetsDoc = (provider, aggregate, updatedTargets) => {
     updatedTargets
   );
 };
-

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -110,6 +110,43 @@ describe('provider-wireup integration tests', () => {
     clock.restore();
   });
 
+  describe('getTargetDocTag', () => {
+    it('uses an ASCII Gregorian tag when the Nepali locale is active and BS months are disabled', () => {
+      const previousLocale = moment.locale();
+      moment.locale('ne');
+
+      try {
+        sinon.stub(rulesStateStore, 'getUseBikramSambatMonths').returns(false);
+        const getTargetDocTag = wireup.__get__('getTargetDocTag');
+
+        expect(getTargetDocTag({ end: moment('2020-04-30').valueOf() })).to.equal('2020-04');
+        expect(moment.locale()).to.equal('ne');
+      } finally {
+        moment.locale(previousLocale);
+      }
+    });
+
+    it('uses an ASCII Gregorian fallback tag when BS conversion fails under the Nepali locale', () => {
+      const previousLocale = moment.locale();
+      moment.locale('ne');
+
+      try {
+        sinon.stub(rulesStateStore, 'getUseBikramSambatMonths').returns(true);
+        const bikramSambat = require('bikram-sambat');
+        const toBik = sinon.stub(bikramSambat, 'toBik').throws(new Error('invalid date'));
+        const warning = sinon.stub(console, 'warn');
+        const getTargetDocTag = wireup.__get__('getTargetDocTag');
+
+        expect(getTargetDocTag({ end: moment('2020-04-30').valueOf() })).to.equal('2020-04');
+        expect(toBik.calledOnce).to.be.true;
+        expect(warning.calledOnce).to.be.true;
+        expect(moment.locale()).to.equal('ne');
+      } finally {
+        moment.locale(previousLocale);
+      }
+    });
+  });
+
   describe('stateChangeCallback', () => {
     it('wireup of contactTaskState to pouch', async () => {
       sinon.spy(provider, 'stateChangeCallback');
@@ -946,31 +983,39 @@ describe('provider-wireup integration tests', () => {
       });
 
       it('should write target docs with Bikram Sambat tags when BS months are enabled', async () => {
-        const settings = {
-          rules: defaultConfigSettingsDoc.tasks.rules,
-          enableTargets: true,
-          targets: [{
-            id: 'uhc',
-          }],
-          monthStartDate: 1,
-          rulesAreDeclarative: true,
-          useBikramSambatMonths: true,
-        };
+        const previousLocale = moment.locale();
+        moment.locale('ne');
 
-        clock.setSystemTime(moment('2020-04-23').valueOf());
-        await wireup.initialize(provider, settings, {});
-        expect(provider.commitTargetDoc.callCount).to.equal(0);
+        try {
+          const settings = {
+            rules: defaultConfigSettingsDoc.tasks.rules,
+            enableTargets: true,
+            targets: [{
+              id: 'uhc',
+            }],
+            monthStartDate: 1,
+            rulesAreDeclarative: true,
+            useBikramSambatMonths: true,
+          };
 
-        const emissions = [
-          mockTargetEmission('uhc', 'doc1', moment('2020-04-23').valueOf(), true), // passes within interval
-        ];
-        const refreshRulesEmissions = sinon.stub().resolves({ targetEmissions: emissions });
-        const withMockRefresher = wireup.__with__({ refreshRulesEmissions });
+          clock.setSystemTime(moment('2020-04-23').valueOf());
+          await wireup.initialize(provider, settings, {});
+          expect(provider.commitTargetDoc.callCount).to.equal(0);
 
-        await withMockRefresher(() => wireup.fetchTasksFor(provider));
-        expect(provider.commitTargetDoc.callCount).to.equal(1);
-        expect(provider.commitTargetDoc.args[0][1]).to.equal('2077-01');
-        expect(provider.commitTargetDoc.args[0][0]).to.deep.equal([{ id: 'uhc', value: { pass: 1, total: 1 }}]);
+          const emissions = [
+            mockTargetEmission('uhc', 'doc1', moment('2020-04-23').valueOf(), true), // passes within interval
+          ];
+          const refreshRulesEmissions = sinon.stub().resolves({ targetEmissions: emissions });
+          const withMockRefresher = wireup.__with__({ refreshRulesEmissions });
+
+          await withMockRefresher(() => wireup.fetchTasksFor(provider));
+          expect(provider.commitTargetDoc.callCount).to.equal(1);
+          expect(provider.commitTargetDoc.args[0][1]).to.equal('2077-01');
+          expect(provider.commitTargetDoc.args[0][0]).to.deep.equal([{ id: 'uhc', value: { pass: 1, total: 1 }}]);
+          expect(moment.locale()).to.equal('ne');
+        } finally {
+          moment.locale(previousLocale);
+        }
       });
     });
   });

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -982,7 +982,7 @@ describe('provider-wireup integration tests', () => {
         expect(provider.commitTargetDoc.args[1][0]).to.deep.equal([{ id: 'uhc', value: { pass: 2, total: 2 }}]);
       });
 
-      it('should write target docs with Bikram Sambat tags when BS months are enabled', async () => {
+      it('should write target docs with Bikram Sambat tags when BS months are enabled and the Nepali locale is active', async () => {
         const previousLocale = moment.locale();
         moment.locale('ne');
 

--- a/shared-libs/rules-engine/test/provider-wireup.spec.js
+++ b/shared-libs/rules-engine/test/provider-wireup.spec.js
@@ -982,7 +982,7 @@ describe('provider-wireup integration tests', () => {
         expect(provider.commitTargetDoc.args[1][0]).to.deep.equal([{ id: 'uhc', value: { pass: 2, total: 2 }}]);
       });
 
-      it('should write target docs with Bikram Sambat tags when BS months are enabled and the Nepali locale is active', async () => {
+      it('should write Bikram Sambat tags when BS months and Nepali locale are active', async () => {
         const previousLocale = moment.locale();
         moment.locale('ne');
 

--- a/webapp/src/ts/services/rules-engine.service.ts
+++ b/webapp/src/ts/services/rules-engine.service.ts
@@ -602,7 +602,7 @@ export class RulesEngineService implements OnDestroy {
 
     if (reportingPeriod === ReportingPeriod.CURRENT) {
       if (useBikramSambatMonths) {
-        const bsEnd = toBik(moment(currentInterval.end).format('YYYY-MM-DD'));
+        const bsEnd = toBik(moment(currentInterval.end).locale('en').format('YYYY-MM-DD'));
         return `${bsEnd.year}-${String(bsEnd.month).padStart(2, '0')}`;
       }
       return moment(currentInterval.end)
@@ -621,7 +621,7 @@ export class RulesEngineService implements OnDestroy {
     }
 
     if (useBikramSambatMonths) {
-      const bsEnd = toBik(moment(interval.end).format('YYYY-MM-DD'));
+      const bsEnd = toBik(moment(interval.end).locale('en').format('YYYY-MM-DD'));
       return `${bsEnd.year}-${String(bsEnd.month).padStart(2, '0')}`;
     }
     return moment(interval.end)

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -3,6 +3,8 @@ import { provideMockStore } from '@ngrx/store/testing';
 import { Store } from '@ngrx/store';
 import sinon from 'sinon';
 import { assert, expect } from 'chai';
+import * as moment from 'moment';
+import 'moment/locale/ne';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DOC_IDS, PREFIXES, DOC_TYPES } from '@medic/constants';
 
@@ -23,6 +25,8 @@ import { PipesService } from '@mm-services/pipes.service';
 import { CHTDatasourceService } from '@mm-services/cht-datasource.service';
 import { Target } from '@medic/cht-datasource';
 import { ReportingPeriod } from '@mm-modules/analytics/analytics-sidebar-filter.component';
+
+moment.locale('en');
 
 describe('RulesEngineService', () => {
   let service: RulesEngineService;
@@ -1400,6 +1404,21 @@ describe('RulesEngineService', () => {
       // Tag is '2081-10'.
       expect(tag).to.equal('2081-10');
       expect(uhcSettingsService.getMonthStartDate.calledOnceWithExactly(settingsDoc)).to.be.true;
+    });
+
+    it('should return BS interval tags when the Nepali locale is active', () => {
+      const previousLocale = moment.locale();
+      moment.locale('ne');
+      try {
+        uhcSettingsService.getUseBikramSambatMonths.returns(true);
+        service = TestBed.inject(RulesEngineService);
+
+        expect(service.getTargetIntervalTag(settingsDoc, ReportingPeriod.CURRENT)).to.equal('2081-11');
+        expect(service.getTargetIntervalTag(settingsDoc, ReportingPeriod.PREVIOUS)).to.equal('2081-10');
+        expect(moment.locale()).to.equal('ne');
+      } finally {
+        moment.locale(previousLocale);
+      }
     });
   });
 

--- a/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
+++ b/webapp/tests/karma/ts/services/rules-engine.service.spec.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import { assert, expect } from 'chai';
 import * as moment from 'moment';
 import 'moment/locale/ne';
+import 'moment/locale/ar';
 import { TranslateFakeLoader, TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DOC_IDS, PREFIXES, DOC_TYPES } from '@medic/constants';
 
@@ -1406,7 +1407,7 @@ describe('RulesEngineService', () => {
       expect(uhcSettingsService.getMonthStartDate.calledOnceWithExactly(settingsDoc)).to.be.true;
     });
 
-    it('should return BS interval tags when the Nepali locale is active', () => {
+    it('should return BS interval tags when a non-ASCII-digit locale is active', () => {
       const previousLocale = moment.locale();
       moment.locale('ne');
       try {
@@ -1416,6 +1417,21 @@ describe('RulesEngineService', () => {
         expect(service.getTargetIntervalTag(settingsDoc, ReportingPeriod.CURRENT)).to.equal('2081-11');
         expect(service.getTargetIntervalTag(settingsDoc, ReportingPeriod.PREVIOUS)).to.equal('2081-10');
         expect(moment.locale()).to.equal('ne');
+      } finally {
+        moment.locale(previousLocale);
+      }
+    });
+
+    it('should return BS interval tags when the Arabic locale is active', () => {
+      const previousLocale = moment.locale();
+      moment.locale('ar');
+      try {
+        uhcSettingsService.getUseBikramSambatMonths.returns(true);
+        service = TestBed.inject(RulesEngineService);
+
+        expect(service.getTargetIntervalTag(settingsDoc, ReportingPeriod.CURRENT)).to.equal('2081-11');
+        expect(service.getTargetIntervalTag(settingsDoc, ReportingPeriod.PREVIOUS)).to.equal('2081-10');
+        expect(moment.locale()).to.equal('ar');
       } finally {
         moment.locale(previousLocale);
       }


### PR DESCRIPTION
# Description

Fixes #11413.

When Moment's Nepali locale is active, its `postformat` hook converts formatted digits to Devanagari. The resulting date strings were passed to `bikram-sambat`, causing target interval lookups to throw or causing target document tags to diverge.

This change forces English formatting at the boundaries where Gregorian dates are serialized for Bikram Sambat conversion and target tags. The calendar interval path uses a cloned moment so caller and global locale state remain unchanged.

Regression coverage includes webapp current and previous interval tags, shared calendar interval calculation, target document tags with BS enabled, Gregorian mode, and the Gregorian fallback after conversion failure.

## Validation

- `shared-libs/calendar-interval`: 38 passing
- `shared-libs/rules-engine`: 224 passing
- Targeted webapp Karma: 59 tests completed; the local runner only reported Windows `EPERM` errors while writing generated coverage artifacts
- ESLint on all changed files
- `git diff --check`

# Code review checklist

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [x] Tested: Unit and/or e2e where appropriate
- [x] Backwards compatible: Works with existing data and configuration
- [x] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/)

<details>
<summary>AI Disclosure</summary>

This pull request was primarily developed with assistance from OpenAI Codex. Codex inspected issue #11413 and the relevant repository code, implemented the fix, added regression tests, and ran focused validation under the supervision of `jmtdev0`.

</details>

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

https://github.com/medic/cht-core.git