### PR TITLE
chore(#11346): add optional AI review CI workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,208 @@
+name: PR Review
+
+env:
+  OCR_LLM_MODEL: claude-sonnet-5
+  OCR_LLM_URL: https://api.anthropic.com
+  OCR_LLM_USE_ANTHROPIC: "true"
+  OCR_LLM_AUTH_HEADER: "x-api-key"
+  CLAUDE_LLM_MODEL: claude-opus-5
+  LANGFUSE_OTEL_BASE: https://us.cloud.langfuse.com/api/public/otel
+
+# Triggered on demand only: comment `/review` on a pull request.
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: >-
+    ${{
+      (
+        github.event.issue.pull_request
+        && github.event.comment.user.type != 'Bot'
+        && startsWith(github.event.comment.body, '/review')
+        && (
+          github.event.comment.author_association == 'OWNER'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+      && format('review-{0}', github.event.issue.number)
+      || format('noop-{0}', github.run_id)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  pr-context:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to react to the triggering comment and read the PR's base ref and head sha
+    # Only maintainers can trigger a review
+    if: |
+      github.event.issue.pull_request && github.event.comment.user.type != 'Bot'
+      && startsWith(github.event.comment.body, '/review')
+      && (
+        github.event.comment.author_association == 'OWNER'
+        || github.event.comment.author_association == 'MEMBER'
+        || github.event.comment.author_association == 'COLLABORATOR'
+      )
+    timeout-minutes: 5
+    outputs:
+      base_ref: ${{ steps.pr-context.outputs.base_ref }}
+      head_sha: ${{ steps.pr-context.outputs.head_sha }}
+      title: ${{ steps.pr-context.outputs.title }}
+    steps:
+      - name: Get PR context
+        id: pr-context
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+            // issue_comment carries no PR refs, so look them up for the action.
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('base_ref', pullRequest.base.ref);
+            core.setOutput('head_sha', pullRequest.head.sha);
+            core.setOutput('title', pullRequest.title);
+
+  # Line-by-line correctness review of the diff based on https://github.com/alibaba/open-code-review/blob/main/examples/github_actions/ocr-review.yml
+  code-review:
+    needs: pr-context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to read the diff under review
+      pull-requests: write # to post the review summary and inline comments
+    timeout-minutes: 30
+    steps:
+      - name: Run OpenCodeReview
+        uses: alibaba/open-code-review@420bae824a43335e2fc4266eb71f33756715e232 # v1.10.1
+        env:
+          OCR_ENABLE_TELEMETRY: "1"
+          OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ env.LANGFUSE_OTEL_BASE }}
+          OTEL_EXPORTER_OTLP_HEADERS: Authorization=Basic ${{ secrets.LANGFUSE_OTEL_BASIC_AUTH }},x-langfuse-ingestion-version=4
+          OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=ci,cicd.pipeline.task.name=${{ github.job }},vcs.repository.name=${{ github.repository }},vcs.change.id=${{ github.event.issue.number }},cicd.pipeline.run.id=${{ github.run_id }}
+        with:
+          llm_url: ${{ env.OCR_LLM_URL }}
+          llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          llm_auth_header: ${{ env.OCR_LLM_AUTH_HEADER }}
+          llm_model: ${{ env.OCR_LLM_MODEL }}
+          llm_use_anthropic: ${{ env.OCR_LLM_USE_ANTHROPIC }}
+          # '{"output_config": {"effort": "high"}}' — low|medium|high|xhigh|max.
+          llm_extra_body: '{"output_config": {"effort": "xhigh"}}'
+          base_ref: ${{ needs.pr-context.outputs.base_ref }}
+          head_sha: ${{ needs.pr-context.outputs.head_sha }}
+          background: ${{ needs.pr-context.outputs.title }}
+          incremental: 'true'
+          sticky_summary: 'false'
+
+  # completeness review that confirms the PR delivers what the linked issue and its description promise
+  completeness-review:
+    needs: pr-context
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to read the diff under review
+      pull-requests: read # to read the PR description
+      issues: read # for `gh issue view` on the linked issues
+    timeout-minutes: 30
+    outputs:
+      structured_output: ${{ steps.review.outputs.structured_output }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ needs.pr-context.outputs.head_sha }}
+          fetch-depth: 0
+      - name: Review PR for completeness
+        id: review
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1.0.189
+        env:
+          CLAUDE_CODE_ENABLE_TELEMETRY: "1"
+          CLAUDE_CODE_ENHANCED_TELEMETRY_BETA: "1"
+          OTEL_TRACES_EXPORTER: otlp
+          OTEL_METRICS_EXPORTER: none
+          OTEL_LOGS_EXPORTER: none
+          OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: http/protobuf
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ env.LANGFUSE_OTEL_BASE }}/v1/traces
+          OTEL_EXPORTER_OTLP_TRACES_HEADERS: Authorization=Basic ${{ secrets.LANGFUSE_OTEL_BASIC_AUTH }},x-langfuse-ingestion-version=4
+          OTEL_LOG_TOOL_DETAILS: "1"
+          OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=ci,cicd.pipeline.task.name=${{ github.job }},vcs.repository.name=${{ github.repository }},vcs.change.id=${{ github.event.issue.number }},cicd.pipeline.run.id=${{ github.run_id }}
+        with:
+          anthropic_api_key: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          plugin_marketplaces: https://github.com/medic/cht-ai-tools.git
+          plugins: |
+            cht-pr-review@medic-cht-ai-tools
+            cht-docs-mcp@medic-cht-ai-tools
+          prompt: |
+            Use the cht-pr-review skill to review pull request
+            ${{ github.event.issue.number }} in ${{ github.repository }}.
+            Follow that skill exactly.
+
+            Return the skill's report verbatim as `report_markdown`. If the skill concludes the PR's intent could not 
+            be established, return that as the report; an inconclusive report is still the result.
+          # Keep the configured tools synced up with what is configured in the frontmatter of the skill
+          claude_args: |
+            --model ${{ env.CLAUDE_LLM_MODEL }}
+            --allowedTools "Skill,Read,Grep,Glob,Bash(/home/runner/.claude/plugins/cache/medic-cht-ai-tools/cht-pr-review/*/scripts/pr-context.sh*),Bash(/home/runner/.claude/plugins/cache/medic-cht-ai-tools/cht-pr-review/*/scripts/pr-diff.sh*),mcp__plugin_cht-docs-mcp_cht-docs__ask_question,mcp__plugin_cht-docs-mcp_cht-docs__search_docs"
+            --disallowedTools "Edit,Write,NotebookEdit"
+            --json-schema '{"type":"object","required":["report_markdown"],"additionalProperties":false,"properties":{"report_markdown":{"type":"string","description":"The complete review report as GitHub-flavored markdown."}}}'
+      - name: Upload Claude execution log
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: completeness-review-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.review.outputs.execution_file }}
+          if-no-files-found: warn
+
+  post-review:
+    needs: [code-review, completeness-review]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to update (or post) the review summary comment
+    timeout-minutes: 5
+    steps:
+      - name: Post review comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          STRUCTURED_OUTPUT: ${{ needs.completeness-review.outputs.structured_output }}
+        with:
+          script: |
+            let report_markdown;
+            try {
+              ({ report_markdown } = JSON.parse(process.env.STRUCTURED_OUTPUT || '{}'));
+            } catch (error) {
+              core.warning(`Could not parse structured_output: ${error.message}`);
+            }
+            if (!report_markdown) {
+              core.setFailed('Review produced no report_markdown; nothing to post.');
+              return;
+            }
+            // Every OCR summary comment opens with this marker
+            const marker = '<!-- ocr-summary';
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const summary = comments.findLast(comment => comment.body?.includes(marker));
+            if (!summary) {
+              core.warning('Found no OpenCodeReview summary comment for this run; posting the report on its own.');
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body: report_markdown,
+              });
+              return;
+            }
+            await github.rest.issues.updateComment({
+              ...context.repo,
+              comment_id: summary.id,
+              body: `${summary.body}\n\n---\n\n${report_markdown}`,
+            });

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,80 +1,22 @@
+# Triggered by setting the `review` label on a PR.
 name: PR Review
 
 env:
   OCR_LLM_MODEL: claude-sonnet-5
   OCR_LLM_URL: https://api.anthropic.com
-  OCR_LLM_USE_ANTHROPIC: "true"
-  OCR_LLM_AUTH_HEADER: "x-api-key"
   CLAUDE_LLM_MODEL: claude-opus-5
   LANGFUSE_OTEL_BASE: https://us.cloud.langfuse.com/api/public/otel
 
-# Triggered on demand only: comment `/review` on a pull request.
 on:
-  issue_comment:
-    types: [created]
+  pull_request_target:
+    types: [labeled]
 
 permissions: {}
 
-concurrency:
-  group: >-
-    ${{
-      (
-        github.event.issue.pull_request
-        && github.event.comment.user.type != 'Bot'
-        && startsWith(github.event.comment.body, '/review')
-        && (
-          github.event.comment.author_association == 'OWNER'
-          || github.event.comment.author_association == 'MEMBER'
-          || github.event.comment.author_association == 'COLLABORATOR'
-        )
-      )
-      && format('review-{0}', github.event.issue.number)
-      || format('noop-{0}', github.run_id)
-    }}
-  cancel-in-progress: true
-
 jobs:
-  pr-context:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # to react to the triggering comment and read the PR's base ref and head sha
-    # Only maintainers can trigger a review
-    if: |
-      github.event.issue.pull_request && github.event.comment.user.type != 'Bot'
-      && startsWith(github.event.comment.body, '/review')
-      && (
-        github.event.comment.author_association == 'OWNER'
-        || github.event.comment.author_association == 'MEMBER'
-        || github.event.comment.author_association == 'COLLABORATOR'
-      )
-    timeout-minutes: 5
-    outputs:
-      base_ref: ${{ steps.pr-context.outputs.base_ref }}
-      head_sha: ${{ steps.pr-context.outputs.head_sha }}
-      title: ${{ steps.pr-context.outputs.title }}
-    steps:
-      - name: Get PR context
-        id: pr-context
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              ...context.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes',
-            });
-            // issue_comment carries no PR refs, so look them up for the action.
-            const { data: pullRequest } = await github.rest.pulls.get({
-              ...context.repo,
-              pull_number: context.issue.number,
-            });
-            core.setOutput('base_ref', pullRequest.base.ref);
-            core.setOutput('head_sha', pullRequest.head.sha);
-            core.setOutput('title', pullRequest.title);
-
   # Line-by-line correctness review of the diff based on https://github.com/alibaba/open-code-review/blob/main/examples/github_actions/ocr-review.yml
   code-review:
-    needs: pr-context
+    if: github.event.label.name == 'review'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to read the diff under review
@@ -88,24 +30,22 @@ jobs:
           OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
           OTEL_EXPORTER_OTLP_ENDPOINT: ${{ env.LANGFUSE_OTEL_BASE }}
           OTEL_EXPORTER_OTLP_HEADERS: Authorization=Basic ${{ secrets.LANGFUSE_OTEL_BASIC_AUTH }},x-langfuse-ingestion-version=4
-          OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=ci,cicd.pipeline.task.name=${{ github.job }},vcs.repository.name=${{ github.repository }},vcs.change.id=${{ github.event.issue.number }},cicd.pipeline.run.id=${{ github.run_id }}
+          OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=ci,cicd.pipeline.task.name=${{ github.job }},vcs.repository.name=${{ github.repository }},vcs.change.id=${{ github.event.pull_request.number }},cicd.pipeline.run.id=${{ github.run_id }}
         with:
           llm_url: ${{ env.OCR_LLM_URL }}
           llm_auth_token: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
-          llm_auth_header: ${{ env.OCR_LLM_AUTH_HEADER }}
+          llm_auth_header: "x-api-key"
           llm_model: ${{ env.OCR_LLM_MODEL }}
-          llm_use_anthropic: ${{ env.OCR_LLM_USE_ANTHROPIC }}
-          # '{"output_config": {"effort": "high"}}' — low|medium|high|xhigh|max.
-          llm_extra_body: '{"output_config": {"effort": "xhigh"}}'
-          base_ref: ${{ needs.pr-context.outputs.base_ref }}
-          head_sha: ${{ needs.pr-context.outputs.head_sha }}
-          background: ${{ needs.pr-context.outputs.title }}
+          llm_use_anthropic: "true"
           incremental: 'true'
           sticky_summary: 'false'
+          background: ${{ github.event.pull_request.title }}
+          # '{"output_config": {"effort": "high"}}' — low|medium|high|xhigh|max.
+          llm_extra_body: '{"output_config": {"effort": "xhigh"}}'
 
-  # completeness review that confirms the PR delivers what the linked issue and its description promise
+  # completeness review that confirms the PR deliver what the linked issue and its description promise
   completeness-review:
-    needs: pr-context
+    if: github.event.label.name == 'review'
     runs-on: ubuntu-latest
     permissions:
       contents: read # to read the diff under review
@@ -118,7 +58,7 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-          ref: ${{ needs.pr-context.outputs.head_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Review PR for completeness
         id: review
@@ -133,7 +73,7 @@ jobs:
           OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ${{ env.LANGFUSE_OTEL_BASE }}/v1/traces
           OTEL_EXPORTER_OTLP_TRACES_HEADERS: Authorization=Basic ${{ secrets.LANGFUSE_OTEL_BASIC_AUTH }},x-langfuse-ingestion-version=4
           OTEL_LOG_TOOL_DETAILS: "1"
-          OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=ci,cicd.pipeline.task.name=${{ github.job }},vcs.repository.name=${{ github.repository }},vcs.change.id=${{ github.event.issue.number }},cicd.pipeline.run.id=${{ github.run_id }}
+          OTEL_RESOURCE_ATTRIBUTES: deployment.environment.name=ci,cicd.pipeline.task.name=${{ github.job }},vcs.repository.name=${{ github.repository }},vcs.change.id=${{ github.event.pull_request.number }},cicd.pipeline.run.id=${{ github.run_id }}
         with:
           anthropic_api_key: ${{ secrets.OCR_LLM_AUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -143,7 +83,7 @@ jobs:
             cht-docs-mcp@medic-cht-ai-tools
           prompt: |
             Use the cht-pr-review skill to review pull request
-            ${{ github.event.issue.number }} in ${{ github.repository }}.
+            ${{ github.event.pull_request.number }} in ${{ github.repository }}.
             Follow that skill exactly.
 
             Return the skill's report verbatim as `report_markdown`. If the skill concludes the PR's intent could not 
@@ -165,7 +105,7 @@ jobs:
     needs: [code-review, completeness-review]
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # to update (or post) the review summary comment
+      pull-requests: write # to update (or post) the review summary comment and clear the label
     timeout-minutes: 5
     steps:
       - name: Post review comment
@@ -206,3 +146,19 @@ jobs:
               comment_id: summary.id,
               body: `${summary.body}\n\n---\n\n${report_markdown}`,
             });
+      - name: Remove the review label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: context.issue.number,
+                name: 'review',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info('Label "review" was already gone.');
+            }

--- a/.opencodereview/rule.json
+++ b/.opencodereview/rule.json
@@ -1,0 +1,65 @@
+{
+  "include": [
+    "**/*.{ts,js}"
+  ],
+  "exclude": [
+    "**/package-lock.json",
+    "api/src/enketo-transformer/**",
+    "api/src/public/login/lib-bowser.js",
+    "webapp/src/js/enketo/bootstrap-datepicker.*.js",
+    ".github/**/compiled/index.js"
+  ],
+  "rules": [
+    {
+      "path": "api/resources/translations/*.properties",
+      "rule": ".opencodereview/rules/translations.md"
+    },
+    {
+      "path": "ddocs/**/*.js",
+      "rule": ".opencodereview/rules/couchdb-ddocs.md",
+      "merge_system_rule": true
+    },
+    {
+      "path": "shared-libs/cht-datasource/src/**/*.{ts,js}",
+      "rule": ".opencodereview/rules/cht-datasource.md",
+      "merge_system_rule": true
+    },
+    {
+      "path": "tests/**/*.{ts,js}",
+      "rule": ".opencodereview/rules/e2e-tests.md"
+    },
+    {
+      "path": "api/tests/integration/**/*.js",
+      "rule": ".opencodereview/rules/e2e-tests.md"
+    },
+    {
+      "path": "**/tests/**/*.{ts,js}",
+      "rule": ".opencodereview/rules/unit-tests.md"
+    },
+    {
+      "path": "shared-libs/*/test/**/*.{ts,js}",
+      "rule": ".opencodereview/rules/unit-tests.md"
+    },
+    {
+      "path": "config/*/test/**/*.js",
+      "rule": ".opencodereview/rules/unit-tests.md"
+    },
+
+    {
+      "path": "webapp/**/src/**/*.{ts,js}",
+      "rule": ".opencodereview/rules/webapp.md",
+      "merge_system_rule": true
+    },
+
+    {
+      "path": "admin/src/js/**/*.js",
+      "rule": ".opencodereview/rules/admin.md",
+      "merge_system_rule": true
+    },
+    {
+      "path": "**/*.{ts,js,mjs,cjs}",
+      "rule": ".opencodereview/rules/base.md",
+      "merge_system_rule": true
+    }
+  ]
+}

--- a/.opencodereview/rules/admin.md
+++ b/.opencodereview/rules/admin.md
@@ -1,0 +1,11 @@
+#### admin — AngularJS
+
+`admin/src/js/` is the legacy AngularJS ("App Management") app, CommonJS modules. It is in maintenance mode:
+prefer the smallest change that fits the surrounding code over any modernisation. Ignore every React item in the
+generic checklist — there is no React here.
+
+- **Digest-cycle safety.** Work that mutates scope from outside AngularJS (a `ChangesService` callback, a raw promise, a DOM event) needs `$scope.$apply` / `$timeout`, and calling `$apply` while a digest is already in progress throws. Flag either mistake.
+- **Watchers and listeners.** `$scope.$watch`, `$scope.$on`, `ChangesService.subscribe`, `setInterval`, and jQuery handlers registered without a matching cleanup on `$destroy` leak for the session.
+- **Injection.** New dependencies must appear in the explicit `$inject` / array-notation annotation; relying on parameter names breaks under minification.
+- Do not suggest migrating this code to Angular, TypeScript, or ES modules.
+- User-facing strings must be translated; RTL layout must hold.

--- a/.opencodereview/rules/base.md
+++ b/.opencodereview/rules/base.md
@@ -1,0 +1,17 @@
+#### cht-core baseline
+
+Applies on top of the generic checklist above. Where the two disagree, this section wins.
+
+#### CouchDB / PouchDB document handling
+
+- **Update conflicts.** A `put` on a doc fetched earlier can fail with a 409 whenever sentinel, replication, or another request may touch the same doc. Flag a write with no 409 branch and no retry where concurrent writes are plausible (contacts, reports, the `settings` doc, user docs).
+- **`bulkDocs` does not throw per row.** It resolves with an array where an individual row may carry `error` / `status`. Flag a `bulkDocs` result that is never inspected for failed rows — the failure is silently swallowed.
+- **Unbounded reads.** `allDocs` / `db.query` / `db.find` with no `limit`, or a view read materialised into an array, is a scale problem on real deployments. Flag it when the result set grows with deployment size (contacts, reports, tasks, messages). A bounded lookup by a known set of ids is fine.
+- **Property naming.** Properties persisted on CouchDB docs are `snake_case`; everything else is `lowerCamelCase`. A new persisted doc property in `camelCase` is a finding.
+- **Shared constants.** Doc ids, doc types, contact types, user roles, and HTTP headers live in `@medic/constants` (`shared-libs/constants`). A re-declared string literal that already exists there is a finding; a genuinely new one belongs in that package.
+
+#### Security and access control
+
+- `api/src/services/replication/authorization.js` and `api/src/middleware/authorization.js` decide what an offline  user may replicate and what an online user may call. Any change that widens the doc set an offline user can read or write, or that relaxes a role/permission check, is a high-severity finding unless the PR explicitly says that widening is the goal.
+- A new route in an `api/src/controllers/*` file that omits the permission or authentication check its siblings in the same controller apply is a finding.
+- User-supplied values reaching a CouchDB view key, a `_find` selector, a shell command, or a URL built by string concatenation must be validated or encoded first.

--- a/.opencodereview/rules/cht-datasource.md
+++ b/.opencodereview/rules/cht-datasource.md
@@ -1,0 +1,22 @@
+#### cht-datasource — versioned public API
+
+`shared-libs/cht-datasource` exposes a **versioned public API** consumed not only across cht-core but by customer configuration code — purging, tasks, targets, contact-summary. Treat its exported surface as a published contract.
+
+**Only passive changes to an existing version** (see `shared-libs/cht-datasource/README.md`). Report as a breaking change, with the version bump as the fix:
+
+- removing or renaming an export, a function, a parameter, or a returned field;
+- narrowing a parameter type or widening a return type;
+- making an optional parameter required, or reordering parameters;
+- changing what a function returns for input that previously succeeded — including throwing where it used to return `null`, or returning `null` where it used to throw;
+- changing page size, ordering, or the shape of a paginated result.
+
+A non-passive change belongs on a new version of the API; the previous version stays, marked `@deprecated`, and internal cht-core callers move to the new one. Flag a new version added without the `@deprecated` marker on the old one, or without the internal callers updated.
+
+**Both adapters, or neither.** Every interaction exists twice: `src/local/` (PouchDB — offline webapp users, api, sentinel) and `src/remote/` (HTTP proxy to api — admin, online webapp users). A change to one adapter without the matching change to the other is a real bug: the same call will behave differently for offline and online users. Check that the two agree on returned shape, null handling, and error behaviour.
+
+**Four levels for a new interaction** — flag any that is missing:
+
+1. implemented in `src/local/` **and** `src/remote/`;
+2. a unified interface exposed from the concept module (`src/person.ts`, `src/place.ts`, `src/contact.ts`, `src/report.ts`, `src/target.ts`);
+3. exported from `src/index.ts`;
+4. the endpoint the remote adapter calls implemented in `api/`. A path or query-parameter change must match the api route it calls.

--- a/.opencodereview/rules/couchdb-ddocs.md
+++ b/.opencodereview/rules/couchdb-ddocs.md
@@ -1,0 +1,8 @@
+#### CouchDB design documents
+
+`ddocs/` holds CouchDB design docs. `medic-client` replicates to every offline device. These are **not** ordinary application files — review them as database schema.
+
+- These run inside CouchDB's own JavaScript engine, not Node. ES6+ (`let`, `const`, arrow functions, template literals, `Object.assign`, spread, optional chaining) is unsafe — this code is intentionally ES5. Flag ES6+ syntax here even though the surrounding repo uses it. Do not flag `var` in these files.
+- Map functions must be pure and deterministic: no `Date.now()`, no `Math.random()`, no reliance on anything outside `doc`. A non-deterministic key makes the index inconsistent across nodes.
+- Emitting a large value bloats the index; emit ids and let the caller fetch. Flag `emit(key, doc)`.
+- Key shape is a contract. Changing the arity, order, or type of an emitted key breaks every existing query, including `startkey`/`endkey` ranges in `api/`, `sentinel/`, and project configuration.

--- a/.opencodereview/rules/e2e-tests.md
+++ b/.opencodereview/rules/e2e-tests.md
@@ -1,0 +1,49 @@
+#### E2E and integration test review rules
+
+These files are test code. The rules below override the generic checklist for them.
+
+**Never report in these files:**
+
+- Hardcoded literals in fixtures, expected values, doc ids, phone numbers, and URLs.
+- Setup repeated across specs, or a long `before`/`beforeEach`.
+- Missing error handling
+- Use of `browser.*` globals without an import; WebdriverIO injects them.
+
+Report what makes a test **flaky, unable to fail, leaky across suites, or asserting the wrong thing**.
+
+#### Flakiness
+
+- **`browser.pause(n)` as a synchronisation primitive.** A fixed sleep standing in for a real wait is the main source of flake in this suite. Flag it and name the `waitForDisplayed` / `waitForClickable` / `browser.waitUntil` condition that should replace it. A pause used to let an animation settle *after* a wait is acceptable.
+- An assertion on an element that was never waited for — `getText()` / `isDisplayed()` straight after a navigation or a click that triggers a re-render.
+- `browser.waitUntil` whose predicate can never become false (it will pass immediately or hang for the full timeout with an unhelpful message).
+- Reading a value once and asserting on it inside `waitUntil` — the predicate must re-read the element each poll.
+- A hardcoded index into a list whose order the test does not control.
+- Depending on sentinel having processed a doc without `utils.waitForDocRev`, `utils.runSentinelTasks`, or an equivalent wait. Sentinel is asynchronous; "save then immediately assert" is a race.
+- Depending on a CouchDB view being current without `utils.waitForIndexes`.
+
+#### Leaking state between suites
+
+- Settings changed with `utils.updateSettings` / `utils.updatePermissions` and not reverted with `utils.revertSettings` (or `utils.revertDb`) in `after`/`afterEach`. The next suite inherits them.
+- Docs or users created and never cleaned up — `utils.deleteAllDocs`, `utils.deleteUsers`, `utils.revertDb`.
+- A service stopped (`utils.stopSentinel`, `utils.stopApi`, `utils.stopHaproxy`) on a path that can throw before the matching start, leaving the rest of the run against a dead instance.
+- Cleanup placed in the `try` of the test body rather than in an `after` hook, so a failing assertion skips it.
+
+#### Tests that cannot fail
+
+- An assertion inside a callback the code under test never invokes, after an early `return`, or in a `catch` with no preceding fail-fast assertion.
+- An `async` `it` whose promise is neither returned nor awaited, or a missing `await` on the call under test — the assertions run after the test has already passed.
+- An expected-failure test that runs the code but never asserts the rejection, via `await expect(...).to.be.rejectedWith(...)`, a `try`/`catch` with `assert.fail()` in the `try`, or an explicit error assertion.
+- Assertions that hold regardless of behaviour: `to.exist` on a literal, a value compared to itself, or asserting how a stub was configured instead of how it was called.
+- A `done` callback that is never called on the failure path, or is called alongside a returned promise.
+
+#### Wrong assertions
+
+- The assertion does not match what the test name claims.
+- `calledWith` / `args[n]` omitting an argument the behaviour depends on, or checking the wrong call index — prefer `to.deep.equal(stub.args[0])` over a partial match when the full argument list matters.
+- `deep.include` / `chai-shallow-deep-equal` / `excluding(...)` used where the claim requires exact equality; an `excluding` list that quietly hides the field the change actually affects.
+- The function under test is itself stubbed, so only the stub is verified.
+- `deepEqualInAnyOrder` used where order is part of the contract (sorted results, sequence of doc writes).
+
+#### Page objects
+- Selectors and waits belong in `tests/page-objects/**`; assertions belong in the spec. A raw `$('...')` selector or a `waitForDisplayed` inline in a spec, where the page object already exposes (or should expose) it, is a finding.
+- A brittle selector (deep CSS descent, `nth-child`, text match on untranslated copy) where a stable hook exists.

--- a/.opencodereview/rules/translations.md
+++ b/.opencodereview/rules/translations.md
@@ -1,0 +1,7 @@
+#### Translation files
+
+- **Keys are a contract.** Check the diff replaces every in-repo usage when a key changes.
+- **Placeholders are named by the caller.** A renamed or newly introduced placeholder must match what the calling code actually passes, or it renders literally.
+- **Pluralisation and gender** belong in messageformat, not in concatenated strings or separate `_singular` / `_plural` keys.
+- **RTL.** Copy that embeds layout assumptions ("click the button on the left", a hardcoded direction, a string assembled from fragments) breaks in right-to-left languages.
+- Keep keys alphabetically grouped with their neighbours

--- a/.opencodereview/rules/unit-tests.md
+++ b/.opencodereview/rules/unit-tests.md
@@ -1,0 +1,37 @@
+#### Unit test review rules
+
+These files are test code. The rules below override the generic checklist for them.
+
+**Never report in these files:**
+
+- Hardcoded literals in fixtures, expected values, doc ids, phone numbers, and URLs
+- Setup repeated across specs, or a long `before`/`beforeEach`.
+- Missing error handling
+- `any`, non-null assertions, and loose types in fixtures and stubs.
+- A long `describe` or a long assertion list. Length alone is not a finding.
+
+Report what makes a test **flaky, unable to fail, leaky across suites, or asserting the wrong thing**.
+
+#### Tests that cannot fail
+
+- An assertion inside a callback the code under test never invokes, after an early `return`, or in a `catch` with no preceding fail-fast assertion.
+- An `async` `it` whose promise is neither returned nor awaited, or a missing `await` on the call under test — the assertions run after the test has already passed.
+- An expected-failure test that runs the code but never asserts the rejection, via `await expect(...).to.be.rejectedWith(...)`, a `try`/`catch` with `assert.fail()` in the `try`, or an explicit error assertion.
+- Assertions that hold regardless of behaviour: `to.exist` on a literal, a value compared to itself, or asserting how a stub was configured instead of how it was called.
+- A `done` callback that is never called on the failure path, or is called alongside a returned promise.
+
+#### Wrong assertions
+
+- The assertion does not match what the test name claims.
+- `calledWith` / `args[n]` omitting an argument the behaviour depends on, or checking the wrong call index — prefer `to.deep.equal(stub.args[0])` over a partial match when the full argument list matters.
+- `deep.include` / `chai-shallow-deep-equal` / `excluding(...)` used where the claim requires exact equality; an `excluding` list that quietly hides the field the change actually affects.
+- The function under test is itself stubbed, so only the stub is verified.
+- `deepEqualInAnyOrder` used where order is part of the contract (sorted results, sequence of doc writes).
+
+#### Sinon hygiene
+
+- `sinon.stub(obj, 'fn')` must be undone. These suites call `sinon.restore()` in `afterEach` — a new file, or a new `describe` that stubs a module or object method without one, leaks the stub into every later test in the run.
+- `onCall(n)` / `resolves` queues shorter than the number of calls the code under test makes, leaving a later call returning `undefined`.
+
+#### Coverage without verification
+Watch for tests written to satisfy coverage gates rather than to verify: a branch invoked but its outcome never asserted, or only "did not throw" asserted where the branch has an observable result.

--- a/.opencodereview/rules/webapp.md
+++ b/.opencodereview/rules/webapp.md
@@ -1,0 +1,26 @@
+#### webapp — Angular + NgRx
+
+`webapp/src/ts/` is Angular (standalone-less modules) with NgRx for state and RxJS throughout. Ignore every React item in the generic checklist above — there is no React in this repo.
+
+**Subscription lifetime.** The convention here is a single `private subscription: Subscription = new Subscription()` field, `this.subscription.add(...)` for every stream, and `this.subscription.unsubscribe()` in `ngOnDestroy`. Flag:
+
+- a new `.subscribe(...)` whose teardown is not added to that subscription (or handled by `takeUntil` / `async` pipe);
+- a component that gains its first subscription but no `ngOnDestroy`;
+- a `ChangesService.subscribe(...)` left unregistered — those fire for the life of the session.
+
+**NgRx.**
+
+- Reducers and selectors must stay pure — no `Date.now()`, no service calls, no mutation of the incoming state.  Mutating a state slice in place instead of returning a new object is a real bug, not a style note.
+- An effect that can throw or reject without a `catchError` inside the inner observable kills the effect stream for the rest of the session. Flag `catchError` placed on the outer pipe instead of inside the `switchMap`/`mergeMap`.
+- `switchMap` where in-flight work must not be cancelled (a save, a delete), or `mergeMap` where only the latest result is wanted (a search-as-you-type) — say which you believe the intent is when reporting.
+- New state read directly from a service in a component where a selector already exposes it.
+
+**Change detection and rendering.**
+
+- Work done in a template expression or a getter bound in the template runs on every change-detection pass; flag anything non-trivial there.
+- `innerHTML` bound to a value that can carry user or configuration content without sanitisation.
+- A `setTimeout` / `setInterval` started in a component and never cleared in `ngOnDestroy`.
+
+**Internationalisation.** Every user-facing string goes through the translate pipe/service and `api/resources/translations/messages-en.properties`. A literal English string in a template or in a value rendered to the user is a finding. Layout must also survive RTL — flag a hardcoded `left`/`right` (margin, padding, position, `text-align`) where a logical property or the existing RTL handling should be used.
+
+**Types.** `webapp/src/ts` is TypeScript; a new `any` without a comment explaining why, or a type assertion that papers over a genuinely nullable value, is worth reporting.


### PR DESCRIPTION
# Description

Closes https://github.com/medic/cht-core/issues/11346 

Adds a new GitHub actions workflow that can be optionally triggered on a PR by maintainers by leaving a comment on the PR starting with `/review`.  The workflow runs two distinct AI reviews of the code changes in the PR:

- `code-review` - This job uses https://github.com/alibaba/open-code-review to do a line-by-line review of the code in the PR looking for code-level bugs, errors, etc.
- `completeness-review` - This job uses the `cht-pr-review` skill from https://github.com/medic/cht-ai-tools to validate the contents of the PR against the requirements documented in the PR description and in any linked issue(s).

OCR will leave in-line comments for any of its finding and the completeness-review report will be documented in a top-level comment on the PR.

## Telemetry

OpenTelemetry metrics are collected from both jobs and are sent to Langfuse for aggregation.  In addition, the execution output data for both jobs is attached to the CI run as artifacts and can be downloaded for further analysis (useful for debugging, etc). 

## opencodereview rules

Most of the value in the open-code-review system is in the ability to easily extend the review functionality with custom rules that can be tuned for the specific repo.  I have added an initial set of rules here. The goal is not so much to be comprehensive, but to just give us a baseline to start from.  We will want to continue tuning these as we get more data about reviews in cht-core.

## AI Disclosure

Claude was used heavily when researching/designing/authoring this.  I have carefully reviewed all the changes and have done extensive testing with an almost identical setup over in https://github.com/jkuester/chtoolbox.  

# Code review checklist
- [X] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/)
- [X] AI disclosure: Please disclose use of AI per [the guidelines](https://docs.communityhealthtoolkit.org/community/contributing/ai-guidelines/).



# Compose URLs
If Build CI hasn't passed, these may 404:

* [Core](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11346-add-ai-review/docker-compose/cht-core.yml)
* [CouchDB Single](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11346-add-ai-review/docker-compose/cht-couchdb.yml)
* [CouchDB Cluster](https://staging.dev.medicmobile.org/_couch/builds_4/medic:medic:11346-add-ai-review/docker-compose/cht-couchdb-clustered.yml)


# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.

